### PR TITLE
Gradients documentation typo fixes

### DIFF
--- a/ivy/array/gradients.py
+++ b/ivy/array/gradients.py
@@ -27,6 +27,7 @@ class ArrayWithGradients(abc.ABC):
         --------
 
         With :code:`ivy.Array` inputs:
+
         >>> dcdw = ivy.array([[[1.1], [3.2], [-6.3]]])
         >>> mw = ivy.array([[0.], [0.], [0.]])
         >>> vw = ivy.array([[0.], [0.], [0.]])

--- a/ivy/array/gradients.py
+++ b/ivy/array/gradients.py
@@ -25,7 +25,6 @@ class ArrayWithGradients(abc.ABC):
 
         Examples
         --------
-
         With :code:`ivy.Array` inputs:
 
         >>> dcdw = ivy.array([[[1.1], [3.2], [-6.3]]])

--- a/ivy/array/gradients.py
+++ b/ivy/array/gradients.py
@@ -25,6 +25,7 @@ class ArrayWithGradients(abc.ABC):
 
         Examples
         --------
+
         With :code:`ivy.Array` inputs:
         >>> dcdw = ivy.array([[[1.1], [3.2], [-6.3]]])
         >>> mw = ivy.array([[0.], [0.], [0.]])

--- a/ivy/container/gradients.py
+++ b/ivy/container/gradients.py
@@ -24,7 +24,8 @@ class ContainerWithGradients(ContainerBase):
 
         Examples
         --------
-        with :code: 'ivy.container' inputs:
+        with :code: `ivy.container` inputs:
+
         >>> dcdw = ivy.Container(a=ivy.array([0., 1., 2.]),\
                          b=ivy.array([3., 4., 5.]))
         >>> mw = ivy.Container(a=ivy.array([0., 0., 0.]),\
@@ -70,7 +71,8 @@ class ContainerWithGradients(ContainerBase):
 
         Examples
         --------
-        with :code: 'ivy.container' inputs:
+        with :code: `ivy.container` inputs:
+
         >>> dcdw = ivy.Container(a=ivy.array([0., 1., 2.]),\
                          b=ivy.array([3., 4., 5.]))
         >>> mw = ivy.Container(a=ivy.array([0., 0., 0.]),\

--- a/ivy/functional/ivy/gradients.py
+++ b/ivy/functional/ivy/gradients.py
@@ -253,6 +253,7 @@ def adam_step(
     Functional Examples
     -------------------
     With :code:`ivy.Array` inputs:
+
     >>> dcdw = ivy.array([1, 2, 3])
     >>> mw = ivy.zeros(3)
     >>> vw = ivy.zeros(1)
@@ -326,7 +327,8 @@ def adam_step(
         ivy.array([0.1, 0.2, 0.3]),
         ivy.array([0.001, 0.004, 0.009]))
 
-    with :code: 'ivy.container' inputs:
+    with :code: `ivy.container` inputs:
+
     >>> dcdw = ivy.Container(a=ivy.array([0., 1., 2.]),\
                              b=ivy.array([3., 4., 5.]))
     >>> mw = ivy.Container(a=ivy.array([0., 0., 0.]),\


### PR DESCRIPTION
Hello @djl11 I worked on the `adam_step` method reformatting task #1687 
It was successfully merged but I checked from Ivy documentation and found out that some examples are not properly formatted. Example: [Gradients ivy documentation](https://lets-unify.ai/ivy/array/gradients.html). 
I made the necessary changes as it was almost typing errors where I used quotation marks instead of the back quote(`) and others well forgetting new lines before starting code examples. 

These changes will solve all these stated problems.

Thanks