### PR TITLE
BitwiseOr to Tensorflow frontend as RawOps Operations

### DIFF
--- a/ivy/functional/frontends/tensorflow/functions.py
+++ b/ivy/functional/frontends/tensorflow/functions.py
@@ -16,5 +16,16 @@ def tan(x, name=None):
 tan.unsupported_dtypes = {"torch": ("float16", "bfloat16")}
 
 
+def cos(x, name=None):
+    return ivy.cos(x)
+
+
+cos.unsupported_dtypes = {"torch": ("float16", "bfloat16")}
+
+
 def concat(values, axis, name="concat"):
     return ivy.concat(values, axis)
+
+
+def bitwise_or(x, y, name=None):
+    return ivy.bitwise_or(x, y)

--- a/ivy_tests/test_ivy/helpers.py
+++ b/ivy_tests/test_ivy/helpers.py
@@ -1200,7 +1200,13 @@ def test_frontend_function(
         )
 
         # compute the return via the frontend framework
-        frontend_fw = importlib.import_module(".".join([frontend] + frontend_submods))
+        if frontend == "tensorflow":
+            if fn_name == "bitwise_or":
+                frontend += ".bitwise"
+                frontend_fw = importlib.import_module(".".join([frontend] + frontend_submods))
+        else:
+            frontend_fw = importlib.import_module(".".join([frontend] + frontend_submods))
+
         if test_unsupported:
             test_unsupported_function(
                 fn=frontend_fw.__dict__[fn_name],
@@ -1208,6 +1214,7 @@ def test_frontend_function(
                 kwargs=kwargs_frontend,
             )
             return
+
         frontend_ret = frontend_fw.__dict__[fn_name](*args_frontend, **kwargs_frontend)
 
         # tuplify the frontend return

--- a/ivy_tests/test_ivy/test_frontends/test_tensorflow/test_tf_functions.py
+++ b/ivy_tests/test_ivy/test_frontends/test_tensorflow/test_tf_functions.py
@@ -67,6 +67,32 @@ def test_tensorflow_tan(
     )
 
 
+# cos
+@given(
+    dtype_and_x=helpers.dtype_and_values(available_dtypes=ivy_tf.valid_float_dtypes),
+    as_variable=st.booleans(),
+    num_positional_args=helpers.num_positional_args(
+        fn_name="ivy.functional.frontends.tensorflow.cos"
+    ),
+    native_array=st.booleans(),
+)
+def test_tensorflow_cos(
+    dtype_and_x, as_variable, num_positional_args, native_array, fw
+):
+    input_dtype, x = dtype_and_x
+    helpers.test_frontend_function(
+        input_dtypes=input_dtype,
+        as_variable_flags=as_variable,
+        with_out=False,
+        num_positional_args=num_positional_args,
+        native_array_flags=native_array,
+        fw=fw,
+        frontend="tensorflow",
+        fn_name="cos",
+        x=np.asarray(x, dtype=input_dtype),
+    )
+
+
 # noinspection DuplicatedCode
 @st.composite
 def _arrays_idx_n_dtypes(draw):
@@ -128,4 +154,37 @@ def test_tensorflow_concat(
         fn_name="concat",
         values=xs,
         axis=unique_idx,
+    )
+
+
+# bitwise_or
+@given(
+    dtype_and_x=helpers.dtype_and_values(
+        available_dtypes=tuple(
+            set(ivy_np.valid_int_dtypes).intersection(set(ivy_tf.valid_int_dtypes))
+        ),
+        num_arrays=2,
+        shared_dtype=True,
+    ),
+    as_variable=st.booleans(),
+    num_positional_args=helpers.num_positional_args(
+        fn_name="ivy.functional.frontends.tensorflow.bitwise_or"
+    ),
+    native_array=st.booleans(),
+)
+def test_tensorflow_bitwise_or(
+    dtype_and_x, as_variable, num_positional_args, native_array, fw
+):
+    input_dtype, x = dtype_and_x
+    helpers.test_frontend_function(
+        input_dtypes=input_dtype,
+        as_variable_flags=as_variable,
+        with_out=False,
+        num_positional_args=num_positional_args,
+        native_array_flags=native_array,
+        fw=fw,
+        frontend="tensorflow",
+        fn_name="bitwise_or",
+        x=np.asarray(x[0], dtype=input_dtype[0]),
+        y=np.asarray(x[1], dtype=input_dtype[1]),
     )


### PR DESCRIPTION
I need to modify the helpers.py file a little bit because only Tensorflow needs to call the BitwiseOr from the bitwise scope such as **tf.bitwise.bitwise_or**.

https://github.com/unifyai/ivy/issues/2278