### PR TITLE
ivy.asarray

### DIFF
--- a/ivy/functional/backends/jax/core/general.py
+++ b/ivy/functional/backends/jax/core/general.py
@@ -3,6 +3,8 @@ Collection of Jax general functions, wrapped to fit Ivy syntax and signature.
 """
 
 # global
+from typing import Optional
+
 import jax as _jax
 import math as _math
 import numpy as _onp
@@ -86,7 +88,25 @@ def array(object_in, dtype=None, dev=None):
     return to_dev(_jnp.array(object_in, dtype=dtype_from_str(default_dtype(dtype, object_in))), default_device(dev))
 
 
-asarray = array
+def asarray(object_in, dtype: Optional[str] = None, dev: Optional[str] = None, copy: Optional[bool] = None):
+    if copy is None:
+        copy = False
+    if copy:
+        if dtype is None and isinstance(object_in, _jnp.ndarray):
+            return to_dev(object_in.copy(), dev)
+        if dtype is None and not isinstance(object_in, _jnp.ndarray):
+            return to_dev(_jnp.asarray(object_in).copy(), dev)
+        else:
+            dtype = dtype_to_str(default_dtype(dtype, object_in))
+            return to_dev(_jnp.asarray(object_in, dtype).copy(), dev)
+    else:
+        if dtype is None and isinstance(object_in, _jnp.ndarray):
+            return to_dev(object_in, dev)
+        if dtype is None and not isinstance(object_in, _jnp.ndarray):
+            return to_dev(_jnp.asarray(object_in), dev)
+        else:
+            dtype = dtype_to_str(default_dtype(dtype, object_in))
+            return to_dev(_jnp.asarray(object_in, dtype), dev)
 
 
 # noinspection PyUnresolvedReferences,PyProtectedMember

--- a/ivy/functional/backends/mxnet/core/general.py
+++ b/ivy/functional/backends/mxnet/core/general.py
@@ -3,6 +3,8 @@ Collection of MXNet general functions, wrapped to fit Ivy syntax and signature.
 """
 
 # global
+from typing import Optional
+
 import ivy
 _round = round
 import logging
@@ -124,7 +126,27 @@ def array(object_in, dtype=None, dev=None):
     return _mx.nd.array(object_in, cont, dtype=default_dtype(dtype, object_in))
 
 
-asarray = array
+def asarray(object_in, dtype: Optional[str] = None, dev: Optional[str] = None, copy: Optional[bool] = None):
+    #mxnet dont have asarray implementation
+    cont = _mxnet_init_context(default_device(dev))
+    if copy is None:
+        copy = False
+    if copy:
+        if dtype is None and isinstance(object_in, _mx.nd.NDArray):
+            return _mx.nd.array(object_in, cont).as_in_context(cont)
+        if dtype is None and not isinstance(object_in, _mx.nd.NDArray):
+            return _mx.nd.array(object_in, cont, dtype=default_dtype(dtype, object_in))
+        else:
+            dtype = dtype_to_str(default_dtype(dtype, object_in))
+            return _mx.nd.array(object_in, cont, dtype=default_dtype(dtype, object_in))
+    else:
+        if dtype is None and isinstance(object_in, _mx.nd.NDArray):
+            return object_in.as_in_context(cont)
+        if dtype is None and not isinstance(object_in, _mx.nd.NDArray):
+            return  _mx.nd.array(object_in, cont, dtype=default_dtype(dtype, object_in))
+        else:
+            dtype = dtype_to_str(default_dtype(dtype, object_in))
+            return _mx.nd.array(object_in, cont, dtype=default_dtype(dtype, object_in))
 
 
 def is_array(x, exclusive=False):

--- a/ivy/functional/backends/mxnet/core/general.py
+++ b/ivy/functional/backends/mxnet/core/general.py
@@ -127,7 +127,7 @@ def array(object_in, dtype=None, dev=None):
 
 
 def asarray(object_in, dtype: Optional[str] = None, dev: Optional[str] = None, copy: Optional[bool] = None):
-    #mxnet dont have asarray implementation
+    # mxnet don't have asarray implementation, haven't properly tested
     cont = _mxnet_init_context(default_device(dev))
     if copy is None:
         copy = False
@@ -143,7 +143,7 @@ def asarray(object_in, dtype: Optional[str] = None, dev: Optional[str] = None, c
         if dtype is None and isinstance(object_in, _mx.nd.NDArray):
             return object_in.as_in_context(cont)
         if dtype is None and not isinstance(object_in, _mx.nd.NDArray):
-            return  _mx.nd.array(object_in, cont, dtype=default_dtype(dtype, object_in))
+            return _mx.nd.array(object_in, cont, dtype=default_dtype(dtype, object_in))
         else:
             dtype = dtype_to_str(default_dtype(dtype, object_in))
             return _mx.nd.array(object_in, cont, dtype=default_dtype(dtype, object_in))

--- a/ivy/functional/backends/numpy/core/general.py
+++ b/ivy/functional/backends/numpy/core/general.py
@@ -90,24 +90,26 @@ def array(object_in, dtype=None, dev=None):
 
 
 def asarray(object_in, dtype: Optional[str] = None, dev: Optional[str] = None, copy: Optional[bool] = None):
+    # If copy=none then try using existing memory buffer
     if copy is None:
         copy = False
     if copy:
+        # No copy is performed if the input is already an ndarray
         if dtype is None and isinstance(object_in, np.ndarray):
-            return _to_dev(np.copy(object_in),dev)
+            return _to_dev(np.copy(object_in), dev)
         if dtype is None and not isinstance(object_in, np.ndarray):
             return _to_dev(np.copy(np.asarray(object_in)), dev)
         else:
             dtype = dtype_to_str(default_dtype(dtype, object_in))
-            return _to_dev(np.copy(np.asarray(object_in, dtype)),dev)
+            return _to_dev(np.copy(np.asarray(object_in, dtype)), dev)
     else:
         if dtype is None and isinstance(object_in, np.ndarray):
-            return _to_dev(object_in,dev)
+            return _to_dev(object_in, dev)
         if dtype is None and not isinstance(object_in, np.ndarray):
             return _to_dev(np.asarray(object_in), dev)
         else:
             dtype = dtype_to_str(default_dtype(dtype, object_in))
-            return _to_dev(np.asarray(object_in, dtype),dev)
+            return _to_dev(np.asarray(object_in, dtype), dev)
 
 
 def is_array(x, exclusive=False):

--- a/ivy/functional/backends/numpy/core/general.py
+++ b/ivy/functional/backends/numpy/core/general.py
@@ -4,6 +4,8 @@ Collection of Numpy general functions, wrapped to fit Ivy syntax and signature.
 
 # global
 import logging
+from typing import Optional
+
 import numpy as _np
 import math as _math
 from operator import mul as _mul
@@ -11,6 +13,8 @@ from functools import reduce as _reduce
 import multiprocessing as _multiprocessing
 
 # local
+import numpy as np
+
 import ivy
 from ivy.functional.ivy.core import default_dtype
 from ivy.functional.backends.numpy.core.device import _dev_callable
@@ -85,7 +89,25 @@ def array(object_in, dtype=None, dev=None):
     return _to_dev(_np.array(object_in, dtype=default_dtype(dtype, object_in)), dev)
 
 
-asarray = array
+def asarray(object_in, dtype: Optional[str] = None, dev: Optional[str] = None, copy: Optional[bool] = None):
+    if copy is None:
+        copy = False
+    if copy:
+        if dtype is None and isinstance(object_in, np.ndarray):
+            return _to_dev(np.copy(object_in),dev)
+        if dtype is None and not isinstance(object_in, np.ndarray):
+            return _to_dev(np.copy(np.asarray(object_in)), dev)
+        else:
+            dtype = dtype_to_str(default_dtype(dtype, object_in))
+            return _to_dev(np.copy(np.asarray(object_in, dtype)),dev)
+    else:
+        if dtype is None and isinstance(object_in, np.ndarray):
+            return _to_dev(object_in,dev)
+        if dtype is None and not isinstance(object_in, np.ndarray):
+            return _to_dev(np.asarray(object_in), dev)
+        else:
+            dtype = dtype_to_str(default_dtype(dtype, object_in))
+            return _to_dev(np.asarray(object_in, dtype),dev)
 
 
 def is_array(x, exclusive=False):

--- a/ivy/functional/backends/tensorflow/core/general.py
+++ b/ivy/functional/backends/tensorflow/core/general.py
@@ -74,7 +74,11 @@ def asarray(object_in, dtype: Optional[str] = None, dev: Optional[str] = None, c
             if dtype is None and isinstance(object_in, _tf.Tensor):
                 return _tf.identity(object_in)
             if dtype is None and not isinstance(object_in, _tf.Tensor):
-                return _tf.identity(_tf.convert_to_tensor(object_in))
+                try:
+                    return _tf.identity(_tf.convert_to_tensor(object_in))
+                except (TypeError, ValueError):
+                    dtype = dtype_to_str(default_dtype(dtype, object_in))
+                    return _tf.identity(_tf.convert_to_tensor(ivy.nested_map(object_in, lambda x: _tf.cast(x, dtype)), dtype=dtype))
             else:
                 dtype = dtype_to_str(default_dtype(dtype, object_in))
                 try:
@@ -86,7 +90,11 @@ def asarray(object_in, dtype: Optional[str] = None, dev: Optional[str] = None, c
             if dtype is None and isinstance(object_in, _tf.Tensor):
                 return object_in
             if dtype is None and not isinstance(object_in, _tf.Tensor):
-                return _tf.convert_to_tensor(object_in)
+                try:
+                    return _tf.convert_to_tensor(object_in)
+                except (TypeError, ValueError):
+                    dtype = dtype_to_str(default_dtype(dtype, object_in))
+                    return _tf.convert_to_tensor(ivy.nested_map(object_in, lambda x: _tf.cast(x, dtype)), dtype=dtype)
             else:
                 dtype = dtype_to_str(default_dtype(dtype, object_in))
                 try:

--- a/ivy/functional/backends/torch/core/general.py
+++ b/ivy/functional/backends/torch/core/general.py
@@ -45,10 +45,10 @@ def asarray(object_in, dtype: Optional[str] = None, dev: Optional[str] = None, c
         if dtype is None and isinstance(object_in, _torch.Tensor):
             return object_in.clone().detach().to(dev_from_str(dev))
         if dtype is None and not isinstance(object_in, _torch.Tensor):
-            return _torch.tensor(object_in, device=dev_from_str(dev))
+            return _torch.tensor(object_in, device=dev_from_str(dev)).clone().detach().to(dev_from_str(dev))
         else:
             dtype = dtype_from_str(default_dtype(dtype, object_in))
-            return _torch.tensor(object_in, dtype=dtype, device=dev_from_str(dev))
+            return _torch.tensor(object_in, dtype=dtype, device=dev_from_str(dev)).clone().detach().to(dev_from_str(dev))
     else:
         if isinstance(object_in, np.ndarray):
             return _torch.tensor(object_in, dtype=dtype, device=dev_from_str(dev))

--- a/ivy/functional/backends/torch/core/general.py
+++ b/ivy/functional/backends/torch/core/general.py
@@ -35,7 +35,30 @@ def array(object_in, dtype: Optional[str] = None, dev: Optional[str] = None):
         return _torch.tensor(object_in, device=dev_from_str(dev))
 
 
-asarray = array
+def asarray(object_in, dtype: Optional[str] = None, dev: Optional[str] = None, copy: Optional[bool] = None):
+    dev = default_device(dev)
+    if copy is None:
+        copy = False
+    if copy:
+        if isinstance(object_in, np.ndarray):
+            return _torch.as_tensor(object_in, device=dev_from_str(dev))
+        if dtype is None and isinstance(object_in, _torch.Tensor):
+            return object_in.clone().detach().to(dev_from_str(dev))
+        if dtype is None and not isinstance(object_in, _torch.Tensor):
+            return _torch.tensor(object_in, device=dev_from_str(dev))
+        else:
+            dtype = dtype_from_str(default_dtype(dtype, object_in))
+            return _torch.tensor(object_in, dtype=dtype, device=dev_from_str(dev))
+    else:
+        if isinstance(object_in, np.ndarray):
+            return _torch.tensor(object_in, dtype=dtype, device=dev_from_str(dev))
+        if dtype is None and isinstance(object_in, _torch.Tensor):
+            return object_in.to(dev_from_str(dev))
+        if dtype is None and not isinstance(object_in, _torch.Tensor):
+            return _torch.tensor(object_in, device=dev_from_str(dev))
+        else:
+            dtype = dtype_from_str(default_dtype(dtype, object_in))
+            return _torch.tensor(object_in, dtype=dtype, device=dev_from_str(dev))
 
 
 def is_array(x, exclusive=False):

--- a/ivy/functional/backends/torch/core/general.py
+++ b/ivy/functional/backends/torch/core/general.py
@@ -39,9 +39,10 @@ def asarray(object_in, dtype: Optional[str] = None, dev: Optional[str] = None, c
     dev = default_device(dev)
     if copy is None:
         copy = False
+    # torch.tensor() always copies data, detach() avoid copy
     if copy:
         if isinstance(object_in, np.ndarray):
-            return _torch.as_tensor(object_in, device=dev_from_str(dev))
+            return _torch.tensor(object_in, dtype=dtype, device=dev_from_str(dev))
         if dtype is None and isinstance(object_in, _torch.Tensor):
             return object_in.clone().detach().to(dev_from_str(dev))
         if dtype is None and not isinstance(object_in, _torch.Tensor):
@@ -51,7 +52,8 @@ def asarray(object_in, dtype: Optional[str] = None, dev: Optional[str] = None, c
             return _torch.tensor(object_in, dtype=dtype, device=dev_from_str(dev)).clone().detach().to(dev_from_str(dev))
     else:
         if isinstance(object_in, np.ndarray):
-            return _torch.tensor(object_in, dtype=dtype, device=dev_from_str(dev))
+            # if numpy array and want to avoid a copy, use torch.as_tensor()
+            return _torch.as_tensor(object_in, device=dev_from_str(dev))
         if dtype is None and isinstance(object_in, _torch.Tensor):
             return object_in.to(dev_from_str(dev))
         if dtype is None and not isinstance(object_in, _torch.Tensor):


### PR DESCRIPTION
#255 adding asarray function in Array API
Current test passing status:

| framework | test_asarray_arrays | test_asarray_scalars |
| --- | --- | --- |
| jax | failed:x: [1] | pass:heavy_check_mark: |
| mxnet | failed:x: [2] | failed:x: [2] |
| numpy | pass:heavy_check_mark: | pass:heavy_check_mark: |
| tensorflow | failed:x:[3] | pass:heavy_check_mark: |
| torch | pass:heavy_check_mark: | pass:heavy_check_mark: |

[1] Error message:
`hypothesis.errors.MultipleFailures: Hypothesis found 3 distinct failures.`
Somehow hypothesis doesn't show me all error messages. Even I already tick do not add "--no-header --no-summary-q" option in pycharm advances settings.

[2] Since we don't care about mxnet. So not huge issues here. Error messages are related to data type conversion from ivy to mxnet.

[3] Error message:
`hypothesis.errors.InvalidArgument: Expected tuple but got shape=TensorShape([]) (type=TensorShape)`
Looks like hypothesis can't extract shape info from TensorShape type?
