### PR TITLE
FAQ and Docstring update.

### DIFF
--- a/docs/partial_source/contributing/15_docstring_examples.rst
+++ b/docs/partial_source/contributing/15_docstring_examples.rst
@@ -151,6 +151,9 @@ Let's start with the functional examples, with :code:`ivy.Array` instances in th
 
 These examples cover points 1, 2, 3, 4 and 5.
 
+Please note that in the above case of `x` having multi-line input, it is necessary for each line of the input
+to be seperated by a '\' so that they can be parsed by the script that tests the examples in the docstrings. 
+
 Point 1 is simple to satisfy. Ignoring the union over :code:`ivy.Array` and :code:`ivy.NativeArray` which is covered by
 points 6 and 7, and ignoring :code:`ivy.Container` which is covered by points 8 and 9,
 then as far as point 1 is concerned, the input :code:`x` only has one possible variation. It must be an array.

--- a/docs/partial_source/faq.rst
+++ b/docs/partial_source/faq.rst
@@ -162,14 +162,3 @@ gradients explicitly as function inputs and outputs. This is not actually requir
 still return the values such that JAX is also supported. Ivy will remain fully functional in design, and we therefore
 assume behavior similar to JAX. Our simple example on the `README`_ trains correctly for all back-ends, which passes
 everything explicitly in a functional manner.
-
-Transpiler
------
-
-**Q: ** Does the authors need to code with Ivy to convert between different frameworks or can it convert let's say
-PyTorch to Jax code directly?
-
-**A:** The code conversion is a little more nuanced than that. Say if you have a pre-written pure PyTorch code, you can
-replace each PyTorch function with its equivalent function in Ivy using Ivy's PyTorch frontend and run this PyTorch code using
-JAX. Once the transpiler interface is implemented, it will be possible to convert between frameworks without any knowledge
-of Ivy whatsoever.


### PR DESCRIPTION
1. Removed transpiler QnA from FAQ
2. Updated docstrings_examples.rst to include why '\' is needed. 