### PR TITLE
adding unsupported and supported device attr and functions

### DIFF
--- a/ivy/functional/backends/tensorflow/layers.py
+++ b/ivy/functional/backends/tensorflow/layers.py
@@ -77,6 +77,9 @@ def conv2d_transpose(
     )
 
 
+conv2d_transpose.unsupported_devices = ('cpu',)
+
+
 def depthwise_conv2d(
     x: Union[tf.Tensor, tf.Variable],
     filters: Union[tf.Tensor, tf.Variable],

--- a/ivy_tests/test_ivy/test_functional/test_nn/test_layers.py
+++ b/ivy_tests/test_ivy/test_functional/test_nn/test_layers.py
@@ -540,6 +540,7 @@ def test_conv2d_transpose(
         instance_method=instance_method,
         fw=fw,
         fn_name="conv2d_transpose",
+        device=device,
         x=x,
         filters=filters,
         strides=stride,


### PR DESCRIPTION
I removed [this](https://github.com/unifyai/ivy/blob/2e096c2fd274a2589196430ed59b08e75422635e/ivy_tests/test_ivy/helpers.py#L525) line because `ivy.invalid_dtypes` was already being added [here](https://github.com/unifyai/ivy/blob/2e096c2fd274a2589196430ed59b08e75422635e/ivy/functional/ivy/data_type.py#L955) in `function_unsupported_dtypes`