### PR TITLE
fixes for `small_value_safety_factor`

### DIFF
--- a/ivy_tests/test_ivy/helpers.py
+++ b/ivy_tests/test_ivy/helpers.py
@@ -2153,181 +2153,216 @@ def array_values(
             )
         values = draw(list_of_length(x=st.integers(min_value, max_value), length=size))
     elif "int" in dtype:
-        if dtype == "int8":
-            min_value = ivy.default(min_value, round(-128 * large_value_safety_factor))
-            max_neg_value = -1 if small_value_safety_factor > 1 else 0
-            min_pos_value = 1 if small_value_safety_factor > 1 else 0
-            max_value = ivy.default(max_value, round(127 * large_value_safety_factor))
 
-        elif dtype == "int16":
-            min_value = ivy.default(
-                min_value, round(-32768 * large_value_safety_factor)
-            )
-            max_neg_value = -1 if small_value_safety_factor > 1 else 0
-            min_pos_value = 1 if small_value_safety_factor > 1 else 0
-            max_value = ivy.default(max_value, round(32767 * large_value_safety_factor))
-
-        elif dtype == "int32":
-            min_value = ivy.default(
-                min_value, round(-2147483648 * large_value_safety_factor)
-            )
-            max_neg_value = -1 if small_value_safety_factor > 1 else 0
-            min_pos_value = 1 if small_value_safety_factor > 1 else 0
-            max_value = ivy.default(
-                max_value, round(2147483647 * large_value_safety_factor)
-            )
-
-        elif dtype == "int64":
-            min_value = ivy.default(
-                min_value,
-                max(
-                    -9223372036854775808,
-                    round(-9223372036854775808 * large_value_safety_factor),
-                ),
-            )
-            max_neg_value = -1 if small_value_safety_factor > 1 else 0
-            min_pos_value = 1 if small_value_safety_factor > 1 else 0
-            max_value = ivy.default(
-                max_value,
-                min(
-                    9223372036854775807,
-                    round(9223372036854775807 * large_value_safety_factor),
-                ),
-            )
-
-        if max_value and min_pos_value > max_value:
-            max_value, min_pos_value = min_pos_value, max_value
-
-        if min_value and min_value > max_neg_value:
-            max_neg_value, min_value = min_value, max_neg_value
-
-        values = draw(
-            list_of_length(
-                x=st.integers(min_value, max_neg_value)
-                | st.integers(min_pos_value, max_value),
-                length=size,
-            )
-        )
-    elif dtype == "float16":
-        limit = math.log(small_value_safety_factor)
-        min_value_neg = min_value
-        max_value_neg = round(-1 * limit, -3)
-
-        if min_value_neg and min_value_neg > max_value_neg:
-            max_value_neg, min_value_neg = min_value_neg, max_value_neg
-
-        min_value_pos = round(limit, -3)
-        max_value_pos = max_value
-
-        if max_value_pos and min_value_pos > max_value_pos:
-            max_value_pos, min_value_pos = min_value_pos, max_value_pos
-
-        values = draw(
-            list_of_length(
-                x=st.floats(
-                    min_value=min_value_neg,
-                    max_value=max_value_neg,
-                    allow_nan=allow_nan,
-                    allow_subnormal=allow_subnormal,
-                    allow_infinity=allow_inf,
-                    width=16,
-                    exclude_min=exclude_min,
-                    exclude_max=exclude_max,
+        if min_value is not None and max_value is not None:
+            values = draw(
+                list_of_length(
+                    x=st.integers(min_value, max_value),
+                    length=size,
                 )
-                | st.floats(
-                    min_value=min_value_pos,
-                    max_value=max_value_pos,
-                    allow_nan=allow_nan,
-                    allow_subnormal=allow_subnormal,
-                    allow_infinity=allow_inf,
-                    width=16,
-                    exclude_min=exclude_min,
-                    exclude_max=exclude_max,
-                ),
-                length=size,
             )
-        )
+        else:
+            if dtype == "int8":
+                min_value = ivy.default(
+                    min_value, round(-128 * large_value_safety_factor)
+                )
+                max_value = ivy.default(
+                    max_value, round(127 * large_value_safety_factor)
+                )
+
+            elif dtype == "int16":
+                min_value = ivy.default(
+                    min_value, round(-32768 * large_value_safety_factor)
+                )
+                max_value = ivy.default(
+                    max_value, round(32767 * large_value_safety_factor)
+                )
+
+            elif dtype == "int32":
+                min_value = ivy.default(
+                    min_value, round(-2147483648 * large_value_safety_factor)
+                )
+                max_value = ivy.default(
+                    max_value, round(2147483647 * large_value_safety_factor)
+                )
+
+            elif dtype == "int64":
+                min_value = ivy.default(
+                    min_value,
+                    max(
+                        -9223372036854775808,
+                        round(-9223372036854775808 * large_value_safety_factor),
+                    ),
+                )
+                max_value = ivy.default(
+                    max_value,
+                    min(
+                        9223372036854775807,
+                        round(9223372036854775807 * large_value_safety_factor),
+                    ),
+                )
+            max_neg_value = -1 if small_value_safety_factor > 1 else 0
+            min_pos_value = 1 if small_value_safety_factor > 1 else 0
+            values = draw(
+                list_of_length(
+                    x=st.integers(min_value, max_neg_value)
+                    | st.integers(min_pos_value, max_value),
+                    length=size,
+                )
+            )
+    elif dtype == "float16":
+
+        if min_value is not None and max_value is not None:
+            values = draw(
+                list_of_length(
+                    x=st.floats(
+                        min_value=min_value,
+                        max_value=max_value,
+                        allow_nan=allow_nan,
+                        allow_subnormal=allow_subnormal,
+                        allow_infinity=allow_inf,
+                        width=16,
+                        exclude_min=exclude_min,
+                        exclude_max=exclude_max,
+                    ),
+                    length=size,
+                )
+            )
+
+        else:
+            limit = math.log(small_value_safety_factor)
+            min_value_neg = min_value
+            max_value_neg = round(-1 * limit, -3)
+            min_value_pos = round(limit, -3)
+            max_value_pos = max_value
+
+            values = draw(
+                list_of_length(
+                    x=st.floats(
+                        min_value=min_value_neg,
+                        max_value=max_value_neg,
+                        allow_nan=allow_nan,
+                        allow_subnormal=allow_subnormal,
+                        allow_infinity=allow_inf,
+                        width=16,
+                        exclude_min=exclude_min,
+                        exclude_max=exclude_max,
+                    )
+                    | st.floats(
+                        min_value=min_value_pos,
+                        max_value=max_value_pos,
+                        allow_nan=allow_nan,
+                        allow_subnormal=allow_subnormal,
+                        allow_infinity=allow_inf,
+                        width=16,
+                        exclude_min=exclude_min,
+                        exclude_max=exclude_max,
+                    ),
+                    length=size,
+                )
+            )
         values = [v * large_value_safety_factor for v in values]
     elif dtype in ["float32", "bfloat16"]:
-        limit = math.log(small_value_safety_factor)
-        min_value_neg = min_value
-        max_value_neg = round(-1 * limit, -6)
-
-        if min_value_neg and min_value_neg > max_value_neg:
-            max_value_neg, min_value_neg = min_value_neg, max_value_neg
-
-        min_value_pos = round(limit, -6)
-        max_value_pos = max_value
-
-        if max_value_pos and min_value_pos > max_value_pos:
-            max_value_pos, min_value_pos = min_value_pos, max_value_pos
-
-        values = draw(
-            list_of_length(
-                x=st.floats(
-                    min_value=min_value_neg,
-                    max_value=max_value_neg,
-                    allow_nan=allow_nan,
-                    allow_subnormal=allow_subnormal,
-                    allow_infinity=allow_inf,
-                    width=32,
-                    exclude_min=exclude_min,
-                    exclude_max=exclude_max,
+        if min_value is not None and max_value is not None:
+            values = draw(
+                list_of_length(
+                    x=st.floats(
+                        min_value=min_value,
+                        max_value=max_value,
+                        allow_nan=allow_nan,
+                        allow_subnormal=allow_subnormal,
+                        allow_infinity=allow_inf,
+                        width=32,
+                        exclude_min=exclude_min,
+                        exclude_max=exclude_max,
+                    ),
+                    length=size,
                 )
-                | st.floats(
-                    min_value=min_value_pos,
-                    max_value=max_value_pos,
-                    allow_nan=allow_nan,
-                    allow_subnormal=allow_subnormal,
-                    allow_infinity=allow_inf,
-                    width=32,
-                    exclude_min=exclude_min,
-                    exclude_max=exclude_max,
-                ),
-                length=size,
             )
-        )
+        else:
+            limit = math.log(small_value_safety_factor)
+            min_value_neg = min_value
+            max_value_neg = round(-1 * limit, -6)
+            min_value_pos = round(limit, -6)
+            max_value_pos = max_value
+
+            values = draw(
+                list_of_length(
+                    x=st.floats(
+                        min_value=min_value_neg,
+                        max_value=max_value_neg,
+                        allow_nan=allow_nan,
+                        allow_subnormal=allow_subnormal,
+                        allow_infinity=allow_inf,
+                        width=32,
+                        exclude_min=exclude_min,
+                        exclude_max=exclude_max,
+                    )
+                    | st.floats(
+                        min_value=min_value_pos,
+                        max_value=max_value_pos,
+                        allow_nan=allow_nan,
+                        allow_subnormal=allow_subnormal,
+                        allow_infinity=allow_inf,
+                        width=32,
+                        exclude_min=exclude_min,
+                        exclude_max=exclude_max,
+                    ),
+                    length=size,
+                )
+            )
         values = [v * large_value_safety_factor for v in values]
     elif dtype == "float64":
-        limit = math.log(small_value_safety_factor)
 
-        min_value_neg = min_value
-        max_value_neg = round(-1 * limit, -15)
-
-        if min_value_neg and min_value_neg > max_value_neg:
-            max_value_neg, min_value_neg = min_value_neg, max_value_neg
-
-        min_value_pos = round(limit, -15)
-        max_value_pos = max_value
-
-        if max_value_pos and min_value_pos > max_value_pos:
-            max_value_pos, min_value_pos = min_value_pos, max_value_pos
-
-        values = draw(
-            list_of_length(
-                x=st.floats(
-                    min_value=min_value_neg,
-                    max_value=max_value_neg,
-                    allow_nan=allow_nan,
-                    allow_subnormal=allow_subnormal,
-                    allow_infinity=allow_inf,
-                    width=64,
-                    exclude_min=exclude_min,
-                    exclude_max=exclude_max,
+        if min_value is not None and max_value is not None:
+            values = draw(
+                list_of_length(
+                    x=st.floats(
+                        min_value=min_value,
+                        max_value=max_value,
+                        allow_nan=allow_nan,
+                        allow_subnormal=allow_subnormal,
+                        allow_infinity=allow_inf,
+                        width=64,
+                        exclude_min=exclude_min,
+                        exclude_max=exclude_max,
+                    ),
+                    length=size,
                 )
-                | st.floats(
-                    min_value=min_value_pos,
-                    max_value=max_value_pos,
-                    allow_nan=allow_nan,
-                    allow_subnormal=allow_subnormal,
-                    allow_infinity=allow_inf,
-                    width=64,
-                    exclude_min=exclude_min,
-                    exclude_max=exclude_max,
-                ),
-                length=size,
             )
-        )
+        else:
+            limit = math.log(small_value_safety_factor)
+
+            min_value_neg = min_value
+            max_value_neg = round(-1 * limit, -15)
+            min_value_pos = round(limit, -15)
+            max_value_pos = max_value
+
+            values = draw(
+                list_of_length(
+                    x=st.floats(
+                        min_value=min_value_neg,
+                        max_value=max_value_neg,
+                        allow_nan=allow_nan,
+                        allow_subnormal=allow_subnormal,
+                        allow_infinity=allow_inf,
+                        width=64,
+                        exclude_min=exclude_min,
+                        exclude_max=exclude_max,
+                    )
+                    | st.floats(
+                        min_value=min_value_pos,
+                        max_value=max_value_pos,
+                        allow_nan=allow_nan,
+                        allow_subnormal=allow_subnormal,
+                        allow_infinity=allow_inf,
+                        width=64,
+                        exclude_min=exclude_min,
+                        exclude_max=exclude_max,
+                    ),
+                    length=size,
+                )
+            )
         values = [v * large_value_safety_factor for v in values]
     elif dtype == "bool":
         values = draw(list_of_length(x=st.booleans(), length=size))

--- a/ivy_tests/test_ivy/test_functional/test_core/test_creation.py
+++ b/ivy_tests/test_ivy/test_functional/test_core/test_creation.py
@@ -82,6 +82,7 @@ def test_native_array(
         max_num_dims=5,
         min_dim_size=1,
         max_dim_size=5,
+        allow_inf=False,
         shared_dtype=True,
         large_value_safety_factor=2,
     ),


### PR DESCRIPTION
There's no problem with using `None` in hypothesis generations and it generates values within the bounds. The tests were failing because of specified `min_value` and `max_value` in some of the tests such as [example](https://github.com/unifyai/ivy/blob/6849501d26bf60988aee894c5f581b12f69cf2cc/ivy_tests/test_ivy/test_functional/test_core/test_random.py#L141). This has been changed to not generate `max_neg_val` and `min_pos_val` for such cases and instead directly draw based on the specified values.