### PR TITLE
fix `compilation` submodule

### DIFF
--- a/ivy/functional/backends/jax/compilation.py
+++ b/ivy/functional/backends/jax/compilation.py
@@ -1,10 +1,15 @@
 """Collection of Jax compilation functions."""
 
 # global
+from typing import Callable, Any, Union, Sequence, Iterable, Optional
 import jax
 
 
 def compile(
-    fn, dynamic=True, example_inputs=None, static_argnums=None, static_argnames=None
-):
+    fn: Callable,
+    dynamic: bool = True,
+    example_inputs: Optional[Union[Any, Sequence[Any]]] = None,
+    static_argnums: Optional[Union[int, Iterable[int]]] = None,
+    static_argnames: Optional[Union[str, Iterable[str]]] = None,
+) -> Callable:
     return jax.jit(fn, static_argnums=static_argnums, static_argnames=static_argnames)

--- a/ivy/functional/backends/mxnet/compilation.py
+++ b/ivy/functional/backends/mxnet/compilation.py
@@ -1,13 +1,18 @@
 """Collection of mxnet compilation functions."""
 
 # global
+from typing import Callable, Any, Union, Sequence, Iterable, Optional
 import logging
 
 
 # noinspection PyUnusedLocal
 def compile(
-    func, dynamic=True, example_inputs=None, static_argnums=None, static_argnames=None
-):
+    func: Callable,
+    dynamic: bool = True,
+    example_inputs: Optional[Union[Any, Sequence[Any]]] = None,
+    static_argnums: Optional[Union[int, Iterable[int]]] = None,
+    static_argnames: Optional[Union[str, Iterable[str]]] = None,
+) -> Callable:
     logging.warning(
         "MXnet does not support compiling arbitrary functions, consider writing a "
         "function using MXNet Symbolic backend instead for compiling.\n"

--- a/ivy/functional/backends/numpy/compilation.py
+++ b/ivy/functional/backends/numpy/compilation.py
@@ -1,13 +1,18 @@
 """Collection of Numpy compilation functions."""
 
 # global
+from typing import Callable, Any, Union, Sequence, Iterable, Optional
 import logging
 
 
 # noinspection PyUnusedLocal
 def compile(
-    func, dynamic=True, example_inputs=None, static_argnums=None, static_argnames=None
-):
+    func: Callable,
+    dynamic: bool = True,
+    example_inputs: Optional[Union[Any, Sequence[Any]]] = None,
+    static_argnums: Optional[Union[int, Iterable[int]]] = None,
+    static_argnames: Optional[Union[str, Iterable[str]]] = None,
+) -> Callable:
     logging.warning(
         "Numpy does not support compiling functions.\n"
         "Now returning the unmodified function."

--- a/ivy/functional/backends/tensorflow/compilation.py
+++ b/ivy/functional/backends/tensorflow/compilation.py
@@ -1,10 +1,15 @@
 """Collection of Tensorflow compilation functions."""
 
 # global
+from typing import Callable, Any, Union, Sequence, Iterable, Optional
 import tensorflow as tf
 
 
 def compile(
-    fn, dynamic=True, example_inputs=None, static_argnums=None, static_argnames=None
-):
+    fn: Callable,
+    dynamic: bool = True,
+    example_inputs: Optional[Union[Any, Sequence[Any]]] = None,
+    static_argnums: Optional[Union[int, Iterable[int]]] = None,
+    static_argnames: Optional[Union[str, Iterable[str]]] = None,
+) -> Callable:
     return tf.function(fn)

--- a/ivy/functional/backends/torch/compilation.py
+++ b/ivy/functional/backends/torch/compilation.py
@@ -3,10 +3,15 @@
 # global
 import torch
 
+# local
+import ivy
+
 
 def compile(
     fn, dynamic=True, example_inputs=None, static_argnums=None, static_argnames=None
 ):
     if dynamic:
         return torch.jit.script(fn)
+    if example_inputs is not None:
+        example_inputs = ivy.to_native(example_inputs, nested=True)
     return torch.jit.trace(fn, example_inputs)

--- a/ivy/functional/backends/torch/compilation.py
+++ b/ivy/functional/backends/torch/compilation.py
@@ -1,6 +1,7 @@
 """Collection of PyTorch compilation functions"""
 
 # global
+from typing import Callable, Any, Union, Sequence, Iterable, Optional
 import torch
 
 # local
@@ -8,8 +9,12 @@ import ivy
 
 
 def compile(
-    fn, dynamic=True, example_inputs=None, static_argnums=None, static_argnames=None
-):
+    fn: Callable,
+    dynamic: bool = True,
+    example_inputs: Optional[Union[Any, Sequence[Any]]] = None,
+    static_argnums: Optional[Union[int, Iterable[int]]] = None,
+    static_argnames: Optional[Union[str, Iterable[str]]] = None,
+) -> Callable:
     if dynamic:
         return torch.jit.script(fn)
     if example_inputs is not None:

--- a/ivy/functional/ivy/compilation.py
+++ b/ivy/functional/ivy/compilation.py
@@ -40,6 +40,7 @@ def compile(
 
     Returns
     -------
+    ret
         The handle to the newly compiled function.
     """
     return current_backend(example_inputs).compile(

--- a/ivy/functional/ivy/compilation.py
+++ b/ivy/functional/ivy/compilation.py
@@ -1,7 +1,7 @@
 """Collection of general Ivy compilation functions."""
 
 # global
-from typing import Callable, Any, Union, Tuple, Iterable
+from typing import Callable, Any, Union, Sequence, Iterable, Optional
 
 # local
 from ivy.backend_handler import current_backend
@@ -14,9 +14,9 @@ from ivy.backend_handler import current_backend
 def compile(
     func: Callable,
     dynamic: bool = True,
-    example_inputs: Union[Any, Tuple[Any]] = None,
-    static_argnums: Union[int, Iterable[int]] = None,
-    static_argnames: Union[int, Iterable[int]] = None,
+    example_inputs: Optional[Union[Any, Sequence[Any]]] = None,
+    static_argnums: Optional[Union[int, Iterable[int]]] = None,
+    static_argnames: Optional[Union[int, Iterable[int]]] = None,
 ) -> Callable:
     """Provide a function which should be compiled, for faster inference. The handle to
     the newly compiled function is returned.

--- a/ivy/functional/ivy/compilation.py
+++ b/ivy/functional/ivy/compilation.py
@@ -16,7 +16,7 @@ def compile(
     dynamic: bool = True,
     example_inputs: Optional[Union[Any, Sequence[Any]]] = None,
     static_argnums: Optional[Union[int, Iterable[int]]] = None,
-    static_argnames: Optional[Union[int, Iterable[int]]] = None,
+    static_argnames: Optional[Union[str, Iterable[str]]] = None,
 ) -> Callable:
     """Provide a function which should be compiled, for faster inference. The handle to
     the newly compiled function is returned.


### PR DESCRIPTION
- included native array conversion for torch (only this backend needs it)
- fix type hints and small fix on docstrings in ivy
- added type hints to backends