### PR TITLE
'negative' function implementation

### DIFF
--- a/ivy/functional/backends/jax/core/general.py
+++ b/ivy/functional/backends/jax/core/general.py
@@ -465,6 +465,8 @@ def inplace_decrement(x, val):
 def inplace_increment(x, val):
     raise Exception('Jax does not support inplace operations')
 
-
+def negative(x):
+    return _jnp.negative(x)
+    
 inplace_arrays_supported = lambda: False
 inplace_variables_supported = lambda: False

--- a/ivy/functional/backends/mxnet/core/general.py
+++ b/ivy/functional/backends/mxnet/core/general.py
@@ -665,6 +665,9 @@ def inplace_increment(x, val):
     x += val
     return x
 
+def negative(x):
+    return _mx.np.negative(x)
+
 
 inplace_arrays_supported = lambda: True
 inplace_variables_supported = lambda: True

--- a/ivy/functional/backends/numpy/core/general.py
+++ b/ivy/functional/backends/numpy/core/general.py
@@ -477,6 +477,8 @@ def inplace_increment(x, val):
     x += val
     return x
 
+def negative(x):
+    return _np.negative(x)
 
 inplace_arrays_supported = lambda: True
 inplace_variables_supported = lambda: True

--- a/ivy/functional/backends/tensorflow/core/general.py
+++ b/ivy/functional/backends/tensorflow/core/general.py
@@ -484,6 +484,10 @@ def inplace_increment(x, val):
         return x
     raise Exception('TensorFlow does not support inplace operations on non-Variable tensors')
 
+def negative(x):
+    if x.dtype in [_tf.uint8, _tf.uint16, _tf.uint32, _tf.uint64]:
+        return _tf.cast(_tf.negative(_tf.cast(x, _tf.float32)), x.dtype)
+    return _tf.negative(x)
 
 inplace_arrays_supported = lambda: False
 inplace_variables_supported = lambda: True

--- a/ivy/functional/backends/torch/core/general.py
+++ b/ivy/functional/backends/torch/core/general.py
@@ -714,6 +714,8 @@ def inplace_increment(x, val):
     x.data += val
     return x
 
+def negative(x):
+    return _torch.neg(x)
 
 inplace_arrays_supported = lambda: True
 inplace_variables_supported = lambda: True

--- a/ivy/functional/ivy/core/general.py
+++ b/ivy/functional/ivy/core/general.py
@@ -1743,3 +1743,16 @@ def inplace_increment(x, val, f=None):
     :return: The variable following the in-place increment.
     """
     return _cur_framework(x, f=f).inplace_increment(x, val)
+
+def negative(x: Union[ivy.Array, ivy.NativeArray], f: ivy.Framework = None)\
+        -> Union[ivy.Array, ivy.NativeArray]:
+    """
+    Computes the numerical negative of each element
+    
+    :param x: Input array
+    :type x: array
+    :param f: Machine learning framework. Inferred from inputs is None.
+    :type f: ml_framework, optional
+    :return: an array containing the evaluated result for each element in x 
+    """
+    return _cur_framework(x, f=f).negative(x)

--- a/ivy_tests/test_array_api/array_api_tests/test_operators_and_elementwise_functions.py
+++ b/ivy_tests/test_array_api/array_api_tests/test_operators_and_elementwise_functions.py
@@ -1244,6 +1244,17 @@ def test_isfinite(dtype, shape):
 # @pytest.mark.parametrize(
 #     unary_argnames, make_unary_params("negative", dh.numeric_dtypes)
 # )
+
+@pytest.mark.parametrize("dtype", ivy.all_dtype_strs)
+@pytest.mark.parametrize("shape", ivy_tests.test_shapes)
+def test_negative(dtype, shape):
+    if ivy.invalid_dtype(dtype):
+        pytest.skip()
+    x = ivy.cast(ivy.random_uniform(0, 10, shape), dtype)
+    out = ivy.negative(x)
+    assert out.dtype == x.dtype
+    assert out.shape == x.shape
+
 # @given(data=st.data())
 # def test_negative(func_name, func, strat, data):
 #     x = data.draw(strat, label="x")


### PR DESCRIPTION
This PR implements `negative` function into `ivy` framework.
`mxnet` was been removed while testing.
- 292 cases passed
- 92 cases skipped
- 3 cases warning
