### PR TITLE
remove device arg from scatter and gather

### DIFF
--- a/ivy/functional/backends/jax/general.py
+++ b/ivy/functional/backends/jax/general.py
@@ -134,13 +134,11 @@ def cumprod(
     return jnp.cumprod(x, axis)
 
 
-def scatter_flat(indices, updates, size=None, tensor=None, reduction="sum", *, device):
+def scatter_flat(indices, updates, size=None, tensor=None, reduction="sum"):
     target = tensor
     target_given = ivy.exists(target)
     if ivy.exists(size) and ivy.exists(target):
         assert len(target.shape) == 1 and target.shape[0] == size
-    if device is None:
-        device = dev(updates)
     if reduction == "sum":
         if not target_given:
             target = jnp.zeros([size], dtype=updates.dtype)
@@ -167,11 +165,11 @@ def scatter_flat(indices, updates, size=None, tensor=None, reduction="sum", *, d
                 reduction
             )
         )
-    return _to_device(target, device)
+    return _to_device(target)
 
 
 # noinspection PyShadowingNames
-def scatter_nd(indices, updates, shape=None, tensor=None, reduction="sum", *, device):
+def scatter_nd(indices, updates, shape=None, tensor=None, reduction="sum"):
 
     # parse numeric inputs
     if indices not in [Ellipsis, ()] and not (
@@ -204,8 +202,6 @@ def scatter_nd(indices, updates, shape=None, tensor=None, reduction="sum", *, de
     target_given = ivy.exists(target)
     if ivy.exists(shape) and ivy.exists(target):
         assert ivy.shape_to_tuple(target.shape) == ivy.shape_to_tuple(shape)
-    if device is None:
-        device = dev(updates)
     shape = list(shape) if ivy.exists(shape) else list(tensor.shape)
     if reduction == "sum":
         if not target_given:
@@ -233,7 +229,7 @@ def scatter_nd(indices, updates, shape=None, tensor=None, reduction="sum", *, de
                 reduction
             )
         )
-    return _to_device(target, device)
+    return _to_device(target)
 
 
 def gather(

--- a/ivy/functional/backends/jax/general.py
+++ b/ivy/functional/backends/jax/general.py
@@ -232,12 +232,8 @@ def scatter_nd(indices, updates, shape=None, tensor=None, reduction="sum"):
     return _to_device(target)
 
 
-def gather(
-    params: JaxArray, indices: JaxArray, axis: Optional[int] = -1, *, device: str
-) -> JaxArray:
-    if device is None:
-        device = dev(params)
-    return _to_device(jnp.take_along_axis(params, indices, axis), device)
+def gather(params: JaxArray, indices: JaxArray, axis: Optional[int] = -1) -> JaxArray:
+    return _to_device(jnp.take_along_axis(params, indices, axis))
 
 
 def gather_nd(params, indices, *, device: str):

--- a/ivy/functional/backends/jax/general.py
+++ b/ivy/functional/backends/jax/general.py
@@ -16,7 +16,7 @@ from haiku._src.data_structures import FlatMapping
 # local
 import ivy
 from ivy.functional.ivy.device import default_device
-from ivy.functional.backends.jax.device import _to_device, _to_array, dev
+from ivy.functional.backends.jax.device import _to_device, _to_array
 from ivy.functional.backends.jax import JaxArray
 
 
@@ -236,9 +236,7 @@ def gather(params: JaxArray, indices: JaxArray, axis: Optional[int] = -1) -> Jax
     return _to_device(jnp.take_along_axis(params, indices, axis))
 
 
-def gather_nd(params, indices, *, device: str):
-    if device is None:
-        device = dev(params)
+def gather_nd(params, indices):
     indices_shape = indices.shape
     params_shape = params.shape
     num_index_dims = indices_shape[-1]
@@ -263,7 +261,7 @@ def gather_nd(params, indices, *, device: str):
     flat_gather = jnp.take(flat_params, flat_indices_for_flat, 0)
     new_shape = list(indices_shape[:-1]) + list(params_shape[num_index_dims:])
     ret = jnp.reshape(flat_gather, new_shape)
-    return _to_device(ret, device)
+    return _to_device(ret)
 
 
 def multiprocessing(context=None):

--- a/ivy/functional/backends/numpy/general.py
+++ b/ivy/functional/backends/numpy/general.py
@@ -163,13 +163,11 @@ def scatter_flat(indices, updates, size=None, tensor=None, reduction="sum"):
 
 
 # noinspection PyShadowingNames
-def scatter_nd(indices, updates, shape=None, tensor=None, reduction="sum", *, device):
+def scatter_nd(indices, updates, shape=None, tensor=None, reduction="sum"):
     target = tensor
     target_given = ivy.exists(target)
     if ivy.exists(shape) and ivy.exists(target):
         assert ivy.shape_to_tuple(target.shape) == ivy.shape_to_tuple(shape)
-    if device is None:
-        device = dev(updates)
     shape = list(shape) if ivy.exists(shape) else list(tensor.shape)
     indices_flat = indices.reshape(-1, indices.shape[-1]).T
     indices_tuple = tuple(indices_flat) + (Ellipsis,)
@@ -201,7 +199,7 @@ def scatter_nd(indices, updates, shape=None, tensor=None, reduction="sum", *, de
                 reduction
             )
         )
-    return _to_device(target, device)
+    return _to_device(target)
 
 
 def gather(

--- a/ivy/functional/backends/numpy/general.py
+++ b/ivy/functional/backends/numpy/general.py
@@ -10,7 +10,7 @@ from numbers import Number
 
 # local
 import ivy
-from ivy.functional.backends.numpy.device import dev, _to_device
+from ivy.functional.backends.numpy.device import _to_device
 
 # Helpers #
 # --------#
@@ -210,9 +210,7 @@ def gather(
     return _to_device(np.take_along_axis(params, indices, axis))
 
 
-def gather_nd(params, indices, *, device: str):
-    if device is None:
-        device = dev(params)
+def gather_nd(params, indices):
     indices_shape = indices.shape
     params_shape = params.shape
     num_index_dims = indices_shape[-1]
@@ -237,7 +235,7 @@ def gather_nd(params, indices, *, device: str):
     flat_gather = np.take(flat_params, flat_indices_for_flat, 0)
     new_shape = list(indices_shape[:-1]) + list(params_shape[num_index_dims:])
     res = np.reshape(flat_gather, new_shape)
-    return _to_device(res, device)
+    return _to_device(res)
 
 
 def multiprocessing(context=None):

--- a/ivy/functional/backends/numpy/general.py
+++ b/ivy/functional/backends/numpy/general.py
@@ -203,11 +203,11 @@ def scatter_nd(indices, updates, shape=None, tensor=None, reduction="sum"):
 
 
 def gather(
-    params: np.ndarray, indices: np.ndarray, axis: Optional[int] = -1, *, device: str
+    params: np.ndarray,
+    indices: np.ndarray,
+    axis: Optional[int] = -1,
 ) -> np.ndarray:
-    if device is None:
-        device = dev(params)
-    return _to_device(np.take_along_axis(params, indices, axis), device)
+    return _to_device(np.take_along_axis(params, indices, axis))
 
 
 def gather_nd(params, indices, *, device: str):

--- a/ivy/functional/backends/numpy/general.py
+++ b/ivy/functional/backends/numpy/general.py
@@ -126,13 +126,11 @@ def cumprod(
     return np.cumprod(x, axis, out=out)
 
 
-def scatter_flat(indices, updates, size=None, tensor=None, reduction="sum", *, device):
+def scatter_flat(indices, updates, size=None, tensor=None, reduction="sum"):
     target = tensor
     target_given = ivy.exists(target)
     if ivy.exists(size) and ivy.exists(target):
         assert len(target.shape) == 1 and target.shape[0] == size
-    if device is None:
-        device = dev(updates)
     if reduction == "sum":
         if not target_given:
             target = np.zeros([size], dtype=updates.dtype)
@@ -161,7 +159,7 @@ def scatter_flat(indices, updates, size=None, tensor=None, reduction="sum", *, d
                 reduction
             )
         )
-    return _to_device(target, device)
+    return _to_device(target)
 
 
 # noinspection PyShadowingNames

--- a/ivy/functional/backends/tensorflow/general.py
+++ b/ivy/functional/backends/tensorflow/general.py
@@ -14,7 +14,7 @@ from numbers import Number
 # local
 import ivy
 from ivy.functional.ivy.device import default_device
-from ivy.functional.backends.tensorflow.device import dev, as_native_dev
+from ivy.functional.backends.tensorflow.device import as_native_dev
 
 
 def is_native_array(x, exclusive=False):
@@ -302,11 +302,8 @@ def gather(
     return tf.gather(params, indices, axis=axis, batch_dims=axis)
 
 
-def gather_nd(params, indices, *, device: str):
-    if device is None:
-        device = dev(params)
-    with tf.device(as_native_dev(device)):
-        return tf.gather_nd(params, indices)
+def gather_nd(params, indices):
+    return tf.gather_nd(params, indices)
 
 
 def one_hot(indices, depth, *, device):

--- a/ivy/functional/backends/tensorflow/general.py
+++ b/ivy/functional/backends/tensorflow/general.py
@@ -144,13 +144,11 @@ def cumprod(
 
 
 # noinspection PyShadowingNames
-def scatter_flat(indices, updates, size=None, tensor=None, reduction="sum", *, device):
+def scatter_flat(indices, updates, size=None, tensor=None, reduction="sum"):
     target = tensor
     target_given = ivy.exists(target)
     if ivy.exists(size) and ivy.exists(target):
         assert len(target.shape) == 1 and target.shape[0] == size
-    if device is None:
-        device = dev(updates)
     dtype = updates.dtype
     if reduction == "sum":
         if target_given:
@@ -185,8 +183,7 @@ def scatter_flat(indices, updates, size=None, tensor=None, reduction="sum", *, d
                 reduction
             )
         )
-    with tf.device(as_native_dev(device)):
-        return res
+    return res
 
 
 def _parse_ellipsis(so, ndims):

--- a/ivy/functional/backends/tensorflow/general.py
+++ b/ivy/functional/backends/tensorflow/general.py
@@ -205,7 +205,7 @@ def _parse_ellipsis(so, ndims):
 
 
 # noinspection PyShadowingNames
-def scatter_nd(indices, updates, shape=None, tensor=None, reduction="sum", *, device):
+def scatter_nd(indices, updates, shape=None, tensor=None, reduction="sum"):
 
     if ivy.exists(tensor) and not isinstance(updates, Number):
         tensor = (
@@ -261,8 +261,6 @@ def scatter_nd(indices, updates, shape=None, tensor=None, reduction="sum", *, de
     target_given = ivy.exists(target)
     if ivy.exists(shape) and ivy.exists(target):
         assert ivy.shape_to_tuple(target.shape) == ivy.shape_to_tuple(shape)
-    if device is None:
-        device = dev(updates)
     shape = list(shape) if ivy.exists(shape) else list(tensor.shape)
     dtype = updates.dtype
     if reduction == "sum":
@@ -292,8 +290,7 @@ def scatter_nd(indices, updates, shape=None, tensor=None, reduction="sum", *, de
                 reduction
             )
         )
-    with tf.device(as_native_dev(device)):
-        return res
+    return res
 
 
 def gather(

--- a/ivy/functional/backends/tensorflow/general.py
+++ b/ivy/functional/backends/tensorflow/general.py
@@ -297,14 +297,9 @@ def gather(
     params: Union[tf.Tensor, tf.Variable],
     indices: Union[tf.Tensor, tf.Variable],
     axis: Optional[int] = -1,
-    *,
-    device: str,
 ) -> Union[tf.Tensor, tf.Variable]:
     axis = axis % len(indices.shape)
-    if device is None:
-        device = dev(params)
-    with tf.device(as_native_dev(device)):
-        return tf.gather(params, indices, axis=axis, batch_dims=axis)
+    return tf.gather(params, indices, axis=axis, batch_dims=axis)
 
 
 def gather_nd(params, indices, *, device: str):

--- a/ivy/functional/backends/torch/general.py
+++ b/ivy/functional/backends/torch/general.py
@@ -328,15 +328,8 @@ def gather(
     params: torch.Tensor,
     indices: torch.Tensor,
     axis: Optional[int] = -1,
-    *,
-    device: torch.device
 ) -> torch.Tensor:
-
-    if device is None:
-        device = dev(params)
-    return torch.gather(params, axis, indices.type(torch.int64)).to(
-        as_native_dev(device)
-    )
+    return torch.gather(params, axis, indices.type(torch.int64))
 
 
 # noinspection PyShadowingNames

--- a/ivy/functional/backends/torch/general.py
+++ b/ivy/functional/backends/torch/general.py
@@ -333,16 +333,14 @@ def gather(
 
 
 # noinspection PyShadowingNames
-def gather_nd(params, indices, *, device: torch.device):
-    if device is None:
-        device = dev(params)
+def gather_nd(params, indices):
     indices_shape = indices.shape
     params_shape = params.shape
     num_index_dims = indices_shape[-1]
     result_dim_sizes_list = [
         reduce(mul, params_shape[i + 1 :], 1) for i in range(len(params_shape) - 1)
     ] + [1]
-    result_dim_sizes = torch.tensor(result_dim_sizes_list).to(as_native_dev(device))
+    result_dim_sizes = torch.tensor(result_dim_sizes_list)
     implicit_indices_factor = int(result_dim_sizes[num_index_dims - 1].item())
     flat_params = torch.reshape(params, (-1,))
     new_shape = [1] * (len(indices_shape) - 1) + [num_index_dims]
@@ -350,9 +348,9 @@ def gather_nd(params, indices, *, device: torch.device):
     indices_for_flat_tiled = torch.reshape(
         torch.sum(indices * indices_scales, -1, keepdim=True), (-1, 1)
     ).repeat(*[1, implicit_indices_factor])
-    implicit_indices = torch.unsqueeze(
-        torch.arange(implicit_indices_factor).to(as_native_dev(device)), 0
-    ).repeat(*[indices_for_flat_tiled.shape[0], 1])
+    implicit_indices = torch.unsqueeze(torch.arange(implicit_indices_factor), 0).repeat(
+        *[indices_for_flat_tiled.shape[0], 1]
+    )
     indices_for_flat = indices_for_flat_tiled + implicit_indices
     flat_indices_for_flat = torch.reshape(indices_for_flat, (-1,)).type(torch.long)
     flat_gather = torch.gather(flat_params, 0, flat_indices_for_flat)

--- a/ivy/functional/backends/torch/general.py
+++ b/ivy/functional/backends/torch/general.py
@@ -204,7 +204,7 @@ def _parse_ellipsis(so, ndims):
 
 
 # noinspection PyShadowingNames
-def scatter_nd(indices, updates, shape=None, tensor=None, reduction="sum", *, device):
+def scatter_nd(indices, updates, shape=None, tensor=None, reduction="sum"):
 
     # handle numeric updates
     updates = torch.tensor(
@@ -257,8 +257,6 @@ def scatter_nd(indices, updates, shape=None, tensor=None, reduction="sum", *, de
     target_given = ivy.exists(target)
     if ivy.exists(shape) and ivy.exists(target):
         assert ivy.shape_to_tuple(target.shape) == ivy.shape_to_tuple(shape)
-    if device is None:
-        device = dev(updates)
     shape = list(shape) if ivy.exists(shape) else list(tensor.shape)
     dtype = updates.dtype
     indices_shape = indices.shape
@@ -266,15 +264,15 @@ def scatter_nd(indices, updates, shape=None, tensor=None, reduction="sum", *, de
     result_dim_sizes_list = [
         reduce(mul, shape[i + 1 :], 1) for i in range(len(shape) - 1)
     ] + [1]
-    result_dim_sizes = torch.tensor(result_dim_sizes_list).to(as_native_dev(device))
+    result_dim_sizes = torch.tensor(result_dim_sizes_list)
     implicit_indices_factor = int(result_dim_sizes[num_index_dims - 1].item())
     flat_result_size = reduce(mul, shape, 1)
     if reduction in ["sum", "replace"]:
-        initial_val = torch.tensor(0).type(dtype).to(as_native_dev(device))
+        initial_val = torch.tensor(0).type(dtype)
     elif reduction == "min":
-        initial_val = torch.tensor(1e12).type(dtype).to(as_native_dev(device))
+        initial_val = torch.tensor(1e12).type(dtype)
     elif reduction == "max":
-        initial_val = torch.tensor(-1e12).type(dtype).to(as_native_dev(device))
+        initial_val = torch.tensor(-1e12).type(dtype)
     else:
         raise Exception(
             'reduction is {}, but it must be one of "sum", "min" or "max"'.format(
@@ -284,19 +282,16 @@ def scatter_nd(indices, updates, shape=None, tensor=None, reduction="sum", *, de
     if target_given:
         flat_output = torch.reshape(tensor, (flat_result_size,))
     else:
-        flat_output = (
-            torch.ones(flat_result_size, dtype=dtype).to(as_native_dev(device))
-            * initial_val
-        )
+        flat_output = torch.ones(flat_result_size, dtype=dtype) * initial_val
     flat_updates = torch.reshape(updates, (-1,))
     new_shape = [1] * (len(indices_shape) - 1) + [num_index_dims]
     indices_scales = torch.reshape(result_dim_sizes[0:num_index_dims], new_shape)
     indices_for_flat_tiled = torch.reshape(
         torch.sum(indices * indices_scales, -1, keepdim=True), (-1, 1)
     ).repeat(*[1, implicit_indices_factor])
-    implicit_indices = torch.unsqueeze(
-        torch.arange(implicit_indices_factor).to(as_native_dev(device)), 0
-    ).repeat(*[indices_for_flat_tiled.shape[0], 1])
+    implicit_indices = torch.unsqueeze(torch.arange(implicit_indices_factor), 0).repeat(
+        *[indices_for_flat_tiled.shape[0], 1]
+    )
     indices_for_flat = indices_for_flat_tiled + implicit_indices
     flat_indices_for_flat = torch.reshape(indices_for_flat, (-1,)).type(torch.long)
     global torch_scatter
@@ -321,9 +316,7 @@ def scatter_nd(indices, updates, shape=None, tensor=None, reduction="sum", *, de
         # noinspection PyTypeChecker
         flat_scatter = torch.where(
             flat_scatter == initial_val,
-            torch.zeros(flat_result_size, dtype=updates.dtype).to(
-                as_native_dev(device)
-            ),
+            torch.zeros(flat_result_size, dtype=updates.dtype),
             flat_scatter,
         )
     res = torch.reshape(flat_scatter, list(shape))

--- a/ivy/functional/backends/torch/general.py
+++ b/ivy/functional/backends/torch/general.py
@@ -139,22 +139,18 @@ def scatter_flat(
     size: Optional[int] = None,
     tensor: Optional[torch.Tensor] = None,
     reduction: str = "sum",
-    *,
-    device: torch.device
 ):
     target = tensor
     target_given = ivy.exists(target)
     if ivy.exists(size) and ivy.exists(target):
         assert len(target.shape) == 1 and target.shape[0] == size
-    if device is None:
-        device = dev(updates)
     dtype = updates.dtype
     if reduction in ["sum", "replace"]:
-        initial_val = torch.tensor(0).type(dtype).to(as_native_dev(device))
+        initial_val = torch.tensor(0).type(dtype)
     elif reduction == "min":
-        initial_val = torch.tensor(1e12).type(dtype).to(as_native_dev(device))
+        initial_val = torch.tensor(1e12).type(dtype)
     elif reduction == "max":
-        initial_val = torch.tensor(-1e12).type(dtype).to(as_native_dev(device))
+        initial_val = torch.tensor(-1e12).type(dtype)
     else:
         raise Exception(
             'reduction is {}, but it must be one of "sum", "min" or "max"'.format(
@@ -164,7 +160,7 @@ def scatter_flat(
     if target_given:
         output = tensor
     else:
-        output = torch.ones([size], dtype=dtype).to(as_native_dev(device)) * initial_val
+        output = torch.ones([size], dtype=dtype) * initial_val
     global torch_scatter
     if torch_scatter is None:
         try:
@@ -183,7 +179,7 @@ def scatter_flat(
     if not target_given:
         return torch.where(
             res == initial_val,
-            torch.zeros([size], dtype=updates.dtype).to(as_native_dev(device)),
+            torch.zeros([size], dtype=updates.dtype),
             res,
         )
     return res

--- a/ivy/functional/ivy/general.py
+++ b/ivy/functional/ivy/general.py
@@ -2117,7 +2117,6 @@ def cumprod(
 
 @to_native_arrays_and_back
 @handle_out_argument
-@infer_device
 @handle_nestable
 def scatter_flat(
     indices: Union[ivy.Array, ivy.NativeArray],
@@ -2125,8 +2124,6 @@ def scatter_flat(
     size: Optional[int] = None,
     tensor: Optional[Union[ivy.Array, ivy.NativeArray]] = None,
     reduction: str = "sum",
-    *,
-    device: Union[ivy.Device, ivy.NativeDevice] = None,
 ) -> Union[ivy.Array, ivy.NativeArray]:
     """Scatter flat updates into a new flat array according to flat indices.
 
@@ -2155,13 +2152,12 @@ def scatter_flat(
 
     """
     return current_backend(indices).scatter_flat(
-        indices, updates, size, tensor, reduction, device=device
+        indices, updates, size, tensor, reduction
     )
 
 
 @to_native_arrays_and_back
 @handle_out_argument
-@infer_device
 @handle_nestable
 def scatter_nd(
     indices: Union[ivy.Array, ivy.NativeArray],
@@ -2169,8 +2165,6 @@ def scatter_nd(
     shape: Optional[Iterable[int]] = None,
     tensor: Optional[Union[ivy.Array, ivy.NativeArray]] = None,
     reduction: str = "sum",
-    *,
-    device: Union[ivy.Device, ivy.NativeDevice] = None,
 ) -> Union[ivy.Array, ivy.NativeArray]:
     """Scatter updates into a new array according to indices.
 
@@ -2200,20 +2194,18 @@ def scatter_nd(
 
     """
     return current_backend(indices).scatter_nd(
-        indices, updates, shape, tensor, reduction, device=device
+        indices, updates, shape, tensor, reduction
     )
 
 
 @to_native_arrays_and_back
 @handle_out_argument
-@infer_device
 @handle_nestable
 def gather(
     params: Union[ivy.Array, ivy.NativeArray],
     indices: Union[ivy.Array, ivy.NativeArray],
     axis: int = -1,
     *,
-    device: Union[ivy.Device, ivy.NativeDevice] = None,
     out: Optional[Union[ivy.Array, ivy.NativeArray]] = None,
 ) -> Union[ivy.Array, ivy.NativeArray]:
     """Gather slices from params at axis according to indices.
@@ -2343,18 +2335,16 @@ def gather(
         }
     }
     """
-    return current_backend(params).gather(params, indices, axis, device=device, out=out)
+    return current_backend(params).gather(params, indices, axis, out=out)
 
 
 @to_native_arrays_and_back
 @handle_out_argument
-@infer_device
 @handle_nestable
 def gather_nd(
     params: Union[ivy.Array, ivy.NativeArray],
     indices: Union[ivy.Array, ivy.NativeArray],
     *,
-    device: Union[ivy.Device, ivy.NativeDevice] = None,
     out: Optional[ivy.Array] = None,
 ) -> Union[ivy.Array, ivy.NativeArray]:
     """Gather slices from params into a array with shape specified by indices.
@@ -2375,7 +2365,7 @@ def gather_nd(
         New array of given shape, with the values gathered at the indices.
 
     """
-    return current_backend(params).gather_nd(params, indices, device=device, out=out)
+    return current_backend(params).gather_nd(params, indices, out=out)
 
 
 @handle_nestable

--- a/ivy_tests/test_ivy/test_functional/test_core/test_general.py
+++ b/ivy_tests/test_ivy/test_functional/test_core/test_general.py
@@ -967,22 +967,22 @@ def test_gather(prms_n_inds_n_axis, dtype, with_out, tensor_fn, call):
 )
 @pytest.mark.parametrize("dtype", ["float32"])
 @pytest.mark.parametrize("tensor_fn", [ivy.array, helpers.var_fn])
-def test_gather_nd(prms_n_inds, dtype, tensor_fn, device, call):
+def test_gather_nd(prms_n_inds, dtype, tensor_fn, call):
     # smoke test
     prms, inds = prms_n_inds
-    prms = tensor_fn(prms, dtype=dtype, device=device)
-    inds = ivy.array(inds, dtype="int32", device=device)
-    ret = ivy.gather_nd(prms, inds, device=device)
+    prms = tensor_fn(prms, dtype=dtype)
+    inds = ivy.array(inds, dtype="int32")
+    ret = ivy.gather_nd(prms, inds)
     # type test
     assert ivy.is_ivy_array(ret)
     # cardinality test
     assert ret.shape == inds.shape[:-1] + prms.shape[inds.shape[-1] :]
     # value test
     assert np.allclose(
-        call(ivy.gather_nd, prms, inds, device=device),
+        call(ivy.gather_nd, prms, inds),
         np.asarray(
             ivy.functional.backends.numpy.gather_nd(
-                ivy.to_numpy(prms), ivy.to_numpy(inds), device=device
+                ivy.to_numpy(prms), ivy.to_numpy(inds)
             )
         ),
     )

--- a/ivy_tests/test_ivy/test_functional/test_core/test_general.py
+++ b/ivy_tests/test_ivy/test_functional/test_core/test_general.py
@@ -922,26 +922,26 @@ def test_scatter_nd(inds_n_upd_n_shape_tnsr_n_wdup, red, dtype, tensor_fn, call)
 @pytest.mark.parametrize("dtype", ["float32"])
 @pytest.mark.parametrize("with_out", [True, False])
 @pytest.mark.parametrize("tensor_fn", [ivy.array, helpers.var_fn])
-def test_gather(prms_n_inds_n_axis, dtype, with_out, tensor_fn, device, call):
+def test_gather(prms_n_inds_n_axis, dtype, with_out, tensor_fn, call):
     # smoke test
     prms, inds, axis = prms_n_inds_n_axis
-    prms = tensor_fn(prms, dtype=dtype, device=device)
-    inds = ivy.array(inds, dtype="int32", device=device)
+    prms = tensor_fn(prms, dtype=dtype)
+    inds = ivy.array(inds, dtype="int32")
     if with_out:
         out = ivy.zeros(inds.shape)
-        ret = ivy.gather(prms, inds, axis, device=device, out=out)
+        ret = ivy.gather(prms, inds, axis, out=out)
     else:
-        ret = ivy.gather(prms, inds, axis, device=device)
+        ret = ivy.gather(prms, inds, axis)
     # type test
     assert ivy.is_ivy_array(ret)
     # cardinality test
     assert ret.shape == inds.shape
     # value test
     assert np.allclose(
-        call(ivy.gather, prms, inds, axis, device=device),
+        call(ivy.gather, prms, inds, axis),
         np.asarray(
             ivy.functional.backends.numpy.gather(
-                ivy.to_numpy(prms), ivy.to_numpy(inds), axis, device=device
+                ivy.to_numpy(prms), ivy.to_numpy(inds), axis
             )
         ),
     )

--- a/ivy_tests/test_ivy/test_functional/test_core/test_general.py
+++ b/ivy_tests/test_ivy/test_functional/test_core/test_general.py
@@ -868,9 +868,7 @@ def test_scatter_flat(inds_n_upd_n_size_n_tnsr_n_wdup, red, dtype, tensor_fn, ca
 @pytest.mark.parametrize("red", ["sum", "min", "max", "replace"])
 @pytest.mark.parametrize("dtype", ["float32"])
 @pytest.mark.parametrize("tensor_fn", [ivy.array, helpers.var_fn])
-def test_scatter_nd(
-    inds_n_upd_n_shape_tnsr_n_wdup, red, dtype, tensor_fn, device, call
-):
+def test_scatter_nd(inds_n_upd_n_shape_tnsr_n_wdup, red, dtype, tensor_fn, call):
     # smoke test
     if red in ("sum", "min", "max") and call is helpers.mx_call:
         # mxnet does not support sum, min or max reduction for scattering
@@ -879,16 +877,16 @@ def test_scatter_nd(
     if ivy.exists(tensor) and call is helpers.mx_call:
         # mxnet does not support scattering into pre-existing tensors
         pytest.skip()
-    inds = ivy.array(inds, dtype="int32", device=device)
-    upd = tensor_fn(upd, dtype=dtype, device=device)
+    inds = ivy.array(inds, dtype="int32")
+    upd = tensor_fn(upd, dtype=dtype)
     if tensor:
         # pytorch variables do not support in-place updates
         tensor = (
-            ivy.array(tensor, dtype=dtype, device=device)
+            ivy.array(tensor, dtype=dtype)
             if ivy.current_backend_str() == "torch"
-            else tensor_fn(tensor, dtype=dtype, device=device)
+            else tensor_fn(tensor, dtype=dtype)
         )
-    ret = ivy.scatter_nd(inds, upd, shape, tensor, red, device=device)
+    ret = ivy.scatter_nd(inds, upd, shape, tensor, red)
     # type test
     assert ivy.is_ivy_array(ret)
     # cardinality test
@@ -900,7 +898,7 @@ def test_scatter_nd(
     if red == "replace" and with_duplicates:
         # replace with duplicates give non-deterministic outputs
         return
-    ret = call(ivy.scatter_nd, inds, upd, shape, tensor, red, device=device)
+    ret = call(ivy.scatter_nd, inds, upd, shape, tensor, red)
     true = np.asarray(
         ivy.functional.backends.numpy.scatter_nd(
             ivy.to_numpy(inds),
@@ -908,7 +906,6 @@ def test_scatter_nd(
             shape,
             ivy.to_numpy(tensor) if ivy.exists(tensor) else tensor,
             red,
-            device=device,
         )
     )
     assert np.allclose(ret, true)

--- a/ivy_tests/test_ivy/test_functional/test_core/test_general.py
+++ b/ivy_tests/test_ivy/test_functional/test_core/test_general.py
@@ -792,9 +792,7 @@ def test_cumprod(x_n_axis, exclusive, dtype, with_out, tensor_fn, device, call):
 @pytest.mark.parametrize("red", ["sum", "min", "max", "replace"])
 @pytest.mark.parametrize("dtype", ["float32"])
 @pytest.mark.parametrize("tensor_fn", [ivy.array, helpers.var_fn])
-def test_scatter_flat(
-    inds_n_upd_n_size_n_tnsr_n_wdup, red, dtype, tensor_fn, device, call
-):
+def test_scatter_flat(inds_n_upd_n_size_n_tnsr_n_wdup, red, dtype, tensor_fn, call):
     # smoke test
     if red in ("sum", "min", "max") and call is helpers.mx_call:
         # mxnet does not support sum, min or max reduction for scattering
@@ -803,16 +801,16 @@ def test_scatter_flat(
     if ivy.exists(tensor) and call is helpers.mx_call:
         # mxnet does not support scattering into pre-existing tensors
         pytest.skip()
-    inds = ivy.array(inds, dtype="int32", device=device)
-    upd = tensor_fn(upd, dtype=dtype, device=device)
+    inds = ivy.array(inds, dtype="int32")
+    upd = tensor_fn(upd, dtype=dtype)
     if tensor:
         # pytorch variables do not support in-place updates
         tensor = (
-            ivy.array(tensor, dtype=dtype, device=device)
+            ivy.array(tensor, dtype=dtype)
             if ivy.current_backend_str() == "torch"
-            else tensor_fn(tensor, dtype=dtype, device=device)
+            else tensor_fn(tensor, dtype=dtype)
         )
-    ret = ivy.scatter_flat(inds, upd, size, tensor, red, device=device)
+    ret = ivy.scatter_flat(inds, upd, size, tensor, red)
     # type test
     assert ivy.is_ivy_array(ret)
     # cardinality test
@@ -825,7 +823,7 @@ def test_scatter_flat(
         # replace with duplicates give non-deterministic outputs
         return
     assert np.allclose(
-        call(ivy.scatter_flat, inds, upd, size, tensor, red, device=device),
+        call(ivy.scatter_flat, inds, upd, size, tensor, red),
         np.asarray(
             ivy.functional.backends.numpy.scatter_flat(
                 ivy.to_numpy(inds),
@@ -833,7 +831,6 @@ def test_scatter_flat(
                 size,
                 ivy.to_numpy(tensor) if ivy.exists(tensor) else tensor,
                 red,
-                device=device,
             )
         ),
     )


### PR DESCRIPTION
Removing the device argument and all handling of it from the functions [scatter_flat](https://github.com/unifyai/ivy/blob/70505d0a2d035543f0c9ad173d1a87453f02ccee/ivy/functional/ivy/general.py#L1248), [scatter_nd](https://github.com/unifyai/ivy/blob/70505d0a2d035543f0c9ad173d1a87453f02ccee/ivy/functional/ivy/general.py#L1288), [gather](https://github.com/unifyai/ivy/blob/70505d0a2d035543f0c9ad173d1a87453f02ccee/ivy/functional/ivy/general.py#L1329), [gather_nd](https://github.com/unifyai/ivy/blob/70505d0a2d035543f0c9ad173d1a87453f02ccee/ivy/functional/ivy/general.py#L1363) from all backends, ivy and ivy tests.