### PR TITLE
reformat argsort

### DIFF
--- a/ivy/functional/backends/mxnet/sorting.py
+++ b/ivy/functional/backends/mxnet/sorting.py
@@ -6,12 +6,13 @@ import ivy
 
 
 def argsort(
-    x: mx.ndarray.ndarray.NDArray,
-    axis: int = -1,
-    descending: bool = False,
-    stable: bool = True,
-    out: Optional[mx.ndarray.ndarray.NDArray] = None,
+        x: mx.ndarray.ndarray.NDArray,
+        axis: int = -1,
+        descending: bool = False,
+        stable: bool = True,
+        out: Optional[mx.ndarray.ndarray.NDArray] = None,
 ) -> mx.ndarray.ndarray.NDArray:
+    # TODO: This does not pass the unit test in _array_module.py.
     ret = mx.nd.array(mx.nd.argsort(mx.nd.array(x), axis=axis, is_ascend=descending))
     if ivy.exists(out):
         return ivy.inplace_update(out, ret)
@@ -19,11 +20,11 @@ def argsort(
 
 
 def sort(
-    x: mx.ndarray.ndarray.NDArray,
-    axis: int = -1,
-    descending: bool = False,
-    stable: bool = True,
-    out: Optional[mx.ndarray.ndarray.NDArray] = None,
+        x: mx.ndarray.ndarray.NDArray,
+        axis: int = -1,
+        descending: bool = False,
+        stable: bool = True,
+        out: Optional[mx.ndarray.ndarray.NDArray] = None,
 ) -> mx.ndarray.ndarray.NDArray:
     kind = "stable" if stable else "quicksort"
     ret = mx.nd.array((mx.nd.sort(mx.nd.sort(x), axis=axis, is_ascend=kind)))

--- a/ivy/functional/ivy/sorting.py
+++ b/ivy/functional/ivy/sorting.py
@@ -11,12 +11,12 @@ from ivy.framework_handler import current_framework as _cur_framework
 
 
 def argsort(
-    x: Union[ivy.Array, ivy.NativeArray],
+    x: Union[ivy.Array, ivy.NativeArray, ivy.Container],
     axis: int = -1,
     descending: bool = False,
     stable: bool = True,
-    out: Optional[Union[ivy.Array, ivy.NativeArray]] = None,
-) -> ivy.Array:
+    out: Optional[Union[ivy.Array, ivy.Container]] = None,
+) -> Union[ivy.Array, ivy.Container]:
     """Returns the indices that sort an array ``x`` along a specified axis.
 
     Parameters
@@ -45,6 +45,19 @@ def argsort(
     ret
         an array of indices. The returned array must have the same shape as ``x``. The
         returned array must have the default array index data type.
+
+    This method conforms to the `Array API Standard
+    <https://data-apis.org/array-api/latest/>`_. This docstring is an extension of the
+    `docstring <https://data-apis.org/array-api/latest/API_specification/generated/signatures.elementwise_functions.tan.html>`_
+    in the standard. The descriptions above assume an array input for simplicity, but
+    the method also accepts :code:`ivy.Container` instances in place of
+    :code:`ivy.Array` or :code:`ivy.NativeArray` instances, as shown in the type hints
+    and also the examples below.
+
+    Functional Examples
+    -------
+
+    With：code:`ivy.Array` input:
 
     """
     return _cur_framework(x).argsort(x, axis, descending, stable, out)

--- a/ivy/functional/ivy/sorting.py
+++ b/ivy/functional/ivy/sorting.py
@@ -37,8 +37,8 @@ def argsort(
         equal (i.e., the relative order of ``x`` values which compare as equal is
         implementation-dependent). Default: ``True``.
     out
-        optional output array, for writing the result to. It must have a shape that the
-        inputs broadcast to.
+        optional output array, for writing the result to. It must have the same shape
+        as ``x``.
 
     Returns
     -------
@@ -59,6 +59,30 @@ def argsort(
 
     With：code:`ivy.Array` input:
 
+    >>> x = ivy.array([3,1,2])
+    >>> y = ivy.argsort(x)
+    >>> print(y)
+    ivy.array([1,2,0])
+
+    >>> x = ivy.array([[1.5, 3.2], [2.3, 2.3]])
+    >>> ivy.argsort(x, 0, True, False, y)
+    >>> print(y)
+    ivy.array([[1, 0], [0, 1]])
+
+    >>> x = ivy.array([[[1,3], [3,2]], [[2,4], [2,0]]])
+    >>> y = ivy.argsort(x, 1, False, True)
+    >>> print(y)
+    ivy.array([[[0, 1], [1, 0]], [[0, 1], [1, 0]]])
+
+    With :code:`ivy.Container` input:
+
+    >>> x = ivy.Container(a=ivy.array([5,1,3]), b=ivy.array([[0, 3], [3, 2]]))
+    >>> y = ivy.argsort(x)
+    >>> print(y)
+    {
+        a: ivy.array([1, 2, 0]),
+        b: ivy.array([[0, 1], [0, 1]])
+    }
     """
     return _cur_framework(x).argsort(x, axis, descending, stable, out)
 


### PR DESCRIPTION
Currently, all frameworks except mxnet pass the unit test. The mxnet one failed due to a hypothesis.errors.InvalidArgument: Could not create full array of dtype=<class 'bool'> with fill value False. Need guide on what to do about it. Thank!