### PR TITLE
initial implementation of unique

### DIFF
--- a/.idea/ivy.iml
+++ b/.idea/ivy.iml
@@ -2,7 +2,7 @@
 <module type="PYTHON_MODULE" version="4">
   <component name="NewModuleRootManager">
     <content url="file://$MODULE_DIR$" />
-    <orderEntry type="jdk" jdkName="Remote Python 3.8.10 Docker (ivydl/ivy:latest)" jdkType="Python SDK" />
+    <orderEntry type="jdk" jdkName="Python 3.8 (ivy)" jdkType="Python SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
   </component>
   <component name="PyDocumentationSettings">

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -3,5 +3,5 @@
   <component name="JavaScriptSettings">
     <option name="languageLevel" value="ES6" />
   </component>
-  <component name="ProjectRootManager" version="2" project-jdk-name="Remote Python 3.8.10 Docker (ivydl/ivy:latest)" project-jdk-type="Python SDK" />
+  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.8 (ivy)" project-jdk-type="Python SDK" />
 </project>

--- a/ivy/functional/backends/jax/core/general.py
+++ b/ivy/functional/backends/jax/core/general.py
@@ -10,6 +10,7 @@ import jax.numpy as _jnp
 import jaxlib as _jaxlib
 from numbers import Number
 from operator import mul as _mul
+from collections import namedtuple
 from functools import reduce as _reduce
 from jaxlib.xla_extension import Buffer
 import multiprocessing as _multiprocessing
@@ -85,7 +86,7 @@ def array(object_in, dtype=None, dev=None):
     if dtype:
         if dtype == 'bool':
             dtype += '_'
-        dtype = _jnp.__dict__[dtype]
+        dtype = _jnp.__dict__[dtype_to_str(dtype)]
     else:
         dtype = None
     return to_dev(_jnp.array(object_in, dtype=dtype), default_device(dev))
@@ -280,6 +281,12 @@ def zeros_like(x, dtype=None, dev=None):
 def full(shape, fill_value, dtype=None, device=None):
     return to_dev(_jnp.full(shape, fill_value, dtype_from_str(default_dtype(dtype, fill_value))), default_device(device))
 
+def unique_all(arr, device=None):
+    UniqueArray = namedtuple('UniqueArray', ['values', 'indices', 'inverse_indices', 'counts'])
+    values, indices, inverse_indices, counts = _jnp.unique(arr, return_index=True, return_inverse=True, return_counts=True)
+    inverse_indices = inverse_indices.reshape(arr.shape)
+    unq = UniqueArray(values, indices, inverse_indices, counts)
+    return unq
 
 # noinspection PyShadowingNames
 def ones(shape, dtype=None, dev=None):

--- a/ivy/functional/backends/numpy/core/general.py
+++ b/ivy/functional/backends/numpy/core/general.py
@@ -9,6 +9,7 @@ import math as _math
 from operator import mul as _mul
 from functools import reduce as _reduce
 import multiprocessing as _multiprocessing
+from collections import namedtuple
 
 # local
 from ivy.functional.ivy.core import default_dtype
@@ -83,7 +84,7 @@ def _flat_array_to_1_dim_array(x):
 def array(object_in, dtype=None, dev=None):
     if dtype:
         dtype = 'bool_' if dtype == 'bool' else dtype
-        dtype = _np.__dict__[dtype]
+        dtype = _np.__dict__[dtype_to_str(dtype)]
     else:
         dtype = None
     return _to_dev(_np.array(object_in, dtype=dtype), dev)
@@ -279,6 +280,14 @@ def zeros_like(x, dtype=None, dev=None):
 
 def full(shape, fill_value, dtype=None, device=None):
     return _to_dev(_np.full(shape, fill_value, dtype_from_str(default_dtype(dtype, fill_value))), device)
+
+
+def unique_all(arr, device=None):
+    UniqueArray = namedtuple('UniqueArray', ['values', 'indices', 'inverse_indices', 'counts'])
+    values, indices, inverse_indices, counts = _np.unique(arr, return_index=True, return_counts=True, return_inverse=True)
+    inverse_indices = inverse_indices.reshape(arr.shape)
+    unq = UniqueArray(values, indices, inverse_indices, counts)
+    return unq
 
 
 # noinspection PyShadowingNames

--- a/ivy/functional/backends/torch/core/general.py
+++ b/ivy/functional/backends/torch/core/general.py
@@ -427,7 +427,7 @@ def full(shape, fill_value, dtype=None, device=None):
 
 def unique_all(arr, device=None):
     UniqueArray = namedtuple('UniqueArray', ['values', 'indices', 'inverse_indices', 'counts'])
-    values, inverse_indices, counts = _torch.unique(arr, sorted=True, return_inverse=True, return_counts=True)
+    values, inverse_indices, counts = _torch.unique(arr,sorted=True, return_inverse=True, return_counts=True)
     # get the indices of the elements in 'values' since torch's unique function doesn't return them
     perm = _torch.arange(inverse_indices.size(0))
     inverse, perm = inverse_indices.flip([0]), perm.flip([0])

--- a/ivy/functional/ivy/core/general.py
+++ b/ivy/functional/ivy/core/general.py
@@ -1071,6 +1071,14 @@ def full(shape: Union[int, Tuple[int]], fill_value: Union[int, float], dtype: Op
     return _cur_framework(f=f).full(shape, fill_value, dtype, device)
 
 
+def unique_all(x: array, f: ivy.Framework = None):
+    """
+    Returns the unique elements of an input array x, the first occurring indices for each unique element in x,
+    the indices from the set of unique elements that reconstruct x,
+    and the corresponding counts for each unique element in x.
+    """
+    return _cur_framework(f=f).unique_all(x)
+
 # noinspection PyShadowingNames
 def one_hot(indices: Union[ivy.Array, ivy.NativeArray], depth: int, dev: ivy.Device = None, f: ivy.Framework = None)\
         -> Union[ivy.Array, ivy.NativeArray]:

--- a/ivy_tests/test_array_api/array_api_tests/test_set_functions.py
+++ b/ivy_tests/test_array_api/array_api_tests/test_set_functions.py
@@ -1,118 +1,122 @@
 # # TODO: disable if opted out, refactor things
-# import math
-# import pytest
-# from collections import Counter, defaultdict
+import math
+import pytest
+from collections import Counter, defaultdict
+
+from hypothesis import assume, given
+import ivy
+import ivy_tests
+from . import _array_module as xp
+from . import dtype_helpers as dh
+from . import hypothesis_helpers as hh
+from . import pytest_helpers as ph
+from . import shape_helpers as sh
+from . import xps
 #
-# from hypothesis import assume, given
-#
-# from . import _array_module as xp
-# from . import dtype_helpers as dh
-# from . import hypothesis_helpers as hh
-# from . import pytest_helpers as ph
-# from . import shape_helpers as sh
-# from . import xps
-#
-# pytestmark = pytest.mark.ci
+pytestmark = pytest.mark.ci
 #
 #
-# @given(xps.arrays(dtype=xps.scalar_dtypes(), shape=hh.shapes(min_side=1)))
-# def test_unique_all(x):
-#     out = xp.unique_all(x)
-#
-#     assert hasattr(out, "values")
-#     assert hasattr(out, "indices")
-#     assert hasattr(out, "inverse_indices")
-#     assert hasattr(out, "counts")
-#
-#     ph.assert_dtype(
-#         "unique_all", x.dtype, out.values.dtype, repr_name="out.values.dtype"
-#     )
-#     ph.assert_default_index(
-#         "unique_all", out.indices.dtype, repr_name="out.indices.dtype"
-#     )
-#     ph.assert_default_index(
-#         "unique_all", out.inverse_indices.dtype, repr_name="out.inverse_indices.dtype"
-#     )
-#     ph.assert_default_index(
-#         "unique_all", out.counts.dtype, repr_name="out.counts.dtype"
-#     )
-#
-#     assert (
-#         out.indices.shape == out.values.shape
-#     ), f"{out.indices.shape=}, but should be {out.values.shape=}"
-#     ph.assert_shape(
-#         "unique_all",
-#         out.inverse_indices.shape,
-#         x.shape,
-#         repr_name="out.inverse_indices.shape",
-#     )
-#     assert (
-#         out.counts.shape == out.values.shape
-#     ), f"{out.counts.shape=}, but should be {out.values.shape=}"
-#
-#     scalar_type = dh.get_scalar_type(out.values.dtype)
-#     counts = defaultdict(int)
-#     firsts = {}
-#     for i, idx in enumerate(sh.ndindex(x.shape)):
-#         val = scalar_type(x[idx])
-#         if counts[val] == 0:
-#             firsts[val] = i
-#         counts[val] += 1
-#
-#     for idx in sh.ndindex(out.indices.shape):
-#         val = scalar_type(out.values[idx])
-#         if math.isnan(val):
-#             break
-#         i = int(out.indices[idx])
-#         expected = firsts[val]
-#         assert i == expected, (
-#             f"out.values[{idx}]={val} and out.indices[{idx}]={i}, "
-#             f"but first occurence of {val} is at {expected}"
-#         )
-#
-#     for idx in sh.ndindex(out.inverse_indices.shape):
-#         ridx = int(out.inverse_indices[idx])
-#         val = out.values[ridx]
-#         expected = x[idx]
-#         msg = (
-#             f"out.inverse_indices[{idx}]={ridx} results in out.values[{ridx}]={val}, "
-#             f"but should result in x[{idx}]={expected}"
-#         )
-#         if dh.is_float_dtype(out.values.dtype) and xp.isnan(expected):
-#             assert xp.isnan(val), msg
-#         else:
-#             assert val == expected, msg
-#
-#     vals_idx = {}
-#     nans = 0
-#     for idx in sh.ndindex(out.values.shape):
-#         val = scalar_type(out.values[idx])
-#         count = int(out.counts[idx])
-#         if math.isnan(val):
-#             nans += 1
-#             assert count == 1, (
-#                 f"out.counts[{idx}]={count} for out.values[{idx}]={val}, "
-#                 "but count should be 1 as NaNs are distinct"
-#             )
-#         else:
-#             expected = counts[val]
-#             assert (
-#                 expected > 0
-#             ), f"out.values[{idx}]={val}, but {val} not in input array"
-#             count = int(out.counts[idx])
-#             assert count == expected, (
-#                 f"out.counts[{idx}]={count} for out.values[{idx}]={val}, "
-#                 f"but should be {expected}"
-#             )
-#             assert (
-#                 val not in vals_idx.keys()
-#             ), f"out[{idx}]={val}, but {val} is also in out[{vals_idx[val]}]"
-#             vals_idx[val] = idx
-#
-#     if dh.is_float_dtype(out.values.dtype):
-#         assume(x.size <= 128)  # may not be representable
-#         expected = sum(v for k, v in counts.items() if math.isnan(k))
-#         assert nans == expected, f"{nans} NaNs in out, but should be {expected}"
+#@given(xps.arrays(dtype=xps.scalar_dtypes(), shape=hh.shapes(min_side=1)))
+@pytest.mark.parametrize('x', [1, 2.4353, [1, 1, 2, 2], [3.43e10, 1.2232], [True, False]])
+@pytest.mark.parametrize('tensor_fn', [ivy.array])
+def test_unique_all(x, tensor_fn):
+    x = tensor_fn(x)
+    out = ivy.unique_all(x)
+
+    assert hasattr(out, "values")
+    assert hasattr(out, "indices")
+    assert hasattr(out, "inverse_indices")
+    assert hasattr(out, "counts")
+
+    ph.assert_dtype(
+        "unique_all", x.dtype, out.values.dtype, repr_name="out.values.dtype"
+    )
+    ph.assert_default_index(
+        "unique_all", out.indices.dtype, repr_name="out.indices.dtype"
+    )
+    ph.assert_default_index(
+        "unique_all", out.inverse_indices.dtype, repr_name="out.inverse_indices.dtype"
+    )
+    ph.assert_default_index(
+        "unique_all", out.counts.dtype, repr_name="out.counts.dtype"
+    )
+
+    assert (
+        out.indices.shape == out.values.shape
+    ), f"{out.indices.shape=}, but should be {out.values.shape=}"
+    ph.assert_shape(
+        "unique_all",
+        out.inverse_indices.shape,
+        x.shape,
+        repr_name="out.inverse_indices.shape",
+    )
+    assert (
+        out.counts.shape == out.values.shape
+    ), f"{out.counts.shape=}, but should be {out.values.shape=}"
+
+    scalar_type = dh.get_scalar_type(out.values.dtype)
+    counts = defaultdict(int)
+    firsts = {}
+    for i, idx in enumerate(sh.ndindex(x.shape)):
+        val = scalar_type(x[idx])
+        if counts[val] == 0:
+            firsts[val] = i
+        counts[val] += 1
+
+    for idx in sh.ndindex(out.indices.shape):
+        val = scalar_type(out.values[idx])
+        if math.isnan(val):
+            break
+        i = int(out.indices[idx])
+        expected = firsts[val]
+        assert i == expected, (
+            f"out.values[{idx}]={val} and out.indices[{idx}]={i}, "
+            f"but first occurence of {val} is at {expected}"
+        )
+
+    for idx in sh.ndindex(out.inverse_indices.shape):
+        ridx = int(out.inverse_indices[idx])
+        val = out.values[ridx]
+        expected = x[idx]
+        msg = (
+            f"out.inverse_indices[{idx}]={ridx} results in out.values[{ridx}]={val}, "
+            f"but should result in x[{idx}]={expected}"
+        )
+        if dh.is_float_dtype(out.values.dtype) and xp.isnan(expected):
+            assert xp.isnan(val), msg
+        else:
+            assert val == expected, msg
+
+    vals_idx = {}
+    nans = 0
+    for idx in sh.ndindex(out.values.shape):
+        val = scalar_type(out.values[idx])
+        count = int(out.counts[idx])
+        if math.isnan(val):
+            nans += 1
+            assert count == 1, (
+                f"out.counts[{idx}]={count} for out.values[{idx}]={val}, "
+                "but count should be 1 as NaNs are distinct"
+            )
+        else:
+            expected = counts[val]
+            assert (
+                expected > 0
+            ), f"out.values[{idx}]={val}, but {val} not in input array"
+            count = int(out.counts[idx])
+            assert count == expected, (
+                f"out.counts[{idx}]={count} for out.values[{idx}]={val}, "
+                f"but should be {expected}"
+            )
+            assert (
+                val not in vals_idx.keys()
+            ), f"out[{idx}]={val}, but {val} is also in out[{vals_idx[val]}]"
+            vals_idx[val] = idx
+
+    if dh.is_float_dtype(out.values.dtype):
+        assume(x.size <= 128)  # may not be representable
+        expected = sum(v for k, v in counts.items() if math.isnan(k))
+        assert nans == expected, f"{nans} NaNs in out, but should be {expected}"
 #
 #
 # @given(xps.arrays(dtype=xps.scalar_dtypes(), shape=hh.shapes(min_side=1)))


### PR DESCRIPTION
Modified tests pass for numpy and jax but fail for pytorch and tensorflow. PyTorch's and Tensorflow's implementations of unique are somewhat different from numpy's and jax's. I used a few tricks to make them similar on PyTorch but get an error regarding the dtype of the torch tensor, which for some reason is generating a KeyError. Your help would be highly appreciated. 