### PR TITLE
tensorflow frontend - `nest` 

### DIFF
--- a/ivy/functional/frontends/tensorflow/nest.py
+++ b/ivy/functional/frontends/tensorflow/nest.py
@@ -1,4 +1,3 @@
-# for review
 # global
 import ivy
 import tensorflow as tf

--- a/ivy/functional/frontends/tensorflow/nest.py
+++ b/ivy/functional/frontends/tensorflow/nest.py
@@ -5,8 +5,8 @@ import tensorflow as tf
 import torch
 
 
-def _is_sparse_array(x):
-    if isinstance(x, tf.SparseTensor):
+def _is_composite_array(x):
+    if isinstance(x, (tf.SparseTensor, tf.RaggedTensor)):
         return True
     if isinstance(x, torch.Tensor):
         if x.layout in [torch.sparse_coo, torch.sparse_csr]:
@@ -14,14 +14,19 @@ def _is_sparse_array(x):
     return False
 
 
-def _flatten_sparse_array(x):
-    if isinstance(x, tf.SparseTensor):
+def _flatten_composite_array(x):
+    if isinstance(x, tf.RaggedTensor):
+        new_struc = [x.flat_values]
+        for row_split in x.nested_row_splits:
+            new_struc.append(row_split)
+        return new_struc
+    elif isinstance(x, tf.SparseTensor):
         return [x.indices, x.values, x.dense_shape]
-    if isinstance(x, torch.Tensor):
+    elif isinstance(x, torch.Tensor):
         if x.layout == torch.sparse_coo:
             x = x.coalesce()
             return [x.indices(), x.values(), ivy.native_array(x.size(), dtype="int64")]
-        if x.layout == torch.sparse_csr:
+        elif x.layout == torch.sparse_csr:
             return [
                 x.crow_indices(),
                 x.col_indices(),
@@ -31,20 +36,14 @@ def _flatten_sparse_array(x):
 
 
 def flatten(structure, expand_composites=False):
-    if expand_composites:
-        if isinstance(structure, tf.RaggedTensor):
-            new_struc = [structure.flat_values]
-            for row_split in structure.nested_row_splits:
-                new_struc.append(row_split)
-            return new_struc
-        if _is_sparse_array(structure):
-            return _flatten_sparse_array(structure)
-    if isinstance(structure, (tuple, list)):
+    if expand_composites and _is_composite_array(structure):
+        return _flatten_composite_array(structure)
+    elif isinstance(structure, (tuple, list)):
         new_struc = []
         for child in structure:
             new_struc += flatten(child)
         return new_struc
-    if isinstance(structure, dict):
+    elif isinstance(structure, dict):
         new_struc = []
         for key in sorted(structure):
             new_struc += flatten(structure[key])

--- a/ivy/functional/frontends/tensorflow/nest.py
+++ b/ivy/functional/frontends/tensorflow/nest.py
@@ -1,3 +1,4 @@
+# for review
 # global
 import ivy
 import tensorflow as tf

--- a/ivy_tests/test_ivy/test_frontends/test_tensorflow/test_nest.py
+++ b/ivy_tests/test_ivy/test_frontends/test_tensorflow/test_nest.py
@@ -1,4 +1,3 @@
-# for review
 # global
 import ivy
 import numpy as np

--- a/ivy_tests/test_ivy/test_frontends/test_tensorflow/test_nest.py
+++ b/ivy_tests/test_ivy/test_frontends/test_tensorflow/test_nest.py
@@ -1,3 +1,4 @@
+# for review
 # global
 import ivy
 import numpy as np


### PR DESCRIPTION
related function:
- `flatten` -  only flattens tuple, list, dict. Arrays are treated as an atom, therefore returned without changes

updates:
- combined `ragged` and `sparse` checking to `_is_composite_array` and `_flatten_composite_array`

notes:
- when `expand_composites` is True, special arrays like `ragged_array` or `sparse_array` is expanded according to components or attributes.
- `ragged_array` is present only in tensorflow
- `sparse_array` is present only in tensorflow and torch, for torch I tried to recover the tf behaviour when `expand_composites` is True

Thanks!