### PR TITLE
first commit, reformatting outer function in linear_algebra from nump…

### DIFF
--- a/ivy/array/linear_algebra.py
+++ b/ivy/array/linear_algebra.py
@@ -17,8 +17,8 @@ class ArrayWithLinearAlgebra(abc.ABC):
         return ivy.matmul(self, x2, out=out)
 
     def outer(
-            self: ivy.Array,
-            x2: Union[ivy.Array, ivy.NativeArray, ivy.Container],
-            out: Optional[Union[ivy.Array, ivy.NativeArray, ivy.Container]] = None,
-        ) -> Union[ivy.Array, ivy.Container]:
-            return ivy.outer(self, x2, out=out)
+        self: ivy.Array,
+        x2: Union[ivy.Array, ivy.NativeArray, ivy.Container],
+        out: Optional[Union[ivy.Array, ivy.NativeArray, ivy.Container]] = None,
+    ) -> Union[ivy.Array, ivy.Container]:
+        return ivy.outer(self, x2, out=out)

--- a/ivy/array/linear_algebra.py
+++ b/ivy/array/linear_algebra.py
@@ -15,3 +15,10 @@ class ArrayWithLinearAlgebra(abc.ABC):
         out: Optional[Union[ivy.Array, ivy.NativeArray, ivy.Container]] = None,
     ) -> Union[ivy.Array, ivy.Container]:
         return ivy.matmul(self, x2, out=out)
+
+    def outer(
+            self: ivy.Array,
+            x2: Union[ivy.Array, ivy.NativeArray, ivy.Container],
+            out: Optional[Union[ivy.Array, ivy.NativeArray, ivy.Container]] = None,
+        ) -> Union[ivy.Array, ivy.Container]:
+            return ivy.outer(self, x2, out=out)

--- a/ivy/container/linear_algebra.py
+++ b/ivy/container/linear_algebra.py
@@ -37,3 +37,31 @@ class ContainerWithLinearAlgebra(ContainerBase):
             ),
             out,
         )
+
+    def outer(
+        self: ivy.Container,
+        x2: Union[ivy.Container, ivy.Array, ivy.NativeArray],
+        key_chains: Optional[Union[List[str], Dict[str, str]]] = None,
+        to_apply: bool = True,
+        prune_unapplied: bool = False,
+        map_sequences: bool = False,
+        out: Optional[ivy.Container] = None,
+    ) -> ivy.Container:
+        kw = {}
+        conts = {"x1": self}
+        if ivy.is_array(x2):
+            kw["x2"] = x2
+        else:
+            conts["x2"] = x2
+        return ContainerBase.handle_inplace(
+            ContainerBase.multi_map(
+                lambda xs, _: ivy.outer(**dict(zip(conts.keys(), xs)), **kw)
+                if ivy.is_array(xs[0])
+                else xs,
+                list(conts.values()),
+                key_chains,
+                to_apply,
+                prune_unapplied,
+            ),
+            out,
+        )

--- a/ivy_tests/test_ivy/test_functional/test_core/test_image.py
+++ b/ivy_tests/test_ivy/test_functional/test_core/test_image.py
@@ -10,7 +10,6 @@ import ivy.functional.backends.numpy
 import ivy_tests.test_ivy.helpers as helpers
 
 
-
 # stack_images
 @given(
     shape=st.lists(st.integers(min_value=1, max_value=8), min_size=4, max_size=8),

--- a/ivy_tests/test_ivy/test_functional/test_core/test_linalg.py
+++ b/ivy_tests/test_ivy/test_functional/test_core/test_linalg.py
@@ -87,6 +87,52 @@ def test_matmul(
         x2=np.random.uniform(size=(b, c)).astype(dtype[1]),
     )
 
+
+# outer
+@given(
+    dtype=helpers.list_of_length(st.sampled_from(ivy_np.valid_float_dtype_strs), 2),
+    as_variable=helpers.list_of_length(st.booleans(), 2),
+    with_out=st.booleans(),
+    num_positional_args=st.integers(0, 2),
+    native_array=helpers.list_of_length(st.booleans(), 2),
+    container=helpers.list_of_length(st.booleans(), 2),
+    instance_method=st.booleans(),
+    a=st.integers(1, 50),
+    b=st.integers(1, 50),
+    c=st.integers(1, 50),
+    seed=st.integers(0, 2**32 - 1),
+)
+def test_outer(
+    dtype,
+    as_variable,
+    with_out,
+    num_positional_args,
+    native_array,
+    container,
+    instance_method,
+    fw,
+    a,
+    b,
+    c,
+    seed,
+):
+    np.random.seed(seed)
+    helpers.test_array_function(
+        dtype,
+        as_variable,
+        with_out,
+        num_positional_args,
+        native_array,
+        container,
+        instance_method,
+        fw,
+        "outer",
+        rtol=5e-02,
+        atol=5e-02,
+        x1=np.random.uniform(size=(a, b)).astype(dtype[0]),
+        x2=np.random.uniform(size=(b, c)).astype(dtype[1]),
+    )
+
 # Still to Add #
 # ---------------#
 
@@ -101,7 +147,6 @@ def test_matmul(
 # matrix_power
 # matrix_rank
 # matrix_transpose
-# outer
 # pinv
 # qr
 # slogdet


### PR DESCRIPTION
Here's a working reformatting of the outer function in numpy's linear algebra methods. As far as I can tell it passes all the tests and certainly works when I try it in the docker instance. Thank you!