### PR TITLE
Add concat to frontends.torch.indexing_slicing_joining_mutating_ops

### DIFF
--- a/ivy/functional/frontends/torch/indexing_slicing_joining_mutating_ops.py
+++ b/ivy/functional/frontends/torch/indexing_slicing_joining_mutating_ops.py
@@ -4,3 +4,7 @@ import ivy
 
 def cat(tensors, dim=0, *, out=None):
     return ivy.concat(tensors, dim, out=out)
+
+
+def concat(tensors, dim=0, *, out=None):
+    return ivy.concat(tensors, dim, out=out)


### PR DESCRIPTION
Question: we still need to add alias (in this case, torch.concat() and torch.cat()) to the frontend to stay consistent, correct?