### PR TITLE
fix docker image build failed

### DIFF
--- a/optional.txt
+++ b/optional.txt
@@ -10,7 +10,7 @@ tensorflow
 tensorflow-addons # mod_name=tensorflow_addons
 tensorflow-probability # mod_name=tensorflow_probability
 torch
-torch-scatter
+torch-scatter # mod_name=torch_scatter
 mxnet
 scipy
 dm-haiku # mod_name=haiku


### PR DESCRIPTION
When I build docker image by running `docker build -t unifyai/ivy:latest --no-cache -f Dockerfile .`, it shows the following error message.
![docker_build_failed](https://user-images.githubusercontent.com/30398092/173079945-b6c6e8de-2a59-4afa-b772-533086c41314.png)

The last step in Dockerfile will execute `test_dependencies.py` to check all modules. But it cannot find torch-scatter and raise an exception, which causes docker build failure. The reason is that the module name of torch-scatter is `torch_scatter` instead of `torch-scatter`.
The simple fix is adding mod_name in optional.txt.