### PR TITLE
create var method for IVY

### DIFF
--- a/ivy/functional/backends/jax/array_api/statistical_functions.py
+++ b/ivy/functional/backends/jax/array_api/statistical_functions.py
@@ -1,0 +1,13 @@
+import jax.numpy as jnp
+from typing import Union, Tuple, Optional, List
+
+# local
+from ivy.functional.backends.jax import JaxArray
+
+
+def var(x: JaxArray,
+        axis: Optional[Union[int, Tuple[int], List[int]]] = None,
+        correction: Union[int, float] = 0.0,
+        keepdims: bool = False) -> JaxArray:
+    ddof = int(correction)
+    return jnp.var(x, axis=axis,ddof=ddof, keepdims=keepdims)

--- a/ivy/functional/backends/mxnet/array_api/statistical_functions.py
+++ b/ivy/functional/backends/mxnet/array_api/statistical_functions.py
@@ -1,0 +1,11 @@
+import mxnet as mx
+from typing import Union, Tuple, Optional, List
+
+from ivy.functional.backends.mxnet import reduce_prod, _flat_array_to_1_dim_array, _1_dim_array_to_flat_array
+
+
+def var(x: mx.ndarray.ndarray.NDArray,
+        axis: Optional[Union[int, Tuple[int], List[int]]] = None,
+        correction: Union[int, float] = 0.0,
+        keepdims: bool = False) -> mx.ndarray.ndarray.NDArray:
+    return mx.nd.array(mx.nd.array(x).asnumpy().var(axis=axis, keepdims=keepdims))

--- a/ivy/functional/backends/numpy/array_api/statistical_functions.py
+++ b/ivy/functional/backends/numpy/array_api/statistical_functions.py
@@ -1,0 +1,11 @@
+import numpy as np
+import numpy.array_api as npa
+
+from typing import Union, Tuple, Optional, List
+
+
+def var(x: np.ndarray,
+        axis: Optional[Union[int, Tuple[int], List[int]]] = None,
+        correction: Union[int, float] = 0.0,
+        keepdims: bool = False) -> np.ndarray:
+    return np.var(npa.asarray(x), axis=axis, keepdims=keepdims)

--- a/ivy/functional/backends/tensorflow/array_api/statistical_functions.py
+++ b/ivy/functional/backends/tensorflow/array_api/statistical_functions.py
@@ -1,0 +1,18 @@
+# global
+import tensorflow as tf
+from typing import Union, Tuple, Optional, List
+from tensorflow.python.types.core import Tensor
+
+
+def var(x: Tensor,
+        axis: Optional[Union[int, Tuple[int], List[int]]] = None,
+        correction: Union[int, float] = 0.0,
+        keepdims: bool = False) -> Tensor:
+    if axis is None:
+        num_dims = len(x.shape)
+        axis = tuple(range(num_dims))
+    elif isinstance(axis, list):
+        axis = tuple(axis)
+
+    m = tf.reduce_mean(x, axis=axis, keepdims=True)
+    return tf.reduce_mean(tf.square(x - m), axis=axis, keepdims=keepdims)

--- a/ivy/functional/backends/torch/array_api/statistical_functions.py
+++ b/ivy/functional/backends/torch/array_api/statistical_functions.py
@@ -1,0 +1,20 @@
+import torch
+from typing import Union, Optional, Tuple, List
+
+
+def var(x: torch.Tensor,
+        axis: Optional[Union[int, Tuple[int], List[int]]] = None,
+        correction: Union[int, float] = 0.0,
+        keepdims: bool = False) -> torch.Tensor:
+
+    if axis is None:
+        num_dims = len(x.shape)
+        axis = list(range(num_dims))
+    if isinstance(axis, int):
+        return torch.var(x, dim=axis, keepdim=keepdims)
+    dims = len(x.shape)
+    axis = [i % dims for i in axis]
+    axis.sort()
+    for i, a in enumerate(axis):
+        x = torch.var(x, dim=a if keepdims else a - i, keepdim=keepdims)
+    return x

--- a/ivy/functional/ivy/array_api/statistical_functions.py
+++ b/ivy/functional/ivy/array_api/statistical_functions.py
@@ -1,0 +1,22 @@
+# global
+from typing import Union, Optional, Tuple, List
+
+# local
+import ivy
+from ivy.framework_handler import current_framework as _cur_framework
+
+
+def var(x: Union[ivy.Array, ivy.NativeArray],
+        axis: Optional[Union[int, Tuple[int], List[int]]] = None,
+        correction: Union[int, float] = 0.0,
+        keepdims: bool = False) \
+        -> ivy.Array:
+    """
+    Calculates the variance of the input array x.
+    :param x: input array
+    :param axis: axis or axes along which variances must be computed. By default, the variance must be computed over the entire array
+    :param correction: degrees of freedom adjustment
+    :param keepdims: Default: False
+    :return: The returned array must have the same data type as x.
+    """
+    return _cur_framework(x).var(x, axis, correction, keepdims)


### PR DESCRIPTION
ivy/ivy_tests/test_array_api/array_api_tests/test_statistical_functions.py

when you test, you need to delete .filter(lambda x: x.size >=2) on line 270 of test_statistical_functions.py
Because this line cannot be verified in jax, tensorflow, torch temporarily