### PR TITLE
Reformating broadcast_arrays method

### DIFF
--- a/ivy/array/data_type.py
+++ b/ivy/array/data_type.py
@@ -15,6 +15,45 @@ class ArrayWithDataTypes(abc.ABC):
     def broadcast_arrays(
         self: ivy.Array, *arrays: Union[ivy.Array, ivy.NativeArray]
     ) -> List[ivy.Array]:
+        """
+        `ivy.Array` instance method variant of `ivy.broadcast_arrays`.
+        This method simply wraps the function,
+        and so the docstring for `ivy.broadcast_arrays`
+        also applies to this method with minimal changes.
+
+        Parameters
+        ----------
+        self
+            An input array to be broadcasted against other input arrays.
+        arrays
+            an arbitrary number of arrays to-be broadcasted.
+            Each array must have the same shape.
+            Each array must have the same dtype as its
+            corresponding input array.
+
+        Returns
+        -------
+        ret
+            A list containing broadcasted arrays of type `ivy.Array`
+        Examples
+        --------
+        With :code:`ivy.Array` inputs:
+
+        >>> x1 = ivy.array([1, 2])
+        >>> x2 = ivy.array([0.2, 0.])
+        >>> x3 = ivy.zeros(2)
+        >>> y = x1.broadcast_arrays(x2, x3)
+        >>> print(y)
+        [ivy.array([1, 2]), ivy.array([0.2, 0. ]), ivy.array([0., 0.])]
+
+        With mixed :code:`ivy.Array` and :code:`ivy.NativeArray` inputs:
+
+        >>> x1 = ivy.array([-1., 3.4])
+        >>> x2 = ivy.native_array([2.4, 5.1])
+        >>> y = x1.broadcast_arrays(x2)
+        >>> print(y)
+        [ivy.array([-1., 3.4]), ivy.array([2.4, 5.1])]
+        """
         return ivy.broadcast_arrays(self._data, *arrays)
 
     def broadcast_to(

--- a/ivy/container/data_type.py
+++ b/ivy/container/data_type.py
@@ -58,12 +58,72 @@ class ContainerWithDataTypes(ContainerBase):
 
     @staticmethod
     def static_broadcast_arrays(
-        *arrays: ivy.Container,
+        *arrays: Union[ivy.Container, ivy.Array, ivy.NativeArray],
         key_chains: Optional[Union[List[str], Dict[str, str]]] = None,
         to_apply: bool = True,
         prune_unapplied: bool = False,
         map_sequences: bool = False,
     ) -> ivy.Container:
+        """
+        `ivy.Container` static method variant of `ivy.broadcast_arrays`.
+        This method simply wraps the function,
+        and so the docstring for `ivy.broadcast_arrays`
+        also applies to this method with minimal changes.
+
+        Parameters
+        ----------
+        arrays
+            an arbitrary number of arrays to-be broadcasted.
+            Each array must have the same shape.
+            And Each array must have the same dtype as its
+            corresponding input array.
+        key_chains
+            The key-chains to apply or not apply the method to. Default is None.
+        to_apply
+            If True, the method will be applied to key_chains, otherwise key_chains
+            will be skipped. Default is True.
+        prune_unapplied
+            Whether to prune key_chains for which the function was not applied.
+            Default is False.
+        map_sequences
+            Whether to also map method to sequences (lists, tuples).
+            Default is False.
+
+        Returns
+        -------
+        ret
+            A list of containers containing broadcasted arrays
+
+        Examples
+        --------
+        With :code:`ivy.Container` inputs:
+
+        >>> x1 = ivy.Container(a=ivy.array([1, 2]), b=ivy.array([3, 4]))
+        >>> x2 = ivy.Container(a=ivy.array([-1.2, 0.4]), b=ivy.array([0, 1]))
+        >>> y = ivy.Container.static_broadcast_arrays(x1, x2)
+        >>> print(y)
+        [{
+            a: ivy.array([1, 2]),
+            b: ivy.array([3, 4])
+        }, {
+            a: ivy.array([-1.2, 0.4]),
+            b: ivy.array([0, 1])
+        }]
+
+        With mixed :code:`ivy.Container` and :code:`ivy.Array` inputs:
+
+        >>> x1 = ivy.Container(a=ivy.array([4, 5]), b=ivy.array([2, -1]))
+        >>> x2 = ivy.array([0.2, 3.])
+        >>> y = ivy.Container.static_broadcast_arrays(x1, x2)
+        >>> print(y)
+        [{
+            a: ivy.array([4, 5]),
+            b: ivy.array([2, -1])
+        }, {
+            a: ivy.array([0.2, 3.]),
+            b: ivy.array([0.2, 3.])
+        }]
+        """
         return ContainerBase.multi_map_in_static_method(
             "broadcast_arrays",
             *arrays,
@@ -75,12 +135,67 @@ class ContainerWithDataTypes(ContainerBase):
 
     def broadcast_arrays(
         self: ivy.Container,
-        *arrays: ivy.Container,
+        *arrays: Union[ivy.Container, ivy.Array, ivy.NativeArray],
         key_chains: Optional[Union[List[str], Dict[str, str]]] = None,
         to_apply: bool = True,
         prune_unapplied: bool = False,
         map_sequences: bool = False,
     ) -> ivy.Container:
+        """
+        `ivy.Container` instance method variant of `ivy.broadcast_arrays`.
+        This method simply wraps the function,
+        and so the docstring for `ivy.broadcast_arrays`
+        also applies to this method with minimal changes.
+
+        Parameters
+        ----------
+        self
+            A container to be broadcatsed against other input arrays.
+        arrays
+            an arbitrary number of containers having arrays to-be broadcasted.
+            Each array must have the same shape.
+            Each array must have the same dtype as its corresponding input array.
+        key_chains
+            The key-chains to apply or not apply the method to. Default is None.
+        to_apply
+            If True, the method will be applied to key_chains, otherwise key_chains
+            will be skipped. Default is True.
+        prune_unapplied
+            Whether to prune key_chains for which the function was not applied.
+            Default is False.
+        map_sequences
+            Whether to also map method to sequences (lists, tuples). Default is False.
+
+        Examples
+        --------
+        With :code:`ivy.Container` inputs:
+
+        >>> x1 = ivy.Container(a=ivy.array([1, 2]), b=ivy.array([3, 4]))
+        >>> x2 = ivy.Container(a=ivy.array([-1.2, 0.4]), b=ivy.array([0, 1]))
+        >>> y = x1.broadcast_arrays(x2)
+        >>> print(y)
+        [{
+            a: ivy.array([1, 2]),
+            b: ivy.array([3, 4])
+        }, {
+            a: ivy.array([-1.2, 0.4]),
+            b: ivy.array([0, 1])
+        }]
+
+        With mixed :code:`ivy.Container` and :code:`ivy.Array` inputs:
+
+        >>> x1 = ivy.Container(a=ivy.array([4, 5]), b=ivy.array([2, -1]))
+        >>> x2 = ivy.zeros(2)
+        >>> y = x1.broadcast_arrays(x2)
+        >>> print(y)
+        [{
+            a: ivy.array([4, 5]),
+            b: ivy.array([2, -1])
+        }, {
+            a: ivy.array([0., 0.]),
+            b: ivy.array([0., 0.])
+        }]
+        """
         return self.static_broadcast_arrays(
             self,
             *arrays,

--- a/ivy/functional/backends/torch/data_type.py
+++ b/ivy/functional/backends/torch/data_type.py
@@ -69,7 +69,7 @@ def astype(x: torch.Tensor, dtype: torch.dtype, *, copy: bool = True) -> torch.T
 
 
 def broadcast_arrays(*arrays: torch.Tensor) -> List[torch.Tensor]:
-    return torch.broadcast_tensors(*arrays)
+    return list(torch.broadcast_tensors(*arrays))
 
 
 def broadcast_to(

--- a/ivy/functional/ivy/data_type.py
+++ b/ivy/functional/ivy/data_type.py
@@ -105,14 +105,68 @@ def broadcast_arrays(*arrays: Union[ivy.Array, ivy.NativeArray]) -> List[ivy.Arr
     Parameters
     ----------
     arrays
-        an arbitrary number of to-be broadcasted arrays.
+        an arbitrary number of arrays to-be broadcasted.
+        Each array must have the same shape. Each array must have the same dtype as its
+        corresponding input array.
 
     Returns
     -------
     ret
-        Each array must have the same shape. Each array must have the same dtype as its
-        corresponding input array.
+        A list containing broadcasted arrays of type `ivy.Array`
 
+    Examples
+    --------
+    With :code:`ivy.Array` input:
+
+    >>> x1 = ivy.array([1, 2, 3])
+    >>> x2 = ivy.array([4, 5, 6])
+    >>> y = ivy.broadcast_arrays(x1, x2)
+    >>> print(y)
+    [ivy.array([1, 2, 3]), ivy.array([4, 5, 6])]
+
+    With :code:`ivy.NativeArray` inputs:
+
+    >>> x1 = ivy.native_array([0.3, 4.3])
+    >>> x2 = ivy.native_array([3.1, 5])
+    >>> x3 = ivy.native_array([2, 0])
+    >>> y = ivy.broadcast_arrays(x1, x2, x3)
+    [ivy.array([0.3, 4.3]), ivy.array([3.1, 5.]), ivy.array([2, 0])]
+
+    With mixed :code:`ivy.Array` and :code:`ivy.NativeArray` inputs:
+
+    >>> x1 = ivy.array([1, 2])
+    >>> x2 = ivy.native_array([0.3, 4.3])
+    >>> y = ivy.broadcast_arrays(x1, x2)
+    >>> print(y)
+    [ivy.array([1, 2]), ivy.array([0.3, 4.3])]
+
+    With :code:`ivy.Container` inputs:
+
+    >>> x1 = ivy.Container(a=ivy.array([3, 1]), b=ivy.zeros(2))
+    >>> x2 = ivy.Container(a=ivy.array([4, 5]), b=ivy.array([2, -1]))
+    >>> y = ivy.broadcast_arrays(x1, x2)
+    >>> print(y)
+    [{
+        a: ivy.array([3, 1]),
+        b: ivy.array([0., 0.])
+    }, {
+        a: ivy.array([4, 5]),
+        b: ivy.array([2, -1])
+    }]
+
+    With mixed :code:`ivy.Array` and :code:`ivy.Container` inputs:
+
+    >>> x1 = ivy.zeros(2)
+    >>> x2 = ivy.Container(a=ivy.array([4, 5]), b=ivy.array([2, -1]))
+    >>> y = ivy.broadcast_arrays(x1, x2)
+    >>> print(y)
+    [{
+        a: ivy.array([0., 0.]),
+        b: ivy.array([0., 0.])
+    }, {
+        a: ivy.array([4, 5]),
+        b: ivy.array([2, -1])
+    }]
     """
     return current_backend(arrays[0]).broadcast_arrays(*arrays)
 


### PR DESCRIPTION
Hi there 🙌

This PR resolves issue #2168 
I added the docstring example to both functional, array, and container instances of the `broadcast_arrays` method.

The output for the torch backend returns a tuple as  shown here
```
import torch
x = torch.arange(3).view(1,3)
y = torch.arange(3).view(1,3)
z = torch.broadcast_tensors(x, y)
print(z)
(tensor([[0, 1, 2]]), tensor([[0, 1, 2]]))
```
I typecasted to return a list to meet functional requirements.

Thanks.
