### PR TITLE
remove redundant dtype/device logic - mxnet

### DIFF
--- a/ivy/functional/backends/mxnet/creation.py
+++ b/ivy/functional/backends/mxnet/creation.py
@@ -5,8 +5,7 @@ from numbers import Number
 
 # local
 import ivy
-from ivy import default_device, as_native_dtype, default_dtype, as_ivy_dtype
-from ivy.functional.backends.mxnet import _mxnet_init_context
+from ivy import as_native_dtype, default_dtype, as_ivy_dtype
 from ivy.functional.backends.mxnet import _1_dim_array_to_flat_array
 
 
@@ -29,60 +28,59 @@ def _linspace(start, stop, num, cont):
     return ret
 
 
-def arange(stop, start=0, step=1, dtype=None, device=None):
-    cont = _mxnet_init_context(default_device(device))
+def arange(stop, start=0, step=1, *, dtype=None, device: mx.context.Context):
     stop = stop if isinstance(stop, Number) else stop.asscalar()
     start = start if isinstance(start, Number) else start.asscalar()
     step = step if isinstance(step, Number) else step.asscalar()
-    return mx.nd.arange(start, stop, ctx=cont, step=step, dtype=dtype)
+    return mx.nd.arange(start, stop, ctx=device, step=step, dtype=dtype)
 
 
 def asarray(
     object_in,
-    dtype: Optional[Union[ivy.Dtype, type]] = None,
-    device: Optional[Union[ivy.Device, mx.context.Context]] = None,
     copy: Optional[bool] = None,
+    *,
+    dtype: Optional[Union[ivy.Dtype, type]] = None,
+    device: mx.context.Context,
 ):
     # mxnet don't have asarray implementation, haven't properly tested
-    cont = _mxnet_init_context(default_device(device))
     if copy is None:
         copy = False
     if copy:
         if dtype is None and isinstance(object_in, mx.nd.NDArray):
-            return mx.nd.array(object_in, cont).as_in_context(cont)
+            return mx.nd.array(object_in, device).as_in_context(device)
         if dtype is None and not isinstance(object_in, mx.nd.NDArray):
-            return mx.nd.array(object_in, cont, dtype=default_dtype(dtype, object_in))
+            return mx.nd.array(object_in, device, dtype=default_dtype(dtype, object_in))
         else:
             dtype = as_ivy_dtype(default_dtype(dtype, object_in))
-            return mx.nd.array(object_in, cont, dtype=default_dtype(dtype, object_in))
+            return mx.nd.array(object_in, device, dtype=default_dtype(dtype, object_in))
     else:
         if dtype is None and isinstance(object_in, mx.nd.NDArray):
-            return object_in.as_in_context(cont)
+            return object_in.as_in_context(device)
         if dtype is None and not isinstance(object_in, mx.nd.NDArray):
-            return mx.nd.array(object_in, cont, dtype=default_dtype(dtype, object_in))
+            return mx.nd.array(object_in, device, dtype=default_dtype(dtype, object_in))
         else:
             dtype = as_ivy_dtype(default_dtype(dtype, object_in))
-            return mx.nd.array(object_in, cont, dtype=default_dtype(dtype, object_in))
+            return mx.nd.array(object_in, device, dtype=default_dtype(dtype, object_in))
 
 
 def empty(
     shape: Union[ivy.NativeShape, Sequence[int]],
-    dtype: Optional[Union[ivy.Dtype, type]] = None,
-    device: Optional[Union[ivy.Device, mx.context.Context]] = None,
+    *,
+    dtype: type,
+    device: mx.context.Context,
 ) -> mx.nd.NDArray:
-    cont = _mxnet_init_context(default_device(device))
-    return mx.nd.empty(shape, as_native_dtype(default_dtype(dtype)), cont)
+    return mx.nd.empty(shape, dtype, device)
 
 
 def eye(
     n_rows: int,
     n_cols: Optional[int] = None,
     k: Optional[int] = 0,
-    dtype: Optional[Union[ivy.Dtype, type]] = None,
-    device: Optional[Union[ivy.Device, mx.context.Context]] = None,
+    *,
+    dtype: type,
+    device: mx.context.Context,
 ) -> mx.nd.NDArray:
-    cont = _mxnet_init_context(default_device(device))
-    return mx.nd.eye(n_rows, n_cols, k, ctx=cont).astype(dtype)
+    return mx.nd.eye(n_rows, n_cols, k, ctx=device).astype(dtype)
 
 
 # noinspection PyUnresolvedReferences
@@ -91,26 +89,28 @@ def from_dlpack(x):
 
 
 def full(
-    shape: Union[ivy.NativeShape, Sequence[int]], fill_value, dtype=None, device=None
+    shape: Union[ivy.NativeShape, Sequence[int]],
+    fill_value,
+    *,
+    dtype=None,
+    device: mx.context.Context,
 ):
     shape = ivy.to_ivy_shape(shape)
-    cont = _mxnet_init_context(default_device(device))
     if len(shape) == 0 or 0 in shape:
         return _1_dim_array_to_flat_array(
             mx.nd.full(
                 (1,),
                 fill_value,
-                cont,
+                device,
                 as_native_dtype(default_dtype(dtype, fill_value)),
             )
         )
     return mx.nd.full(
-        shape, fill_value, cont, as_native_dtype(default_dtype(dtype, fill_value))
+        shape, fill_value, device, as_native_dtype(default_dtype(dtype, fill_value))
     )
 
 
-def linspace(start, stop, num, axis=None, device=None):
-    cont = _mxnet_init_context(default_device(device))
+def linspace(start, stop, num, axis=None, *, dtype: type, device: mx.context.Context):
     num = num.asnumpy()[0] if isinstance(num, mx.nd.NDArray) else num
     start_is_array = isinstance(start, mx.nd.NDArray)
     stop_is_array = isinstance(stop, mx.nd.NDArray)
@@ -122,13 +122,13 @@ def linspace(start, stop, num, axis=None, device=None):
         start_shape = list(stop.shape)
         stop = stop.reshape((-1,))
     if start_is_array and stop_is_array:
-        res = [_linspace(strt, stp, num, cont) for strt, stp in zip(start, stop)]
+        res = [_linspace(strt, stp, num, device) for strt, stp in zip(start, stop)]
     elif start_is_array and not stop_is_array:
-        res = [_linspace(strt, stop, num, cont) for strt in start]
+        res = [_linspace(strt, stop, num, device) for strt in start]
     elif not start_is_array and stop_is_array:
-        res = [_linspace(start, stp, num, cont) for stp in stop]
+        res = [_linspace(start, stp, num, device) for stp in stop]
     else:
-        return _linspace(start, stop, num, cont)
+        return _linspace(start, stop, num, device)
     new_shape = start_shape + [num]
     res = mx.nd.concat(*res, dim=-1).reshape(new_shape)
     if axis is not None:
@@ -144,24 +144,25 @@ def meshgrid(*xs: mx.nd.NDArray, indexing: Optional[str] = "xy") -> List[mx.nd.N
 
 def ones(
     shape: Union[ivy.NativeShape, Sequence[int]],
-    dtype: Optional[Union[ivy.Dtype, type]] = None,
-    device: Optional[Union[ivy.Device, mx.context.Context]] = None,
+    *,
+    dtype: type,
+    device: mx.context.Context,
 ) -> mx.nd.NDArray:
-    cont = _mxnet_init_context(default_device(device))
     shape = [shape] if shape is not isinstance(shape, Iterable) else shape
     if len(shape) == 0 or 0 in shape:
-        return _1_dim_array_to_flat_array(mx.nd.ones((1,), ctx=cont).astype(dtype))
-    return mx.nd.ones(shape, ctx=cont).astype(dtype)
+        return _1_dim_array_to_flat_array(mx.nd.ones((1,), ctx=device).astype(dtype))
+    return mx.nd.ones(shape, ctx=device).astype(dtype)
 
 
 def ones_like(
     x: mx.nd.NDArray,
+    *,
     dtype: Optional[Union[ivy.Dtype, type]] = None,
     device: Optional[Union[ivy.Device, mx.context.Context]] = None,
 ) -> mx.nd.NDArray:
     if x.shape == ():
-        return mx.nd.array(1.0, ctx=_mxnet_init_context(default_device(device)))
-    mx_ones = mx.nd.ones_like(x, ctx=_mxnet_init_context(default_device(device)))
+        return mx.nd.array(1.0, ctx=device)
+    mx_ones = mx.nd.ones_like(x, ctx=device)
     return mx_ones if dtype is None else mx_ones.astype(dtype)
 
 
@@ -175,17 +176,16 @@ def zeros(
     dtype: type,
     device: mx.context.Context,
 ) -> mx.nd.NDArray:
-    cont = _mxnet_init_context(device)
     if len(shape) == 0 or 0 in shape:
-        return _1_dim_array_to_flat_array(mx.nd.zeros((1,), ctx=cont).astype(dtype))
-    return mx.nd.zeros(shape, ctx=cont).astype(dtype)
+        return _1_dim_array_to_flat_array(mx.nd.zeros((1,), ctx=device).astype(dtype))
+    return mx.nd.zeros(shape, ctx=device).astype(dtype)
 
 
-def zeros_like(x, dtype=None, device=None):
+def zeros_like(x, *, dtype: type, device: mx.context.Context):
     if x.shape == ():
-        return mx.nd.array(0.0, ctx=_mxnet_init_context(default_device(device)))
-    mx_zeros = mx.nd.zeros_like(x, ctx=_mxnet_init_context(default_device(device)))
-    return mx_zeros if not dtype else mx_zeros.astype(dtype)
+        return mx.nd.array(0.0, ctx=device)
+    mx_zeros = mx.nd.zeros_like(x, ctx=device)
+    return mx_zeros.astype(dtype)
 
 
 # Extra #
@@ -195,6 +195,6 @@ def zeros_like(x, dtype=None, device=None):
 array = asarray
 
 
-def logspace(start, stop, num, base=10.0, axis=None, device=None):
-    power_seq = linspace(start, stop, num, axis, default_device(device))
+def logspace(start, stop, num, base=10.0, axis=None, *, device: mx.context.Context):
+    power_seq = linspace(start, stop, num, axis, device)
     return base**power_seq

--- a/ivy/functional/backends/mxnet/creation.py
+++ b/ivy/functional/backends/mxnet/creation.py
@@ -28,7 +28,14 @@ def _linspace(start, stop, num, cont):
     return ret
 
 
-def arange(stop, start=0, step=1, *, dtype=None, device: mx.context.Context):
+def arange(
+    stop,
+    start=0,
+    step=1,
+    *,
+    dtype: Optional[Union[ivy.Dtype, type]] = None,
+    device: mx.context.Context,
+):
     stop = stop if isinstance(stop, Number) else stop.asscalar()
     start = start if isinstance(start, Number) else start.asscalar()
     step = step if isinstance(step, Number) else step.asscalar()
@@ -90,9 +97,9 @@ def from_dlpack(x):
 
 def full(
     shape: Union[ivy.NativeShape, Sequence[int]],
-    fill_value,
+    fill_value: Union[int, float],
     *,
-    dtype=None,
+    dtype: Optional[Union[ivy.Dtype, ivy.NativeDtype]] = None,
     device: mx.context.Context,
 ):
     shape = ivy.to_ivy_shape(shape)

--- a/ivy/functional/backends/mxnet/creation.py
+++ b/ivy/functional/backends/mxnet/creation.py
@@ -157,8 +157,8 @@ def ones(
 def ones_like(
     x: mx.nd.NDArray,
     *,
-    dtype: Optional[Union[ivy.Dtype, type]] = None,
-    device: Optional[Union[ivy.Device, mx.context.Context]] = None,
+    dtype: type,
+    device: mx.context.Context,
 ) -> mx.nd.NDArray:
     if x.shape == ():
         return mx.nd.array(1.0, ctx=device)

--- a/ivy/functional/backends/mxnet/general.py
+++ b/ivy/functional/backends/mxnet/general.py
@@ -97,8 +97,8 @@ def inplace_update(
 
 def inplace_arrays_supported():
     return True
-    
-    
+
+
 inplace_variables_supported = lambda: True
 
 
@@ -245,7 +245,7 @@ def multiprocessing(context=None):
     )
 
 
-def one_hot(indices, depth, device=None):
+def one_hot(indices, depth, *, device):
     return mx.nd.one_hot(indices, depth)
 
 

--- a/ivy/functional/backends/mxnet/general.py
+++ b/ivy/functional/backends/mxnet/general.py
@@ -245,7 +245,7 @@ def multiprocessing(context=None):
     )
 
 
-def one_hot(indices, depth, *, device):
+def one_hot(indices: mx.nd.NDArray, depth: int, *, device: mx.context.Context):
     return mx.nd.one_hot(indices, depth)
 
 

--- a/ivy/functional/backends/mxnet/random.py
+++ b/ivy/functional/backends/mxnet/random.py
@@ -6,12 +6,7 @@ from typing import Optional, Union, Sequence
 
 # local
 import ivy
-from ivy.functional.ivy.device import default_device
-
-# noinspection PyProtectedMember
 from ivy.functional.backends.mxnet import _mxnet_init_context
-
-# noinspection PyProtectedMember
 from ivy.functional.backends.mxnet import _1_dim_array_to_flat_array
 
 
@@ -30,7 +25,7 @@ def random_uniform(
         low = low.asscalar()
     if isinstance(high, mx.nd.NDArray):
         high = high.asscalar()
-    ctx = _mxnet_init_context(default_device(device))
+    ctx = _mxnet_init_context(device)
     if shape is None or len(shape) == 0:
         return _1_dim_array_to_flat_array(
             mx.nd.random.uniform(low, high, (1,), ctx=ctx, dtype=dtype)
@@ -48,7 +43,7 @@ def random_normal(
         mean = mean.asscalar()
     if isinstance(std, mx.nd.NDArray):
         std = std.asscalar()
-    ctx = _mxnet_init_context(default_device(device))
+    ctx = _mxnet_init_context(device)
     if shape is None or len(shape) == 0:
         return _1_dim_array_to_flat_array(mx.nd.random.normal(mean, std, (1,), ctx=ctx))
     return mx.nd.random.uniform(mean, std, shape, ctx=ctx)
@@ -64,7 +59,7 @@ def multinomial(
 ) -> mx.nd.NDArray:
     if not replace:
         raise Exception("MXNet does not support multinomial without replacement")
-    ctx = _mxnet_init_context(default_device(device))
+    ctx = _mxnet_init_context(device)
     if probs is None:
         probs = (
             mx.nd.ones(
@@ -92,7 +87,7 @@ def randint(
         low = int(low.asscalar())
     if isinstance(high, mx.nd.NDArray):
         high = int(high.asscalar())
-    ctx = _mxnet_init_context(default_device(device))
+    ctx = _mxnet_init_context(device)
     if len(shape) == 0:
         return _1_dim_array_to_flat_array(
             mx.nd.random.randint(low, high, (1,), ctx=ctx)

--- a/ivy/functional/backends/mxnet/random.py
+++ b/ivy/functional/backends/mxnet/random.py
@@ -6,7 +6,6 @@ from typing import Optional, Union, Sequence
 
 # local
 import ivy
-from ivy.functional.backends.mxnet import _mxnet_init_context
 from ivy.functional.backends.mxnet import _1_dim_array_to_flat_array
 
 
@@ -18,35 +17,37 @@ def random_uniform(
     low: Union[float, mx.nd.NDArray] = 0.0,
     high: Union[float, mx.nd.NDArray] = 1.0,
     shape: Optional[Union[ivy.NativeShape, Sequence[int]]] = None,
-    device: Optional[Union[ivy.Device, mx.context.Context]] = None,
-    dtype=None,
+    *,
+    device: mx.context.Context,
+    dtype: type,
 ) -> mx.nd.NDArray:
     if isinstance(low, mx.nd.NDArray):
         low = low.asscalar()
     if isinstance(high, mx.nd.NDArray):
         high = high.asscalar()
-    ctx = _mxnet_init_context(device)
     if shape is None or len(shape) == 0:
         return _1_dim_array_to_flat_array(
-            mx.nd.random.uniform(low, high, (1,), ctx=ctx, dtype=dtype)
+            mx.nd.random.uniform(low, high, (1,), ctx=device, dtype=dtype)
         )
-    return mx.nd.random.uniform(low, high, shape, ctx=ctx, dtype=dtype)
+    return mx.nd.random.uniform(low, high, shape, ctx=device, dtype=dtype)
 
 
 def random_normal(
     mean: float = 0.0,
     std: float = 1.0,
     shape: Optional[Union[ivy.NativeShape, Sequence[int]]] = None,
-    device: Optional[Union[ivy.Device, mx.context.Context]] = None,
+    *,
+    device: mx.context.Context,
 ) -> mx.nd.NDArray:
     if isinstance(mean, mx.nd.NDArray):
         mean = mean.asscalar()
     if isinstance(std, mx.nd.NDArray):
         std = std.asscalar()
-    ctx = _mxnet_init_context(device)
     if shape is None or len(shape) == 0:
-        return _1_dim_array_to_flat_array(mx.nd.random.normal(mean, std, (1,), ctx=ctx))
-    return mx.nd.random.uniform(mean, std, shape, ctx=ctx)
+        return _1_dim_array_to_flat_array(
+            mx.nd.random.normal(mean, std, (1,), ctx=device)
+        )
+    return mx.nd.random.uniform(mean, std, shape, ctx=device)
 
 
 def multinomial(
@@ -55,11 +56,11 @@ def multinomial(
     batch_size: int = 1,
     probs: Optional[mx.nd.NDArray] = None,
     replace: bool = True,
-    device: Optional[Union[ivy.Device, mx.context.Context]] = None,
+    *,
+    device: mx.context.Context,
 ) -> mx.nd.NDArray:
     if not replace:
         raise Exception("MXNet does not support multinomial without replacement")
-    ctx = _mxnet_init_context(device)
     if probs is None:
         probs = (
             mx.nd.ones(
@@ -67,7 +68,7 @@ def multinomial(
                     batch_size,
                     population_size,
                 ),
-                ctx=ctx,
+                ctx=device,
             )
             / population_size
         )
@@ -87,12 +88,11 @@ def randint(
         low = int(low.asscalar())
     if isinstance(high, mx.nd.NDArray):
         high = int(high.asscalar())
-    ctx = _mxnet_init_context(device)
     if len(shape) == 0:
         return _1_dim_array_to_flat_array(
-            mx.nd.random.randint(low, high, (1,), ctx=ctx)
+            mx.nd.random.randint(low, high, (1,), ctx=device)
         )
-    return mx.nd.random.randint(low, high, shape, ctx=ctx)
+    return mx.nd.random.randint(low, high, shape, ctx=device)
 
 
 def seed(seed_value: int = 0) -> None:


### PR DESCRIPTION
- removed redundant logic in functions with `@infer_device` or `@infer_dtype` (or both)

`@infer_device`
- creation: arange, asarray, zeros, ones, full_like, ones_like, zeros_like, empty, empty_like, eye, linspace, full, logspace
- general: one_hot
- random: random_uniform, random_normal, multinomial, randint

`@infer_dtype`
- creation: zeros, ones, full_like, ones_like, zeros_like, empty, empty_like, eye, linspace
- random: random_uniform