### PR TITLE
container legacy method `arrays_as_lists` to equivalent `to_list` method in `ivy/container/general.py`

### DIFF
--- a/ivy/array/general.py
+++ b/ivy/array/general.py
@@ -259,6 +259,24 @@ class ArrayWithGeneral(abc.ABC):
         """
         return ivy.to_numpy(self)
 
+    def to_list(self: ivy.Array):
+        """
+        ivy.Array instance method variant of ivy.to_list. This method simply wraps
+        the function, and so the docstring for ivy.to_list also applies to this method
+        with minimal changes.
+
+        Parameters
+        ----------
+        self
+            input array.
+
+        Returns
+        -------
+        ret
+            A list representation of the input array ``x``.
+        """
+        return ivy.to_list(self)
+
     def stable_divide(
         self,
         denominator: Union[Number, ivy.Array, ivy.NativeArray, ivy.Container],

--- a/ivy/container/base.py
+++ b/ivy/container/base.py
@@ -2392,40 +2392,6 @@ class ContainerBase(dict, abc.ABC):
         )
         return ret
 
-    def arrays_as_lists(
-        self, key_chains=None, to_apply=True, prune_unapplied=False, map_sequences=False
-    ):
-        """Converts all nested arrays to lists, a useful intermediate step for
-        conversion to other framework array types.
-
-        Parameters
-        ----------
-        key_chains
-            The key-chains to apply or not apply the method to. Default is None.
-        to_apply
-            If True, the method will be applied to key_chains, otherwise key_chains will
-            be skipped. Default is True.
-        prune_unapplied
-            Whether to prune key_chains for which the function was not applied. Default
-            is False.
-        map_sequences
-            Whether to also map method to sequences (lists, tuples). Default is False.
-
-        Returns
-        -------
-            container with each array converted to a list.
-
-        """
-        return self.map(
-            lambda x, kc: self._ivy.to_list(x)
-            if self._ivy.is_native_array(x) or isinstance(x, ivy.Array)
-            else x,
-            key_chains,
-            to_apply,
-            prune_unapplied,
-            map_sequences,
-        )
-
     def to_disk_as_hdf5(
         self, h5_obj_or_filepath, starting_index=0, mode="a", max_batch_size=None
     ):

--- a/ivy/container/general.py
+++ b/ivy/container/general.py
@@ -1061,6 +1061,88 @@ class ContainerWithGeneral(ContainerBase):
         )
 
     @staticmethod
+    def static_to_list(
+        x: Union[ivy.Array, ivy.NativeArray, ivy.Container],
+        key_chains: Optional[Union[List[str], Dict[str, str]]] = None,
+        to_apply: bool = True,
+        prune_unapplied: bool = False,
+        map_sequences: bool = False,
+    ) -> ivy.Container:
+        """
+        ivy.Container static method variant of ivy.to_list. This method simply wraps
+        the function, and so the docstring for ivy.to_list also applies to this method
+        with minimal changes.
+
+        Parameters
+        ----------
+        x
+            input container.
+        key_chains
+            The key-chains to apply or not apply the method to. Default is None.
+        to_apply
+            If True, the method will be applied to key_chains, otherwise key_chains
+            will be skipped. Default is True.
+        prune_unapplied
+            Whether to prune key_chains for which the function was not applied.
+            Default is False.
+        map_sequences
+            Whether to also map method to sequences (lists, tuples). Default is False.
+
+        Returns
+        -------
+        ret
+            A list representation of the input array ``x``.
+        """
+        return ContainerBase.multi_map_in_static_method(
+            "to_list",
+            x,
+            key_chains=key_chains,
+            to_apply=to_apply,
+            prune_unapplied=prune_unapplied,
+            map_sequences=map_sequences,
+        )
+
+    def to_list(
+        self: ivy.Container,
+        key_chains: Optional[Union[List[str], Dict[str, str]]] = None,
+        to_apply: bool = True,
+        prune_unapplied: bool = False,
+        map_sequences: bool = False,
+    ) -> ivy.Container:
+        """
+        ivy.Container instance method variant of ivy.to_list. This method simply wraps
+        the function, and so the docstring for ivy.to_list also applies to this method
+        with minimal changes.
+
+        Parameters
+        ----------
+        self
+            input container.
+        key_chains
+            The key-chains to apply or not apply the method to. Default is None.
+        to_apply
+            If True, the method will be applied to key_chains, otherwise key_chains
+            will be skipped. Default is True.
+        prune_unapplied
+            Whether to prune key_chains for which the function was not applied.
+            Default is False.
+        map_sequences
+            Whether to also map method to sequences (lists, tuples). Default is False.
+
+        Returns
+        -------
+        ret
+            A list representation of the input array ``x``.
+        """
+        return self.static_to_list(
+            self,
+            key_chains,
+            to_apply,
+            prune_unapplied,
+            map_sequences,
+        )
+
+    @staticmethod
     def static_stable_divide(
         numerator: ivy.Container,
         denominator: Union[Number, ivy.Array, ivy.Container],

--- a/ivy_tests/test_ivy/test_container.py
+++ b/ivy_tests/test_ivy/test_container.py
@@ -1501,39 +1501,6 @@ def test_container_from_numpy(device, call):
     assert ivy.is_ivy_array(container_from_numpy.b.d)
 
 
-def test_container_arrays_as_lists(device, call):
-    dict_in = {
-        "a": ivy.array(
-            [[[1.0, 2.0], [3.0, 4.0]], [[5.0, 6.0], [7.0, 8.0]]], device=device
-        ),
-        "b": {
-            "c": ivy.array(
-                [[[8.0, 7.0], [6.0, 5.0]], [[4.0, 3.0], [2.0, 1.0]]], device=device
-            ),
-            "d": ivy.array(
-                [[[2.0, 4.0], [6.0, 8.0]], [[10.0, 12.0], [14.0, 16.0]]], device=device
-            ),
-        },
-    }
-    container = Container(dict_in)
-
-    assert ivy.is_ivy_array(container["a"])
-    assert ivy.is_ivy_array(container.a)
-    assert ivy.is_ivy_array(container["b"]["c"])
-    assert ivy.is_ivy_array(container.b.c)
-    assert ivy.is_ivy_array(container["b"]["d"])
-    assert ivy.is_ivy_array(container.b.d)
-
-    # without key_chains specification
-    container_arrays_as_lists = container.arrays_as_lists()
-    assert isinstance(container_arrays_as_lists["a"], list)
-    assert isinstance(container_arrays_as_lists.a, list)
-    assert isinstance(container_arrays_as_lists["b"]["c"], list)
-    assert isinstance(container_arrays_as_lists.b.c, list)
-    assert isinstance(container_arrays_as_lists["b"]["d"], list)
-    assert isinstance(container_arrays_as_lists.b.d, list)
-
-
 def test_container_has_key(device, call):
     dict_in = {
         "a": ivy.array([1], device=device),


### PR DESCRIPTION
in progress...