### PR TITLE
fixes diagonal function format

### DIFF
--- a/ivy/functional/backends/numpy/linear_algebra.py
+++ b/ivy/functional/backends/numpy/linear_algebra.py
@@ -31,7 +31,11 @@ def det(x: np.ndarray) -> np.ndarray:
 
 
 def diagonal(
-    x: np.ndarray, offset: int = 0, axis1: int = -2, axis2: int = -1
+    x: np.ndarray,
+    offset: int = 0,
+    axis1: int = -2,
+    axis2: int = -1,
+    out: Optional[np.ndarray] = None
 ) -> np.ndarray:
     ret = np.diagonal(x, offset=offset, axis1=axis1, axis2=axis2)
     return ret

--- a/ivy/functional/backends/torch/linear_algebra.py
+++ b/ivy/functional/backends/torch/linear_algebra.py
@@ -47,7 +47,11 @@ def det(x: torch.Tensor, *, out: Optional[torch.Tensor] = None) -> torch.Tensor:
 
 
 def diagonal(
-    x: torch.Tensor, offset: int = 0, axis1: int = -2, axis2: int = -1
+    x: torch.Tensor,
+    offset: int = 0,
+    axis1: int = -2,
+    axis2: int = -1,
+    out: Optional[torch.Tensor] = None
 ) -> torch.Tensor:
     return torch.diagonal(x, offset=offset, dim1=axis1, dim2=axis2)
 

--- a/ivy/functional/ivy/linear_algebra.py
+++ b/ivy/functional/ivy/linear_algebra.py
@@ -331,7 +331,7 @@ def diagonal(
 
     This function conforms to the `Array API Standard
     <https://data-apis.org/array-api/latest/>`_. This docstring is an extension of the
-    `docstring <https://data-apis.org/array-api/latest/API_specification/generated/signatures.elementwise_functions.tan.html>`_
+    `docstring <https://data-apis.org/array-api/latest/API_specification/generated/signatures.elementwise_functions.tan.html>`_ # noqa
     in the standard.
 
     Both the description and the type hints above assumes an array input for simplicity,

--- a/ivy/functional/ivy/linear_algebra.py
+++ b/ivy/functional/ivy/linear_algebra.py
@@ -318,6 +318,10 @@ def diagonal(
         axis to be used as the second axis of the 2-D sub-arrays from which the
         diagonals should be taken. Defaults to second axis (-1).
 
+    out
+        optional output array to write the result in. Must have the same number
+        of dimensions as the function output.
+
     Returns
     -------
     ret
@@ -325,6 +329,14 @@ def diagonal(
         last two dimensions and appending a dimension equal to the size of the resulting
         diagonals. The returned array must have the same data type as ``x``.
 
+    This function conforms to the `Array API Standard
+    <https://data-apis.org/array-api/latest/>`_. This docstring is an extension of the
+    `docstring <https://data-apis.org/array-api/latest/API_specification/generated/signatures.elementwise_functions.tan.html>`_
+    in the standard.
+
+    Both the description and the type hints above assumes an array input for simplicity,
+    but this function is *nestable*, and therefore also accepts :code:`ivy.Container`
+    instances in place of any of the arguments.
 
     Functional Examples
     ------------------
@@ -427,6 +439,22 @@ def diagonal(
     ivy.array([0, 4, 8])
 
 
+    With :code:`ivy.Container` inputs:
+
+    >>> x = ivy.Container(\
+            a = ivy.array([[7, 1, 2],\
+                           [1, 3, 5],\
+                           [0, 7, 4]]),\
+            b = ivy.array([[4, 3, 2],\
+                           [1, 9, 5],\
+                           [7, 0, 6]])\
+        )
+    >>> d = ivy.diagonal(x)
+    >>> print(d)
+    {
+        a: ivy.array([7, 3, 4]),
+        b: ivy.array([4, 9, 6])
+    }
     """
     return current_backend(x).diagonal(x, offset, axis1=axis1, axis2=axis2, out=out)
 


### PR DESCRIPTION
 - Updated ivy.diagonal docstrings.
 - Added "out" parameter at torch and numpy backends diagonal functions to let diagonal function work with these backends (but in these cases, the "out" parameter isn't updated by the function).
 - fixes #1746 