### PR TITLE
numeric support for operator functions - ivy (old)

### DIFF
--- a/ivy/functional/ivy/elementwise.py
+++ b/ivy/functional/ivy/elementwise.py
@@ -54,8 +54,8 @@ def bitwise_left_shift(
 @to_native_arrays_and_back
 @handle_out_argument
 def add(
-    x1: Union[ivy.Array, ivy.NativeArray],
-    x2: Union[ivy.Array, ivy.NativeArray],
+    x1: Union[float, ivy.Array, ivy.NativeArray],
+    x2: Union[float, ivy.Array, ivy.NativeArray],
     *,
     out: Optional[ivy.Array] = None,
 ) -> ivy.Array:
@@ -172,7 +172,7 @@ def add(
     ivy.array([5, 7, 9])
 
     With :code:`ivy.Container` input:
-    
+
     >>> x = ivy.Container(a=ivy.array([1, 2, 3]), \
                         b=ivy.array([2, 3, 4]))
     >>> y = ivy.Container(a=ivy.array([4, 5, 6]),\
@@ -279,10 +279,10 @@ def bitwise_xor(
     out: Optional[Union[ivy.Array, ivy.NativeArray]] = None,
 ) -> ivy.Array:
     """Computes the bitwise XOR of the underlying binary representation of each element
-    ``x1_i`` of the input array ``x1`` with the respective element ``x2_i`` of the input   
-    array ``x2``.   
+    ``x1_i`` of the input array ``x1`` with the respective element ``x2_i`` of the input
+    array ``x2``.
 
-    **Special cases**   
+    **Special cases**
 
     This function does not take floating point operands
 
@@ -327,7 +327,7 @@ def bitwise_xor(
     >>> ivy.bitwise_xor(a, b, out=y)
     >>> print(y)
     ivy.array([12, 22, 79])
- 
+
     >>> a = ivy.array([1, 2, 3])
     >>> b = ivy.array([3, 2, 1])
     >>> ivy.bitwise_xor(a, b, out = a)
@@ -341,8 +341,8 @@ def bitwise_xor(
     >>> y = ivy.bitwise_xor(a, b)
     >>> print(y)
     ivy.array([[ 4, 6, 89, 26, 57]])
-   
-    With a mix of :code: `ivy.Array` and :code:`ivy.NativeArray` inputs:  
+
+    With a mix of :code: `ivy.Array` and :code:`ivy.NativeArray` inputs:
 
     >>> a = ivy.array([0, 1, 3, 67, 91])
     >>> a = ivy.native_array([4, 7, 90, 89, 98])
@@ -350,7 +350,7 @@ def bitwise_xor(
     >>> print(y)
     ivy.array([[4, 6, 89, 26, 57]])
 
-    With :code: `ivy.Container` input:  
+    With :code: `ivy.Container` input:
 
     >>> x = ivy.Container(a = ivy.array([89]), \
     b = ivy.array([90]))
@@ -364,7 +364,7 @@ def bitwise_xor(
     }
 
     With a mix of :code:`ivy.Array` and :code:`ivy.Container` inputs:
-    
+
     >>> x = ivy.Container(a = ivy.array([-67, 21]), \
     b = ivy.array([78, 34]))
     >>> y = ivy.array([12, 13]])
@@ -384,9 +384,9 @@ def bitwise_xor(
     >>> b = ivy.array([[[19, 26, 27], [22, 23, 20]]])
     >>> y = a.bitwise_xor(b)
     >>> print(y)
-    ivy.array([[74, 41, 59], 
+    ivy.array([[74, 41, 59],
     [24, 5, 7]])
-    
+
     Using :code:`ivy.Container` instance method:
 
     >>>x = ivy.Container(a = ivy.array([89]), \
@@ -398,12 +398,12 @@ def bitwise_xor(
     {
     a:ivy.array([20])
     b:ivy.array([85])
-    } 
-    
+    }
+
     Operator Examples
     -----------------
 
-    With :code:`ivy.Array` instances:  
+    With :code:`ivy.Array` instances:
 
     >>> a = ivy.array([1, 2, 3])
     >>> b = ivy.array([3, 2, 1])
@@ -411,7 +411,7 @@ def bitwise_xor(
     >>> print(y)
     ivy.array([2, 0, 2])
 
-    With :code:`ivy.Container` instances:   
+    With :code:`ivy.Container` instances:
 
     >>> x = ivy.Container(a = ivy.array([89]), \
     b = ivy.array([90]))
@@ -422,8 +422,8 @@ def bitwise_xor(
     {
     a:ivy.array([20])
     b:ivy.array([85])
-    }   
-    
+    }
+
     With mix of :code:`ivy.Array` and :code:`ivy.Container` instances:
 
     >>> x = ivy.Container(a = ivy.array([-67, 21]), \
@@ -434,7 +434,7 @@ def bitwise_xor(
     {
     a: ivy.array([-79, 24])
     b: ivy.array([6, 74])
-    }   
+    }
     """
     return current_backend(x1, x2).bitwise_xor(x1, x2, out=out)
 
@@ -866,8 +866,8 @@ def isinf(
 @handle_out_argument
 @handle_nestable
 def greater(
-    x1: Union[ivy.Array, ivy.NativeArray],
-    x2: Union[ivy.Array, ivy.NativeArray],
+    x1: Union[float, ivy.Array, ivy.NativeArray],
+    x2: Union[float, ivy.Array, ivy.NativeArray],
     *,
     out: Optional[Union[ivy.Array, ivy.NativeArray]] = None,
 ) -> ivy.Array:
@@ -903,8 +903,8 @@ def greater(
 @handle_out_argument
 @handle_nestable
 def greater_equal(
-    x1: Union[ivy.Array, ivy.NativeArray],
-    x2: Union[ivy.Array, ivy.NativeArray],
+    x1: Union[float, ivy.Array, ivy.NativeArray],
+    x2: Union[float, ivy.Array, ivy.NativeArray],
     *,
     out: Optional[Union[ivy.Array, ivy.NativeArray]] = None,
 ) -> ivy.Array:
@@ -1068,8 +1068,8 @@ def greater_equal(
 @handle_out_argument
 @handle_nestable
 def less_equal(
-    x1: Union[ivy.Array, ivy.NativeArray],
-    x2: Union[ivy.Array, ivy.NativeArray],
+    x1: Union[float, ivy.Array, ivy.NativeArray],
+    x2: Union[float, ivy.Array, ivy.NativeArray],
     *,
     out: Optional[Union[ivy.Array, ivy.NativeArray]] = None,
 ) -> ivy.Array:
@@ -1098,8 +1098,8 @@ def less_equal(
 @handle_out_argument
 @handle_nestable
 def multiply(
-    x1: Union[ivy.Array, ivy.NativeArray],
-    x2: Union[ivy.Array, ivy.NativeArray],
+    x1: Union[float, ivy.Array, ivy.NativeArray],
+    x2: Union[float, ivy.Array, ivy.NativeArray],
     *,
     out: Optional[Union[ivy.Array, ivy.NativeArray]] = None,
 ) -> ivy.Array:
@@ -1564,8 +1564,8 @@ def isnan(
 @handle_out_argument
 @handle_nestable
 def less(
-    x1: Union[ivy.Array, ivy.NativeArray],
-    x2: Union[ivy.Array, ivy.NativeArray],
+    x1: Union[float, ivy.Array, ivy.NativeArray],
+    x2: Union[float, ivy.Array, ivy.NativeArray],
     *,
     out: Optional[Union[ivy.Array, ivy.NativeArray]] = None,
 ) -> ivy.Array:
@@ -1913,7 +1913,7 @@ def sin(
 @handle_out_argument
 @handle_nestable
 def negative(
-    x: Union[ivy.Array, ivy.NativeArray],
+    x: Union[float, ivy.Array, ivy.NativeArray],
     *,
     out: Optional[ivy.Array] = None,
 ) -> ivy.Array:
@@ -2024,8 +2024,8 @@ def negative(
 @handle_out_argument
 @handle_nestable
 def not_equal(
-    x1: Union[ivy.Array, ivy.NativeArray],
-    x2: Union[ivy.Array, ivy.NativeArray],
+    x1: Union[float, ivy.Array, ivy.NativeArray],
+    x2: Union[float, ivy.Array, ivy.NativeArray],
     *,
     out: Optional[Union[ivy.Array, ivy.NativeArray]] = None,
 ) -> ivy.Array:
@@ -2057,8 +2057,8 @@ def not_equal(
 @handle_out_argument
 @handle_nestable
 def floor_divide(
-    x1: Union[ivy.Array, ivy.NativeArray],
-    x2: Union[ivy.Array, ivy.NativeArray],
+    x1: Union[float, ivy.Array, ivy.NativeArray],
+    x2: Union[float, ivy.Array, ivy.NativeArray],
     *,
     out: Optional[Union[ivy.Array, ivy.NativeArray]] = None,
 ) -> ivy.Array:
@@ -2163,7 +2163,7 @@ def sinh(
 @handle_out_argument
 @handle_nestable
 def positive(
-    x: Union[ivy.Array, ivy.NativeArray],
+    x: Union[float, ivy.Array, ivy.NativeArray],
     *,
     out: Optional[Union[ivy.Array, ivy.NativeArray]] = None,
 ) -> ivy.Array:
@@ -2407,7 +2407,7 @@ def trunc(
 @handle_out_argument
 @handle_nestable
 def abs(
-    x: Union[ivy.Array, ivy.NativeArray],
+    x: Union[float, ivy.Array, ivy.NativeArray],
     *,
     out: Optional[Union[ivy.Array, ivy.NativeArray]] = None,
 ) -> ivy.Array:
@@ -2511,7 +2511,7 @@ def tan(
                         [-4.4, -5.5, -6.6]])
     >>> ivy.tan(x, out=x)
     >>> print(x)
-    ivy.array([[1.96, -1.37, 0.16], 
+    ivy.array([[1.96, -1.37, 0.16],
         [-3.1, 0.996, -0.328]])
 
     With :code:`ivy.NativeArray` input:
@@ -2746,8 +2746,8 @@ def atanh(
 @handle_out_argument
 @handle_nestable
 def subtract(
-    x1: Union[ivy.Array, ivy.NativeArray],
-    x2: Union[ivy.Array, ivy.NativeArray],
+    x1: Union[float, ivy.Array, ivy.NativeArray],
+    x2: Union[float, ivy.Array, ivy.NativeArray],
     *,
     out: Optional[Union[ivy.Array, ivy.NativeArray]] = None,
 ) -> ivy.Array:
@@ -2778,8 +2778,8 @@ def subtract(
 @handle_out_argument
 @handle_nestable
 def divide(
-    x1: Union[ivy.Array, ivy.NativeArray],
-    x2: Union[ivy.Array, ivy.NativeArray],
+    x1: Union[float, ivy.Array, ivy.NativeArray],
+    x2: Union[float, ivy.Array, ivy.NativeArray],
     *,
     out: Optional[Union[ivy.Array, ivy.NativeArray]] = None,
 ) -> ivy.Array:
@@ -2808,8 +2808,8 @@ def divide(
 @handle_out_argument
 @handle_nestable
 def pow(
-    x1: Union[ivy.Array, ivy.NativeArray],
-    x2: Union[ivy.Array, ivy.NativeArray],
+    x1: Union[float, ivy.Array, ivy.NativeArray],
+    x2: Union[float, ivy.Array, ivy.NativeArray],
     *,
     out: Optional[Union[ivy.Array, ivy.NativeArray]] = None,
 ) -> ivy.Array:
@@ -2897,8 +2897,8 @@ def pow(
 @handle_out_argument
 @handle_nestable
 def remainder(
-    x1: Union[ivy.Array, ivy.NativeArray],
-    x2: Union[ivy.Array, ivy.NativeArray],
+    x1: Union[float, ivy.Array, ivy.NativeArray],
+    x2: Union[float, ivy.Array, ivy.NativeArray],
     *,
     out: Optional[Union[ivy.Array, ivy.NativeArray]] = None,
 ) -> ivy.Array:
@@ -3024,8 +3024,8 @@ def bitwise_right_shift(
 @handle_out_argument
 @handle_nestable
 def equal(
-    x1: Union[ivy.Array, ivy.NativeArray],
-    x2: Union[ivy.Array, ivy.NativeArray],
+    x1: Union[float, ivy.Array, ivy.NativeArray],
+    x2: Union[float, ivy.Array, ivy.NativeArray],
     *,
     out: Optional[Union[ivy.Array, ivy.NativeArray]] = None,
 ) -> ivy.Array:


### PR DESCRIPTION
operator functions with numeric support added: 
- add, subtract, divide, floor_divide, multiply, remainder, pow
- positive, negative, abs
- less, less_equal, greater, greater_equal, equal, not_equal
- bitwise => and, or, xor, invert, left_shift, right_shift

Feel free to let me know if I left out any other operator functions! Thank you!!