### PR TITLE
 modified set_backend() function on the code snippet in the documenta…

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -126,7 +126,7 @@ You can immediately use Ivy to train a neural network, using your favorite frame
             x = ivy.relu(self.linear0(x))
             return ivy.sigmoid(self.linear1(x))
 
-    ivy.set_backend('torch')  # change to any backend!
+    ivy.set_framework('torch')  # change to any backend!
     model = MyModel()
     optimizer = ivy.Adam(1e-4)
     x_in = ivy.array([1., 2., 3.])
@@ -134,8 +134,7 @@ You can immediately use Ivy to train a neural network, using your favorite frame
 
     def loss_fn(v):
         out = model(x_in, v=v)
-        return ivy.mean((out - target)**2)
-
+        return ivy.torch.reduce_mean((out-target)**2) # using the mean function of torch can be changed as per the backend used 
     for step in range(100):
         loss, grads = ivy.execute_with_gradients(loss_fn, model.v)
         model.v = optimizer.step(model.v, grads)


### PR DESCRIPTION
…tion to set_framework(). The issue mentioned previously was outlined in issue (AttributeError: module 'ivy' has no attribute 'set_backend' #2056). The second bugfix was assigning the backend-appropriate (here we used tensorflow) mean function by changing "return ivy.mean()" to the mean function of pytorch to "ivy.torch.reduce_mean()". 