### PR TITLE
device fix to allow empty string (also for ivy gym)

### DIFF
--- a/ivy/__init__.py
+++ b/ivy/__init__.py
@@ -75,7 +75,9 @@ class Shape(tuple):
             shape_tup = (shape_tup,)
         elif isinstance(shape_tup, list):
             shape_tup = tuple(shape_tup)
-        assert builtins.all([isinstance(v, int) for v in shape_tup])
+        assert builtins.all(
+            [isinstance(v, int) or ivy.is_int_dtype(v.dtype) for v in shape_tup]
+        )
         if ivy.shape_array_mode():
             return ivy.array(shape_tup)
         return tuple.__new__(cls, shape_tup)

--- a/ivy/__init__.py
+++ b/ivy/__init__.py
@@ -51,10 +51,11 @@ class NativeShape:
 
 class Device(str):
     def __new__(cls, dev_str):
-        assert dev_str[0:3] in ["gpu", "tpu", "cpu"]
-        if dev_str != "cpu":
-            assert dev_str[3] == ":"
-            assert dev_str[4:].isnumeric()
+        if dev_str != "":
+            assert dev_str[0:3] in ["gpu", "tpu", "cpu"]
+            if dev_str != "cpu":
+                assert dev_str[3] == ":"
+                assert dev_str[4:].isnumeric()
         return str.__new__(cls, dev_str)
 
 

--- a/ivy/functional/backends/jax/device.py
+++ b/ivy/functional/backends/jax/device.py
@@ -32,7 +32,7 @@ def dev(
     x: JaxArray, as_native: bool = False
 ) -> Union[ivy.Device, jaxlib.xla_extension.Device]:
     if isinstance(x, jax.interpreters.partial_eval.DynamicJaxprTracer):
-        return None
+        return ""
     try:
         dv = _to_array(x).device_buffer.device
         dv = dv()


### PR DESCRIPTION
- added int check for array in shape (torch allows this)
- changed empty device in Jax from `None` to `''`
- assert `cpu`, `gpu` or `cuda` only when device is not empty