### PR TITLE
Solving pip install fails on windowsOS

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -63,9 +63,12 @@ def _is_raw_block(line):
         return True
     return False
 
+def read_description(path):
+    with open(path, 'r', encoding='utf-8') as f:
+        return f.read()
 
 this_directory = Path(__file__).parent
-text = (this_directory / "README.rst").read_text()
+text = read_description('README.rst')
 lines = _replace_logos_html(text).split("\n")
 lines = [line for line in lines if not (_is_html(line) or _is_raw_block(line))]
 long_description = "\n".join(lines)
@@ -88,7 +91,7 @@ setup(
         "Source": "https://github.com/unifyai/ivy",
     },
     packages=setuptools.find_packages(),
-    install_requires=[_strip(line) for line in open("requirements.txt", "r")],
+    install_requires=[_strip(line) for line in open("requirements.txt", "r", encoding='utf-8')],
     classifiers=["License :: OSI Approved :: Apache Software License"],
     license="Apache 2.0",
 )


### PR DESCRIPTION
If you do `pip install .` in WindowsOS you will get error. 
```
UnicodeDecodeError: 'cp932' codec can't decode byte 0x93 in position 471: illegal multibyte sequence
```

This PR fix the problem so windows users could build the lastest fork through `pip install .`.