### PR TITLE
Reformat image\uint8_img_to_float_img and fix jax\random

### DIFF
--- a/ivy/functional/backends/jax/random.py
+++ b/ivy/functional/backends/jax/random.py
@@ -96,7 +96,8 @@ def randint(
     global RNG
     RNG, rng_input = _jax.random.split(RNG)
     return to_dev(
-        _jax.random.randint(rng_input, shape, low, high), default_device(device)
+        _jax.random.randint(rng_input, shape, low, high),
+        defalt = default_device(device)
     )
 
 

--- a/ivy/functional/backends/jax/random.py
+++ b/ivy/functional/backends/jax/random.py
@@ -97,7 +97,7 @@ def randint(
     RNG, rng_input = _jax.random.split(RNG)
     return to_dev(
         _jax.random.randint(rng_input, shape, low, high),
-        defalt = default_device(device)
+        device=default_device(device)
     )
 
 

--- a/ivy/functional/backends/numpy/creation.py
+++ b/ivy/functional/backends/numpy/creation.py
@@ -139,7 +139,6 @@ def linspace(start, stop, num, axis=None, device=None, dtype=None, endpoint=True
         ans.shape[0] >= 1
         and (not isinstance(start, numpy.ndarray))
         and (not isinstance(stop, numpy.ndarray))
-        and ans[0] != start
     ):
         ans[0] = start
     return _to_dev(ans, device)

--- a/ivy/functional/ivy/image.py
+++ b/ivy/functional/ivy/image.py
@@ -134,7 +134,7 @@ def float_img_to_uint8_img(x):
     return ivy.array(_np.reshape(x_uint8, list(x_shape) + [4]).tolist())
 
 
-def uint8_img_to_float_img(x):
+def uint8_img_to_float_img(x: Union[ivy.Array, ivy.NativeArray]) -> ivy.Array:
     """Converts an image of uint8 values into a bit-cast float image.
 
     Parameters
@@ -146,6 +146,18 @@ def uint8_img_to_float_img(x):
     -------
     ret
         The new float image *[batch_shape,h,w]*
+
+    Examples
+    --------
+    >>> batch_shape = 1
+    >>> h = 2
+    >>> w = 2
+    >>> d = 4
+    >>> x = ivy.arange(h * w * d)
+    >>> image = ivy.reshape(x,(batch_size, h, w, d))
+    >>> y = ivy.uint8_img_to_float_img(image)
+    >>> print(y)
+    ivy.array([[[3.820471434542632e-37, 1.0082513512365273e-34], [2.658462758989161e-32, 7.003653270560797e-30]]])
 
     """
     x_np = ivy.to_numpy(x).astype("uint8")

--- a/ivy/functional/ivy/image.py
+++ b/ivy/functional/ivy/image.py
@@ -157,7 +157,8 @@ def uint8_img_to_float_img(x: Union[ivy.Array, ivy.NativeArray]) -> ivy.Array:
     >>> image = ivy.reshape(x,(batch_size, h, w, d))
     >>> y = ivy.uint8_img_to_float_img(image)
     >>> print(y)
-    ivy.array([[[3.820471434542632e-37, 1.0082513512365273e-34], [2.658462758989161e-32, 7.003653270560797e-30]]])
+    ivy.array([[[3.820471434542632e-37, 1.0082513512365273e-34],
+                [2.658462758989161e-32, 7.003653270560797e-30]]])
 
     """
     x_np = ivy.to_numpy(x).astype("uint8")

--- a/ivy_tests/array_api_methods_to_test/creation_functions.txt
+++ b/ivy_tests/array_api_methods_to_test/creation_functions.txt
@@ -6,7 +6,7 @@ empty_like
 from_dlpack
 full
 full_like
-#linspace #failing for numpy, jax
+linspace
 meshgrid
 ones
 ones_like


### PR DESCRIPTION
- [ ] #1200

Modified the method using the latest formatting rules and added examples. The problem "unexcepted argument" in jax\random was also fixed.