### PR TITLE
elementwise ceil (#765)

### DIFF
--- a/ivy/functional/ivy/elementwise.py
+++ b/ivy/functional/ivy/elementwise.py
@@ -187,6 +187,7 @@ def ceil(x: Union[ivy.Array, ivy.NativeArray])\
     -------
     out:
         an array containing the rounded result for each element in ``x``. The returned array must have the same data type as ``x``.
+        
     Examples:
     >>> x = ivy.array([0.1, 0, -0.1])
     >>> y = ivy.ceil(x)

--- a/ivy/functional/ivy/elementwise.py
+++ b/ivy/functional/ivy/elementwise.py
@@ -187,6 +187,11 @@ def ceil(x: Union[ivy.Array, ivy.NativeArray])\
     -------
     out:
         an array containing the rounded result for each element in ``x``. The returned array must have the same data type as ``x``.
+    Examples:
+    >>> x = ivy.array([0.1, 0, -0.1])
+    >>> y = ivy.ceil(x)
+    >>> print(y)
+    [1.0, 0.0, -0.0]
     """
     return _cur_framework(x).ceil(x)
 

--- a/ivy_tests/test_ivy/test_functional/test_core/test_general.py
+++ b/ivy_tests/test_ivy/test_functional/test_core/test_general.py
@@ -583,6 +583,8 @@ def test_ceil(x_n_x_ceiled, dtype, tensor_fn, dev, call):
     assert ret.shape == x.shape
     # value test
     assert np.allclose(call(ivy.ceil, x), np.array(x_n_x_ceiled[1]))
+    # docstring test
+    helpers.assert_docstring_examples_run(ivy.ceil)
 
 
 


### PR DESCRIPTION
Added the docstring example for ceil along with its test in the test file. Local tests for the function were green, so there was no need to edit the implementation.