### PR TITLE
ivy.Shape fixes

### DIFF
--- a/ivy/functional/backends/jax/general.py
+++ b/ivy/functional/backends/jax/general.py
@@ -67,7 +67,7 @@ def to_list(x: JaxArray) -> list:
     return _to_array(x).tolist()
 
 
-def shape(x: JaxArray, as_array: bool = False) -> Union[JaxArray, ivy.Shape, ivy.Array]:
+def shape(x: JaxArray, as_array: bool = False) -> Union[ivy.Shape, ivy.Array]:
     if as_array:
         return ivy.array(x.shape)
     else:

--- a/ivy/functional/backends/jax/general.py
+++ b/ivy/functional/backends/jax/general.py
@@ -69,7 +69,7 @@ def to_list(x: JaxArray) -> list:
 
 def shape(x: JaxArray, as_array: bool = False) -> Union[JaxArray, ivy.Shape, ivy.Array]:
     if as_array:
-        return jnp.asarray(jnp.shape(x))
+        return ivy.array(x.shape)
     else:
         return ivy.Shape(x.shape)
 

--- a/ivy/functional/backends/jax/general.py
+++ b/ivy/functional/backends/jax/general.py
@@ -67,11 +67,11 @@ def to_list(x: JaxArray) -> list:
     return _to_array(x).tolist()
 
 
-def shape(x: JaxArray, as_array: bool = False) -> Union[tuple, JaxArray]:
+def shape(x: JaxArray, as_array: bool = False) -> Union[JaxArray, ivy.Shape, ivy.Array]:
     if as_array:
         return jnp.asarray(jnp.shape(x))
     else:
-        return x.shape
+        return ivy.Shape(x.shape)
 
 
 def get_num_dims(x, as_tensor=False):

--- a/ivy/functional/backends/jax/general.py
+++ b/ivy/functional/backends/jax/general.py
@@ -69,7 +69,10 @@ def to_list(x: JaxArray) -> list:
 
 def shape(x: JaxArray, as_array: bool = False) -> Union[ivy.Shape, ivy.Array]:
     if as_array:
-        return ivy.array(x.shape)
+        shape = jnp.shape(x)
+        if isinstance(shape, tuple):
+            return ivy.array(shape)
+        return shape
     else:
         return ivy.Shape(x.shape)
 

--- a/ivy/functional/backends/jax/general.py
+++ b/ivy/functional/backends/jax/general.py
@@ -69,10 +69,7 @@ def to_list(x: JaxArray) -> list:
 
 def shape(x: JaxArray, as_array: bool = False) -> Union[ivy.Shape, ivy.Array]:
     if as_array:
-        shape = jnp.shape(x)
-        if isinstance(shape, tuple):
-            return ivy.array(shape)
-        return shape
+        return ivy.array(jnp.shape(x))
     else:
         return ivy.Shape(x.shape)
 

--- a/ivy/functional/backends/mxnet/general.py
+++ b/ivy/functional/backends/mxnet/general.py
@@ -246,9 +246,11 @@ def one_hot(indices, depth, device=None):
     return mx.nd.one_hot(indices, depth)
 
 
-def shape(x: mx.nd.NDArray, as_array: bool = False) -> Union[ivy.Shape, ivy.Array]:
+def shape(
+    x: mx.nd.NDArray, as_array: bool = False
+) -> Union[mx.nd.NDArray, ivy.Shape, ivy.Array]:
     if as_array:
-        return ivy.array(x.shape)
+        return mx.nd.shape_array(x)
     else:
         return ivy.Shape(x.shape)
 

--- a/ivy/functional/backends/mxnet/general.py
+++ b/ivy/functional/backends/mxnet/general.py
@@ -246,11 +246,13 @@ def one_hot(indices, depth, device=None):
     return mx.nd.one_hot(indices, depth)
 
 
-def shape(x: mx.nd.NDArray, as_array: bool = False) -> Union[tuple, mx.nd.NDArray]:
+def shape(
+    x: mx.nd.NDArray, as_array: bool = False
+) -> Union[mx.nd.NDArray, ivy.Shape, ivy.Array]:
     if as_array:
         return mx.nd.shape_array(x)
     else:
-        return x.shape
+        return ivy.Shape(x.shape)
 
 
 def get_num_dims(x, as_tensor=False):

--- a/ivy/functional/backends/mxnet/general.py
+++ b/ivy/functional/backends/mxnet/general.py
@@ -250,7 +250,7 @@ def shape(
     x: mx.nd.NDArray, as_array: bool = False
 ) -> Union[mx.nd.NDArray, ivy.Shape, ivy.Array]:
     if as_array:
-        return mx.nd.shape_array(x)
+        return ivy.array(mx.nd.shape_array(x))
     else:
         return ivy.Shape(x.shape)
 

--- a/ivy/functional/backends/mxnet/general.py
+++ b/ivy/functional/backends/mxnet/general.py
@@ -246,9 +246,7 @@ def one_hot(indices, depth, device=None):
     return mx.nd.one_hot(indices, depth)
 
 
-def shape(
-    x: mx.nd.NDArray, as_array: bool = False
-) -> Union[mx.nd.NDArray, ivy.Shape, ivy.Array]:
+def shape(x: mx.nd.NDArray, as_array: bool = False) -> Union[ivy.Shape, ivy.Array]:
     if as_array:
         return ivy.array(x.shape)
     else:

--- a/ivy/functional/backends/mxnet/general.py
+++ b/ivy/functional/backends/mxnet/general.py
@@ -250,7 +250,7 @@ def shape(
     x: mx.nd.NDArray, as_array: bool = False
 ) -> Union[mx.nd.NDArray, ivy.Shape, ivy.Array]:
     if as_array:
-        return mx.nd.shape_array(x)
+        return ivy.array(x.shape)
     else:
         return ivy.Shape(x.shape)
 

--- a/ivy/functional/backends/numpy/general.py
+++ b/ivy/functional/backends/numpy/general.py
@@ -267,10 +267,7 @@ def one_hot(indices, depth, *, device):
 
 def shape(x: np.ndarray, as_array: bool = False) -> Union[ivy.Shape, ivy.Array]:
     if as_array:
-        shape = np.shape(x)
-        if isinstance(shape, tuple):
-            return ivy.array(shape)
-        return shape
+        return ivy.array(np.shape(x))
     else:
         return ivy.Shape(x.shape)
 

--- a/ivy/functional/backends/numpy/general.py
+++ b/ivy/functional/backends/numpy/general.py
@@ -265,11 +265,13 @@ def one_hot(indices, depth, *, device):
     return res.reshape(list(indices.shape) + [depth])
 
 
-def shape(x: np.ndarray, as_array: bool = False) -> Union[tuple, np.ndarray]:
+def shape(
+    x: np.ndarray, as_array: bool = False
+) -> Union[np.ndarray, ivy.Shape, ivy.Array]:
     if as_array:
         return np.asarray(np.shape(x))
     else:
-        return x.shape
+        return ivy.Shape(x.shape)
 
 
 def get_num_dims(x, as_tensor=False):

--- a/ivy/functional/backends/numpy/general.py
+++ b/ivy/functional/backends/numpy/general.py
@@ -267,7 +267,10 @@ def one_hot(indices, depth, *, device):
 
 def shape(x: np.ndarray, as_array: bool = False) -> Union[ivy.Shape, ivy.Array]:
     if as_array:
-        return ivy.array(x.shape)
+        shape = np.shape(x)
+        if isinstance(shape, tuple):
+            return ivy.array(shape)
+        return shape
     else:
         return ivy.Shape(x.shape)
 

--- a/ivy/functional/backends/numpy/general.py
+++ b/ivy/functional/backends/numpy/general.py
@@ -269,7 +269,7 @@ def shape(
     x: np.ndarray, as_array: bool = False
 ) -> Union[np.ndarray, ivy.Shape, ivy.Array]:
     if as_array:
-        return np.asarray(np.shape(x))
+        return ivy.array(x.shape)
     else:
         return ivy.Shape(x.shape)
 

--- a/ivy/functional/backends/numpy/general.py
+++ b/ivy/functional/backends/numpy/general.py
@@ -265,9 +265,7 @@ def one_hot(indices, depth, *, device):
     return res.reshape(list(indices.shape) + [depth])
 
 
-def shape(
-    x: np.ndarray, as_array: bool = False
-) -> Union[np.ndarray, ivy.Shape, ivy.Array]:
+def shape(x: np.ndarray, as_array: bool = False) -> Union[ivy.Shape, ivy.Array]:
     if as_array:
         return ivy.array(x.shape)
     else:

--- a/ivy/functional/backends/tensorflow/general.py
+++ b/ivy/functional/backends/tensorflow/general.py
@@ -337,9 +337,9 @@ def indices_where(x):
 def shape(
     x: Union[tf.Tensor, tf.Variable],
     as_array: bool = False,
-) -> Union[ivy.Shape, ivy.Array]:
+) -> Union[tf.Tensor, ivy.Shape, ivy.Array]:
     if as_array:
-        return ivy.array(x.shape)
+        return tf.shape(x)
     else:
         return ivy.Shape(x.shape)
 

--- a/ivy/functional/backends/tensorflow/general.py
+++ b/ivy/functional/backends/tensorflow/general.py
@@ -338,11 +338,11 @@ def indices_where(x):
 def shape(
     x: Union[tf.Tensor, tf.Variable],
     as_array: bool = False,
-) -> Union[tf.Tensor, tf.Variable, TensorShape]:
+) -> Union[tf.Tensor, tf.Variable, TensorShape, ivy.Shape, ivy.Array]:
     if as_array:
         return tf.shape(x)
     else:
-        return tuple(x.shape)
+        return ivy.Shape(x.shape)
 
 
 def get_num_dims(x, as_tensor=False):

--- a/ivy/functional/backends/tensorflow/general.py
+++ b/ivy/functional/backends/tensorflow/general.py
@@ -10,7 +10,6 @@ import numpy as np
 import multiprocessing as _multiprocessing
 from numbers import Number
 import tensorflow as tf
-from tensorflow.python.framework.tensor_shape import TensorShape
 
 # local
 import ivy
@@ -338,7 +337,7 @@ def indices_where(x):
 def shape(
     x: Union[tf.Tensor, tf.Variable],
     as_array: bool = False,
-) -> Union[tf.Tensor, tf.Variable, TensorShape, ivy.Shape, ivy.Array]:
+) -> Union[ivy.Shape, ivy.Array]:
     if as_array:
         return ivy.array(x.shape)
     else:

--- a/ivy/functional/backends/tensorflow/general.py
+++ b/ivy/functional/backends/tensorflow/general.py
@@ -340,7 +340,7 @@ def shape(
     as_array: bool = False,
 ) -> Union[tf.Tensor, tf.Variable, TensorShape, ivy.Shape, ivy.Array]:
     if as_array:
-        return tf.shape(x)
+        return ivy.array(x.shape)
     else:
         return ivy.Shape(x.shape)
 

--- a/ivy/functional/backends/tensorflow/general.py
+++ b/ivy/functional/backends/tensorflow/general.py
@@ -339,7 +339,7 @@ def shape(
     as_array: bool = False,
 ) -> Union[tf.Tensor, ivy.Shape, ivy.Array]:
     if as_array:
-        return tf.shape(x)
+        return ivy.array(tf.shape(x))
     else:
         return ivy.Shape(x.shape)
 

--- a/ivy/functional/backends/torch/general.py
+++ b/ivy/functional/backends/torch/general.py
@@ -396,9 +396,7 @@ def one_hot(indices, depth: int, *, device: torch.device):
     )
 
 
-def shape(
-    x: torch.Tensor, as_array: bool = False
-) -> Union[torch.Tensor, ivy.Shape, ivy.Array]:
+def shape(x: torch.Tensor, as_array: bool = False) -> Union[ivy.Shape, ivy.Array]:
     if as_array:
         return ivy.array(x.shape)
     else:

--- a/ivy/functional/backends/torch/general.py
+++ b/ivy/functional/backends/torch/general.py
@@ -396,11 +396,13 @@ def one_hot(indices, depth: int, *, device: torch.device):
     )
 
 
-def shape(x: torch.Tensor, as_array: bool = False) -> Union[torch.Size, torch.Tensor]:
+def shape(
+    x: torch.Tensor, as_array: bool = False
+) -> Union[torch.Tensor, ivy.Shape, ivy.Array]:
     if as_array:
         return torch.tensor(x.shape)
     else:
-        return x.shape
+        return ivy.Shape(x.shape)
 
 
 def get_num_dims(x, as_tensor=False) -> Union[torch.Tensor, int]:

--- a/ivy/functional/backends/torch/general.py
+++ b/ivy/functional/backends/torch/general.py
@@ -400,7 +400,7 @@ def shape(
     x: torch.Tensor, as_array: bool = False
 ) -> Union[torch.Tensor, ivy.Shape, ivy.Array]:
     if as_array:
-        return torch.tensor(x.shape)
+        return ivy.array(x.shape)
     else:
         return ivy.Shape(x.shape)
 

--- a/ivy/functional/ivy/general.py
+++ b/ivy/functional/ivy/general.py
@@ -2534,12 +2534,11 @@ def shape(
 
     Examples
     --------
-    >>> ivy.set_backend('torch')
     >>> x = ivy.array([[-1, 0, 1],[1, 0, -1]])
     >>> y = ivy.shape(x)
     >>> z = ivy.shape(x, as_array = True)
     >>> print(y)
-    torch.Size([2, 3])
+    (2, 3)
 
     >>> print(z)
     ivy.array([2, 3])


### PR DESCRIPTION
- fixed backend type hints `Union[ivy.Shape, ivy.Array]`
- fixed return of each backend `shape` function to be ivy.Shape(x.shape) 

note:
- `jnp.shape` always return native shape, therefore `ivy.array` is used directly
- `np.shape` always return native shape, therefore `ivy.array` is used directly