### PR TITLE
reformat float_img_to_uint8_img

### DIFF
--- a/ivy/functional/ivy/image.py
+++ b/ivy/functional/ivy/image.py
@@ -54,17 +54,24 @@ def gradient_image(x):
 def float_img_to_uint8_img(x):
     """
     Converts an image of floats into a bit-cast 4-channel image of uint8s, which can be saved to disk.
+    Parameters
+    ----------
+    x:
+        Input float image [batch_shape,h,w].
 
-    :param x: Input float image *[batch_shape,h,w]*.
-    :type x: array
-    :return: The new encoded uint8 image *[batch_shape,h,w,4]* .
+    dtype:
+        array data type.
+
+    Returns
+    -------
+    out:
+        The new encoded uint8 image [batch_shape,h,w,4] .
     """
     x_np = ivy.to_numpy(x)
     x_shape = x_np.shape
     x_bytes = x_np.tobytes()
     x_uint8 = _np.frombuffer(x_bytes, _np.uint8)
     return ivy.array(_np.reshape(x_uint8, list(x_shape) + [4]).tolist())
-
 
 def uint8_img_to_float_img(x):
     """


### PR DESCRIPTION
1. Reformatted  def float_to_uint8 in image.py into NumPy style for docstring
2. passed 8 tests out of 8
3. Could not find float_to_uint8 method in backend files

Please let me know any corrections.

#867 is the issue in reference to this PR

Thankyou
