### PR TITLE
Reformat Leaky ReLU

### DIFF
--- a/ivy/functional/backends/jax/activations.py
+++ b/ivy/functional/backends/jax/activations.py
@@ -2,12 +2,24 @@
 Collection of Jax activation functions, wrapped to fit Ivy syntax and signature.
 """
 
+from typing import Optional
+
 # global
 import jax
 import jax.numpy as jnp
 
+# local
+from ivy.functional.backends.jax import JaxArray
+
+
 relu = lambda x: jnp.maximum(x, 0)
-leaky_relu = lambda x, alpha=0.2: jnp.where(x > 0, x, x * alpha)
+
+
+def leaky_relu(x: JaxArray, alpha: Optional[float] = 0.2)\
+        -> JaxArray:
+    return jnp.where(x > 0, x, x * alpha)
+
+
 gelu = jax.nn.gelu
 tanh = jnp.tanh
 sigmoid = lambda x: 1 / (1 + jnp.exp(-x))

--- a/ivy/functional/backends/mxnet/activations.py
+++ b/ivy/functional/backends/mxnet/activations.py
@@ -2,12 +2,18 @@
 Collection of MXNet activation functions, wrapped to fit Ivy syntax and signature.
 """
 
+from typing import Optional
+
 # global
 import numpy as _np
 import mxnet as _mx
 
 relu = _mx.nd.relu
-leaky_relu = lambda x, alpha=0.2: _mx.nd.LeakyReLU(x, slope=alpha)
+
+
+def leaky_relu(x: _mx.nd.NDArray, alpha: Optional[float] = 0.2)\
+        -> _mx.nd.NDArray:
+    return _mx.nd.LeakyReLU(x, slope=alpha)
 
 
 def gelu(x, approximate=True):

--- a/ivy/functional/backends/numpy/activations.py
+++ b/ivy/functional/backends/numpy/activations.py
@@ -2,6 +2,8 @@
 Collection of Numpy activation functions, wrapped to fit Ivy syntax and signature.
 """
 
+from typing import Optional
+
 # global
 import numpy as np
 try:
@@ -10,7 +12,11 @@ except (ImportError, ModuleNotFoundError):
     _erf = None
 
 relu = lambda x: np.maximum(x, 0)
-leaky_relu = lambda x, alpha=0.2: np.where(x > 0, x, x * alpha)
+
+
+def leaky_relu(x: np.ndarray, alpha: Optional[float] = 0.2)\
+        -> np.ndarray:
+    return np.where(x > 0, x, x * alpha)
 
 
 def gelu(x, approximate=True):

--- a/ivy/functional/backends/tensorflow/activations.py
+++ b/ivy/functional/backends/tensorflow/activations.py
@@ -2,11 +2,21 @@
 Collection of TensorFlow activation functions, wrapped to fit Ivy syntax and signature.
 """
 
+from typing import Optional
+
 # global
 import tensorflow as tf
 
+from tensorflow.python.types.core import Tensor
+
 relu = tf.nn.relu
-leaky_relu = tf.nn.leaky_relu
+
+
+def leaky_relu(x: Tensor, alpha: Optional[float] = 0.2)\
+        -> Tensor:
+    return tf.nn.leaky_relu(x, alpha)
+
+
 gelu = lambda x, approximate=True: tf.nn.gelu(x, approximate)
 tanh = tf.nn.tanh
 sigmoid = tf.nn.sigmoid

--- a/ivy/functional/backends/torch/activations.py
+++ b/ivy/functional/backends/torch/activations.py
@@ -2,6 +2,8 @@
 Collection of PyTorch activation functions, wrapped to fit Ivy syntax and signature.
 """
 
+from typing import Optional
+
 # global
 import numpy as _np
 import torch
@@ -11,7 +13,8 @@ def relu(x):
     return torch.relu(x)
 
 
-def leaky_relu(x, alpha: float = 0.2):
+def leaky_relu(x: torch.Tensor, alpha: Optional[float] = 0.2)\
+        -> torch.Tensor:
     return torch.nn.functional.leaky_relu(x, alpha)
 
 

--- a/ivy/functional/ivy/activations.py
+++ b/ivy/functional/ivy/activations.py
@@ -2,7 +2,10 @@
 Collection of Ivy activation functions.
 """
 
+from typing import Union, Optional
+
 # local
+import ivy
 from ivy.framework_handler import current_framework as _cur_framework
 
 
@@ -20,15 +23,28 @@ def relu(x):
     return _cur_framework(x).relu(x)
 
 
-def leaky_relu(x, alpha=0.2):
-    """
-    Applies the leaky rectified linear unit function element-wise.
+def leaky_relu(x: Union[ivy.Array, ivy.NativeArray], alpha: Optional[float] = 0.2)\
+        -> ivy.Array:
+    """Applies the leaky rectified linear unit function element-wise.
 
-    :param x: Input array.
-    :type x: array
-    :param alpha: Negative slope for ReLU
-    :type alpha: float
-    :return: The input array with leaky relu applied element-wise.
+    Parameters
+    ----------
+    x : ivy.Array or ivy.NativeArray
+        Input array.
+    alpha : float, default=0.2
+        Negative slope for ReLU.
+
+    Returns
+    -------
+    ivy.Array
+        The input array with leaky relu applied element-wise.
+
+    Examples:
+    >>> x = ivy.array([0.39, -0.85])
+    >>> y = ivy.leaky_relu(x)
+    >>> print(y)
+    [0.39, -0.17]
+
     """
     return _cur_framework(x).leaky_relu(x, alpha)
 

--- a/ivy_tests/test_ivy/helpers.py
+++ b/ivy_tests/test_ivy/helpers.py
@@ -192,6 +192,19 @@ def assert_compilable(fn):
         raise e
 
 
+def assert_docstring_examples_run(fn):
+    fn_name = fn.__name__
+    docstring = ivy.framework_handler.ivy_original_dict[fn_name].__doc__
+
+    exec_lines = filter(lambda line: '>>>' in line, docstring.split('\n'))
+    example = map(lambda line: line.split('>>>')[1][1:], exec_lines)
+
+    for line in example:
+        exec(line)
+
+    return True
+
+
 def var_fn(a, b=None, c=None):
     return ivy.variable(ivy.array(a, b, c))
 

--- a/ivy_tests/test_ivy/helpers.py
+++ b/ivy_tests/test_ivy/helpers.py
@@ -197,11 +197,9 @@ def assert_docstring_examples_run(fn):
     docstring = ivy.framework_handler.ivy_original_dict[fn_name].__doc__
     if docstring is None:
         return True
-
     executable_lines = [line.split('>>>')[1][1:] for line in docstring.split('\n') if '>>>' in line]
     for line in executable_lines:
         exec(line)
-
     return True
 
 

--- a/ivy_tests/test_ivy/test_functional/test_nn/test_activations.py
+++ b/ivy_tests/test_ivy/test_functional/test_nn/test_activations.py
@@ -48,6 +48,8 @@ def test_leaky_relu(x, dtype, tensor_fn, dev, call):
     assert ret.shape == x.shape
     # value test
     assert np.allclose(call(ivy.leaky_relu, x), ivy.functional.backends.numpy.leaky_relu(ivy.to_numpy(x)))
+    # docstring test
+    helpers.assert_docstring_examples_run(ivy.leaky_relu)
 
 
 # gelu


### PR DESCRIPTION
This PR covers #768 , which includes:

- An implementation of `assert_docstring_examples_run`
- The docstring of Leaky ReLU in NumPy format
- Backend APIs of Leaky ReLU