### PR TITLE
Minor fix for test_qr in linalg submodule + fixed pytest discovery fail

### DIFF
--- a/ivy_tests/test_ivy/test_functional/test_core/test_linalg.py
+++ b/ivy_tests/test_ivy/test_functional/test_core/test_linalg.py
@@ -936,13 +936,7 @@ def test_pinv(
 # qr
 @handle_cmd_line_args
 @given(
-    dtype_x=helpers.dtype_and_values(
-        available_dtypes=ivy_np.valid_float_dtypes,
-        min_num_dims=2,
-        max_num_dims=2,
-        min_dim_size=2,
-        max_dim_size=5,
-    ),
+    dtype_x=_get_dtype_and_matrix(),
     num_positional_args=helpers.num_positional_args(fn_name="qr"),
     mode=st.sampled_from(("reduced", "complete")),
 )


### PR DESCRIPTION
* Added `__init__.py` file in `test_frontends/test_tensorflow/__init__.py` as it's absence was causing PyTest discovery error in VSCode. 
* Updated `test_qr`, minor fix to include _only_ square matrices. 