### PR TITLE
Enabling development environment on M1 based Macbooks

### DIFF
--- a/optional_m1_1.txt
+++ b/optional_m1_1.txt
@@ -1,0 +1,12 @@
+h5py==3.7.0
+pytest==7.1.2
+networkx==2.8.4
+hypothesis==6.48.2
+matplotlib==3.5.2
+opencv-python==4.6.0.66 # mod_name=cv2
+jax==0.3.14
+jaxlib==0.3.14
+tensorflow-macos==2.9.1
+tensorflow-addons==0.17.1 # mod_name=tensorflow_addons
+tensorflow-probability==0.17.0 # mod_name=tensorflow_probability
+torch==1.11.0

--- a/optional_m1_2.txt
+++ b/optional_m1_2.txt
@@ -1,0 +1,4 @@
+torch-scatter==2.0.9 # torch_scatter requires a prior existing installation of torch, hence 2 optional files 
+# mxnet version 2.0.0 is to be built from source for m1 devices link : https://mxnet.apache.org/versions/1.9.0/get_started/osx_setup
+scipy==1.8.1
+dm-haiku==0.0.6 # mod_name=haiku


### PR DESCRIPTION
These 2 additional files will now enable development on M1-based Macbooks which was previously only possible via docker.

Steps :
1. pip install -r optional_m1_1.txt
2. pip install -r optional_m1_2.txt
3.  Follow steps provided here : https://mxnet.apache.org/versions/1.9.0/get_started/osx_setup
