### PR TITLE
Delete README.rst of ivy/ivy directory 

### DIFF
--- a/ivy/README.rst
+++ b/ivy/README.rst
@@ -1,4 +1,0 @@
-Ivy
-===
-
-Ivy library.


### PR DESCRIPTION
The PR removes the README.rst of the ivy/ivy directory which is adding no value to the repository. 