### PR TITLE
container legacy method `as_variables` to equivalent `variable` method in `ivy/container/gradients.py`

### DIFF
--- a/ivy/container/base.py
+++ b/ivy/container/base.py
@@ -2203,39 +2203,6 @@ class ContainerBase(dict, abc.ABC):
             map_sequences,
         )
 
-    def as_variables(
-        self, key_chains=None, to_apply=True, prune_unapplied=False, map_sequences=False
-    ):
-        """Converts all nested arrays to variables, which support gradient computation.
-
-        Parameters
-        ----------
-        key_chains
-            The key-chains to apply or not apply the method to. Default is None.
-        to_apply
-            If True, the method will be applied to key_chains, otherwise key_chains will
-            be skipped. Default is True.
-        prune_unapplied
-            Whether to prune key_chains for which the function was not applied. Default
-            is False.
-        map_sequences
-            Whether to also map method to sequences (lists, tuples). Default is False.
-
-        Returns
-        -------
-            container with each array converted to a variable.
-
-        """
-        return self.map(
-            lambda x, kc: self._ivy.variable(x)
-            if self._ivy.is_native_array(x) or isinstance(x, ivy.Array)
-            else x,
-            key_chains,
-            to_apply,
-            prune_unapplied,
-            map_sequences,
-        )
-
     def as_arrays(
         self, key_chains=None, to_apply=True, prune_unapplied=False, map_sequences=False
     ):

--- a/ivy_tests/test_ivy/test_container.py
+++ b/ivy_tests/test_ivy/test_container.py
@@ -1307,41 +1307,6 @@ def test_container_stop_gradients(device, call):
     assert "b/d" not in container_stopped_grads
 
 
-def test_container_as_variables(device, call):
-    dict_in = {
-        "a": ivy.array(
-            [[[1.0, 2.0], [3.0, 4.0]], [[5.0, 6.0], [7.0, 8.0]]], device=device
-        ),
-        "b": {
-            "c": ivy.array(
-                [[[8.0, 7.0], [6.0, 5.0]], [[4.0, 3.0], [2.0, 1.0]]], device=device
-            ),
-            "d": ivy.array(
-                [[[2.0, 4.0], [6.0, 8.0]], [[10.0, 12.0], [14.0, 16.0]]], device=device
-            ),
-        },
-    }
-    container = Container(dict_in)
-
-    assert ivy.is_ivy_array(container["a"])
-    assert ivy.is_ivy_array(container.a)
-    assert ivy.is_ivy_array(container["b"]["c"])
-    assert ivy.is_ivy_array(container.b.c)
-    assert ivy.is_ivy_array(container["b"]["d"])
-    assert ivy.is_ivy_array(container.b.d)
-
-    variable_cont = container.as_variables()
-
-    if call is not helpers.np_call:
-        # Numpy does not support variables or gradients
-        assert ivy.is_variable(variable_cont["a"])
-        assert ivy.is_variable(variable_cont.a)
-        assert ivy.is_variable(variable_cont["b"]["c"])
-        assert ivy.is_variable(variable_cont.b.c)
-        assert ivy.is_variable(variable_cont["b"]["d"])
-        assert ivy.is_variable(variable_cont.b.d)
-
-
 def test_container_as_arrays(device, call):
     dict_in = {
         "a": ivy.variable(


### PR DESCRIPTION
in progress...