### PR TITLE
rename legacy method `split` to `split_conts` and add normal `split` method in `ivy/container/manipulation.py`

### DIFF
--- a/ivy/array/manipulation.py
+++ b/ivy/array/manipulation.py
@@ -28,8 +28,10 @@ class ArrayWithManipulation(abc.ABC):
         axis: int = 0,
         with_remainder: bool = False,
     ) -> List[ivy.Array]:
-        """Splits a container into multiple sub-containers, by splitting their
-        constituent arrays.
+        """
+        ivy.Array instance method variant of ivy.split. This method simply
+        wraps the function, and so the docstring for ivy.split also applies
+        to this method with minimal changes.
 
         Parameters
         ----------

--- a/ivy/array/manipulation.py
+++ b/ivy/array/manipulation.py
@@ -24,7 +24,7 @@ class ArrayWithManipulation(abc.ABC):
 
     def split(
         self: ivy.Array,
-        num_or_size_splits: Optional[int] = None,
+        num_or_size_splits: Optional[Union[int, Iterable[int]]] = None,
         axis: int = 0,
         with_remainder: bool = False,
     ) -> List[ivy.Array]:

--- a/ivy/array/manipulation.py
+++ b/ivy/array/manipulation.py
@@ -22,6 +22,36 @@ class ArrayWithManipulation(abc.ABC):
     ) -> ivy.Array:
         return ivy.concat([self._data] + xs, axis, out=out)
 
+    def split(
+        self: ivy.Array,
+        num_or_size_splits: Optional[int] = None,
+        axis: int = 0,
+        with_remainder: bool = False,
+    ) -> List[ivy.Array]:
+        """Splits a container into multiple sub-containers, by splitting their
+        constituent arrays.
+
+        Parameters
+        ----------
+        self
+            array to be divided into sub-arrays.
+        num_or_size_splits
+            Number of equal arrays to divide the array into along the given axis if an
+            integer. The size of each split element if a sequence of integers. Default
+            is to divide into as many 1-dimensional arrays as the axis dimension.
+        axis
+            The axis along which to split, default is 0.
+        with_remainder
+            If the tensor does not split evenly, then store the last remainder entry.
+            Default is False.
+
+        Returns
+        -------
+            A list of sub-arrays.
+
+        """
+        return ivy.split(self._data, num_or_size_splits, axis, with_remainder)
+
     def flip(
         self: ivy.Array,
         axis: Optional[Union[int, Tuple[int], List[int]]] = None,

--- a/ivy/container/base.py
+++ b/ivy/container/base.py
@@ -1993,7 +1993,7 @@ class ContainerBase(dict, abc.ABC):
             for i in range(dim_size)
         ]
 
-    def split(
+    def split_conts(
         self,
         num_or_size_splits=None,
         axis=0,

--- a/ivy/container/manipulation.py
+++ b/ivy/container/manipulation.py
@@ -199,6 +199,118 @@ class ContainerWithManipulation(ContainerBase):
             out=out,
         )
 
+    @staticmethod
+    def static_split(
+        x: Union[ivy.Container, ivy.Array, ivy.NativeArray],
+        num_or_size_splits: Optional[Union[int, Iterable[int]]] = None,
+        axis: int = 0,
+        with_remainder: bool = False,
+        key_chains: Optional[Union[List[str], Dict[str, str]]] = None,
+        to_apply: bool = True,
+        prune_unapplied: bool = False,
+        map_sequences: bool = False,
+    ) -> Union[ivy.Container, List[ivy.Container]]:
+        """
+        ivy.Container static method variant of ivy.split. This method simply
+        wraps the function, and so the docstring for ivy.split also applies
+        to this method with minimal changes.
+
+        Parameters
+        ----------
+        x
+            array to be divided into sub-arrays.
+        num_or_size_splits
+            Number of equal arrays to divide the array into along the given axis if an
+            integer. The size of each split element if a sequence of integers. Default
+            is to divide into as many 1-dimensional arrays as the axis dimension.
+        axis
+            The axis along which to split, default is 0.
+        with_remainder
+            If the tensor does not split evenly, then store the last remainder entry.
+            Default is False.
+        key_chains
+            The key-chains to apply or not apply the method to. Default is None.
+        to_apply
+            If True, the method will be applied to key_chains, otherwise key_chains will
+            be skipped. Default is True.
+        prune_unapplied
+            Whether to prune key_chains for which the function was not applied. Default
+            is False.
+        map_sequences
+            Whether to also map method to sequences (lists, tuples). Default is False.
+
+        Returns
+        -------
+            A container with list of sub-arrays.
+
+        """
+        return ContainerBase.multi_map_in_static_method(
+            "split",
+            x,
+            num_or_size_splits,
+            axis,
+            with_remainder,
+            key_chains=key_chains,
+            to_apply=to_apply,
+            prune_unapplied=prune_unapplied,
+            map_sequences=map_sequences,
+        )
+
+    def split(
+        self: ivy.Container,
+        num_or_size_splits: Optional[Union[int, Iterable[int]]] = None,
+        axis: int = 0,
+        with_remainder: bool = False,
+        key_chains: Optional[Union[List[str], Dict[str, str]]] = None,
+        to_apply: bool = True,
+        prune_unapplied: bool = False,
+        map_sequences: bool = False,
+    ) -> Union[ivy.Container, List[ivy.Container]]:
+        """
+        ivy.Container instance method variant of ivy.split. This method simply
+        wraps the function, and so the docstring for ivy.split also applies
+        to this method with minimal changes.
+
+        Parameters
+        ----------
+        self
+            array to be divided into sub-arrays.
+        num_or_size_splits
+            Number of equal arrays to divide the array into along the given axis if an
+            integer. The size of each split element if a sequence of integers. Default
+            is to divide into as many 1-dimensional arrays as the axis dimension.
+        axis
+            The axis along which to split, default is 0.
+        with_remainder
+            If the tensor does not split evenly, then store the last remainder entry.
+            Default is False.
+        key_chains
+            The key-chains to apply or not apply the method to. Default is None.
+        to_apply
+            If True, the method will be applied to key_chains, otherwise key_chains will
+            be skipped. Default is True.
+        prune_unapplied
+            Whether to prune key_chains for which the function was not applied. Default
+            is False.
+        map_sequences
+            Whether to also map method to sequences (lists, tuples). Default is False.
+
+        Returns
+        -------
+            A container with list of sub-arrays.
+
+        """
+        return self.static_split(
+            self,
+            num_or_size_splits,
+            axis,
+            with_remainder,
+            key_chains,
+            to_apply,
+            prune_unapplied,
+            map_sequences,
+        )
+
     def permute_dims(
         self: ivy.Container,
         axes: Tuple[int, ...],
@@ -266,8 +378,8 @@ class ContainerWithManipulation(ContainerBase):
             input container.
 
         shape
-            The new shape should be compatible with the original shape. 
-            One shape dimension can be -1. In this case, the value is 
+            The new shape should be compatible with the original shape.
+            One shape dimension can be -1. In this case, the value is
             inferred from the length of the array and remaining dimensions.
         copy
             boolean indicating whether or not to copy the input array.
@@ -293,7 +405,7 @@ class ContainerWithManipulation(ContainerBase):
         Returns
         -------
         ret
-            optional output container, for writing the result to. It must have a shape 
+            optional output container, for writing the result to. It must have a shape
             that the inputs broadcast to.
 
         Examples

--- a/ivy_tests/test_ivy/test_container.py
+++ b/ivy_tests/test_ivy/test_container.py
@@ -1179,7 +1179,7 @@ def test_container_unstack(device, call):
         assert np.array_equal(ivy.to_numpy(cont.b.d), np.array([bd]))
 
 
-def test_container_split(device, call):
+def test_container_split_conts(device, call):
     dict_in = {
         "a": ivy.array([[1], [2], [3]], device=device),
         "b": {
@@ -1190,7 +1190,7 @@ def test_container_split(device, call):
     container = Container(dict_in)
 
     # without key_chains specification
-    container_split = container.split(1, -1)
+    container_split = container.split_conts(1, -1)
     for cont, a, bc, bd in zip(container_split, [1, 2, 3], [2, 3, 4], [3, 4, 5]):
         assert np.array_equal(ivy.to_numpy(cont["a"])[0], np.array([a]))
         assert np.array_equal(ivy.to_numpy(cont.a)[0], np.array([a]))


### PR DESCRIPTION
- rename to `split_conts` for the container version (includes unstacking containers if applicable)
- added normal `split` instance methods for array and container (split at leaves only)