### PR TITLE
Unskipping tests for dtypes supported in torch

### DIFF
--- a/ivy/functional/backends/torch/image.py
+++ b/ivy/functional/backends/torch/image.py
@@ -58,6 +58,9 @@ def linear_resample(x, num_samples: int, axis: int = -1):
     return ret
 
 
+linear_resample.unsupported_dtypes = ("float16",)
+
+
 # noinspection PyUnresolvedReferences
 def bilinear_resample(x, warp):
     batch_shape = x.shape[:-3]

--- a/ivy/functional/backends/torch/sorting.py
+++ b/ivy/functional/backends/torch/sorting.py
@@ -10,6 +10,9 @@ def argsort(
     return ret
 
 
+argsort.unsupported_dtypes = ("uint16", "uint32", "uint64",)
+
+
 def sort(
     x: torch.Tensor,
     axis: int = -1,

--- a/ivy_tests/test_ivy/test_functional/test_core/test_creation.py
+++ b/ivy_tests/test_ivy/test_functional/test_core/test_creation.py
@@ -170,8 +170,6 @@ def test_from_dlpack(
     fw,
 ):
     dtype, x = dtype_and_x
-    if fw == "torch" and dtype == "float16":
-        return
     helpers.test_array_function(
         dtype,
         as_variable,
@@ -251,8 +249,6 @@ def test_ones_like(
     fw,
 ):
     dtype, x = dtype_and_x
-    if fw == "torch" and dtype == "float16":
-        return
     helpers.test_array_function(
         dtype,
         as_variable,
@@ -291,8 +287,6 @@ def test_zeros_like(
     fw,
 ):
     dtype, x = dtype_and_x
-    if fw == "torch" and dtype == "float16":
-        return
     helpers.test_array_function(
         dtype,
         as_variable,

--- a/ivy_tests/test_ivy/test_functional/test_core/test_dtype.py
+++ b/ivy_tests/test_ivy/test_functional/test_core/test_dtype.py
@@ -91,9 +91,6 @@ def test_broadcast_to(
     instance_method,
     fw,
 ):
-    # smoke this for torch
-    if fw == "torch" and input_dtype in ["uint16", "uint32", "uint64"]:
-        return
     x = data.draw(helpers.nph.arrays(shape=array_shape, dtype=input_dtype))
     helpers.test_array_function(
         input_dtype,
@@ -288,9 +285,6 @@ def test_is_float_dtype(
     instance_method,
     fw,
 ):
-    # smoke this for torch
-    if fw == "torch" and input_dtype in ["uint16", "uint32", "uint64"]:
-        return
     x = data.draw(helpers.nph.arrays(shape=array_shape, dtype=input_dtype))
     helpers.test_array_function(
         input_dtype,
@@ -330,9 +324,6 @@ def test_is_int_dtype(
     instance_method,
     fw,
 ):
-    # smoke this for torch
-    if fw == "torch" and input_dtype in ["uint16", "uint32", "uint64"]:
-        return
     x = data.draw(helpers.nph.arrays(shape=array_shape, dtype=input_dtype))
     helpers.test_array_function(
         input_dtype,

--- a/ivy_tests/test_ivy/test_functional/test_core/test_image.py
+++ b/ivy_tests/test_ivy/test_functional/test_core/test_image.py
@@ -69,8 +69,6 @@ def test_linear_resample(
     container,
     fw,
 ):
-    if fw == "torch" and input_dtype == "float16":
-        return
     x = ivy_np.random_normal(shape=shape, device=ivy.default_device())
     axis = random.randint(0, len(shape) - 1)
     helpers.test_array_function(
@@ -113,8 +111,6 @@ def test_bilinear_resample(
     container,
     fw,
 ):
-    if fw == "torch" and input_dtype == "float16":
-        return
     x = ivy.random_normal(shape=batch_shape + h_w + [n_dims])
     warp = ivy.random_uniform(shape=batch_shape + [n_samples, 2])
     helpers.test_array_function(

--- a/ivy_tests/test_ivy/test_functional/test_core/test_manipulation.py
+++ b/ivy_tests/test_ivy/test_functional/test_core/test_manipulation.py
@@ -99,10 +99,6 @@ def test_expand_dims(
     seed,
     fw,
 ):
-    # smoke this for torch
-    if fw == "torch" and input_dtype in ["uint16", "uint32", "uint64"]:
-        return
-
     np.random.seed(seed)
 
     x = np.random.uniform(size=array_shape).astype(input_dtype)
@@ -150,10 +146,6 @@ def test_flip(
     seed,
     fw,
 ):
-    # smoke this for torch
-    if fw == "torch" and input_dtype in ["uint16", "uint32", "uint64"]:
-        return
-
     np.random.seed(seed)
 
     x = np.random.uniform(size=array_shape).astype(input_dtype)
@@ -199,9 +191,6 @@ def test_permute_dims(
     seed,
     fw,
 ):
-    # smoke this for torch
-    if fw == "torch" and input_dtype in ["uint16", "uint32", "uint64"]:
-        return
 
     np.random.seed(seed)
 
@@ -252,10 +241,6 @@ def test_reshape(
     instance_method,
     fw,
 ):
-    # smoke for torch
-    if fw == "torch" and input_dtype in ["uint16", "uint32", "uint64"]:
-        return
-
     x = data.draw(helpers.nph.arrays(shape=array_shape, dtype=input_dtype))
 
     # draw a valid reshape shape
@@ -302,10 +287,6 @@ def test_roll(
     instance_method,
     fw,
 ):
-    # smoke for torch
-    if fw == "torch" and input_dtype in ["uint16", "uint32", "uint64"]:
-        return
-
     x = data.draw(helpers.nph.arrays(shape=array_shape, dtype=input_dtype))
     ndim = len(x.shape)
 
@@ -374,10 +355,6 @@ def test_squeeze(
     instance_method,
     fw,
 ):
-    # smoke for torch
-    if fw == "torch" and input_dtype in ["uint16", "uint32", "uint64"]:
-        return
-
     x = data.draw(helpers.nph.arrays(shape=array_shape, dtype=input_dtype))
     squeezable_axes = [i for i, side in enumerate(x.shape) if side == 1]
 
@@ -434,10 +411,6 @@ def test_stack(
     instance_method,
     fw,
 ):
-    # smoke for torch
-    if fw == "torch" and input_dtype in ["uint16", "uint32", "uint64"]:
-        return
-
     xs = [
         data.draw(helpers.nph.arrays(shape=array_shape, dtype=input_dtype[i]))
         for i in range(num_arrays)
@@ -489,7 +462,6 @@ def test_repeat(
     instance_method,
     fw,
 ):
-
     # smoke for torch
     # smoke for tensorflow as well, since it was throwing an error
     # as unint16 not implemented in Tile or something
@@ -548,10 +520,6 @@ def test_tile(
     instance_method,
     fw,
 ):
-    # smoke for torch
-    if fw == "torch" and input_dtype in ["uint16", "uint32", "uint64"]:
-        return
-
     x = data.draw(helpers.nph.arrays(shape=array_shape, dtype=input_dtype))
 
     # tensorflow needs that reps is exactly of same dimensions as the input
@@ -608,10 +576,6 @@ def test_constant_pad(
     instance_method,
     fw,
 ):
-    # smoke for torch
-    if fw == "torch" and input_dtype in ["uint16", "uint32", "uint64"]:
-        return
-
     x = data.draw(helpers.nph.arrays(shape=array_shape, dtype=input_dtype))
     pads = [
         (data.draw(st.integers(0, 3)), data.draw(st.integers(0, 3)))
@@ -661,10 +625,6 @@ def test_zero_pad(
     instance_method,
     fw,
 ):
-    # smoke for torch
-    if fw == "torch" and input_dtype in ["uint16", "uint32", "uint64"]:
-        return
-
     x = data.draw(helpers.nph.arrays(shape=array_shape, dtype=input_dtype))
     pads = [
         (data.draw(st.integers(0, 3)), data.draw(st.integers(0, 3)))
@@ -712,10 +672,6 @@ def test_swapaxes(
     instance_method,
     fw,
 ):
-    # smoke for torch
-    if fw == "torch" and input_dtype in ["uint16", "uint32", "uint64"]:
-        return
-
     x = data.draw(helpers.nph.arrays(shape=array_shape, dtype=input_dtype))
     valid_axes = st.integers(0, len(x.shape) - 1)
     axis0 = data.draw(valid_axes)

--- a/ivy_tests/test_ivy/test_functional/test_core/test_set.py
+++ b/ivy_tests/test_ivy/test_functional/test_core/test_set.py
@@ -32,10 +32,8 @@ def test_unique_values(
     fw,
     device,
 ):
-    if fw == "torch" and ("int" in input_dtype or "16" in input_dtype):
-        return
-
     shape = tuple(array_shape)
+
     x = np.random.uniform(size=shape).astype(input_dtype)
 
     helpers.test_array_function(
@@ -74,10 +72,8 @@ def test_unique_all(
     fw,
     device,
 ):
-    if fw == "torch" and ("int" in input_dtype or "16" in input_dtype):
-        return
-
     shape = tuple(array_shape)
+
     x = np.random.uniform(size=shape).astype(input_dtype)
 
     helpers.test_array_function(
@@ -118,9 +114,6 @@ def test_unique_counts(
     fw,
     device,
 ):
-    if fw == "torch" and ("int" in input_dtype or "16" in input_dtype):
-        return
-
     x = data.draw(helpers.nph.arrays(shape=array_shape, dtype=input_dtype))
 
     helpers.test_array_function(
@@ -161,7 +154,6 @@ def test_unique_inverse(
     fw,
     device,
 ):
-
     if fw == "torch" and ("int" in input_dtype or "16" in input_dtype):
         return
 

--- a/ivy_tests/test_ivy/test_functional/test_core/test_sorting.py
+++ b/ivy_tests/test_ivy/test_functional/test_core/test_sorting.py
@@ -35,10 +35,6 @@ def test_argsort(
     instance_method,
     fw,
 ):
-    # smoke for torch
-    if fw == "torch" and input_dtype in ["uint16", "uint32", "uint64"]:
-        return
-
     # we do not want any nans
     x = data.draw(
         helpers.nph.arrays(shape=array_shape, dtype=input_dtype).filter(


### PR DESCRIPTION
・Unskipping tests for dtypes supported in torch
・`unsupported_dtypes` attribute added to torch backends where necessary for only the dtypes that require skipping