### PR TITLE
floor_divide_incomplete

### DIFF
--- a/ivy/functional/backends/jax/array_api/elementwise_functions.py
+++ b/ivy/functional/backends/jax/array_api/elementwise_functions.py
@@ -44,6 +44,9 @@ def less(x1: JaxArray,x2:JaxArray)\
         -> JaxArray:
     return jnp.less(x1,x2)
 
+def floor_divide(x1:JaxArray,x2:JaxArray)\
+    -> JaxArray:
+    return jnp.floor_divide(x1,x2)
 
 def cos(x: JaxArray)\
         -> JaxArray:

--- a/ivy/functional/backends/jax/array_api/elementwise_functions.py
+++ b/ivy/functional/backends/jax/array_api/elementwise_functions.py
@@ -42,11 +42,11 @@ def isnan(x: JaxArray)\
 
 def less(x1: JaxArray,x2:JaxArray)\
         -> JaxArray:
-    return jnp.less(x1,x2)
+    return jnp.less(x1, x2)
 
-# def floor_divide(x1:JaxArray,x2:JaxArray)\
-#     -> JaxArray:
-#     return jnp.floor_divide(x1,x2)
+def floor_divide(x1:JaxArray,x2:JaxArray)\
+    -> JaxArray:
+    return jnp.floor_divide(x1, x2)
 
 def cos(x: JaxArray)\
         -> JaxArray:

--- a/ivy/functional/backends/jax/array_api/elementwise_functions.py
+++ b/ivy/functional/backends/jax/array_api/elementwise_functions.py
@@ -44,9 +44,9 @@ def less(x1: JaxArray,x2:JaxArray)\
         -> JaxArray:
     return jnp.less(x1,x2)
 
-def floor_divide(x1:JaxArray,x2:JaxArray)\
-    -> JaxArray:
-    return jnp.floor_divide(x1,x2)
+# def floor_divide(x1:JaxArray,x2:JaxArray)\
+#     -> JaxArray:
+#     return jnp.floor_divide(x1,x2)
 
 def cos(x: JaxArray)\
         -> JaxArray:

--- a/ivy/functional/backends/numpy/array_api/elementwise_functions.py
+++ b/ivy/functional/backends/numpy/array_api/elementwise_functions.py
@@ -46,13 +46,9 @@ def less(x1: np.ndarray,x2: np.ndarray)\
 def floor_divide(x1: np.ndarray, x2: np.ndarray)\
         -> np.ndarray:
     if hasattr(x1, 'dtype') and hasattr(x2, 'dtype'):
-        print("x1 type:" + str(x1.dtype))
-        print("x2 type:" + str(x2.dtype))
         promoted_type = np.promote_types(x1.dtype,x2.dtype)
-        print("promoted type: " + str(promoted_type))
         x1 = x1.astype(promoted_type)
         x2 = x2.astype(promoted_type)
-
     return np.floor_divide(x1,x2)
 
 def cos(x: np.ndarray)\

--- a/ivy/functional/backends/numpy/array_api/elementwise_functions.py
+++ b/ivy/functional/backends/numpy/array_api/elementwise_functions.py
@@ -49,7 +49,7 @@ def floor_divide(x1: np.ndarray, x2: np.ndarray)\
         promoted_type = np.promote_types(x1.dtype,x2.dtype)
         x1 = x1.astype(promoted_type)
         x2 = x2.astype(promoted_type)
-    return np.floor_divide(x1,x2)
+    return np.floor_divide(x1, x2)
 
 def cos(x: np.ndarray)\
         -> np.ndarray:

--- a/ivy/functional/backends/numpy/array_api/elementwise_functions.py
+++ b/ivy/functional/backends/numpy/array_api/elementwise_functions.py
@@ -43,6 +43,17 @@ def less(x1: np.ndarray,x2: np.ndarray)\
         -> np.ndarray:
     return np.less(x1,x2)
 
+def floor_divide(x1: np.ndarray, x2: np.ndarray)\
+        -> np.ndarray:
+    if hasattr(x1, 'dtype') and hasattr(x2, 'dtype'):
+        print("x1 type:" + str(x1.dtype))
+        print("x2 type:" + str(x2.dtype))
+        promoted_type = np.promote_types(x1.dtype,x2.dtype)
+        print("promoted type: " + str(promoted_type))
+        x1 = x1.astype(promoted_type)
+        x2 = x2.astype(promoted_type)
+
+    return np.floor_divide(x1,x2)
 
 def cos(x: np.ndarray)\
         -> np.ndarray:

--- a/ivy/functional/backends/tensorflow/array_api/elementwise_functions.py
+++ b/ivy/functional/backends/tensorflow/array_api/elementwise_functions.py
@@ -54,6 +54,13 @@ def less(x1: Tensor, x2: Tensor)\
         x2 = tf.cast(x2, promoted_type)
     return tf.math.less(x1, x2)
 
+def floor_divide(x1: Tensor, x2: Tensor)\
+        -> Tensor:
+    if hasattr(x1, 'dtype') and hasattr(x2, 'dtype'):
+        promoted_type = tf.experimental.numpy.promote_types(x1.dtype, x2.dtype)
+        x1 = tf.cast(x1, promoted_type)
+        x2 = tf.cast(x2, promoted_type)
+    return tf.math.floordiv(x1, x2)
 
 def cos(x: Tensor)\
         -> Tensor:

--- a/ivy/functional/backends/torch/array_api/elementwise_functions.py
+++ b/ivy/functional/backends/torch/array_api/elementwise_functions.py
@@ -47,13 +47,10 @@ def less(x1: torch.Tensor, x2: torch.Tensor):
 
 def floor_divide(x1: torch.Tensor, x2: torch.Tensor):
     if hasattr(x1, 'dtype') and hasattr(x2, 'dtype'):
-        print("x1 type:"+x1.dtype)
-        print("x2 type:"+x2.dtype)
         promoted_type = torch.promote_types(x1.dtype, x2.dtype)
-        print("promoted type: "+promoted_type)
         x1 = x1.to(promoted_type)
         x2 = x2.to(promoted_type)
-    return torch.floor_divide(x1,x2)
+    return torch.floor_divide(x1, x2)
 
 def cos(x: torch.Tensor)\
         -> torch.Tensor:

--- a/ivy/functional/backends/torch/array_api/elementwise_functions.py
+++ b/ivy/functional/backends/torch/array_api/elementwise_functions.py
@@ -45,6 +45,15 @@ def less(x1: torch.Tensor, x2: torch.Tensor):
         x2 = x2.to(promoted_type)
     return torch.lt(x1, x2)
 
+def floor_divide(x1: torch.Tensor, x2: torch.Tensor):
+    if hasattr(x1, 'dtype') and hasattr(x2, 'dtype'):
+        print("x1 type:"+x1.dtype)
+        print("x2 type:"+x2.dtype)
+        promoted_type = torch.promote_types(x1.dtype, x2.dtype)
+        print("promoted type: "+promoted_type)
+        x1 = x1.to(promoted_type)
+        x2 = x2.to(promoted_type)
+    return torch.floor_divide(x1,x2)
 
 def cos(x: torch.Tensor)\
         -> torch.Tensor:

--- a/ivy/functional/ivy/array_api/elementwise_functions.py
+++ b/ivy/functional/ivy/array_api/elementwise_functions.py
@@ -144,9 +144,10 @@ def floor_divide(x1: Union[ivy.Array, ivy.NativeArray],
     :type x2: array
     :param f: Machine learning framework. Inferred from inputs if None.
     :type f: ml_framework, optional
-    :return: an array containing the element-wise results. The returned array must have a data type of bool.
+    :return: an array containing the element-wise results. The returned array must have a data type of the
+    dtype with safe encoding.
     """
-    return _cur_framework(x1).floor_divide(x1,x2)
+    return _cur_framework(x1, f=f).floor_divide(x1,x2)
 
 
 def logical_not(x: Union[ivy.Array, ivy.NativeArray])\

--- a/ivy/functional/ivy/array_api/elementwise_functions.py
+++ b/ivy/functional/ivy/array_api/elementwise_functions.py
@@ -134,20 +134,7 @@ def cos(x: Union[ivy.Array, ivy.NativeArray])\
 def floor_divide(x1: Union[ivy.Array, ivy.NativeArray],
          x2: Union[ivy.Array, ivy.NativeArray])\
         -> ivy.Array:
-    """
-    Computes the truth value of x1_i < x2_i for each element x1_i of the input array x1 with the respective
-    element x2_i of the input array x2.
-
-    :param x1: Input array.
-    :type x1: array
-    :param x2: Input array.
-    :type x2: array
-    :param f: Machine learning framework. Inferred from inputs if None.
-    :type f: ml_framework, optional
-    :return: an array containing the element-wise results. The returned array must have a data type of the
-    dtype with safe encoding.
-    """
-    return _cur_framework(x1, f=f).floor_divide(x1,x2)
+    return _cur_framework(x1, f=f).floor_divide(x1, x2)
 
 
 def logical_not(x: Union[ivy.Array, ivy.NativeArray])\

--- a/ivy/functional/ivy/array_api/elementwise_functions.py
+++ b/ivy/functional/ivy/array_api/elementwise_functions.py
@@ -131,6 +131,23 @@ def cos(x: Union[ivy.Array, ivy.NativeArray])\
     """
     return _cur_framework(x).cos(x)
 
+def floor_divide(x1: Union[ivy.Array, ivy.NativeArray],
+         x2: Union[ivy.Array, ivy.NativeArray])\
+        -> ivy.Array:
+    """
+    Computes the truth value of x1_i < x2_i for each element x1_i of the input array x1 with the respective
+    element x2_i of the input array x2.
+
+    :param x1: Input array.
+    :type x1: array
+    :param x2: Input array.
+    :type x2: array
+    :param f: Machine learning framework. Inferred from inputs if None.
+    :type f: ml_framework, optional
+    :return: an array containing the element-wise results. The returned array must have a data type of bool.
+    """
+    return _cur_framework(x1).floor_divide(x1,x2)
+
 
 def logical_not(x: Union[ivy.Array, ivy.NativeArray])\
         -> ivy.Array:

--- a/ivy/functional/ivy/core/array_builtins.py
+++ b/ivy/functional/ivy/core/array_builtins.py
@@ -112,6 +112,8 @@ def builtin_rtruediv(x, other):
 
 # noinspection PyShadowingBuiltins
 def builtin_floordiv(x, other):
+    if hasattr(x,'dtype') and hasattr(other,'dtype'):
+        promoted_type = ivy.cast(x,)
     return x.__floordiv__(other)
 
 

--- a/ivy_tests/array_api_methods_to_test/elementwise_functions.txt
+++ b/ivy_tests/array_api_methods_to_test/elementwise_functions.txt
@@ -21,7 +21,7 @@ cosh
 #exp
 #expm1
 #floor
-#floor_divide
+floor_divide
 #greater
 #greater_equal
 isfinite


### PR DESCRIPTION
implemented numpy & torch floor_div to adjust to dtype for 1 out of 5 test cases for each. I don't quite understand the error that comes from other test cases, for some with the function name __floordiv__, I am not sure why the types don't match, and for other function names e.g. __ifloordiv__, it gives TypeError: array() got an unexpected keyword argument 'copy'. May someone help me take a look? Thanks