### PR TITLE
Typo fixes for `round` method instance reformating.

### DIFF
--- a/ivy/array/elementwise.py
+++ b/ivy/array/elementwise.py
@@ -1344,6 +1344,7 @@ class ArrayWithElementwise(abc.ABC):
         Examples
         --------
         With :code:`ivy.Array` input:
+
         >>> x = ivy.array([1.2, 2.4, 3.6])
         >>> y = x.round()
         >>> print(y)

--- a/ivy/array/elementwise.py
+++ b/ivy/array/elementwise.py
@@ -1340,6 +1340,14 @@ class ArrayWithElementwise(abc.ABC):
         ret
             an array containing the rounded result for each element in ``self``.
             The returned array must have the same data type as ``self``.
+
+        Examples
+        --------
+        With :code:`ivy.Array` input:
+        >>> x = ivy.array([1.2, 2.4, 3.6])
+        >>> y = x.round()
+        >>> print(y)
+        ivy.array([1., 2., 4.])
         """
         return ivy.round(self._data, out=out)
 

--- a/ivy/container/elementwise.py
+++ b/ivy/container/elementwise.py
@@ -4897,8 +4897,8 @@ class ContainerWithElementwise(ContainerBase):
             a container containing the rounded result for each element in ``self``.
             The returned container must have the same data type as ``self``.
 
-        Examaples
-        ---------
+        Examples
+        --------
         With :code:`ivy.Container` input:
 
         >>> x = ivy.Container(a=ivy.array([4.20, 8.6, 6.90, 0.0]),\

--- a/ivy/container/elementwise.py
+++ b/ivy/container/elementwise.py
@@ -4836,6 +4836,17 @@ class ContainerWithElementwise(ContainerBase):
             a container containing the rounded result for each element in ``x``.
             The returned container must have the same data type as ``x``.
 
+        Examples
+        --------
+        With :code:`ivy.Container` input:
+        >>> x = ivy.Container(a=ivy.array([4.20, 8.6, 6.90, 0.0]),\
+                    b=ivy.array([-300.9, -527.3, 4.5]))
+        >>> y = ivy.Container.static_round(x)
+        >>> print(y)
+        {
+            a: ivy.array([4., 9., 7., 0.]),
+            b: ivy.array([-301., -527., 4.])
+        }
         """
         return ContainerBase.multi_map_in_static_method(
             "round",
@@ -4885,6 +4896,17 @@ class ContainerWithElementwise(ContainerBase):
             a container containing the rounded result for each element in ``self``.
             The returned container must have the same data type as ``self``.
 
+        Examaples
+        ---------
+        With :code:`ivy.Container` input:
+        >>> x = ivy.Container(a=ivy.array([4.20, 8.6, 6.90, 0.0]),\
+                    b=ivy.array([-300.9, -527.3, 4.5]))
+        >>> y = x.round()
+        >>> print(y)
+        {
+            a: ivy.array([4., 9., 7., 0.]),
+            b: ivy.array([-301., -527., 4.])
+        }
         """
         return self.static_round(
             self, key_chains, to_apply, prune_unapplied, map_sequences, out=out

--- a/ivy/container/elementwise.py
+++ b/ivy/container/elementwise.py
@@ -4839,6 +4839,7 @@ class ContainerWithElementwise(ContainerBase):
         Examples
         --------
         With :code:`ivy.Container` input:
+
         >>> x = ivy.Container(a=ivy.array([4.20, 8.6, 6.90, 0.0]),\
                     b=ivy.array([-300.9, -527.3, 4.5]))
         >>> y = ivy.Container.static_round(x)
@@ -4899,6 +4900,7 @@ class ContainerWithElementwise(ContainerBase):
         Examaples
         ---------
         With :code:`ivy.Container` input:
+
         >>> x = ivy.Container(a=ivy.array([4.20, 8.6, 6.90, 0.0]),\
                     b=ivy.array([-300.9, -527.3, 4.5]))
         >>> y = x.round()

--- a/ivy/functional/ivy/elementwise.py
+++ b/ivy/functional/ivy/elementwise.py
@@ -3296,6 +3296,7 @@ def round(
     Functional Examples
     -------------------
     With :code:`ivy.Array` input:
+
     >>> x = ivy.array([1.2, 2.4, 3.6])
     >>> y = ivy.round(x)
     >>> print(y)
@@ -3319,36 +3320,22 @@ def round(
     ivy.array([[0.,5.,-343.,2.],[-6.,44.,12.,12.]])
 
     With :code:`ivy.NativeArray` input:
-    >>> x = ivy.NativeArray([20.2, 30.5, -5.81])
+
+    >>> x = ivy.native_array([20.2, 30.5, -5.81])
     >>> y = ivy.round(x)
     >>> print(y)
     ivy.array([20.,30.,-6.])
 
     With :code:`ivy.Container` input:
+
     >>> x = ivy.Container(a=ivy.array([4.20, 8.6, 6.90, 0.0]),\
                   b=ivy.array([-300.9, -527.3, 4.5]))
     >>> y = ivy.round(x)
     >>> print(y)
-    {a:ivy.array([4.,9.,7.,0.]),b:ivy.array([-301.,-527.,4.])}
-
-    Instance Method Examples
-    ------------------------
-    Using :code:`ivy.Array` instance method:
-    >>> x = ivy.array([5.4, 1.2, 2.3])
-    >>> y = x.round()
-    >>> print(y)
-    ivy.array([5., 1., 2.])
-
-    Using :code:`ivy.Container` instance method:
-    >>> x = ivy.Container(a=ivy.array([0.3, 1.5, 201.5]), b=ivy.array([3.6, 4.4, -5.2]))
-    >>> y = x.round()
-    >>> print(y)
     {
-        a: ivy.array([0., 2., 202.]),
-        b: ivy.array([4., 4., -5.])
+        a:ivy.array([4.,9.,7.,0.]),
+        b:ivy.array([-301.,-527.,4.])
     }
-
-
     """
     return ivy.current_backend(x).round(x, out=out)
 


### PR DESCRIPTION
Hello @jiahanxie353 I checked the current documentation of Ivy and found that the `round` method has typos in the way docstring examples are displayed and the container instance still had the lambda function. as you can see from [round method](https://lets-unify.ai/ivy/functional/ivy/elementwise/round.html)

In this PR I corrected the typos, and added the docstring to both **array** and container **instances**, and replaced the lambda function by adding a static method.

Thanks