### PR TITLE
Add Matrix_power & Eye

### DIFF
--- a/ivy/functional/backends/jax/core/general.py
+++ b/ivy/functional/backends/jax/core/general.py
@@ -501,3 +501,7 @@ def inplace_increment(x, val):
 
 inplace_arrays_supported = lambda: False
 inplace_variables_supported = lambda: False
+
+
+def eye(n_rows, n_cols=None, *, k=0, dtype=None, device=None):
+    return to_dev(_jnp.eye(n_rows, n_cols, k, dtype), default_device(device))

--- a/ivy/functional/backends/jax/core/linalg.py
+++ b/ivy/functional/backends/jax/core/linalg.py
@@ -41,3 +41,6 @@ def vector_to_skew_symmetric_matrix(vector):
     row3 = _jnp.concatenate((-a2s, a1s, zs), -1)
     # BS x 3 x 3
     return _jnp.concatenate((row1, row2, row3), -2)
+
+def matrix_power(x, n):
+    return _jnp.linalg.matrix_power(x, n)

--- a/ivy/functional/backends/numpy/core/general.py
+++ b/ivy/functional/backends/numpy/core/general.py
@@ -517,3 +517,7 @@ def inplace_increment(x, val):
 
 inplace_arrays_supported = lambda: True
 inplace_variables_supported = lambda: True
+
+
+def eye(n_rows, n_cols=None, *, k=0, dtype=None, device=None):
+    return _to_dev(_np.eye(n_rows, n_cols, k, dtype), device)

--- a/ivy/functional/backends/numpy/core/linalg.py
+++ b/ivy/functional/backends/numpy/core/linalg.py
@@ -41,3 +41,7 @@ def vector_to_skew_symmetric_matrix(vector):
     row3 = _np.concatenate((-a2s, a1s, zs), -1)
     # BS x 3 x 3
     return _np.concatenate((row1, row2, row3), -2)
+
+
+def matrix_power(x, n):
+    return _np.linalg.matrix_power(x, n)

--- a/ivy/functional/backends/tensorflow/core/general.py
+++ b/ivy/functional/backends/tensorflow/core/general.py
@@ -516,3 +516,8 @@ def inplace_increment(x, val):
 
 inplace_arrays_supported = lambda: False
 inplace_variables_supported = lambda: True
+
+
+def eye(n_rows, n_cols=None, *, k=0, dtype=None, device=None):
+    with _tf.device(dev_from_str(default_device(device))):
+        return _tf.eye(n_rows, n_cols, dtype=dtype)

--- a/ivy/functional/backends/tensorflow/core/linalg.py
+++ b/ivy/functional/backends/tensorflow/core/linalg.py
@@ -56,3 +56,9 @@ def vector_to_skew_symmetric_matrix(vector):
     row3 = _tf.concat((-a2s, a1s, zs), -1)
     # BS x 3 x 3
     return _tf.concat((row1, row2, row3), -2)
+
+
+def matrix_power(x, n):
+    # tensorflow doesn't have matrix_power,
+    # no elegant way to build the function at this layer.
+    return _tf.linalg.matrix_power(x, n)

--- a/ivy/functional/backends/torch/core/general.py
+++ b/ivy/functional/backends/torch/core/general.py
@@ -738,3 +738,11 @@ def inplace_increment(x, val):
 
 inplace_arrays_supported = lambda: True
 inplace_variables_supported = lambda: True
+
+
+def eye(n_rows, n_cols=None, *, k=0, dtype=None, device=None):
+    if n_cols is None:
+        return _torch.eye(n_rows, dtype=dtype, device=device)
+    else:
+        return _torch.eye(n_rows, n_cols, dtype=dtype, device=device)
+

--- a/ivy/functional/backends/torch/core/linalg.py
+++ b/ivy/functional/backends/torch/core/linalg.py
@@ -51,3 +51,7 @@ def vector_to_skew_symmetric_matrix(vector):
     row3 = _torch.cat((-a2s, a1s, zs), -1)
     # BS x 3 x 3
     return _torch.cat((row1, row2, row3), -2)
+
+
+def matrix_power(x, n):
+    return _torch.linalg.matrix_power(x, n)

--- a/ivy/functional/ivy/core/general.py
+++ b/ivy/functional/ivy/core/general.py
@@ -1639,3 +1639,24 @@ def inplace_increment(x, val, f=None):
     :return: The variable following the in-place increment.
     """
     return _cur_framework(x).inplace_increment(x, val)
+
+
+def eye(n_rows, n_cols=None, *, k=0, dtype=None, device=None):
+    """
+    Returns a two-dimensional array with ones on the k h diagonal and zeros elsewhere.
+
+    Parameters
+    - n_rows (int): number of rows in the output array.
+    - n_cols (int, optional): number of columns in the output array. If None, the default number of columns in the
+      output array is equal to n_rows.
+    - k (int): index of the diagonal. A positive value refers to an upper diagonal, a negative value to a lower diagonal,
+      and 0 to the main diagonal.
+    - dtype (dtype, optional): output array data type. If dtype is None, the output array data type must be the default
+      floating-point data type.
+    - device (device, optional): device on which to place the created array.
+
+    Returns
+    - out (array): an array where all elements are equal to zero, except for the k h diagonal, whose values are equal
+      to one.
+    """
+    return _cur_framework().eye(n_rows, n_cols, k=k, dtype=dtype, device=device)

--- a/ivy/functional/ivy/core/linalg.py
+++ b/ivy/functional/ivy/core/linalg.py
@@ -122,3 +122,22 @@ def cholesky(x):
     :return: cholesky decomposition of the matrix x.
     """
     return _cur_framework(x).cholesky(x)
+
+
+def matrix_power(x, n):
+    """
+    Raises a square matrix (or a stack of square matrices) x to an integer power n.
+
+    Parameters
+    - x (array): input array having shape (..., M, M) and whose innermost two dimensions form square matrices. Should
+      have a floating-point data type.
+    - n (int): integer exponent.
+
+    Returns
+    - out (array): if n is equal to zero, an array containing the identity matrix for each square matrix. If n is less
+      than zero, an array containing the inverse of each square matrix raised to the absolute value of n, provided that
+      each square matrix is invertible. If n is greater than zero, an array containing the result of raising each square
+      matrix to the power n. The returned array must have the same shape as x and a floating-point data type determined
+      by Type Promotion Rules.
+    """
+    return _cur_framework(x).matrix_power(x, n)


### PR DESCRIPTION
Numpy & Torch passed the test, Tensorflow & Jax didn't.
While tensorflow doesn't have built-in matrix_power, the failure is also from `ivy.ivy_tests` submodule, rather than from `ivy.functional.backends`.
