### PR TITLE
Add test_torch_concat to test_frontends.test_indexing_slicing_joining…

### DIFF
--- a/ivy_tests/test_ivy/test_frontends/test_torch/test_indexing_slicing_joining_mutating_ops.py
+++ b/ivy_tests/test_ivy/test_frontends/test_torch/test_indexing_slicing_joining_mutating_ops.py
@@ -37,7 +37,7 @@ def _arrays_idx_n_dtypes(draw):
     return xs, input_dtypes, unique_idx
 
 
-# concat
+# cat
 @given(
     xs_n_input_dtypes_n_unique_idx=_arrays_idx_n_dtypes(),
     as_variable=helpers.array_bools(),
@@ -66,6 +66,41 @@ def test_torch_cat(
         fw=fw,
         frontend="torch",
         fn_name="cat",
+        tensors=xs,
+        dim=unique_idx,
+        out=None,
+    )
+
+    
+# concat
+@given(
+    xs_n_input_dtypes_n_unique_idx=_arrays_idx_n_dtypes(),
+    as_variable=helpers.array_bools(),
+    num_positional_args=helpers.num_positional_args(
+        fn_name="ivy.functional.frontends.torch.concat"
+    ),
+    native_array=helpers.array_bools(),
+    with_out=st.booleans(),
+)
+def test_torch_concat(
+    xs_n_input_dtypes_n_unique_idx,
+    as_variable,
+    num_positional_args,
+    native_array,
+    with_out,
+    fw,
+):
+    xs, input_dtypes, unique_idx = xs_n_input_dtypes_n_unique_idx
+    xs = [np.asarray(x, dtype=dt) for x, dt in zip(xs, input_dtypes)]
+    helpers.test_frontend_function(
+        input_dtypes=input_dtypes,
+        as_variable_flags=as_variable,
+        with_out=with_out,
+        num_positional_args=num_positional_args,
+        native_array_flags=native_array,
+        fw=fw,
+        frontend="torch",
+        fn_name="concat",
         tensors=xs,
         dim=unique_idx,
         out=None,


### PR DESCRIPTION
…_mutating_ops

Question: we still need to add alias (in this case, torch.concat() and torch.cat()) to the frontend to stay consistent, correct?