### PR TITLE
Reformat `softplus`, add docs, and docstring test

### DIFF
--- a/ivy/functional/backends/jax/activations.py
+++ b/ivy/functional/backends/jax/activations.py
@@ -32,4 +32,6 @@ def softmax(x, axis=-1):
     return exp_x / jnp.sum(exp_x, axis, keepdims=True)
 
 
-softplus = lambda x: jnp.log(jnp.exp(x) + 1)
+def softplus(x: JaxArray)\
+        -> JaxArray:
+    return jnp.log(jnp.exp(x) + 1)

--- a/ivy/functional/backends/mxnet/activations.py
+++ b/ivy/functional/backends/mxnet/activations.py
@@ -28,4 +28,8 @@ def gelu(x, approximate=True):
 tanh = _mx.nd.tanh
 sigmoid = _mx.nd.sigmoid
 softmax = lambda x, axis=-1: _mx.nd.softmax(x, axis=axis)
-softplus = lambda x: _mx.nd.log(_mx.nd.exp(x) + 1)
+
+
+def softplus(x: _mx.nd.NDArray)\
+        -> _mx.nd.NDArray:
+    return _mx.nd.log(_mx.nd.exp(x) + 1)

--- a/ivy/functional/backends/numpy/activations.py
+++ b/ivy/functional/backends/numpy/activations.py
@@ -39,4 +39,6 @@ def softmax(x, axis=-1):
     return exp_x / np.sum(exp_x, axis, keepdims=True)
 
 
-softplus = lambda x: np.log(np.exp(x) + 1)
+def softplus(x: np.ndarray)\
+        -> np.ndarray:
+    return np.log(np.exp(x) + 1)

--- a/ivy/functional/backends/tensorflow/activations.py
+++ b/ivy/functional/backends/tensorflow/activations.py
@@ -23,4 +23,8 @@ gelu = lambda x, approximate=True: tf.nn.gelu(x, approximate)
 tanh = tf.nn.tanh
 sigmoid = tf.nn.sigmoid
 softmax = tf.nn.softmax
-softplus = tf.nn.softplus
+
+
+def softplus(x: Tensor)\
+        -> Tensor:
+    return tf.nn.softplus(x)

--- a/ivy/functional/backends/torch/activations.py
+++ b/ivy/functional/backends/torch/activations.py
@@ -37,5 +37,6 @@ def softmax(x, axis: int = -1):
     return torch.softmax(x, axis)
 
 
-def softplus(x):
+def softplus(x: torch.Tensor)\
+        -> torch.Tensor:
     return torch.nn.functional.softplus(x)

--- a/ivy/functional/ivy/activations.py
+++ b/ivy/functional/ivy/activations.py
@@ -111,12 +111,25 @@ def softmax(x, axis=-1):
     return _cur_framework(x).softmax(x, axis)
 
 
-def softplus(x):
+def softplus(x: Union[ivy.Array, ivy.NativeArray])\
+        -> ivy.Array:
     """
     Applies the softplus function element-wise.
 
-    :param x: Input array.
-    :type x: array
-    :return: The input array with softplus applied element-wise.
+    Parameters
+    ----------
+    x:
+        input array.
+
+    Returns
+    -------
+    out:
+        an array containing the softplus activation of each element in ``x``.
+
+    Examples:
+    >>> x = ivy.array([-0.3461, -0.6491])
+    >>> y = ivy.softplus(x)
+    >>> print(y)
+    [0.5350, 0.4203]
     """
     return _cur_framework(x).softplus(x)

--- a/ivy_tests/test_ivy/test_functional/test_nn/test_activations.py
+++ b/ivy_tests/test_ivy/test_functional/test_nn/test_activations.py
@@ -149,3 +149,5 @@ def test_softplus(x, dtype, tensor_fn, dev, call):
     assert ret.shape == x.shape
     # value test
     assert np.allclose(call(ivy.softplus, x), ivy.functional.backends.numpy.softplus(ivy.to_numpy(x)))
+    # docstring test
+    helpers.assert_docstring_examples_run(ivy.softplus)


### PR DESCRIPTION
This PR resolves issue https://github.com/unifyai/ivy/issues/786 with the following contributions:
* Reformatting of softplus activation function for contemporary backends.
* Changed `ivy.softplus` function's docstring to NumPy-style docstring.
* Added docstring test with `assert_docstring_examples_run` method.

P.S. Sorry for delay in my PR. I hope this doesn't affect me for internship selection process. :)