### PR TITLE
Fixed runtime error in docstring_test

### DIFF
--- a/ivy_tests/test_ivy/helpers.py
+++ b/ivy_tests/test_ivy/helpers.py
@@ -258,8 +258,6 @@ def docstring_examples_run(fn):
 
     docstring = ivy.backend_handler.ivy_original_dict[fn_name].__doc__
 
-    print(fn_name)
-
     if docstring is None:
         return True
 
@@ -297,7 +295,7 @@ def docstring_examples_run(fn):
             try:
                 exec(line)
             except RuntimeError:
-                raise Exception("ERROR EXECUTING FUNCTION IN DOCSTRING")
+                raise Exception("ERROR EXECUTING IN DOCSTRING")
 
     output = f.getvalue()
     output = output.rstrip()
@@ -325,11 +323,8 @@ def docstring_examples_run(fn):
     print("Output: ", output)
     print("Putput: ", parsed_output)
 
-    # assert output == parsed_output, "Output is unequal to the docstrings output."
-    if output == parsed_output:
-        return True
-
-    return False
+    assert output == parsed_output, "Output is unequal to the docstrings output."
+    return True
 
 
 def var_fn(a, b=None, c=None, dtype=None):

--- a/ivy_tests/test_ivy/test_docstrings.py
+++ b/ivy_tests/test_ivy/test_docstrings.py
@@ -24,7 +24,8 @@ def test_docstrings():
         "get_backend",
     ]
 
-    for k, v in ivy.__dict__.copy().items():
+    function_list = ivy.__dict__.items()
+    for k, v in function_list:
         if k in skip_functions:
             continue
         if k in ["namedtuple", "DType", "Dtype"] or helpers.docstring_examples_run(v):


### PR DESCRIPTION
Runtime error was being caused by `ivy.__dict__items()` changing size at runtime. A simple fix was creating a copy of this list before the loop. This also optimised the test significantly. 