### PR TITLE
update API standardization for "qr" in tf, torch, np, and jax

### DIFF
--- a/ivy/functional/backends/jax/array_api/creation_functions.py
+++ b/ivy/functional/backends/jax/array_api/creation_functions.py
@@ -29,3 +29,9 @@ def tril(x: JaxArray,
          -> JaxArray:
     return jnp.tril(x, k)
 
+
+def triu(x: JaxArray,
+         k: int = 0) \
+         -> JaxArray:
+    return jnp.triu(x, k)
+    

--- a/ivy/functional/backends/jax/array_api/linear_algebra.py
+++ b/ivy/functional/backends/jax/array_api/linear_algebra.py
@@ -1,6 +1,7 @@
 # global
 import jax.numpy as jnp
 from typing import Union, Optional, Tuple, Literal
+from collections import namedtuple
 
 # local
 from ivy import inf
@@ -29,3 +30,10 @@ def diagonal(x: JaxArray,
              axis1: int = -2,
              axis2: int = -1) -> JaxArray:
     return jnp.diagonal(x, offset, axis1, axis2)
+
+
+def qr(x: JaxArray,
+       mode: str = 'reduced') -> namedtuple('qr', ['Q', 'R']):
+    res = namedtuple('qr', ['Q', 'R'])
+    q, r = jnp.linalg.qr(x, mode=mode)
+    return res(q, r)

--- a/ivy/functional/backends/numpy/array_api/creation_functions.py
+++ b/ivy/functional/backends/numpy/array_api/creation_functions.py
@@ -27,3 +27,10 @@ def tril(x: np.ndarray,
          k: int = 0) \
          -> np.ndarray:
     return np.tril(x, k)
+
+
+def triu(x: np.ndarray,
+         k: int = 0) \
+         -> np.ndarray:
+    return np.triu(x, k)
+    

--- a/ivy/functional/backends/numpy/array_api/linear_algebra.py
+++ b/ivy/functional/backends/numpy/array_api/linear_algebra.py
@@ -1,6 +1,7 @@
 # global
 import numpy as np
 from typing import Union, Optional, Tuple, Literal
+from collections import namedtuple
 
 # local
 from ivy import inf
@@ -29,3 +30,10 @@ def diagonal(x: np.ndarray,
              axis1: int = -2,
              axis2: int = -1) -> np.ndarray:
     return np.diagonal(x, offset=offset, axis1=axis1, axis2=axis2)
+
+
+def qr(x: np.ndarray,
+       mode: str = 'reduced') -> namedtuple('qr', ['Q', 'R']):
+    res = namedtuple('qr', ['Q', 'R'])
+    q, r = np.linalg.qr(x, mode=mode)
+    return res(q, r)

--- a/ivy/functional/backends/tensorflow/array_api/creation_functions.py
+++ b/ivy/functional/backends/tensorflow/array_api/creation_functions.py
@@ -32,3 +32,10 @@ def tril(x: tf.Tensor,
          k: int = 0) \
          -> tf.Tensor:
     return tf.experimental.numpy.tril(x, k)
+
+
+def triu(x: tf.Tensor,
+         k: int = 0) \
+         -> tf.Tensor:
+    return tf.experimental.numpy.triu(x, k)
+    

--- a/ivy/functional/backends/tensorflow/array_api/linear_algebra.py
+++ b/ivy/functional/backends/tensorflow/array_api/linear_algebra.py
@@ -2,6 +2,7 @@
 import tensorflow as tf
 from tensorflow.python.types.core import Tensor
 from typing import Union, Optional, Tuple, Literal
+from collections import namedtuple
 
 # local
 from ivy import inf
@@ -35,3 +36,16 @@ def diagonal(x: tf.Tensor,
              axis1: int = -2,
              axis2: int = -1) -> tf.Tensor:
     return tf.experimental.numpy.diagonal(x, offset, axis1=axis1, axis2=axis2)
+
+
+def qr(x: tf.Tensor,
+       mode: str = 'reduced') -> namedtuple('qr', ['Q', 'R']):
+    res = namedtuple('qr', ['Q', 'R'])
+    if mode == 'reduced':
+        q, r = tf.linalg.qr(x, full_matrices=False)
+        return res(q, r)
+    elif mode == 'complete':
+        q, r = tf.linalg.qr(x, full_matrices=True)
+        return res(q, r)
+    else:
+        raise Exception("Only 'reduced' and 'complete' qr modes are allowed for the tensorflow backend.")

--- a/ivy/functional/backends/torch/array_api/creation_functions.py
+++ b/ivy/functional/backends/torch/array_api/creation_functions.py
@@ -28,3 +28,9 @@ def tril(x: torch.Tensor,
          -> torch.Tensor:
     return torch.tril(x, diagonal=k)
 
+
+def triu(x: torch.Tensor,
+         k: int = 0) \
+         -> torch.Tensor:
+    return torch.triu(x, diagonal=k)
+    

--- a/ivy/functional/backends/torch/array_api/linear_algebra.py
+++ b/ivy/functional/backends/torch/array_api/linear_algebra.py
@@ -1,6 +1,7 @@
 # global
 import torch
 from typing import Union, Optional, Tuple, Literal
+from collections import namedtuple
 
 # local
 from ivy import inf
@@ -25,3 +26,16 @@ def diagonal(x: torch.Tensor,
              axis1: int = -2,
              axis2: int = -1) -> torch.Tensor:
     return torch.diagonal(x, offset=offset, dim1=axis1, dim2=axis2)
+
+
+def qr(x: torch.Tensor,
+       mode: str = 'reduced') -> namedtuple('qr', ['Q', 'R']):
+    res = namedtuple('qr', ['Q', 'R'])
+    if mode == 'reduced':
+        q, r = torch.qr(x, some=True)
+        return res(q, r)
+    elif mode == 'complete':
+        q, r = torch.qr(x, some=False)
+        return res(q, r)
+    else:
+        raise Exception("Only 'reduced' and 'complete' qr modes are allowed for the torch backend.")

--- a/ivy/functional/ivy/array_api/creation_functions.py
+++ b/ivy/functional/ivy/array_api/creation_functions.py
@@ -76,3 +76,28 @@ def tril(x: Union[ivy.Array, ivy.NativeArray],
         same device as x.
     """
     return _cur_framework(x).tril(x, k)
+
+
+def triu(x: Union[ivy.Array, ivy.NativeArray],
+         k: int = 0) \
+         -> ivy.Array:
+    """
+    Returns the upper triangular part of a matrix (or a stack of matrices) x.
+
+    Parameters
+    ----------
+    x:
+        input array having shape (..., M, N) and whose innermost two dimensions form MxN matrices.
+    k:
+        diagonal below which to zero elements. If k = 0, the diagonal is the main diagonal. If k < 0, the diagonal is 
+        below the main diagonal. If k > 0, the diagonal is above the main diagonal. Default: 0.
+
+    Returns
+    -------
+    out:
+        an array containing the upper triangular part(s). The returned array must have the same shape and data type as 
+        x. All elements below the specified diagonal k must be zeroed. The returned array should be allocated on the 
+        same device as x.
+    """
+    return _cur_framework(x).triu(x, k)
+    

--- a/ivy/functional/ivy/array_api/linear_algebra.py
+++ b/ivy/functional/ivy/array_api/linear_algebra.py
@@ -1,5 +1,6 @@
 # global
 from typing import Union, Optional, Tuple, Literal
+from collections import namedtuple
 
 # local
 import ivy
@@ -99,3 +100,27 @@ def diagonal(x: ivy.Array,
         an array containing the diagonals and whose shape is determined by removing the last two dimensions and appending a dimension equal to the size of the resulting diagonals. The returned array must have the same data type as ``x``.
     """
     return _cur_framework(x).diagonal(x, offset, axis1=axis1, axis2=axis2)
+
+
+def qr(x: ivy.Array,
+       mode: str = 'reduced') -> namedtuple('qr', ['Q', 'R']):
+    """
+    Returns the qr decomposition x = QR of a full column rank matrix (or a stack of matrices), where Q is an orthonormal matrix (or a stack of matrices) and R is an upper-triangular matrix (or a stack of matrices).
+    Parameters
+    ----------
+    x:
+        input array having shape (..., M, N) and whose innermost two dimensions form MxN matrices of rank N. Should have a floating-point data type.
+    mode:
+        decomposition mode. Should be one of the following modes:
+        - 'reduced': compute only the leading K columns of q, such that q and r have dimensions (..., M, K) and (..., K, N), respectively, and where K = min(M, N).
+        - 'complete': compute q and r with dimensions (..., M, M) and (..., M, N), respectively.
+        Default: 'reduced'.
+    
+    Returns
+    -------
+    out:
+        a namedtuple (Q, R) whose
+        - first element must have the field name Q and must be an array whose shape depends on the value of mode and contain matrices with orthonormal columns. If mode is 'complete', the array must have shape (..., M, M). If mode is 'reduced', the array must have shape (..., M, K), where K = min(M, N). The first x.ndim-2 dimensions must have the same size as those of the input array x.
+        - second element must have the field name R and must be an array whose shape depends on the value of mode and contain upper-triangular matrices. If mode is 'complete', the array must have shape (..., M, N). If mode is 'reduced', the array must have shape (..., K, N), where K = min(M, N). The first x.ndim-2 dimensions must have the same size as those of the input x.
+    """
+    return _cur_framework(x).qr(x, mode)

--- a/ivy_tests/array_api_methods_to_test/creation_functions.txt
+++ b/ivy_tests/array_api_methods_to_test/creation_functions.txt
@@ -11,6 +11,6 @@ full
 ones
 #ones_like
 tril
-#triu
+triu
 zeros
 #zeros_like

--- a/ivy_tests/array_api_methods_to_test/linear_algebra.txt
+++ b/ivy_tests/array_api_methods_to_test/linear_algebra.txt
@@ -12,7 +12,7 @@ diagonal
 #matrix_transpose
 #outer
 #pinv
-#qr
+qr
 #slogdet
 #solve
 #svd


### PR DESCRIPTION
"qr" has been implemented, however, there are still errors, because "triu" has not been implemented for any framework (or maybe there's some other issue I'm not catching).  Submitting PR for feedback.