### PR TITLE
Added `sin` function for Numpy frontend

### DIFF
--- a/ivy/functional/frontends/numpy/mathematical_functions/trigonometric_functions.py
+++ b/ivy/functional/frontends/numpy/mathematical_functions/trigonometric_functions.py
@@ -2,6 +2,28 @@
 import ivy
 
 
+def sin(
+    x,
+    /,
+    out=None,
+    *,
+    where=True,
+    casting="same_kind",
+    order="k",
+    dtype=None,
+    subok=True,
+):
+    if dtype:
+        x = ivy.astype(ivy.array(x), ivy.as_ivy_dtype(dtype))
+    ret = ivy.sin(x, out=out)
+    if ivy.is_array(where):
+        ret = ivy.where(where, ret, ivy.default(out, ivy.zeros_like(ret)), out=out)
+    return ret
+
+
+sin.unsupported_dtypes = {"torch": ("float16",)}
+
+
 def tan(
     x,
     /,

--- a/ivy_tests/test_ivy/test_frontends/test_numpy/test_mathematical_functions/test_np_trigonometric_functions.py
+++ b/ivy_tests/test_ivy/test_frontends/test_numpy/test_mathematical_functions/test_np_trigonometric_functions.py
@@ -8,6 +8,56 @@ import ivy.functional.backends.numpy as ivy_np
 import ivy_tests.test_ivy.test_frontends.test_numpy.helpers as np_frontend_helpers
 
 
+# sin
+@given(
+    dtype_and_x=helpers.dtype_and_values(available_dtypes=ivy_np.valid_float_dtypes),
+    dtype=st.sampled_from(ivy_np.valid_float_dtypes + (None,)),
+    where=np_frontend_helpers.where(),
+    as_variable=helpers.array_bools(),
+    with_out=st.booleans(),
+    num_positional_args=helpers.num_positional_args(
+        fn_name="ivy.functional.frontends.numpy.sin"
+    ),
+    native_array=helpers.array_bools(),
+)
+def test_numpy_sin(
+    dtype_and_x,
+    dtype,
+    where,
+    as_variable,
+    with_out,
+    num_positional_args,
+    native_array,
+    fw,
+):
+    input_dtype, x = dtype_and_x
+    input_dtype = [input_dtype]
+    where = np_frontend_helpers.handle_where_and_array_bools(
+        where=where,
+        input_dtype=input_dtype,
+        as_variable=as_variable,
+        native_array=native_array,
+    )
+    np_frontend_helpers.test_frontend_function(
+        input_dtypes=input_dtype,
+        as_variable_flags=as_variable,
+        with_out=with_out,
+        num_positional_args=num_positional_args,
+        native_array_flags=native_array,
+        fw=fw,
+        frontend="numpy",
+        fn_name="sin",
+        x=np.asarray(x, dtype=input_dtype[0]),
+        out=None,
+        where=where,
+        casting="same_kind",
+        order="k",
+        dtype=dtype,
+        subok=True,
+        test_values=False,
+    )
+
+
 # tan
 @given(
     dtype_and_x=helpers.dtype_and_values(available_dtypes=ivy_np.valid_float_dtypes),


### PR DESCRIPTION
Hello @jkeane508 
This PR solves issue #2443 

I added the frontend `sin` function for NumPy.
But I have the failing tests and I saw the same goes for tan implemented function before, maybe the problem is with the helper function. 

Thanks.