### PR TITLE
Pytorch frontend Seed function added

### DIFF
--- a/ivy/functional/frontends/torch/random_sampling.py
+++ b/ivy/functional/frontends/torch/random_sampling.py
@@ -1,0 +1,6 @@
+# local
+import ivy
+
+
+def seed():
+    return ivy.seed()

--- a/ivy_tests/test_ivy/test_frontends/test_torch/test_random_sampling.py
+++ b/ivy_tests/test_ivy/test_frontends/test_torch/test_random_sampling.py
@@ -1,0 +1,32 @@
+# global
+from hypothesis import given, strategies as st
+
+# local
+import ivy_tests.test_ivy.helpers as helpers
+from ivy_tests.test_ivy.helpers import handle_cmd_line_args
+import ivy.functional.backends.torch as ivy_torch
+
+
+@handle_cmd_line_args
+@given(
+    num_positional_args=helpers.num_positional_args(
+        fn_name="ivy.functional.frontends.torch.seed"
+    ),
+)
+def test_torch_seed(
+    as_variable,
+    num_positional_args,
+    native_array,
+    with_out,
+    fw
+):
+    helpers.test_frontend_function(
+        input_dtypes=ivy_torch.valid_int_dtypes,
+        as_variable_flags=as_variable,
+        with_out=with_out,
+        num_positional_args=num_positional_args,
+        native_array_flags=native_array,
+        fw=fw,
+        frontend="torch",
+        fn_tree="seed"
+    )


### PR DESCRIPTION
This PR solve #3432 

The test_torch_seed function, has an arbitrary `input_dtypes` because it doesn't have any input parameters.