### PR TITLE
added matrix_mean function

### DIFF
--- a/ivy/functional/frontends/numpy/mathematical_functions/arithmetic_operations.py
+++ b/ivy/functional/frontends/numpy/mathematical_functions/arithmetic_operations.py
@@ -24,3 +24,20 @@ def add(
 
 
 add.unsupported_dtypes = {"torch": ("float16",)}
+
+def matrix_mean(a,
+               axis=None,
+               dtype=None,
+               out=None,
+               keepdims=np._NoValue,
+               *,
+               where=np._NoValue):
+    if len(a)==0:
+        return "NaN"
+    try:
+        res = ivy.mean(a, axis, dtype, out, keepdims, where)
+        return res
+    except:
+        print("An exception occurred")
+        
+add.unsupported_dtypes = {"torch": ("float16",)}


### PR DESCRIPTION
I didn't find any backend for the matrix_mean in the backend of ivy so the function isnt working probably because of that so i would like some help with it am i doing something wrong or should i just switch to another issues if this one really doesnt have a backend