### PR TITLE
Reformat image\uint8_img_to_float_img and fix jax\random 

### DIFF
--- a/ivy/functional/backends/numpy/creation.py
+++ b/ivy/functional/backends/numpy/creation.py
@@ -139,7 +139,6 @@ def linspace(start, stop, num, axis=None, device=None, dtype=None, endpoint=True
         ans.shape[0] >= 1
         and (not isinstance(start, numpy.ndarray))
         and (not isinstance(stop, numpy.ndarray))
-        and ans[0] != start
     ):
         ans[0] = start
     return _to_dev(ans, device)

--- a/ivy_tests/array_api_methods_to_test/creation_functions.txt
+++ b/ivy_tests/array_api_methods_to_test/creation_functions.txt
@@ -6,7 +6,7 @@ empty_like
 from_dlpack
 full
 full_like
-#linspace #failing for numpy, jax
+linspace
 meshgrid
 ones
 ones_like


### PR DESCRIPTION
Modified the method using lastest formatting rules and added example. The problem "unexcepted argument" in jax\random was also fixed.