### PR TITLE
linspace

### DIFF
--- a/ivy/functional/backends/jax/array_api/creation_functions.py
+++ b/ivy/functional/backends/jax/array_api/creation_functions.py
@@ -22,3 +22,16 @@ def zeros(shape: Union[int, Tuple[int], List[int]],
           device: Optional[jaxlib.xla_extension.Device] = None) \
         -> JaxArray:
     return to_dev(jnp.zeros(shape, dtype_from_str(default_dtype(dtype))), default_device(device))
+
+def linspace(start: Union[int, float],
+             stop: Union[int, float],
+             num: int,
+             dtype: Optional[jnp.dtype] = None,
+             device: Optional[jaxlib.xla_extension.Device] = None,
+             endpoint: bool = True) \
+             -> JaxArray:
+    if dtype is None:
+        dtype = jnp.float32
+    return to_dev(jnp.linspace(jnp.double(start), jnp.double(stop), num, dtype=dtype, endpoint=endpoint),
+                  default_device(device))
+

--- a/ivy/functional/backends/jax/core/general.py
+++ b/ivy/functional/backends/jax/core/general.py
@@ -161,12 +161,6 @@ def arange(stop, start=0, step=1, dtype=None, dev=None):
     return to_dev(_jnp.arange(start, stop, step=step, dtype=dtype), default_device(dev))
 
 
-def linspace(start, stop, num, axis=None, dev=None):
-    if axis is None:
-        axis = -1
-    return to_dev(_jnp.linspace(start, stop, num, axis=axis), default_device(dev))
-
-
 def logspace(start, stop, num, base=10., axis=None, dev=None):
     if axis is None:
         axis = -1

--- a/ivy/functional/backends/mxnet/array_api/creation_functions.py
+++ b/ivy/functional/backends/mxnet/array_api/creation_functions.py
@@ -26,3 +26,16 @@ def ones(shape: Union[int, Tuple[int]],
     if len(shape) == 0 or 0 in shape:
         return _1_dim_array_to_flat_array(mx.nd.ones((1,), ctx=cont).astype(dtype))
     return mx.nd.ones(shape, ctx=cont).astype(dtype)
+
+
+def linspace(start: Union[int, float],
+             stop: Union[int, float],
+             num: int,
+             dtype: Optional[mx.nd.dtype] = None,
+             device: Optional[str] = None,
+             endpoint: bool = True) \
+             -> mx.ndarray.ndarray.NDArray:
+    cont = _mxnet_init_context(default_device(device))
+    if dtype is None:
+        dtype = mx.np.float32
+    return mx.np.linspace(start, stop, num, dtype=dtype, endpoint=endpoint, ctx=cont)

--- a/ivy/functional/backends/mxnet/core/general.py
+++ b/ivy/functional/backends/mxnet/core/general.py
@@ -181,7 +181,8 @@ def _linspace(start, stop, num, cont):
     return ret
 
 
-def linspace(start, stop, num, axis=None, dev=None):
+# Needed for logspace
+def linspace_non_standard(start, stop, num, axis=None, dev=None):
     cont = _mxnet_init_context(default_device(dev))
     num = num.asnumpy()[0] if isinstance(num, _mx.nd.NDArray) else num
     start_is_array = isinstance(start, _mx.nd.NDArray)
@@ -208,8 +209,9 @@ def linspace(start, stop, num, axis=None, dev=None):
     return res
 
 
+# Dependent on nonstandard linspace implementation
 def logspace(start, stop, num, base=10., axis=None, dev=None):
-    power_seq = linspace(start, stop, num, axis, default_device(dev))
+    power_seq = linspace_non_standard(start, stop, num, axis, default_device(dev))
     return base ** power_seq
 
 

--- a/ivy/functional/backends/numpy/array_api/creation_functions.py
+++ b/ivy/functional/backends/numpy/array_api/creation_functions.py
@@ -30,8 +30,6 @@ def linspace(start: Union[int, float],
              device: Optional[str] = None,
              endpoint: bool = True) \
              -> np.ndarray:
-
-
     if dtype is None:
         dtype = np.float32
     return _to_dev(np.linspace(np.longdouble(start), np.longdouble(stop), num, dtype=dtype, endpoint=endpoint), device)

--- a/ivy/functional/backends/numpy/array_api/creation_functions.py
+++ b/ivy/functional/backends/numpy/array_api/creation_functions.py
@@ -21,3 +21,17 @@ def ones(shape: Union[int, Tuple[int], List[int]],
         -> np.ndarray:
     dtype = dtype_from_str(default_dtype(dtype))
     return _to_dev(np.ones(shape, dtype), device)
+
+
+def linspace(start: Union[int, float],
+             stop: Union[int, float],
+             num: int,
+             dtype: Optional[np.dtype] = None,
+             device: Optional[str] = None,
+             endpoint: bool = True) \
+             -> np.ndarray:
+
+
+    if dtype is None:
+        dtype = np.float32
+    return _to_dev(np.linspace(np.longdouble(start), np.longdouble(stop), num, dtype=dtype, endpoint=endpoint), device)

--- a/ivy/functional/backends/numpy/core/general.py
+++ b/ivy/functional/backends/numpy/core/general.py
@@ -159,12 +159,6 @@ def arange(stop, start=0, step=1, dtype=None, dev=None):
     return res
 
 
-def linspace(start, stop, num, axis=None, dev=None):
-    if axis is None:
-        axis = -1
-    return _to_dev(_np.linspace(start, stop, num, axis=axis), dev)
-
-
 def logspace(start, stop, num, base=10., axis=None, dev=None):
     if axis is None:
         axis = -1

--- a/ivy/functional/backends/tensorflow/array_api/creation_functions.py
+++ b/ivy/functional/backends/tensorflow/array_api/creation_functions.py
@@ -26,3 +26,19 @@ def ones(shape: Union[int, Tuple[int]],
     dev = dev_from_str(default_device(device))
     with tf.device(dev):
         return tf.ones(shape, dtype)
+
+
+def linspace(start: Union[int, float],
+             stop: Union[int, float],
+             num: int,
+             dtype: Optional[Dtype] = None,
+             device: Optional[str] = None,
+             endpoint: bool = True) \
+             -> tf.Tensor:
+    dtype = dtype_from_str(default_dtype(dtype))
+    dev = dev_from_str(default_device(device))
+    with tf.device(dev):
+        if endpoint:
+            return tf.cast(tf.linspace(start, stop, num), dtype)
+        else:
+            return tf.cast(tf.linspace(start, stop, num+1), dtype)[:-1]

--- a/ivy/functional/backends/tensorflow/core/general.py
+++ b/ivy/functional/backends/tensorflow/core/general.py
@@ -153,8 +153,8 @@ def arange(stop, start=0, step=1, dtype=None, dev=None):
     with _tf.device(dev_from_str(dev)):
         return _tf.range(start, stop, delta=step, dtype=dtype)
 
-
-def linspace(start, stop, num, axis=None, dev=None):
+# Needed for logspace
+def linspace_non_standard(start, stop, num, axis=None, dev=None):
     if axis is None:
         axis = -1
     dev = default_device(dev)
@@ -162,8 +162,9 @@ def linspace(start, stop, num, axis=None, dev=None):
         return _tf.linspace(start, stop, num, axis=axis)
 
 
+# Dependent on nonstandard linspace implementation
 def logspace(start, stop, num, base=10., axis=None, dev=None):
-    power_seq = linspace(start, stop, num, axis, default_device(dev))
+    power_seq = linspace_non_standard(start, stop, num, axis, default_device(dev))
     return base ** power_seq
 
 

--- a/ivy/functional/backends/torch/array_api/creation_functions.py
+++ b/ivy/functional/backends/torch/array_api/creation_functions.py
@@ -21,3 +21,18 @@ def ones(shape: Union[int, Tuple[int]],
     dtype_val: torch.dtype = dtype_from_str(dtype)
     dev = default_device(device)
     return torch.ones(shape, dtype=dtype_val, device=dev_from_str(dev))
+
+
+def linspace(start: Union[int, float],
+             stop: Union[int, float],
+             num: int,
+             dtype: Optional[torch.dtype] = None,
+             device: Optional[Union[torch.device, str]] = None,
+             endpoint: bool = True) \
+             -> torch.Tensor:
+    dtype: torch.dtype = dtype_from_str(dtype)
+    device = default_device(device)
+    if endpoint:
+        return torch.linspace(start, stop, num, dtype=dtype, device=dev_from_str(device))
+    else:
+        return torch.linspace(start, stop, num+1, dtype=dtype, device=dev_from_str(device))[:-1]

--- a/ivy/functional/backends/torch/core/general.py
+++ b/ivy/functional/backends/torch/core/general.py
@@ -185,8 +185,8 @@ def _differentiable_linspace(start, stop, num, device):
     return res
 
 
-# noinspection PyUnboundLocalVariable,PyShadowingNames
-def linspace(start, stop, num, axis=None, dev=None):
+# Needed for logspace
+def linspace_non_standard(start, stop, num, axis=None, dev=None):
     num = num.detach().numpy().item() if isinstance(num, _torch.Tensor) else num
     start_is_array = isinstance(start, _torch.Tensor)
     stop_is_array = isinstance(stop, _torch.Tensor)
@@ -247,8 +247,9 @@ def linspace(start, stop, num, axis=None, dev=None):
     return res.to(dev_from_str(dev))
 
 
+# Dependent on nonstandard linspace implementation
 def logspace(start, stop, num, base=10., axis=None, dev=None):
-    power_seq = linspace(start, stop, num, axis, default_device(dev))
+    power_seq = linspace_non_standard(start, stop, num, axis, default_device(dev))
     return base ** power_seq
 
 

--- a/ivy/functional/ivy/array_api/creation_functions.py
+++ b/ivy/functional/ivy/array_api/creation_functions.py
@@ -36,3 +36,30 @@ def ones(shape: Union[int, Tuple[int], List[int]],
     :return: an array containing ones.
     """
     return _cur_framework().ones(shape, dtype, device)
+
+
+def linspace(start: Union[int, float],
+             stop: Union[int, float],
+             num: int,
+             dtype: Optional[ivy.Dtype] = None,
+             device: Optional[ivy.Device] = None,
+             endpoint: bool = True) \
+             -> ivy.Array:
+    """
+    Returns evenly spaced numbers over a specified interval.
+
+    :param start: the start of the interval.
+    :param stop: the end of the interval. If endpoint is False, the function must generate a
+                 sequence of num+1 evenly spaced numbers starting with start and ending with stop and exclude the
+                 stop from the returned array such that the returned array consists of evenly spaced numbers over the
+                 half-open interval [start, stop). If endpoint is True, the output array must consist of
+                 evenly spaced numbers over the closed interval [start, stop]. Default: True.
+    :param num: number of samples. Must be a non-negative integer value;
+                otherwise, the function must raise an exception.
+    :param dtype: output array data type. If dtype is None, the output array data type must be the
+                  default floating-point data type. Default: None.
+    :param device: device on which to place the created array. Default: None.
+    :param endpoint: boolean indicating whether to include stop in the interval. Default: True.
+    :return: a one-dimensional array containing evenly spaced values.
+    """
+    return _cur_framework().linspace(start, stop, num, dtype, device, endpoint)

--- a/ivy/functional/ivy/core/general.py
+++ b/ivy/functional/ivy/core/general.py
@@ -472,30 +472,6 @@ def arange(stop: Number, start: Number = 0, step: Number = 1, dtype: ivy.Dtype =
 
 
 # noinspection PyShadowingNames
-def linspace(start: Union[ivy.Array, ivy.NativeArray, Number], stop: Union[ivy.Array, ivy.NativeArray, Number],
-             num: int, axis: int = None, dev: ivy.Device = None)\
-        -> Union[ivy.Array, ivy.NativeArray]:
-    """
-    Generates a certain number of evenly-spaced values in an interval along a given axis.
-
-    See :math:`arange` that allows to specify the step size of evenly spaced values in an interval.
-
-    :param start: First entry in the range.
-    :type start: array
-    :param stop: Final entry in the range.
-    :type stop: array
-    :param num: Number of values to generate.
-    :type num: int
-    :param axis: Axis along which the operation is performed.
-    :type axis: int
-    :param dev: device on which to create the array 'cuda:0', 'cuda:1', 'cpu' etc.
-    :type dev: ivy.Device
-    :return: Tensor of evenly-spaced values.
-    """
-    return _cur_framework(start).linspace(start, stop, num, axis, dev)
-
-
-# noinspection PyShadowingNames
 def logspace(start: Union[ivy.Array, ivy.NativeArray, Number], stop: Union[ivy.Array, ivy.NativeArray, Number],
              num: int, base: float = 10., axis: int = None, dev: ivy.Device = None)\
         -> Union[ivy.Array, ivy.NativeArray]:
@@ -534,23 +510,6 @@ def concatenate(xs: Iterable[Union[ivy.Array, ivy.NativeArray]], axis: int = -1)
     :return: The concatenated array.
     """
     return _cur_framework(xs[0]).concatenate(xs, axis)
-
-
-def flip(x: Union[ivy.Array, ivy.NativeArray], axis: int = None, batch_shape: Iterable[int] = None,
-         ) -> Union[ivy.Array, ivy.NativeArray]:
-    """
-    Reverses the ord of elements in an array along the given axis.
-    The shape of the array is preserved, but the elements are reordered.
-
-    :param x: Input array.
-    :type x: array
-    :param axis: Axis or axes along which to flip over. The default, axis: int = None, will flip over all axes.
-    :type axis: None or int or sequence of ints, optional
-    :param batch_shape: Shape of batch. Inferred from inputs if None.
-    :type batch_shape: sequence of ints, optional
-    :return: An array with the entries of axis reversed.
-    """
-    return _cur_framework(x).flip(x, axis, batch_shape)
 
 
 def stack(xs: Iterable[Union[ivy.Array, ivy.NativeArray]], axis: int = 0)\

--- a/ivy_tests/array_api_methods_to_test/creation_functions.txt
+++ b/ivy_tests/array_api_methods_to_test/creation_functions.txt
@@ -6,7 +6,7 @@
 #from_dlpack
 full
 #full_like
-#linspace
+linspace
 #meshgrid
 ones
 #ones_like


### PR DESCRIPTION
ISSUE1: in numpy test there is error when start or stop argument of linspace are -0.0. linspace sometimes return -0 sometimes +0 but must returns -0.
ISSUE2: in jax,tensorflow,torch maximum floating point precision is 64(unlike numpy) so there is no way of passing tests when start or stop arguments are large numbers like 9007199254740993 because they are internally converted to floating point numbers.
ISSUE3: tests are not consistent, sometimes all test passes sometimes there is error even if there is no change in functions code. For example i only encountered ISSUE1 few times and in most cases -0 isn't covered by tests.
ISSUE4: sometimes in torch i get ivy.array(23.999996, dtype=float32), but should be 24.0 because start and stop should be exactly the same as first and last element of returned array.
ISSUE5: logspace function is dependent on nonstandard linspace implementation in torch and tensorflow, but logspace itself don't exists in standard api so I can't rewrite it to match standards and use standard linspace implementation if necessary.

For ISSUE1 and ISSUE4 maybe i can manually set first and last element of array to be same as start and stop, but this solution is not so elegant

For ISSUE4 maybe data standard api can add special cases for linspace for edge float numbers and +0.0, -0.0

Also for some reason torch don't have problem with large start and stop parameters even it supports maximum of 64bit floating point precision.