### PR TITLE
conv3d_transpose#1793

### DIFF
--- a/ivy/functional/backends/jax/layers.py
+++ b/ivy/functional/backends/jax/layers.py
@@ -60,5 +60,15 @@ def conv3d(*_):
     raise Exception("Convolutions not yet implemented for jax library")
 
 
-def conv3d_transpose(*_):
-    raise Exception("Convolutions not yet implemented for jax library")
+def conv3d_transpose(
+    x: JaxArray,
+    filters: JaxArray,
+    strides: Union[int, Tuple[int], Tuple[int, int], Tuple[int, int, int]],
+    padding: str,
+    data_format: str = "NDHWC",
+    dilations: int = 1,
+) -> JaxArray:
+    return JaxArray.nn.conv3d_transpose(
+        x, filters, strides, padding, data_format, dilations
+    )
+    

--- a/ivy/functional/backends/jax/layers.py
+++ b/ivy/functional/backends/jax/layers.py
@@ -1,12 +1,11 @@
 """Collection of Jax network layers, wrapped to fit Ivy syntax and signature."""
 
 # global
-
 import jax.lax as jlax
 
 # local
 from ivy.functional.backends.jax import JaxArray
-from typing import Union, Tuple, Sequence, List
+from typing import Union, Tuple, Sequence
 
 
 def conv1d(
@@ -72,8 +71,6 @@ def conv3d_transpose(
     strides = [strides] * 3 if isinstance(strides, int) else strides
     dilations = [dilations] * 3 if isinstance(dilations, int) else dilations
     dimension_numbers = (data_format, "HWDIO", data_format)
-    if data_format == "NDHWC":
-        x = jlax.conv_transpose(0, 4, 1, 2, 3)
     res = jlax.conv_transpose(
         x, filters, strides, padding, dilations, dimension_numbers
     )

--- a/ivy/functional/backends/jax/layers.py
+++ b/ivy/functional/backends/jax/layers.py
@@ -1,11 +1,13 @@
 """Collection of Jax network layers, wrapped to fit Ivy syntax and signature."""
 
 # global
+import math
+
 import jax.lax as jlax
 
 # local
 from ivy.functional.backends.jax import JaxArray
-from typing import Union, Tuple
+from typing import Union, Tuple, Sequence, List
 
 
 def conv1d(
@@ -65,9 +67,23 @@ def conv3d_transpose(
     filters: JaxArray,
     strides: Union[int, Tuple[int], Tuple[int, int], Tuple[int, int, int]],
     padding: Union[str, Sequence[Tuple[int, int]]],
-    dilations: Optional[Sequence[int]],
+    dilations: Union[int, Tuple[int], Tuple[int, int], Tuple[int, int, int]] = 1,
     data_format: str = "NDHWC"
 ) -> JaxArray:
-    return JaxArray.nn.conv3d_transpose(
-        x, filters, strides, padding, None, dilations, (data_format, "WIO", data_format)
-    ) 
+    filter_shape = list(filters.shape[0:1])
+    filters = filters.permute(3, 4, 0, 1, 2)
+    if data_format == "NDHWC":
+        x = jlax.conv_transpose(0, 4, 1, 2, 3)
+    if padding == "VALID":
+        padding_list: List[int] = [0, 0, 0]
+    elif padding == "SAME":
+        padding_list: List[int] = [math.floor(item / 2) for item in filter_shape]
+    else:
+        raise Exception(
+            "Invalid padding arg {}\n"
+            'Must be one of: "VALID" or "SAME"'.format(padding)
+        )
+    res = jlax.conv_transpose(
+        x, filters, strides, padding_list, None, dilation= dilations
+    )
+    return res

--- a/ivy/functional/backends/jax/layers.py
+++ b/ivy/functional/backends/jax/layers.py
@@ -1,7 +1,6 @@
 """Collection of Jax network layers, wrapped to fit Ivy syntax and signature."""
 
 # global
-import math
 
 import jax.lax as jlax
 
@@ -70,20 +69,12 @@ def conv3d_transpose(
     dilations: Union[int, Tuple[int], Tuple[int, int], Tuple[int, int, int]] = 1,
     data_format: str = "NDHWC"
 ) -> JaxArray:
-    filter_shape = list(filters.shape[0:1])
-    filters = filters.permute(3, 4, 0, 1, 2)
+    strides = [strides] * 3 if isinstance(strides, int) else strides
+    dilations = [dilations] * 3 if isinstance(dilations, int) else dilations
+    dimension_numbers = (data_format, "HWDIO", data_format)
     if data_format == "NDHWC":
         x = jlax.conv_transpose(0, 4, 1, 2, 3)
-    if padding == "VALID":
-        padding_list: List[int] = [0, 0, 0]
-    elif padding == "SAME":
-        padding_list: List[int] = [math.floor(item / 2) for item in filter_shape]
-    else:
-        raise Exception(
-            "Invalid padding arg {}\n"
-            'Must be one of: "VALID" or "SAME"'.format(padding)
-        )
     res = jlax.conv_transpose(
-        x, filters, strides, padding_list, None, dilation= dilations
+        x, filters, strides, padding, dilations, dimension_numbers
     )
     return res

--- a/ivy/functional/backends/jax/layers.py
+++ b/ivy/functional/backends/jax/layers.py
@@ -70,5 +70,4 @@ def conv3d_transpose(
 ) -> JaxArray:
     return JaxArray.nn.conv3d_transpose(
         x, filters, strides, padding, None, dilations, (data_format, "WIO", data_format)
-
-    
+    ) 

--- a/ivy/functional/backends/jax/layers.py
+++ b/ivy/functional/backends/jax/layers.py
@@ -64,11 +64,11 @@ def conv3d_transpose(
     x: JaxArray,
     filters: JaxArray,
     strides: Union[int, Tuple[int], Tuple[int, int], Tuple[int, int, int]],
-    padding: str,
-    data_format: str = "NDHWC",
-    dilations: int = 1,
+    padding: Union[str, Sequence[Tuple[int, int]]],
+    dilations: Optional[Sequence[int]],
+    data_format: str = "NDHWC"
 ) -> JaxArray:
     return JaxArray.nn.conv3d_transpose(
-        x, filters, strides, padding, data_format, dilations
-    )
+        x, filters, strides, padding, None, dilations, (data_format, "WIO", data_format)
+
     


### PR DESCRIPTION
I updated the conv3d_transpose function for Jax -  ivy.functional.backends.jax.layers

conv3d_transpose already has a backend implementation for mxnet, torch and Tensorflow so I didn't change anything in them for this task.

I didn't make any changes for this function in numpy because I could not find a way to implement it correctly.

Note: Please let me know if I implemented this function in the Jax backend properly. As well as any other changes that would need to be made 