### PR TITLE
small fixes on `device` for ivy gym

### DIFF
--- a/ivy/__init__.py
+++ b/ivy/__init__.py
@@ -71,7 +71,9 @@ class Shape(tuple):
             shape_tup = (shape_tup,)
         elif isinstance(shape_tup, list):
             shape_tup = tuple(shape_tup)
-        assert builtins.all([isinstance(v, int) for v in shape_tup])
+        assert builtins.all(
+            [isinstance(v, int) or ivy.is_int_dtype(v.dtype) for v in shape_tup]
+        )
         if ivy.shape_array_mode():
             return ivy.array(shape_tup)
         return tuple.__new__(cls, shape_tup)

--- a/ivy/functional/backends/jax/device.py
+++ b/ivy/functional/backends/jax/device.py
@@ -33,6 +33,7 @@ def dev(
 ) -> Union[ivy.Device, jaxlib.xla_extension.Device]:
     if isinstance(x, jax.interpreters.partial_eval.DynamicJaxprTracer):
         dv = ivy.default_device()
+        x = jax.device_put(x, as_native_dev(dv))
     try:
         dv = _to_array(x).device_buffer.device
         dv = dv()

--- a/ivy/functional/backends/jax/device.py
+++ b/ivy/functional/backends/jax/device.py
@@ -32,7 +32,7 @@ def dev(
     x: JaxArray, as_native: bool = False
 ) -> Union[ivy.Device, jaxlib.xla_extension.Device]:
     if isinstance(x, jax.interpreters.partial_eval.DynamicJaxprTracer):
-        return None
+        dv = ivy.default_device()
     try:
         dv = _to_array(x).device_buffer.device
         dv = dv()

--- a/ivy/functional/backends/tensorflow/device.py
+++ b/ivy/functional/backends/tensorflow/device.py
@@ -27,6 +27,8 @@ def dev(
     dv = x.device
     if dv == "":
         dv = ivy.default_device()
+        with tf.device(dv):
+            x = tf.identity(x)
     if as_native:
         return dv
     return as_ivy_dev(dv)

--- a/ivy/functional/backends/tensorflow/device.py
+++ b/ivy/functional/backends/tensorflow/device.py
@@ -25,6 +25,8 @@ def dev(
     as_native: bool = False,
 ) -> Union[ivy.Device, str]:
     dv = x.device
+    if dv == "":
+        dv = ivy.default_device()
     if as_native:
         return dv
     return as_ivy_dev(dv)


### PR DESCRIPTION
when diving into ivy gym, I found out that certain returns from Jax and TensorFlow does not have a device by default, thus throwing errors when an ivy.Array is being created from its native version

are we allowed to add these small changes so that ivy.default_device is set when there isn't one from the backend?

Thanks!