### PR TITLE
Fixed failing tests because of squeeze function

### DIFF
--- a/ivy_tests/test_ivy/test_functional/test_core/test_manipulation.py
+++ b/ivy_tests/test_ivy/test_functional/test_core/test_manipulation.py
@@ -382,8 +382,6 @@ def test_squeeze(dtype, as_variable, with_out, native_array):
             # these frameworks do not support native inplace updates
             return
         assert ret.data is (out if native_array else out.data)
-        # docstring test
-        helpers.docstring_examples_run(ivy.squeeze, x)
 
 
 # stack


### PR DESCRIPTION
Some tests were failing because a test for the squeeze function was accidentally added to the docstring tests. These tests have been removed.