### PR TITLE
Update numpy version in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy
+numpy>=1.22.0
 einops
 psutil
 termcolor


### PR DESCRIPTION
#1398 

The use of numpy.array_api is only available for numpy version >= v1.22.

Using the numpy version lower than v1.22 would result in import failure of ivy because import numpy.array_api is not found.