### PR TITLE
Test Fix - exclude device total_mem_on_dev from docstring test

### DIFF
--- a/ivy_tests/test_docstrings.py
+++ b/ivy_tests/test_docstrings.py
@@ -35,6 +35,7 @@ def test_docstrings(backend):
         "Dtype",
         "multinomial",
         "num_cpu_cores",
+        "total_mem_on_dev",
         "get_all_ivy_arrays_on_dev",
         "num_ivy_arrays_on_dev",
         "function_unsupported_dtypes",


### PR DESCRIPTION
docstring test failing in master for `device.total_mem_on_dev`.