### PR TITLE
test_cos_arrary_api

### DIFF
--- a/ivy/functional/backends/torch/core/math.py
+++ b/ivy/functional/backends/torch/core/math.py
@@ -16,6 +16,8 @@ def sin(x):
 def cos(x):
     if isinstance(x, float):
         return math.cos(x)
+    if x.dtype == _torch.float16:
+        return _torch.cos(_torch.tensor(x, dtype=_torch.float32))
     return _torch.cos(x)
 
 

--- a/ivy_tests/test_array_api/array_api_tests/test_operators_and_elementwise_functions.py
+++ b/ivy_tests/test_array_api/array_api_tests/test_operators_and_elementwise_functions.py
@@ -677,15 +677,13 @@ def test_cos(dtype, shape):
     ph.assert_shape("cos", out.shape, x.shape)
     #checking domain and codomain when the input shape in non-empty.
     if shape != ():
-        assert [ivy.array([1.], dtype=dtype) >= i for i in out]
-        assert [ivy.array([-1.], dtype=dtype) <= i for i in out]
-        assert [ivy.array([-float('inf')], dtype=dtype) < i for i in x]
-        assert [ivy.array([float('inf')], dtype=dtype) > i for i in x]
-
+        ONE = ivy.cast(ivy.broadcast_to(ivy.array([1.]), out.shape), dtype)
+        INFINITY = ivy.cast(ivy.broadcast_to(ivy.array(float('inf')), x.shape), dtype)
+        assert ivy.all(ivy.logical_and((out <= ONE), (out >= -ONE)))
+        assert ivy.all(ivy.logical_and((x < INFINITY), (x>-INFINITY)))
 
     #cos maps (-inf, inf) to [-1, 1]. Values outside this domain are mapped
     #to nan, which is already tested in the special cases.
-    # ah.assert_exactly_equal(domain, codomain)
 #
 #
 # @given(xps.arrays(dtype=xps.floating_dtypes(), shape=hh.shapes()))


### PR DESCRIPTION
Modified pytest bcz the already written one didn't handle rank one tensors well. Only torch backened required a mini tweak to deal with cos for float16.  
All tests passing for tensorflow, torch, jax, numpy.