### PR TITLE
backend specific dtype handling

### DIFF
--- a/ivy_tests/test_ivy/helpers.py
+++ b/ivy_tests/test_ivy/helpers.py
@@ -2083,8 +2083,6 @@ def dtype_and_values(
         max_dim_size = draw(max_dim_size)
     if isinstance(available_dtypes, st._internal.SearchStrategy):
         available_dtypes = draw(available_dtypes)
-        print(f"\nCurrent Backend-: {ivy.current_backend_str()}")
-        print(available_dtypes)
     if not isinstance(num_arrays, int):
         num_arrays = draw(num_arrays)
     if dtype is None:

--- a/ivy_tests/test_ivy/helpers.py
+++ b/ivy_tests/test_ivy/helpers.py
@@ -338,7 +338,7 @@ def var_fn(x, *, dtype=None, device=None):
 
 
 @st.composite
-def get_dtypes(draw, type, index=0, full=False):
+def get_dtypes(draw, kind, index=0, full=False):
     """
     Draws valid dtypes based on the backend set on the stack
     Parameters
@@ -357,7 +357,7 @@ def get_dtypes(draw, type, index=0, full=False):
     -------
 
     """
-    dtype_dict = {
+    type_dict = {
         "valid": ivy.valid_dtypes,
         "numeric": ivy.valid_numeric_dtypes,
         "float": ivy.valid_float_dtypes,
@@ -365,8 +365,8 @@ def get_dtypes(draw, type, index=0, full=False):
         "unsigned": ivy.valid_uint_dtypes,
     }
     if full:
-        return dtype_dict[type][index:]
-    return draw(st.sampled_from(dtype_dict[type][index:]))
+        return type_dict[kind][index:]
+    return draw(st.sampled_from(type_dict[kind][index:]))
 
 
 @st.composite
@@ -1484,6 +1484,7 @@ def test_function(
     args_np, kwargs_np = kwargs_to_args_n_kwargs(
         num_positional_args=num_positional_args, kwargs=all_as_kwargs_np
     )
+    # bfloat16 is not supported by numpy
     assume(not ("bfloat16" in input_dtypes))
 
     fn = getattr(ivy, fn_name)

--- a/ivy_tests/test_ivy/helpers.py
+++ b/ivy_tests/test_ivy/helpers.py
@@ -115,20 +115,6 @@ _iterable_types = [list, tuple, dict]
 _excluded = []
 
 
-@st.composite
-def get_dtype(draw, type, index=0, full=False):
-    dtype_dict = {
-        "valid": ivy.valid_dtypes,
-        "numeric": ivy.valid_numeric_dtypes,
-        "float": ivy.valid_float_dtypes,
-        "integer": ivy.valid_int_dtypes,
-        "unsigned": ivy.valid_uint_dtypes,
-    }
-    if full:
-        return dtype_dict[type]
-    return draw(st.sampled_from(dtype_dict[type][index:]))
-
-
 def _convert_vars(
     *, vars_in, from_type, to_type_callable=None, keep_other=True, to_type=None
 ):
@@ -349,6 +335,38 @@ def docstring_examples_run(
 def var_fn(x, *, dtype=None, device=None):
     """Returns x as an Ivy Variable wrapping an Ivy Array with given dtype and device"""
     return ivy.variable(ivy.array(x, dtype=dtype, device=device))
+
+
+@st.composite
+def get_dtypes(draw, type, index=0, full=False):
+    """
+    Draws valid dtypes based on the backend set on the stack
+    Parameters
+    ----------
+    draw
+        special function that draws data randomly (but is reproducible) from a given
+        data-set (ex. list).
+    type
+        Supported types are integer, float, valid, numeric, and unsigned
+    index
+        list indexing incase a test needs to be skipped for a particular dtype(s)
+    full
+        returns the complete list of valid types
+
+    Returns
+    -------
+
+    """
+    dtype_dict = {
+        "valid": ivy.valid_dtypes,
+        "numeric": ivy.valid_numeric_dtypes,
+        "float": ivy.valid_float_dtypes,
+        "integer": ivy.valid_int_dtypes,
+        "unsigned": ivy.valid_uint_dtypes,
+    }
+    if full:
+        return dtype_dict[type][index:]
+    return draw(st.sampled_from(dtype_dict[type][index:]))
 
 
 @st.composite

--- a/ivy_tests/test_ivy/helpers.py
+++ b/ivy_tests/test_ivy/helpers.py
@@ -338,7 +338,7 @@ def var_fn(x, *, dtype=None, device=None):
 
 
 @st.composite
-def get_dtypes(draw, kind, index=0, full=False):
+def get_dtypes(draw, kind, index=0, full=False, none=False):
     """
     Draws valid dtypes based on the backend set on the stack
     Parameters
@@ -352,6 +352,7 @@ def get_dtypes(draw, kind, index=0, full=False):
         list indexing incase a test needs to be skipped for a particular dtype(s)
     full
         returns the complete list of valid types
+    none
 
     Returns
     -------
@@ -364,6 +365,8 @@ def get_dtypes(draw, kind, index=0, full=False):
         "integer": ivy.valid_int_dtypes,
         "unsigned": ivy.valid_uint_dtypes,
     }
+    if none:
+        return draw(st.sampled_from(type_dict[kind][index:] + (None,)))
     if full:
         return type_dict[kind][index:]
     return draw(st.sampled_from(type_dict[kind][index:]))

--- a/ivy_tests/test_ivy/helpers.py
+++ b/ivy_tests/test_ivy/helpers.py
@@ -116,7 +116,7 @@ _excluded = []
 
 
 @st.composite
-def get_dtype(draw, type, full=False):
+def get_dtype(draw, type, index=0, full=False):
     dtype_dict = {
         "valid": ivy.valid_dtypes,
         "numeric": ivy.valid_numeric_dtypes,
@@ -126,7 +126,7 @@ def get_dtype(draw, type, full=False):
     }
     if full:
         return dtype_dict[type]
-    return draw(st.sampled_from(dtype_dict[type]))
+    return draw(st.sampled_from(dtype_dict[type][index:]))
 
 
 def _convert_vars(

--- a/ivy_tests/test_ivy/helpers.py
+++ b/ivy_tests/test_ivy/helpers.py
@@ -352,6 +352,7 @@ def get_dtypes(draw, kind, index=0, full=False, none=False):
         list indexing incase a test needs to be skipped for a particular dtype(s)
     full
         returns the complete list of valid types
+        returns the complete list of valid types
     none
 
     Returns

--- a/ivy_tests/test_ivy/test_functional/test_core/test_creation.py
+++ b/ivy_tests/test_ivy/test_functional/test_core/test_creation.py
@@ -16,7 +16,7 @@ from ivy_tests.test_ivy.helpers import handle_cmd_line_args
 @handle_cmd_line_args
 @given(
     dtype_and_x=helpers.dtype_and_values(
-        available_dtypes=helpers.get_dtype("numeric", full=True),
+        available_dtypes=helpers.get_dtypes("numeric", full=True),
         dtype=ivy.valid_numeric_dtypes,
         num_arrays=1,
         min_num_dims=1,
@@ -58,7 +58,7 @@ def test_native_array(
 @handle_cmd_line_args
 @given(
     dtype_and_start_stop=helpers.dtype_and_values(
-        available_dtypes=helpers.get_dtype("float", full=True),
+        available_dtypes=helpers.get_dtypes("float", full=True),
         num_arrays=2,
         min_value=None,
         max_value=None,
@@ -108,7 +108,7 @@ def test_linspace(
 @handle_cmd_line_args
 @given(
     dtype_and_start_stop=helpers.dtype_and_values(
-        available_dtypes=helpers.get_dtype("float", full=True),
+        available_dtypes=helpers.get_dtypes("float", full=True),
         num_arrays=2,
         min_value=None,
         max_value=None,
@@ -166,7 +166,7 @@ def test_logspace(
     step=helpers.ints(min_value=-50, max_value=50).filter(
         lambda x: True if x != 0 else False
     ),
-    dtype=helpers.get_dtype("numeric"),
+    dtype=helpers.get_dtypes("numeric"),
     num_positional_args=helpers.num_positional_args(fn_name="arange"),
 )
 def test_arange(
@@ -202,7 +202,7 @@ def test_arange(
 @handle_cmd_line_args
 @given(
     dtype_and_x=helpers.dtype_and_values(
-        available_dtypes=helpers.get_dtype("numeric", full=True),
+        available_dtypes=helpers.get_dtypes("numeric", full=True),
         num_arrays=1,
         min_num_dims=0,
         max_num_dims=5,
@@ -248,7 +248,7 @@ def test_asarray(
         min_dim_size=1,
         max_dim_size=5,
     ),
-    dtype=helpers.get_dtype("numeric"),
+    dtype=helpers.get_dtypes("numeric"),
     num_positional_args=helpers.num_positional_args(fn_name="empty"),
 )
 def test_empty(
@@ -287,7 +287,7 @@ def test_empty(
 @handle_cmd_line_args
 @given(
     dtype_and_x=helpers.dtype_and_values(
-        available_dtypes=helpers.get_dtype("numeric", full=True),
+        available_dtypes=helpers.get_dtypes("numeric", full=True),
         num_arrays=1,
         min_num_dims=1,
         max_num_dims=5,
@@ -341,7 +341,7 @@ def test_empty_like(
     batch_shape=st.lists(
         helpers.ints(min_value=1, max_value=10), min_size=1, max_size=2
     ),
-    dtype=helpers.get_dtype("integer"),
+    dtype=helpers.get_dtypes("integer"),
     num_positional_args=helpers.num_positional_args(fn_name="eye"),
 )
 def test_eye(
@@ -380,7 +380,7 @@ def test_eye(
 @handle_cmd_line_args
 @given(
     dtype_and_x=helpers.dtype_and_values(
-        available_dtypes=helpers.get_dtype("numeric", full=True),
+        available_dtypes=helpers.get_dtypes("numeric", full=True),
         num_arrays=1,
         min_num_dims=1,
         max_num_dims=5,
@@ -418,7 +418,7 @@ def test_from_dlpack(
 def _dtypes(draw):
     return draw(
         st.shared(
-            helpers.list_of_length(x=helpers.get_dtype("numeric"), length=1),
+            helpers.list_of_length(x=helpers.get_dtypes("numeric"), length=1),
             key="dtype",
         )
     )
@@ -479,7 +479,7 @@ def test_full(
 def _dtype_and_values(draw):
     return draw(
         helpers.dtype_and_values(
-            available_dtypes=helpers.get_dtype("numeric", full=True),
+            available_dtypes=helpers.get_dtypes("numeric", full=True),
             num_arrays=1,
             min_num_dims=1,
             max_num_dims=5,
@@ -535,7 +535,7 @@ array_shape = st.shared(
     st.lists(helpers.ints(min_value=1, max_value=10), min_size=1, max_size=1),
     key="array_shape",
 )
-dtype_shared = st.shared(helpers.get_dtype("numeric"), key="dtype")
+dtype_shared = st.shared(helpers.get_dtypes("numeric"), key="dtype")
 
 
 @handle_cmd_line_args
@@ -586,7 +586,7 @@ def test_meshgrid(
         min_dim_size=1,
         max_dim_size=5,
     ),
-    dtype=helpers.get_dtype("numeric"),
+    dtype=helpers.get_dtypes("numeric"),
     num_positional_args=helpers.num_positional_args(fn_name="ones"),
 )
 def test_ones(
@@ -618,7 +618,7 @@ def test_ones(
 @handle_cmd_line_args
 @given(
     dtype_and_x=helpers.dtype_and_values(
-        available_dtypes=helpers.get_dtype("numeric", full=True),
+        available_dtypes=helpers.get_dtypes("numeric", full=True),
         num_arrays=1,
         min_num_dims=1,
         max_num_dims=5,
@@ -659,7 +659,7 @@ def test_ones_like(
 @handle_cmd_line_args
 @given(
     dtype_and_x=helpers.dtype_and_values(
-        available_dtypes=helpers.get_dtype("numeric", full=True),
+        available_dtypes=helpers.get_dtypes("numeric", full=True),
         num_arrays=1,
         min_num_dims=2,
         max_num_dims=5,
@@ -701,7 +701,7 @@ def test_tril(
 @handle_cmd_line_args
 @given(
     dtype_and_x=helpers.dtype_and_values(
-        available_dtypes=helpers.get_dtype("numeric", full=True),
+        available_dtypes=helpers.get_dtypes("numeric", full=True),
         num_arrays=1,
         min_num_dims=2,
         max_num_dims=5,
@@ -749,7 +749,7 @@ def test_triu(
         min_dim_size=1,
         max_dim_size=5,
     ),
-    dtype=helpers.get_dtype("integer"),
+    dtype=helpers.get_dtypes("integer"),
     num_positional_args=helpers.num_positional_args(fn_name="zeros"),
 )
 def test_zeros(
@@ -781,7 +781,7 @@ def test_zeros(
 @handle_cmd_line_args
 @given(
     dtype_and_x=helpers.dtype_and_values(
-        available_dtypes=helpers.get_dtype("numeric", full=True),
+        available_dtypes=helpers.get_dtypes("numeric", full=True),
         num_arrays=1,
         min_num_dims=1,
         max_num_dims=5,

--- a/ivy_tests/test_ivy/test_functional/test_core/test_creation.py
+++ b/ivy_tests/test_ivy/test_functional/test_core/test_creation.py
@@ -8,7 +8,6 @@ from hypothesis import given, strategies as st
 
 # local
 import ivy
-import ivy.functional.backends.numpy as ivy_np
 import ivy_tests.test_ivy.helpers as helpers
 from ivy_tests.test_ivy.helpers import handle_cmd_line_args
 
@@ -17,8 +16,8 @@ from ivy_tests.test_ivy.helpers import handle_cmd_line_args
 @handle_cmd_line_args
 @given(
     dtype_and_x=helpers.dtype_and_values(
-        available_dtypes=ivy_np.valid_numeric_dtypes,
-        dtype=ivy_np.valid_numeric_dtypes,
+        available_dtypes=helpers.get_dtype("numeric", full=True),
+        dtype=ivy.valid_numeric_dtypes,
         num_arrays=1,
         min_num_dims=1,
         max_num_dims=5,
@@ -59,7 +58,7 @@ def test_native_array(
 @handle_cmd_line_args
 @given(
     dtype_and_start_stop=helpers.dtype_and_values(
-        available_dtypes=ivy_np.valid_float_dtypes,
+        available_dtypes=helpers.get_dtype("float", full=True),
         num_arrays=2,
         min_value=None,
         max_value=None,
@@ -109,7 +108,7 @@ def test_linspace(
 @handle_cmd_line_args
 @given(
     dtype_and_start_stop=helpers.dtype_and_values(
-        available_dtypes=ivy_np.valid_float_dtypes,
+        available_dtypes=helpers.get_dtype("float", full=True),
         num_arrays=2,
         min_value=None,
         max_value=None,
@@ -167,7 +166,7 @@ def test_logspace(
     step=helpers.ints(min_value=-50, max_value=50).filter(
         lambda x: True if x != 0 else False
     ),
-    dtype=st.sampled_from(ivy_np.valid_int_dtypes),
+    dtype=helpers.get_dtype("numeric"),
     num_positional_args=helpers.num_positional_args(fn_name="arange"),
 )
 def test_arange(
@@ -203,7 +202,7 @@ def test_arange(
 @handle_cmd_line_args
 @given(
     dtype_and_x=helpers.dtype_and_values(
-        available_dtypes=ivy_np.valid_numeric_dtypes,
+        available_dtypes=helpers.get_dtype("numeric", full=True),
         num_arrays=1,
         min_num_dims=0,
         max_num_dims=5,
@@ -249,7 +248,7 @@ def test_asarray(
         min_dim_size=1,
         max_dim_size=5,
     ),
-    dtype=st.sampled_from(ivy_np.valid_numeric_dtypes),
+    dtype=helpers.get_dtype("numeric"),
     num_positional_args=helpers.num_positional_args(fn_name="empty"),
 )
 def test_empty(
@@ -288,7 +287,7 @@ def test_empty(
 @handle_cmd_line_args
 @given(
     dtype_and_x=helpers.dtype_and_values(
-        available_dtypes=ivy_np.valid_numeric_dtypes,
+        available_dtypes=helpers.get_dtype("numeric", full=True),
         num_arrays=1,
         min_num_dims=1,
         max_num_dims=5,
@@ -342,7 +341,7 @@ def test_empty_like(
     batch_shape=st.lists(
         helpers.ints(min_value=1, max_value=10), min_size=1, max_size=2
     ),
-    dtype=st.sampled_from(ivy_np.valid_int_dtypes),
+    dtype=helpers.get_dtype("integer"),
     num_positional_args=helpers.num_positional_args(fn_name="eye"),
 )
 def test_eye(
@@ -381,7 +380,7 @@ def test_eye(
 @handle_cmd_line_args
 @given(
     dtype_and_x=helpers.dtype_and_values(
-        available_dtypes=ivy_np.valid_numeric_dtypes,
+        available_dtypes=helpers.get_dtype("numeric", full=True),
         num_arrays=1,
         min_num_dims=1,
         max_num_dims=5,
@@ -419,9 +418,7 @@ def test_from_dlpack(
 def _dtypes(draw):
     return draw(
         st.shared(
-            helpers.list_of_length(
-                x=st.sampled_from(ivy_np.valid_numeric_dtypes), length=1
-            ),
+            helpers.list_of_length(x=helpers.get_dtype("numeric"), length=1),
             key="dtype",
         )
     )
@@ -482,7 +479,7 @@ def test_full(
 def _dtype_and_values(draw):
     return draw(
         helpers.dtype_and_values(
-            available_dtypes=ivy_np.valid_numeric_dtypes,
+            available_dtypes=helpers.get_dtype("numeric", full=True),
             num_arrays=1,
             min_num_dims=1,
             max_num_dims=5,
@@ -538,7 +535,7 @@ array_shape = st.shared(
     st.lists(helpers.ints(min_value=1, max_value=10), min_size=1, max_size=1),
     key="array_shape",
 )
-dtype_shared = st.shared(st.sampled_from(ivy_np.valid_numeric_dtypes), key="dtype")
+dtype_shared = st.shared(helpers.get_dtype("numeric"), key="dtype")
 
 
 @handle_cmd_line_args
@@ -589,7 +586,7 @@ def test_meshgrid(
         min_dim_size=1,
         max_dim_size=5,
     ),
-    dtype=st.sampled_from(ivy_np.valid_numeric_dtypes),
+    dtype=helpers.get_dtype("numeric"),
     num_positional_args=helpers.num_positional_args(fn_name="ones"),
 )
 def test_ones(
@@ -621,7 +618,7 @@ def test_ones(
 @handle_cmd_line_args
 @given(
     dtype_and_x=helpers.dtype_and_values(
-        available_dtypes=ivy_np.valid_numeric_dtypes,
+        available_dtypes=helpers.get_dtype("numeric", full=True),
         num_arrays=1,
         min_num_dims=1,
         max_num_dims=5,
@@ -662,7 +659,7 @@ def test_ones_like(
 @handle_cmd_line_args
 @given(
     dtype_and_x=helpers.dtype_and_values(
-        available_dtypes=ivy_np.valid_numeric_dtypes,
+        available_dtypes=helpers.get_dtype("numeric", full=True),
         num_arrays=1,
         min_num_dims=2,
         max_num_dims=5,
@@ -704,7 +701,7 @@ def test_tril(
 @handle_cmd_line_args
 @given(
     dtype_and_x=helpers.dtype_and_values(
-        available_dtypes=ivy_np.valid_numeric_dtypes,
+        available_dtypes=helpers.get_dtype("numeric", full=True),
         num_arrays=1,
         min_num_dims=2,
         max_num_dims=5,
@@ -752,7 +749,7 @@ def test_triu(
         min_dim_size=1,
         max_dim_size=5,
     ),
-    dtype=st.sampled_from(ivy_np.valid_int_dtypes),
+    dtype=helpers.get_dtype("integer"),
     num_positional_args=helpers.num_positional_args(fn_name="zeros"),
 )
 def test_zeros(
@@ -784,7 +781,7 @@ def test_zeros(
 @handle_cmd_line_args
 @given(
     dtype_and_x=helpers.dtype_and_values(
-        available_dtypes=ivy_np.valid_numeric_dtypes,
+        available_dtypes=helpers.get_dtype("numeric", full=True),
         num_arrays=1,
         min_num_dims=1,
         max_num_dims=5,

--- a/ivy_tests/test_ivy/test_functional/test_core/test_device.py
+++ b/ivy_tests/test_ivy/test_functional/test_core/test_device.py
@@ -78,7 +78,7 @@ def _empty_dir(path, recreate=False):
         max_size="num_dims",
         size_bounds=[1, 3],
     ),
-    dtype=helpers.get_dtype("numeric"),
+    dtype=helpers.get_dtypes("numeric"),
 )
 def test_dev(*, array_shape, dtype, as_variable, fw):
 
@@ -113,7 +113,7 @@ def test_dev(*, array_shape, dtype, as_variable, fw):
         max_size="num_dims",
         size_bounds=[1, 3],
     ),
-    dtype=helpers.get_dtype("numeric"),
+    dtype=helpers.get_dtypes("numeric"),
 )
 def test_as_ivy_dev(*, array_shape, dtype, as_variable, fw):
 
@@ -144,7 +144,7 @@ def test_as_ivy_dev(*, array_shape, dtype, as_variable, fw):
         max_size="num_dims",
         size_bounds=[1, 3],
     ),
-    dtype=helpers.get_dtype("float", index=1),
+    dtype=helpers.get_dtypes("float", index=1),
 )
 def test_as_native_dev(*, array_shape, dtype, as_variable, fw):
 
@@ -218,7 +218,7 @@ def test_default_device(device):
         max_size="num_dims",
         size_bounds=[1, 3],
     ),
-    dtype=helpers.get_dtype("numeric"),
+    dtype=helpers.get_dtypes("numeric"),
     stream=helpers.ints(min_value=0, max_value=50),
 )
 def test_to_device(*, array_shape, dtype, as_variable, with_out, fw, device, stream):
@@ -285,7 +285,7 @@ def _axis(draw):
         max_size="num_dims",
         size_bounds=[1, 3],
     ),
-    dtype=helpers.get_dtype("numeric"),
+    dtype=helpers.get_dtypes("numeric"),
     chunk_size=helpers.ints(min_value=1, max_value=3),
     axis=_axis(),
 )
@@ -331,7 +331,7 @@ def test_split_func_call(
         max_size="num_dims",
         size_bounds=[2, 3],
     ),
-    dtype=helpers.get_dtype("numeric"),
+    dtype=helpers.get_dtypes("numeric"),
     chunk_size=helpers.ints(min_value=1, max_value=3),
     axis=helpers.ints(min_value=0, max_value=1),
 )

--- a/ivy_tests/test_ivy/test_functional/test_core/test_device.py
+++ b/ivy_tests/test_ivy/test_functional/test_core/test_device.py
@@ -16,7 +16,6 @@ from hypothesis import strategies as st, given, assume
 
 # local
 import ivy
-import ivy.functional.backends.numpy as ivy_np
 import ivy_tests.test_ivy.helpers as helpers
 from ivy_tests.test_ivy.helpers import handle_cmd_line_args
 
@@ -79,7 +78,7 @@ def _empty_dir(path, recreate=False):
         max_size="num_dims",
         size_bounds=[1, 3],
     ),
-    dtype=st.sampled_from(ivy_np.valid_numeric_dtypes),
+    dtype=helpers.get_dtype("numeric"),
 )
 def test_dev(*, array_shape, dtype, as_variable, fw):
 
@@ -114,7 +113,7 @@ def test_dev(*, array_shape, dtype, as_variable, fw):
         max_size="num_dims",
         size_bounds=[1, 3],
     ),
-    dtype=st.sampled_from(ivy_np.valid_numeric_dtypes),
+    dtype=helpers.get_dtype("numeric"),
 )
 def test_as_ivy_dev(*, array_shape, dtype, as_variable, fw):
 
@@ -145,7 +144,7 @@ def test_as_ivy_dev(*, array_shape, dtype, as_variable, fw):
         max_size="num_dims",
         size_bounds=[1, 3],
     ),
-    dtype=st.sampled_from(ivy_np.valid_float_dtypes[1:]),
+    dtype=helpers.get_dtype("float", index=1),
 )
 def test_as_native_dev(*, array_shape, dtype, as_variable, fw):
 
@@ -219,12 +218,10 @@ def test_default_device(device):
         max_size="num_dims",
         size_bounds=[1, 3],
     ),
-    dtype=st.sampled_from(ivy_np.valid_numeric_dtypes),
+    dtype=helpers.get_dtype("numeric"),
     stream=helpers.ints(min_value=0, max_value=50),
 )
-def test_to_device(
-    *, array_shape, dtype, as_variable, with_out, fw, device, stream
-):
+def test_to_device(*, array_shape, dtype, as_variable, with_out, fw, device, stream):
     assume(not (fw == "torch" and "int" in dtype))
 
     x = np.random.uniform(size=tuple(array_shape)).astype(dtype)
@@ -288,13 +285,14 @@ def _axis(draw):
         max_size="num_dims",
         size_bounds=[1, 3],
     ),
-    dtype=st.sampled_from(ivy_np.valid_numeric_dtypes),
+    dtype=helpers.get_dtype("numeric"),
     chunk_size=helpers.ints(min_value=1, max_value=3),
     axis=_axis(),
 )
 def test_split_func_call(
     *, array_shape, dtype, as_variable, chunk_size, axis, fw, device
 ):
+    assume(not ("bfloat16" in dtype))
     assume(not (fw == "torch" and "int" in dtype))
 
     # inputs
@@ -333,7 +331,7 @@ def test_split_func_call(
         max_size="num_dims",
         size_bounds=[2, 3],
     ),
-    dtype=st.sampled_from(ivy_np.valid_numeric_dtypes),
+    dtype=helpers.get_dtype("numeric"),
     chunk_size=helpers.ints(min_value=1, max_value=3),
     axis=helpers.ints(min_value=0, max_value=1),
 )

--- a/ivy_tests/test_ivy/test_functional/test_core/test_dtype.py
+++ b/ivy_tests/test_ivy/test_functional/test_core/test_dtype.py
@@ -147,9 +147,9 @@ def dtypes_shared(draw, num_dtypes):
 @handle_cmd_line_args
 @given(
     dtype_and_x=helpers.dtype_and_values(
-        available_dtypes=ivy_np.valid_dtypes, num_arrays=1
+        available_dtypes=helpers.get_dtypes("valid", full=True), num_arrays=1
     ),
-    dtype=st.sampled_from(ivy_np.valid_dtypes),
+    dtype=helpers.get_dtypes("valid"),
 )
 def test_astype(
     dtype_and_x,
@@ -282,9 +282,9 @@ def test_broadcast_to(
 @handle_cmd_line_args
 @given(
     dtype_and_x=helpers.dtype_and_values(
-        available_dtypes=ivy_np.valid_dtypes, num_arrays=1
+        available_dtypes=helpers.get_dtypes("valid", full=True), num_arrays=1
     ),
-    to_dtype=st.sampled_from(ivy_np.valid_dtypes),
+    to_dtype=helpers.get_dtypes("valid"),
     as_variable=st.booleans(),
     num_positional_args=helpers.num_positional_args(fn_name="can_cast"),
     native_array=st.booleans(),
@@ -527,7 +527,7 @@ def test_closest_valid_dtype(
 # default_dtype
 @handle_cmd_line_args
 @given(
-    input_dtype=st.sampled_from(ivy_np.valid_dtypes),
+    input_dtype=helpers.get_dtypes("valid"),
     as_native=st.booleans(),
 )
 def test_default_dtype(
@@ -595,7 +595,7 @@ def test_dtype(
 # dtype_bits
 @handle_cmd_line_args
 @given(
-    input_dtype=st.sampled_from(ivy_np.valid_dtypes),
+    input_dtype=helpers.get_dtypes("valid"),
     num_positional_args=helpers.num_positional_args(fn_name="dtype_bits"),
 )
 def test_dtype_bits(
@@ -796,7 +796,7 @@ def test_promote_types(
 @handle_cmd_line_args
 @given(
     dtype_and_values=helpers.dtype_and_values(
-        available_dtypes=ivy_np.valid_dtypes,
+        available_dtypes=helpers.get_dtypes("valid", full=True),
         num_arrays=2,
         shared_dtype=False,
     ),

--- a/ivy_tests/test_ivy/test_functional/test_core/test_dtype.py
+++ b/ivy_tests/test_ivy/test_functional/test_core/test_dtype.py
@@ -147,9 +147,9 @@ def dtypes_shared(draw, num_dtypes):
 @handle_cmd_line_args
 @given(
     dtype_and_x=helpers.dtype_and_values(
-        available_dtypes=helpers.get_dtypes("valid", full=True), num_arrays=1
+        available_dtypes=helpers.get_dtypess("valid", full=True), num_arrays=1
     ),
-    dtype=helpers.get_dtypes("valid"),
+    dtype=helpers.get_dtypess("valid"),
 )
 def test_astype(
     dtype_and_x,
@@ -282,9 +282,9 @@ def test_broadcast_to(
 @handle_cmd_line_args
 @given(
     dtype_and_x=helpers.dtype_and_values(
-        available_dtypes=helpers.get_dtypes("valid", full=True), num_arrays=1
+        available_dtypes=helpers.get_dtypess("valid", full=True), num_arrays=1
     ),
-    to_dtype=helpers.get_dtypes("valid"),
+    to_dtype=helpers.get_dtypess("valid"),
     as_variable=st.booleans(),
     num_positional_args=helpers.num_positional_args(fn_name="can_cast"),
     native_array=st.booleans(),
@@ -527,7 +527,7 @@ def test_closest_valid_dtype(
 # default_dtype
 @handle_cmd_line_args
 @given(
-    input_dtype=helpers.get_dtypes("valid"),
+    input_dtype=helpers.get_dtypess("valid"),
     as_native=st.booleans(),
 )
 def test_default_dtype(
@@ -595,7 +595,7 @@ def test_dtype(
 # dtype_bits
 @handle_cmd_line_args
 @given(
-    input_dtype=helpers.get_dtypes("valid"),
+    input_dtype=helpers.get_dtypess("valid"),
     num_positional_args=helpers.num_positional_args(fn_name="dtype_bits"),
 )
 def test_dtype_bits(
@@ -796,7 +796,7 @@ def test_promote_types(
 @handle_cmd_line_args
 @given(
     dtype_and_values=helpers.dtype_and_values(
-        available_dtypes=helpers.get_dtypes("valid", full=True),
+        available_dtypes=helpers.get_dtypess("valid", full=True),
         num_arrays=2,
         shared_dtype=False,
     ),

--- a/ivy_tests/test_ivy/test_functional/test_core/test_elementwise.py
+++ b/ivy_tests/test_ivy/test_functional/test_core/test_elementwise.py
@@ -8,7 +8,6 @@ from hypothesis import given, assume, strategies as st
 
 # local
 import ivy
-import ivy.functional.backends.numpy as ivy_np
 import ivy_tests.test_ivy.helpers as helpers
 from ivy_tests.test_ivy.helpers import handle_cmd_line_args
 
@@ -24,7 +23,9 @@ def _not_too_close_to_zero(x):
 # abs
 @handle_cmd_line_args
 @given(
-    dtype_and_x=helpers.dtype_and_values(available_dtypes=ivy_np.valid_numeric_dtypes),
+    dtype_and_x=helpers.dtype_and_values(
+        available_dtypes=helpers.get_dtypes("numeric", full=True)
+    ),
     num_positional_args=helpers.num_positional_args(fn_name="abs"),
 )
 def test_abs(
@@ -56,7 +57,9 @@ def test_abs(
 # acosh
 @handle_cmd_line_args
 @given(
-    dtype_and_x=helpers.dtype_and_values(available_dtypes=ivy_np.valid_float_dtypes),
+    dtype_and_x=helpers.dtype_and_values(
+        available_dtypes=helpers.get_dtypes("float", full=True)
+    ),
     num_positional_args=helpers.num_positional_args(fn_name="acosh"),
 )
 def test_acosh(
@@ -88,7 +91,9 @@ def test_acosh(
 # acos
 @handle_cmd_line_args
 @given(
-    dtype_and_x=helpers.dtype_and_values(available_dtypes=ivy_np.valid_float_dtypes),
+    dtype_and_x=helpers.dtype_and_values(
+        available_dtypes=helpers.get_dtypes("float", full=True)
+    ),
     num_positional_args=helpers.num_positional_args(fn_name="acos"),
 )
 def test_acos(
@@ -121,7 +126,7 @@ def test_acos(
 @handle_cmd_line_args
 @given(
     dtype_and_x=helpers.dtype_and_values(
-        available_dtypes=ivy_np.valid_numeric_dtypes, num_arrays=2
+        available_dtypes=helpers.get_dtypes("numeric", full=True), num_arrays=2
     ),
     num_positional_args=helpers.num_positional_args(fn_name="add"),
 )
@@ -156,7 +161,9 @@ def test_add(
 # asin
 @handle_cmd_line_args
 @given(
-    dtype_and_x=helpers.dtype_and_values(available_dtypes=ivy_np.valid_float_dtypes),
+    dtype_and_x=helpers.dtype_and_values(
+        available_dtypes=helpers.get_dtypes("float", full=True)
+    ),
     num_positional_args=helpers.num_positional_args(fn_name="asin"),
 )
 def test_asin(
@@ -188,7 +195,9 @@ def test_asin(
 # asinh
 @handle_cmd_line_args
 @given(
-    dtype_and_x=helpers.dtype_and_values(available_dtypes=ivy_np.valid_float_dtypes),
+    dtype_and_x=helpers.dtype_and_values(
+        available_dtypes=helpers.get_dtypes("float", full=True)
+    ),
     num_positional_args=helpers.num_positional_args(fn_name="asinh"),
 )
 def test_asinh(
@@ -220,7 +229,9 @@ def test_asinh(
 # atan
 @handle_cmd_line_args
 @given(
-    dtype_and_x=helpers.dtype_and_values(available_dtypes=ivy_np.valid_float_dtypes),
+    dtype_and_x=helpers.dtype_and_values(
+        available_dtypes=helpers.get_dtypes("float", full=True)
+    ),
     num_positional_args=helpers.num_positional_args(fn_name="atan"),
 )
 def test_atan(
@@ -253,7 +264,7 @@ def test_atan(
 @handle_cmd_line_args
 @given(
     dtype_and_x=helpers.dtype_and_values(
-        available_dtypes=ivy_np.valid_float_dtypes,
+        available_dtypes=helpers.get_dtypes("float", full=True),
         num_arrays=2,
         min_num_dims=1,
         max_num_dims=5,
@@ -301,7 +312,9 @@ def test_atan2(
 # atanh
 @handle_cmd_line_args
 @given(
-    dtype_and_x=helpers.dtype_and_values(available_dtypes=ivy_np.valid_float_dtypes),
+    dtype_and_x=helpers.dtype_and_values(
+        available_dtypes=helpers.get_dtypes("float", full=True)
+    ),
     num_positional_args=helpers.num_positional_args(fn_name="atanh"),
 )
 def test_atanh(
@@ -563,7 +576,9 @@ def test_bitwise_xor(
 # ceil
 @handle_cmd_line_args
 @given(
-    dtype_and_x=helpers.dtype_and_values(available_dtypes=ivy_np.valid_numeric_dtypes),
+    dtype_and_x=helpers.dtype_and_values(
+        available_dtypes=helpers.get_dtypes("numeric", full=True)
+    ),
     num_positional_args=helpers.num_positional_args(fn_name="ceil"),
 )
 def test_ceil(
@@ -595,7 +610,9 @@ def test_ceil(
 # cos
 @handle_cmd_line_args
 @given(
-    dtype_and_x=helpers.dtype_and_values(available_dtypes=ivy_np.valid_float_dtypes),
+    dtype_and_x=helpers.dtype_and_values(
+        available_dtypes=helpers.get_dtypes("float", full=True)
+    ),
     num_positional_args=helpers.num_positional_args(fn_name="cos"),
 )
 def test_cos(
@@ -627,7 +644,9 @@ def test_cos(
 # cosh
 @handle_cmd_line_args
 @given(
-    dtype_and_x=helpers.dtype_and_values(available_dtypes=ivy_np.valid_float_dtypes),
+    dtype_and_x=helpers.dtype_and_values(
+        available_dtypes=helpers.get_dtypes("float", full=True)
+    ),
     num_positional_args=helpers.num_positional_args(fn_name="cosh"),
 )
 def test_cosh(
@@ -660,7 +679,7 @@ def test_cosh(
 @handle_cmd_line_args
 @given(
     dtype_and_x=helpers.dtype_and_values(
-        available_dtypes=ivy_np.valid_numeric_dtypes, num_arrays=2
+        available_dtypes=helpers.get_dtypes("numeric", full=True), num_arrays=2
     ),
     num_positional_args=helpers.num_positional_args(fn_name="divide"),
 )
@@ -702,7 +721,7 @@ def test_divide(
 @handle_cmd_line_args
 @given(
     dtype_and_x=helpers.dtype_and_values(
-        available_dtypes=ivy_np.valid_dtypes, num_arrays=2
+        available_dtypes=helpers.get_dtypes("valid", full=True), num_arrays=2
     ),
     num_positional_args=helpers.num_positional_args(fn_name="equal"),
 )
@@ -737,7 +756,9 @@ def test_equal(
 # exp
 @handle_cmd_line_args
 @given(
-    dtype_and_x=helpers.dtype_and_values(available_dtypes=ivy_np.valid_float_dtypes),
+    dtype_and_x=helpers.dtype_and_values(
+        available_dtypes=helpers.get_dtypes("float", full=True)
+    ),
     num_positional_args=helpers.num_positional_args(fn_name="exp"),
 )
 def test_exp(
@@ -769,7 +790,9 @@ def test_exp(
 # expm1
 @handle_cmd_line_args
 @given(
-    dtype_and_x=helpers.dtype_and_values(available_dtypes=ivy_np.valid_float_dtypes),
+    dtype_and_x=helpers.dtype_and_values(
+        available_dtypes=helpers.get_dtypes("float", full=True)
+    ),
     num_positional_args=helpers.num_positional_args(fn_name="expm1"),
 )
 def test_expm1(
@@ -801,7 +824,9 @@ def test_expm1(
 # floor
 @handle_cmd_line_args
 @given(
-    dtype_and_x=helpers.dtype_and_values(available_dtypes=ivy_np.valid_numeric_dtypes),
+    dtype_and_x=helpers.dtype_and_values(
+        available_dtypes=helpers.get_dtypes("numeric", full=True)
+    ),
     num_positional_args=helpers.num_positional_args(fn_name="floor"),
 )
 def test_floor(
@@ -837,7 +862,7 @@ def test_floor(
 @handle_cmd_line_args
 @given(
     dtype_and_x=helpers.dtype_and_values(
-        available_dtypes=ivy_np.valid_numeric_dtypes,
+        available_dtypes=helpers.get_dtypes("numeric", full=True),
         num_arrays=2,
         allow_inf=False,
         large_value_safety_factor=1.1,
@@ -884,7 +909,7 @@ def test_floor_divide(
 @handle_cmd_line_args
 @given(
     dtype_and_x=helpers.dtype_and_values(
-        available_dtypes=ivy_np.valid_numeric_dtypes, num_arrays=2
+        available_dtypes=helpers.get_dtypes("numeric", full=True), num_arrays=2
     ),
     num_positional_args=helpers.num_positional_args(fn_name="greater"),
 )
@@ -926,7 +951,7 @@ def test_greater(
 @handle_cmd_line_args
 @given(
     dtype_and_x=helpers.dtype_and_values(
-        available_dtypes=ivy_np.valid_numeric_dtypes, num_arrays=2
+        available_dtypes=helpers.get_dtypes("numeric", full=True), num_arrays=2
     ),
     num_positional_args=helpers.num_positional_args(fn_name="greater_equal"),
 )
@@ -966,7 +991,9 @@ def test_greater_equal(
 # isfinite
 @handle_cmd_line_args
 @given(
-    dtype_and_x=helpers.dtype_and_values(available_dtypes=ivy_np.valid_numeric_dtypes),
+    dtype_and_x=helpers.dtype_and_values(
+        available_dtypes=helpers.get_dtypes("numeric", full=True)
+    ),
     num_positional_args=helpers.num_positional_args(fn_name="isfinite"),
 )
 def test_isfinite(
@@ -998,7 +1025,9 @@ def test_isfinite(
 # isinf
 @handle_cmd_line_args
 @given(
-    dtype_and_x=helpers.dtype_and_values(available_dtypes=ivy_np.valid_numeric_dtypes),
+    dtype_and_x=helpers.dtype_and_values(
+        available_dtypes=helpers.get_dtypes("numeric", full=True)
+    ),
     num_positional_args=helpers.num_positional_args(fn_name="isinf"),
 )
 def test_isinf(
@@ -1030,7 +1059,9 @@ def test_isinf(
 # isnan
 @handle_cmd_line_args
 @given(
-    dtype_and_x=helpers.dtype_and_values(available_dtypes=ivy_np.valid_numeric_dtypes),
+    dtype_and_x=helpers.dtype_and_values(
+        available_dtypes=helpers.get_dtypes("numeric", full=True)
+    ),
     num_positional_args=helpers.num_positional_args(fn_name="isnan"),
 )
 def test_isnan(
@@ -1063,7 +1094,7 @@ def test_isnan(
 @handle_cmd_line_args
 @given(
     dtype_and_x=helpers.dtype_and_values(
-        available_dtypes=ivy_np.valid_numeric_dtypes,
+        available_dtypes=helpers.get_dtypes("numeric", full=True),
         num_arrays=2,
         min_num_dims=1,
     ),
@@ -1085,6 +1116,8 @@ def test_less(
     x1 = np.asarray(x[0], dtype=input_dtype[0])
     x2 = np.asarray(x[1], dtype=input_dtype[1])
 
+    # bfloat16 is not supported by numpy
+    assume(not ("bfloat16" in input_dtype))
     # make sure they're not too close together
     assume(not (np.any(np.isclose(x1, x2)) or np.any(np.isclose(x2, x1))))
 
@@ -1107,7 +1140,7 @@ def test_less(
 @handle_cmd_line_args
 @given(
     dtype_and_x=helpers.dtype_and_values(
-        available_dtypes=ivy_np.valid_numeric_dtypes, num_arrays=2
+        available_dtypes=helpers.get_dtypes("numeric", full=True), num_arrays=2
     ),
     num_positional_args=helpers.num_positional_args(fn_name="less_equal"),
 )
@@ -1127,6 +1160,8 @@ def test_less_equal(
     x1 = np.asarray(x[0], dtype=input_dtype[0])
     x2 = np.asarray(x[1], dtype=input_dtype[1])
 
+    # bfloat16 is not supported by numpy
+    assume(not ("bfloat16" in input_dtype))
     # make sure they're not too close together
     assume(not (np.any(np.isclose(x1, x2)) or np.any(np.isclose(x2, x1))))
 
@@ -1148,7 +1183,9 @@ def test_less_equal(
 # log
 @handle_cmd_line_args
 @given(
-    dtype_and_x=helpers.dtype_and_values(available_dtypes=ivy_np.valid_float_dtypes),
+    dtype_and_x=helpers.dtype_and_values(
+        available_dtypes=helpers.get_dtypes("float", full=True)
+    ),
     num_positional_args=helpers.num_positional_args(fn_name="log"),
 )
 def test_log(
@@ -1184,7 +1221,9 @@ def test_log(
 # log1p
 @handle_cmd_line_args
 @given(
-    dtype_and_x=helpers.dtype_and_values(available_dtypes=ivy_np.valid_float_dtypes),
+    dtype_and_x=helpers.dtype_and_values(
+        available_dtypes=helpers.get_dtypes("float", full=True)
+    ),
     num_positional_args=helpers.num_positional_args(fn_name="log1p"),
 )
 def test_log1p(
@@ -1220,7 +1259,9 @@ def test_log1p(
 # log2
 @handle_cmd_line_args
 @given(
-    dtype_and_x=helpers.dtype_and_values(available_dtypes=ivy_np.valid_float_dtypes),
+    dtype_and_x=helpers.dtype_and_values(
+        available_dtypes=helpers.get_dtypes("float", full=True)
+    ),
     num_positional_args=helpers.num_positional_args(fn_name="log2"),
 )
 def test_log2(
@@ -1256,7 +1297,9 @@ def test_log2(
 # log10
 @handle_cmd_line_args
 @given(
-    dtype_and_x=helpers.dtype_and_values(available_dtypes=ivy_np.valid_float_dtypes),
+    dtype_and_x=helpers.dtype_and_values(
+        available_dtypes=helpers.get_dtypes("float", full=True)
+    ),
     num_positional_args=helpers.num_positional_args(fn_name="log10"),
 )
 def test_log10(
@@ -1293,7 +1336,7 @@ def test_log10(
 @handle_cmd_line_args
 @given(
     dtype_and_x=helpers.dtype_and_values(
-        available_dtypes=ivy_np.valid_float_dtypes, num_arrays=2
+        available_dtypes=helpers.get_dtypes("float", full=True), num_arrays=2
     ),
     num_positional_args=helpers.num_positional_args(fn_name="logaddexp"),
 )
@@ -1464,7 +1507,7 @@ def test_logical_xor(
 @handle_cmd_line_args
 @given(
     dtype_and_x=helpers.dtype_and_values(
-        available_dtypes=ivy_np.valid_numeric_dtypes, num_arrays=2
+        available_dtypes=helpers.get_dtypes("numeric", full=True), num_arrays=2
     ),
     num_positional_args=helpers.num_positional_args(fn_name="multiply"),
 )
@@ -1499,7 +1542,9 @@ def test_multiply(
 # negative
 @handle_cmd_line_args
 @given(
-    dtype_and_x=helpers.dtype_and_values(available_dtypes=ivy_np.valid_numeric_dtypes),
+    dtype_and_x=helpers.dtype_and_values(
+        available_dtypes=helpers.get_dtypes("numeric", full=True)
+    ),
     num_positional_args=helpers.num_positional_args(fn_name="negative"),
 )
 def test_negative(
@@ -1532,7 +1577,7 @@ def test_negative(
 @handle_cmd_line_args
 @given(
     dtype_and_x=helpers.dtype_and_values(
-        available_dtypes=ivy_np.valid_dtypes, num_arrays=2
+        available_dtypes=helpers.get_dtypes("valid", full=True), num_arrays=2
     ),
     num_positional_args=helpers.num_positional_args(fn_name="not_equal"),
 )
@@ -1567,7 +1612,9 @@ def test_not_equal(
 # positive
 @handle_cmd_line_args
 @given(
-    dtype_and_x=helpers.dtype_and_values(available_dtypes=ivy_np.valid_numeric_dtypes),
+    dtype_and_x=helpers.dtype_and_values(
+        available_dtypes=helpers.get_dtypes("numeric", full=True)
+    ),
     num_positional_args=helpers.num_positional_args(fn_name="positive"),
 )
 def test_positive(
@@ -1600,7 +1647,7 @@ def test_positive(
 @handle_cmd_line_args
 @given(
     dtype_and_x=helpers.dtype_and_values(
-        available_dtypes=ivy_np.valid_numeric_dtypes, num_arrays=2
+        available_dtypes=helpers.get_dtypes("numeric", full=True), num_arrays=2
     ),
     num_positional_args=helpers.num_positional_args(fn_name="pow"),
 )
@@ -1617,6 +1664,9 @@ def test_pow(
 ):
     input_dtype, x = dtype_and_x
     # input_dtype, x = (['int16', 'int8'], [[2], [64]])
+
+    # bfloat16 is not supported by numpy
+    assume(not ("bfloat16" in input_dtype))
 
     # Make sure x2 isn't a float when x1 is integer
     assume(
@@ -1657,7 +1707,9 @@ def test_pow(
 @handle_cmd_line_args
 @given(
     dtype_and_x=helpers.dtype_and_values(
-        available_dtypes=ivy_np.valid_numeric_dtypes, num_arrays=1, allow_inf=True
+        available_dtypes=helpers.get_dtypes("numeric", full=True),
+        num_arrays=1,
+        allow_inf=True,
     ),
     num_positional_args=helpers.num_positional_args(fn_name="reciprocal"),
 )
@@ -1691,7 +1743,9 @@ def test_reciprocal(
 @handle_cmd_line_args
 @given(
     dtype_and_x=helpers.dtype_and_values(
-        available_dtypes=ivy_np.valid_numeric_dtypes, num_arrays=2, allow_inf=False
+        available_dtypes=helpers.get_dtypes("numeric", full=True),
+        num_arrays=2,
+        allow_inf=False,
     ),
     num_positional_args=helpers.num_positional_args(fn_name="remainder"),
     modulus=st.booleans(),
@@ -1738,7 +1792,9 @@ def test_remainder(
 # round
 @handle_cmd_line_args
 @given(
-    dtype_and_x=helpers.dtype_and_values(available_dtypes=ivy_np.valid_numeric_dtypes),
+    dtype_and_x=helpers.dtype_and_values(
+        available_dtypes=helpers.get_dtypes("numeric", full=True)
+    ),
     num_positional_args=helpers.num_positional_args(fn_name="round"),
 )
 def test_round(
@@ -1770,7 +1826,9 @@ def test_round(
 # sign
 @handle_cmd_line_args
 @given(
-    dtype_and_x=helpers.dtype_and_values(available_dtypes=ivy_np.valid_numeric_dtypes),
+    dtype_and_x=helpers.dtype_and_values(
+        available_dtypes=helpers.get_dtypes("numeric", full=True)
+    ),
     num_positional_args=helpers.num_positional_args(fn_name="sign"),
 )
 def test_sign(
@@ -1806,7 +1864,9 @@ def test_sign(
 # sin
 @handle_cmd_line_args
 @given(
-    dtype_and_x=helpers.dtype_and_values(available_dtypes=ivy_np.valid_float_dtypes),
+    dtype_and_x=helpers.dtype_and_values(
+        available_dtypes=helpers.get_dtypes("float", full=True)
+    ),
     num_positional_args=helpers.num_positional_args(fn_name="sin"),
 )
 def test_sin(
@@ -1838,7 +1898,9 @@ def test_sin(
 # sinh
 @handle_cmd_line_args
 @given(
-    dtype_and_x=helpers.dtype_and_values(available_dtypes=ivy_np.valid_float_dtypes),
+    dtype_and_x=helpers.dtype_and_values(
+        available_dtypes=helpers.get_dtypes("float", full=True)
+    ),
     num_positional_args=helpers.num_positional_args(fn_name="sinh"),
 )
 def test_sinh(
@@ -1870,7 +1932,9 @@ def test_sinh(
 # square
 @handle_cmd_line_args
 @given(
-    dtype_and_x=helpers.dtype_and_values(available_dtypes=ivy_np.valid_numeric_dtypes),
+    dtype_and_x=helpers.dtype_and_values(
+        available_dtypes=helpers.get_dtypes("numeric", full=True)
+    ),
     num_positional_args=helpers.num_positional_args(fn_name="square"),
 )
 def test_square(
@@ -1903,7 +1967,7 @@ def test_square(
 @handle_cmd_line_args
 @given(
     dtype_and_x=helpers.dtype_and_values(
-        available_dtypes=ivy_np.valid_float_dtypes, allow_inf=False
+        available_dtypes=helpers.get_dtypes("float", full=True), allow_inf=False
     ),
     num_positional_args=helpers.num_positional_args(fn_name="sqrt"),
 )
@@ -1937,7 +2001,7 @@ def test_sqrt(
 @handle_cmd_line_args
 @given(
     dtype_and_x=helpers.dtype_and_values(
-        available_dtypes=ivy_np.valid_numeric_dtypes, num_arrays=2
+        available_dtypes=helpers.get_dtypes("numeric", full=True), num_arrays=2
     ),
     num_positional_args=helpers.num_positional_args(fn_name="subtract"),
 )
@@ -1972,7 +2036,9 @@ def test_subtract(
 # tan
 @handle_cmd_line_args
 @given(
-    dtype_and_x=helpers.dtype_and_values(available_dtypes=ivy_np.valid_float_dtypes),
+    dtype_and_x=helpers.dtype_and_values(
+        available_dtypes=helpers.get_dtypes("float", full=True)
+    ),
     num_positional_args=helpers.num_positional_args(fn_name="tan"),
 )
 def test_tan(
@@ -2004,7 +2070,9 @@ def test_tan(
 # tanh
 @handle_cmd_line_args
 @given(
-    dtype_and_x=helpers.dtype_and_values(available_dtypes=ivy_np.valid_float_dtypes),
+    dtype_and_x=helpers.dtype_and_values(
+        available_dtypes=helpers.get_dtypes("float", full=True)
+    ),
     num_positional_args=helpers.num_positional_args(fn_name="tanh"),
 )
 def test_tanh(
@@ -2036,7 +2104,9 @@ def test_tanh(
 # trunc
 @handle_cmd_line_args
 @given(
-    dtype_and_x=helpers.dtype_and_values(available_dtypes=ivy_np.valid_numeric_dtypes),
+    dtype_and_x=helpers.dtype_and_values(
+        available_dtypes=helpers.get_dtypes("numeric", full=True)
+    ),
     num_positional_args=helpers.num_positional_args(fn_name="trunc"),
 )
 def test_trunc(
@@ -2072,7 +2142,9 @@ def test_trunc(
 # erf
 @handle_cmd_line_args
 @given(
-    dtype_and_x=helpers.dtype_and_values(available_dtypes=ivy_np.valid_float_dtypes),
+    dtype_and_x=helpers.dtype_and_values(
+        available_dtypes=helpers.get_dtypes("float", full=True)
+    ),
     num_positional_args=helpers.num_positional_args(fn_name="erf"),
 )
 def test_erf(
@@ -2105,7 +2177,7 @@ def test_erf(
 @handle_cmd_line_args
 @given(
     dtype_and_x=helpers.dtype_and_values(
-        available_dtypes=ivy_np.valid_numeric_dtypes, num_arrays=2
+        available_dtypes=helpers.get_dtypes("numeric", full=True), num_arrays=2
     ),
     num_positional_args=helpers.num_positional_args(fn_name="minimum"),
 )
@@ -2150,7 +2222,7 @@ def test_minimum(
 @handle_cmd_line_args
 @given(
     dtype_and_x=helpers.dtype_and_values(
-        available_dtypes=ivy_np.valid_numeric_dtypes, num_arrays=2
+        available_dtypes=helpers.get_dtypes("numeric", full=True), num_arrays=2
     ),
     num_positional_args=helpers.num_positional_args(fn_name="maximum"),
 )

--- a/ivy_tests/test_ivy/test_functional/test_core/test_general.py
+++ b/ivy_tests/test_ivy/test_functional/test_core/test_general.py
@@ -122,7 +122,11 @@ def test_get_referrers_recursive(*, device):
 
 # copy array
 @handle_cmd_line_args
-@given(dtype_and_x=helpers.dtype_and_values(available_dtypes=ivy_np.valid_dtypes))
+@given(
+    dtype_and_x=helpers.dtype_and_values(
+        available_dtypes=helpers.get_dtypes("valid", full=True)
+    )
+)
 def test_copy_array(*, dtype_and_x, device, fw):
     dtype, x = dtype_and_x
     assume(not (fw == "torch" and dtype in ["uint16", "uint32", "uint64"]))
@@ -146,13 +150,15 @@ def test_copy_array(*, dtype_and_x, device, fw):
 @handle_cmd_line_args
 @given(
     x0_n_x1_n_res=helpers.dtype_and_values(
-        available_dtypes=ivy_np.valid_dtypes, num_arrays=2
+        available_dtypes=helpers.get_dtypes("valid", full=True), num_arrays=2
     )
 )
 def test_array_equal(*, x0_n_x1_n_res, device, fw):
     dtype0, x0 = x0_n_x1_n_res[0][0], x0_n_x1_n_res[1][0]
     dtype1, x1 = x0_n_x1_n_res[0][1], x0_n_x1_n_res[1][1]
 
+    # bfloat16 is not supported by numpy
+    assume(not ("bfloat16" in (dtype0, dtype1)))
     # torch does not support those dtypes
     assume(
         not (
@@ -189,7 +195,7 @@ def test_array_equal(*, x0_n_x1_n_res, device, fw):
 @handle_cmd_line_args
 @given(
     x0_n_x1_n_res=helpers.dtype_and_values(
-        available_dtypes=ivy_np.valid_dtypes, num_arrays=3
+        available_dtypes=helpers.get_dtypes("valid", full=True), num_arrays=3
     )
 )
 def test_arrays_equal(*, x0_n_x1_n_res, device, fw):
@@ -236,9 +242,15 @@ def test_arrays_equal(*, x0_n_x1_n_res, device, fw):
 
 # to_numpy
 @handle_cmd_line_args
-@given(x0_n_x1_n_res=helpers.dtype_and_values(available_dtypes=ivy_np.valid_dtypes))
+@given(
+    x0_n_x1_n_res=helpers.dtype_and_values(
+        available_dtypes=helpers.get_dtypes("valid", full=True)
+    )
+)
 def test_to_numpy(*, x0_n_x1_n_res, device, fw):
     dtype, object_in = x0_n_x1_n_res
+    # bfloat16 is not supported by numpy
+    assume(not ("bfloat16" in dtype))
     assume(not (fw == "torch" and (dtype in ["uint16", "uint32", "uint64"])))
     # torch does not support those dtypes
     assume(not (fw == "mxnet" and dtype == "int16"))
@@ -257,9 +269,11 @@ def test_to_numpy(*, x0_n_x1_n_res, device, fw):
 @handle_cmd_line_args
 @given(
     object_in=st.sampled_from([[0.0], [[[1]]], [True], [[1.0]]]),
-    dtype=st.sampled_from(ivy_np.valid_dtypes),
+    dtype=helpers.get_dtypes("valid"),
 )
 def test_to_scalar(*, object_in, dtype, device, fw):
+    # bfloat16 is not supported by numpy
+    assume(not ("bfloat16" in dtype))
     assume(not (fw == "torch" and (dtype in ["uint16", "uint32", "uint64"])))
     # torch does not support those dtypes
     assume(not (fw == "mxnet" and dtype == "int16"))
@@ -275,9 +289,15 @@ def test_to_scalar(*, object_in, dtype, device, fw):
 
 # to_list
 @handle_cmd_line_args
-@given(x0_n_x1_n_res=helpers.dtype_and_values(available_dtypes=ivy_np.valid_dtypes))
+@given(
+    x0_n_x1_n_res=helpers.dtype_and_values(
+        available_dtypes=helpers.get_dtypes("valid", full=True)
+    )
+)
 def test_to_list(*, x0_n_x1_n_res, device, fw):
     dtype, object_in = x0_n_x1_n_res
+    # bfloat16 is not supported by numpy
+    assume(not ("bfloat16" in dtype))
     assume(dtype in ivy.valid_dtypes)
     # smoke test
     arr = ivy.array(object_in, dtype=dtype, device=device)
@@ -301,7 +321,9 @@ def test_to_list(*, x0_n_x1_n_res, device, fw):
 # shape
 @handle_cmd_line_args
 @given(
-    x0_n_x1_n_res=helpers.dtype_and_values(available_dtypes=ivy_np.valid_dtypes),
+    x0_n_x1_n_res=helpers.dtype_and_values(
+        available_dtypes=helpers.get_dtypes("valid", full=True)
+    ),
     as_tensor=st.booleans(),
     tensor_fn=st.sampled_from([ivy.array, helpers.var_fn]),
 )
@@ -339,7 +361,9 @@ def test_shape(*, x0_n_x1_n_res, as_tensor, tensor_fn, device, fw):
 # get_num_dims
 @handle_cmd_line_args
 @given(
-    x0_n_x1_n_res=helpers.dtype_and_values(available_dtypes=ivy_np.valid_dtypes),
+    x0_n_x1_n_res=helpers.dtype_and_values(
+        available_dtypes=helpers.get_dtypes("valid", full=True)
+    ),
     as_tensor=st.booleans(),
     tensor_fn=st.sampled_from([ivy.array, helpers.var_fn]),
 )

--- a/ivy_tests/test_ivy/test_functional/test_core/test_gradients.py
+++ b/ivy_tests/test_ivy/test_functional/test_core/test_gradients.py
@@ -62,7 +62,9 @@ def test_unset_with_grads(grads):
 # variable
 @handle_cmd_line_args
 @given(
-    dtype_and_x=helpers.dtype_and_values(available_dtypes=ivy_np.valid_float_dtypes),
+    dtype_and_x=helpers.dtype_and_values(
+        available_dtypes=helpers.get_dtypes("float", full=True)
+    ),
 )
 def test_variable(
     *,
@@ -90,7 +92,9 @@ def test_variable(
 # is_variable
 @handle_cmd_line_args
 @given(
-    dtype_and_x=helpers.dtype_and_values(available_dtypes=ivy_np.valid_float_dtypes),
+    dtype_and_x=helpers.dtype_and_values(
+        available_dtypes=helpers.get_dtypes("float", full=True)
+    ),
 )
 def test_is_variable(
     *,
@@ -118,7 +122,9 @@ def test_is_variable(
 # variable data
 @handle_cmd_line_args
 @given(
-    dtype_and_x=helpers.dtype_and_values(available_dtypes=ivy_np.valid_float_dtypes),
+    dtype_and_x=helpers.dtype_and_values(
+        available_dtypes=helpers.get_dtypes("float", full=True)
+    ),
 )
 def test_variable_data(dtype_and_x, native_array, container, instance_method, fw):
     dtype, x = dtype_and_x
@@ -139,7 +145,9 @@ def test_variable_data(dtype_and_x, native_array, container, instance_method, fw
 # stop_gradient
 @handle_cmd_line_args
 @given(
-    dtype_and_x=helpers.dtype_and_values(available_dtypes=ivy_np.valid_float_dtypes),
+    dtype_and_x=helpers.dtype_and_values(
+        available_dtypes=helpers.get_dtypes("float", full=True)
+    ),
     preserve_type=st.booleans(),
 )
 def test_stop_gradient(
@@ -165,7 +173,7 @@ def test_stop_gradient(
 @handle_cmd_line_args
 @given(
     dtype_and_xs=helpers.dtype_and_values(
-        available_dtypes=ivy_np.valid_float_dtypes,
+        available_dtypes=helpers.get_dtypes("float", full=True),
         min_num_dims=1,
         min_dim_size=1,
         min_value=0,

--- a/ivy_tests/test_ivy/test_functional/test_core/test_linalg.py
+++ b/ivy_tests/test_ivy/test_functional/test_core/test_linalg.py
@@ -44,7 +44,7 @@ def dtype_value1_value2_axis(
     shape = shape[:axis] + [specific_dim_size] + shape[axis:]
     shape = tuple(shape)
 
-    dtype = draw(st.sampled_from(available_dtypes))
+    dtype = draw(available_dtypes)
 
     values = []
     for i in range(2):
@@ -91,8 +91,7 @@ def _get_dtype_value1_value2_axis_for_tensordot(
         )
     )
     axis = draw(helpers.ints(min_value=1, max_value=len(shape)))
-
-    dtype = draw(st.sampled_from(available_dtypes))
+    dtype = draw(available_dtypes)
 
     values = []
     for i in range(2):
@@ -258,7 +257,7 @@ def test_vector_to_skew_symmetric_matrix(
 @handle_cmd_line_args
 @given(
     dtype_x=helpers.dtype_and_values(
-        available_dtypes=ivy_np.valid_float_dtypes,
+        available_dtypes=helpers.get_dtypes("float", full=True),
         min_value=0,
         max_value=50,
         shape=helpers.ints(min_value=2, max_value=8).map(lambda x: tuple([x, x])),
@@ -449,7 +448,7 @@ def test_eigvalsh(
 @handle_cmd_line_args
 @given(
     dtype_x=helpers.dtype_and_values(
-        available_dtypes=ivy_np.valid_float_dtypes,
+        available_dtypes=helpers.get_dtypes("float", full=True),
         min_value=0,
         max_value=50,
         shape=helpers.ints(min_value=2, max_value=20).map(lambda x: tuple([x, x])),
@@ -519,7 +518,7 @@ def test_matrix_transpose(
 @handle_cmd_line_args
 @given(
     dtype_xy=helpers.dtype_and_values(
-        available_dtypes=ivy_np.valid_numeric_dtypes,
+        available_dtypes=helpers.get_dtypes("numeric", full=True),
         num_arrays=2,
         min_value=1,
         max_value=50,
@@ -566,7 +565,7 @@ def test_outer(
 @handle_cmd_line_args
 @given(
     dtype_x=helpers.dtype_and_values(
-        available_dtypes=ivy_np.valid_float_dtypes,
+        available_dtypes=helpers.get_dtypes("float", full=True),
         min_value=0,
         max_value=50,
         shape=helpers.ints(min_value=2, max_value=20).map(lambda x: tuple([x, x])),
@@ -679,7 +678,7 @@ def test_solve(
 @handle_cmd_line_args
 @given(
     dtype_x=helpers.dtype_and_values(
-        available_dtypes=ivy_np.valid_float_dtypes,
+        available_dtypes=helpers.get_dtypes("float", full=True),
         min_value=0,
         max_value=50,
         min_num_dims=2,
@@ -716,7 +715,7 @@ def test_svdvals(
 @handle_cmd_line_args
 @given(
     dtype_x1_x2_axis=_get_dtype_value1_value2_axis_for_tensordot(
-        available_dtypes=ivy_np.valid_numeric_dtypes,
+        available_dtypes=helpers.get_dtypes("numeric"),
         min_num_dims=3,
         max_num_dims=8,
         min_dim_size=1,
@@ -742,6 +741,7 @@ def test_tensordot(
         x2,
         axis,
     ) = dtype_x1_x2_axis
+
     as_variable = [as_variable, as_variable]
     native_array = [native_array, native_array]
     container = [container, container]
@@ -766,7 +766,7 @@ def test_tensordot(
 @handle_cmd_line_args
 @given(
     dtype_x=helpers.dtype_and_values(
-        available_dtypes=ivy_np.valid_float_dtypes,
+        available_dtypes=helpers.get_dtypes("float", full=True),
         min_num_dims=2,
         max_num_dims=3,
         min_dim_size=1,
@@ -807,7 +807,7 @@ def test_trace(
 @handle_cmd_line_args
 @given(
     dtype_x1_x2_axis=dtype_value1_value2_axis(
-        available_dtypes=ivy_np.valid_numeric_dtypes,
+        available_dtypes=helpers.get_dtypes("numeric"),
         min_num_dims=1,
         max_num_dims=6,
         min_dim_size=1,
@@ -851,7 +851,7 @@ def test_vecdot(
 @handle_cmd_line_args
 @given(
     dtype_values_axis=helpers.dtype_values_axis(
-        available_dtypes=ivy_np.valid_float_dtypes,
+        available_dtypes=helpers.get_dtypes("float", full=True),
         min_num_dims=2,
         max_num_dims=3,
         min_dim_size=2,
@@ -897,7 +897,7 @@ def test_vector_norm(
 @handle_cmd_line_args
 @given(
     dtype_x=helpers.dtype_and_values(
-        available_dtypes=ivy_np.valid_float_dtypes,
+        available_dtypes=helpers.get_dtypes("float", full=True),
         min_num_dims=2,
         max_num_dims=5,
         min_dim_size=1,
@@ -984,7 +984,7 @@ def test_qr(
 @handle_cmd_line_args
 @given(
     dtype_x=helpers.dtype_and_values(
-        available_dtypes=ivy_np.valid_float_dtypes,
+        available_dtypes=helpers.get_dtypes("float", full=True),
         min_num_dims=3,
         max_num_dims=5,
         min_dim_size=2,
@@ -1053,7 +1053,7 @@ def test_svd(
 @handle_cmd_line_args
 @given(
     dtype_x=helpers.dtype_and_values(
-        available_dtypes=ivy_np.valid_float_dtypes,
+        available_dtypes=helpers.get_dtypes("float", full=True),
         min_num_dims=2,
         max_num_dims=5,
         min_dim_size=1,
@@ -1098,7 +1098,7 @@ def test_matrix_norm(
 @handle_cmd_line_args
 @given(
     dtype_x=helpers.dtype_and_values(
-        available_dtypes=ivy_np.valid_float_dtypes[1:],
+        available_dtypes=helpers.get_dtypes("float", index=1, full=True),
         min_num_dims=3,
         max_num_dims=3,
         min_dim_size=2,
@@ -1139,7 +1139,7 @@ def test_matrix_rank(
 @handle_cmd_line_args
 @given(
     dtype_x=helpers.dtype_and_values(
-        available_dtypes=ivy_np.valid_float_dtypes,
+        available_dtypes=helpers.get_dtypes("float", full=True),
         min_value=0,
         max_value=10,
         shape=helpers.ints(min_value=2, max_value=5).map(lambda x: tuple([x, x])),
@@ -1188,7 +1188,7 @@ def test_cholesky(
 @handle_cmd_line_args
 @given(
     dtype_x1_x2_axis=dtype_value1_value2_axis(
-        available_dtypes=ivy_np.valid_numeric_dtypes,
+        available_dtypes=helpers.get_dtypes("numeric", full=True),
         min_num_dims=1,
         max_num_dims=10,
         min_dim_size=3,
@@ -1231,7 +1231,7 @@ def test_cross(
 @handle_cmd_line_args
 @given(
     dtype_x=helpers.dtype_and_values(
-        available_dtypes=ivy_np.valid_numeric_dtypes,
+        available_dtypes=helpers.get_dtypes("numeric", full=True),
         min_num_dims=2,
         max_num_dims=2,
         min_dim_size=1,

--- a/ivy_tests/test_ivy/test_functional/test_core/test_linalg.py
+++ b/ivy_tests/test_ivy/test_functional/test_core/test_linalg.py
@@ -1188,7 +1188,7 @@ def test_cholesky(
 @handle_cmd_line_args
 @given(
     dtype_x1_x2_axis=dtype_value1_value2_axis(
-        available_dtypes=helpers.get_dtypes("numeric", full=True),
+        available_dtypes=helpers.get_dtypes("numeric"),
         min_num_dims=1,
         max_num_dims=10,
         min_dim_size=3,

--- a/ivy_tests/test_ivy/test_functional/test_core/test_manipulation.py
+++ b/ivy_tests/test_ivy/test_functional/test_core/test_manipulation.py
@@ -88,7 +88,7 @@ def test_concat(
 @handle_cmd_line_args
 @given(
     dtype_value=helpers.dtype_and_values(
-        available_dtypes=ivy_np.valid_dtypes,
+        available_dtypes=helpers.get_dtypes("valid", full=True),
         shape=st.shared(helpers.get_shape(), key="value_shape"),
     ),
     axis=helpers.get_axis(
@@ -135,7 +135,7 @@ def test_expand_dims(
 @handle_cmd_line_args
 @given(
     dtype_value=helpers.dtype_and_values(
-        available_dtypes=ivy_np.valid_dtypes,
+        available_dtypes=helpers.get_dtypes("valid", full=True),
         shape=st.shared(helpers.get_shape(min_num_dims=1), key="value_shape"),
     ),
     axis=helpers.get_axis(
@@ -190,7 +190,7 @@ def _permute_dims_helper(draw):
 @handle_cmd_line_args
 @given(
     dtype_value=helpers.dtype_and_values(
-        available_dtypes=ivy_np.valid_dtypes,
+        available_dtypes=helpers.get_dtypes("valid", full=True),
         shape=st.shared(helpers.get_shape(min_num_dims=1), key="value_shape"),
     ),
     permutation=_permute_dims_helper(),
@@ -231,7 +231,7 @@ def test_permute_dims(
 @handle_cmd_line_args
 @given(
     dtype_value=helpers.dtype_and_values(
-        available_dtypes=ivy_np.valid_dtypes,
+        available_dtypes=helpers.get_dtypes("valid", full=True),
         shape=st.shared(helpers.get_shape(), key="value_shape"),
     ),
     reshape=helpers.reshape_shapes(
@@ -294,7 +294,7 @@ def test_reshape(
 @handle_cmd_line_args
 @given(
     dtype_value=helpers.dtype_and_values(
-        available_dtypes=ivy_np.valid_dtypes,
+        available_dtypes=helpers.get_dtypes("valid", full=True),
         shape=st.shared(helpers.get_shape(min_num_dims=1), key="value_shape"),
     ),
     shift=helpers.dtype_and_values(
@@ -380,7 +380,7 @@ def _squeeze_helper(draw):
 @handle_cmd_line_args
 @given(
     dtype_value=helpers.dtype_and_values(
-        available_dtypes=ivy_np.valid_dtypes,
+        available_dtypes=helpers.get_dtypes("valid", full=True),
         shape=st.shared(helpers.get_shape(), key="value_shape"),
     ),
     axis=_squeeze_helper(),
@@ -484,7 +484,9 @@ def test_stack(
 @handle_cmd_line_args
 @given(
     x_min_n_max=helpers.dtype_and_values(
-        available_dtypes=ivy_np.valid_numeric_dtypes, num_arrays=3, shared_dtype=True
+        available_dtypes=helpers.get_dtypes("numeric", full=True),
+        num_arrays=3,
+        shared_dtype=True,
     ),
     num_positional_args=helpers.num_positional_args(fn_name="clip"),
     data=st.data(),
@@ -616,7 +618,7 @@ def _repeat_helper(draw):
 @handle_cmd_line_args
 @given(
     dtype_value=helpers.dtype_and_values(
-        available_dtypes=ivy_np.valid_dtypes,
+        available_dtypes=helpers.get_dtypes("valid", full=True),
         shape=st.shared(helpers.get_shape(min_num_dims=1), key="value_shape"),
     ),
     axis=st.shared(
@@ -729,7 +731,7 @@ def _split_helper(draw):
 @handle_cmd_line_args
 @given(
     dtype_value=helpers.dtype_and_values(
-        available_dtypes=ivy_np.valid_dtypes,
+        available_dtypes=helpers.get_dtypes("valid", full=True),
         shape=st.shared(helpers.get_shape(min_num_dims=1), key="value_shape"),
     ),
     axis=st.shared(
@@ -783,7 +785,7 @@ def test_split(
 @handle_cmd_line_args
 @given(
     dtype_value=helpers.dtype_and_values(
-        available_dtypes=ivy_np.valid_dtypes,
+        available_dtypes=helpers.get_dtypes("valid", full=True),
         shape=st.shared(helpers.get_shape(min_num_dims=2), key="shape"),
     ),
     axis0=helpers.get_axis(
@@ -844,7 +846,7 @@ def test_swapaxes(
 @handle_cmd_line_args
 @given(
     dtype_value=helpers.dtype_and_values(
-        available_dtypes=ivy_np.valid_dtypes,
+        available_dtypes=helpers.get_dtypes("valid", full=True),
         shape=st.shared(helpers.get_shape(min_num_dims=1), key="value_shape"),
     ),
     repeat=helpers.dtype_and_values(

--- a/ivy_tests/test_ivy/test_functional/test_core/test_random.py
+++ b/ivy_tests/test_ivy/test_functional/test_core/test_random.py
@@ -15,16 +15,16 @@ from ivy_tests.test_ivy.helpers import handle_cmd_line_args
 @handle_cmd_line_args
 @given(
     dtype_and_low=helpers.dtype_and_values(
-        available_dtypes=ivy_np.valid_float_dtypes,
+        available_dtypes=helpers.get_dtypes("float", full=True),
         min_value=-1000,
         max_value=100,
     ),
     dtype_and_high=helpers.dtype_and_values(
-        available_dtypes=ivy_np.valid_float_dtypes,
+        available_dtypes=helpers.get_dtypes("float", full=True),
         min_value=101,
         max_value=1000,
     ),
-    dtype=st.sampled_from(ivy_np.valid_float_dtypes + (None,)),
+    dtype=helpers.get_dtypes("float", none=True),
     num_positional_args=helpers.num_positional_args(fn_name="random_uniform"),
 )
 def test_random_uniform(
@@ -71,16 +71,16 @@ def test_random_uniform(
 @handle_cmd_line_args
 @given(
     dtype_and_mean=helpers.dtype_and_values(
-        available_dtypes=ivy_np.valid_float_dtypes,
+        available_dtypes=helpers.get_dtypes("float", full=True),
         min_value=-1000,
         max_value=1000,
     ),
     dtype_and_std=helpers.dtype_and_values(
-        available_dtypes=ivy_np.valid_float_dtypes,
+        available_dtypes=helpers.get_dtypes("float", full=True),
         min_value=0,
         max_value=1000,
     ),
-    dtype=st.sampled_from(ivy_np.valid_float_dtypes + (None,)),
+    dtype=helpers.get_dtypes("float", none=True),
     num_positional_args=helpers.num_positional_args(fn_name="random_normal"),
 )
 def test_random_normal(
@@ -265,7 +265,7 @@ def test_seed(seed_val):
 @handle_cmd_line_args
 @given(
     dtype_and_x=helpers.dtype_and_values(
-        available_dtypes=ivy_np.valid_float_dtypes,
+        available_dtypes=helpers.get_dtypes("float", full=True),
         allow_inf=False,
         min_num_dims=1,
         min_dim_size=2,

--- a/ivy_tests/test_ivy/test_functional/test_core/test_searching.py
+++ b/ivy_tests/test_ivy/test_functional/test_core/test_searching.py
@@ -19,7 +19,7 @@ from ivy_tests.test_ivy.helpers import handle_cmd_line_args
 def _dtype_x_limited_axis(draw, *, allow_none=False):
     dtype, x, shape = draw(
         helpers.dtype_and_values(
-            available_dtypes=ivy_np.valid_float_dtypes,
+            available_dtypes=helpers.get_dtypes("float", full=True),
             min_num_dims=1,
             min_dim_size=1,
             ret_shape=True,
@@ -121,7 +121,7 @@ def test_argmin(
 @handle_cmd_line_args
 @given(
     dtype_and_x=helpers.dtype_and_values(
-        available_dtypes=ivy_np.valid_int_dtypes,
+        available_dtypes=helpers.get_dtypes("integer", full=True),
         min_num_dims=1,
         max_num_dims=5,
         min_dim_size=1,

--- a/ivy_tests/test_ivy/test_functional/test_core/test_set.py
+++ b/ivy_tests/test_ivy/test_functional/test_core/test_set.py
@@ -4,7 +4,6 @@ from hypothesis import given, assume, settings
 
 # local
 import ivy_tests.test_ivy.helpers as helpers
-import ivy.functional.backends.numpy as ivy_np
 from ivy_tests.test_ivy.helpers import handle_cmd_line_args
 
 
@@ -12,7 +11,7 @@ from ivy_tests.test_ivy.helpers import handle_cmd_line_args
 @handle_cmd_line_args
 @given(
     dtype_and_x=helpers.dtype_and_values(
-        available_dtypes=ivy_np.valid_numeric_dtypes,
+        available_dtypes=helpers.get_dtypes("numeric", full=True),
         min_num_dims=1,
         max_num_dims=3,
         min_dim_size=1,
@@ -53,7 +52,7 @@ def test_unique_values(
 @handle_cmd_line_args
 @given(
     dtype_and_x=helpers.dtype_and_values(
-        available_dtypes=ivy_np.valid_numeric_dtypes,
+        available_dtypes=helpers.get_dtypes("numeric", full=True),
         min_num_dims=1,
         max_num_dims=5,
         min_dim_size=1,
@@ -92,7 +91,7 @@ def test_unique_all(
 @handle_cmd_line_args
 @given(
     dtype_and_x=helpers.dtype_and_values(
-        available_dtypes=ivy_np.valid_numeric_dtypes,
+        available_dtypes=helpers.get_dtypes("numeric", full=True),
         min_num_dims=2,
         max_num_dims=5,
         min_dim_size=2,
@@ -131,7 +130,7 @@ def test_unique_counts(
 @handle_cmd_line_args
 @given(
     dtype_and_x=helpers.dtype_and_values(
-        available_dtypes=ivy_np.valid_numeric_dtypes,
+        available_dtypes=helpers.get_dtypes("numeric", full=True),
         min_num_dims=2,
         max_num_dims=5,
         min_dim_size=2,

--- a/ivy_tests/test_ivy/test_functional/test_core/test_sorting.py
+++ b/ivy_tests/test_ivy/test_functional/test_core/test_sorting.py
@@ -6,7 +6,6 @@ import numpy as np
 
 # local
 import ivy_tests.test_ivy.helpers as helpers
-import ivy.functional.backends.numpy as ivy_np
 from ivy_tests.test_ivy.helpers import handle_cmd_line_args
 
 
@@ -14,7 +13,7 @@ from ivy_tests.test_ivy.helpers import handle_cmd_line_args
 @handle_cmd_line_args
 @given(
     dtype_x_axis=helpers.dtype_values_axis(
-        available_dtypes=ivy_np.valid_numeric_dtypes,
+        available_dtypes=helpers.get_dtypes("numeric", full=True),
         min_num_dims=1,
         max_num_dims=5,
         min_dim_size=1,
@@ -62,7 +61,7 @@ def test_argsort(
 @handle_cmd_line_args
 @given(
     dtype_x_axis=helpers.dtype_values_axis(
-        available_dtypes=ivy_np.valid_numeric_dtypes,
+        available_dtypes=helpers.get_dtypes("numeric", full=True),
         min_num_dims=1,
         max_num_dims=5,
         min_dim_size=1,

--- a/ivy_tests/test_ivy/test_functional/test_core/test_statistical.py
+++ b/ivy_tests/test_ivy/test_functional/test_core/test_statistical.py
@@ -338,11 +338,13 @@ def test_std(
             ("ij,j", (np.arange(25).reshape(5, 5), np.arange(5)), (5,)),
         ]
     ),
-    dtype=st.sampled_from(ivy_np.valid_float_dtypes),
+    dtype=helpers.get_dtypes("float"),
     with_out=st.booleans(),
     tensor_fn=st.sampled_from([ivy.array, helpers.var_fn]),
 )
 def test_einsum(*, eq_n_op_n_shp, dtype, with_out, tensor_fn, fw, device):
+    # bfloat16 is not supported by numpy
+    assume(not ("bfloat16" in dtype))
     # smoke test
     eq, operands, true_shape = eq_n_op_n_shp
     operands = [tensor_fn(op, dtype=dtype, device=device) for op in operands]

--- a/ivy_tests/test_ivy/test_functional/test_core/test_utility.py
+++ b/ivy_tests/test_ivy/test_functional/test_core/test_utility.py
@@ -5,7 +5,6 @@ import numpy as np
 from hypothesis import given, strategies as st
 
 # local
-import ivy.functional.backends.numpy as ivy_np
 import ivy_tests.test_ivy.helpers as helpers
 from ivy_tests.test_ivy.helpers import handle_cmd_line_args
 
@@ -14,7 +13,7 @@ from ivy_tests.test_ivy.helpers import handle_cmd_line_args
 @handle_cmd_line_args
 @given(
     dtype_x_axis=helpers.dtype_values_axis(
-        available_dtypes=ivy_np.valid_int_dtypes,
+        available_dtypes=helpers.get_dtypes("integer", full=True),
         min_value=0,
         max_value=1,
         allow_inf=False,
@@ -57,7 +56,7 @@ def test_all(
 @handle_cmd_line_args
 @given(
     dtype_x_axis=helpers.dtype_values_axis(
-        available_dtypes=ivy_np.valid_int_dtypes,
+        available_dtypes=helpers.get_dtypes("integer", full=True),
         min_value=0,
         max_value=1,
         allow_inf=False,

--- a/ivy_tests/test_ivy/test_functional/test_nn/test_activations.py
+++ b/ivy_tests/test_ivy/test_functional/test_nn/test_activations.py
@@ -6,14 +6,15 @@ from hypothesis import given, strategies as st
 
 # local
 import ivy_tests.test_ivy.helpers as helpers
-import ivy.functional.backends.numpy as ivy_np
 from ivy_tests.test_ivy.helpers import handle_cmd_line_args
 
 
 # relu
 @handle_cmd_line_args
 @given(
-    dtype_and_x=helpers.dtype_and_values(available_dtypes=ivy_np.valid_float_dtypes),
+    dtype_and_x=helpers.dtype_and_values(
+        available_dtypes=helpers.get_dtypes("float", full=True)
+    ),
     num_positional_args=helpers.num_positional_args(fn_name="relu"),
 )
 def test_relu(
@@ -45,7 +46,9 @@ def test_relu(
 # leaky_relu
 @handle_cmd_line_args
 @given(
-    dtype_and_x=helpers.dtype_and_values(available_dtypes=ivy_np.valid_float_dtypes),
+    dtype_and_x=helpers.dtype_and_values(
+        available_dtypes=helpers.get_dtypes("float", full=True)
+    ),
     num_positional_args=helpers.num_positional_args(fn_name="leaky_relu"),
     alpha=st.floats(width=16),
 )
@@ -82,7 +85,8 @@ def test_leaky_relu(
 @handle_cmd_line_args
 @given(
     dtype_and_x=helpers.dtype_and_values(
-        available_dtypes=ivy_np.valid_float_dtypes, large_value_safety_factor=2.0
+        available_dtypes=helpers.get_dtypes("float", full=True),
+        large_value_safety_factor=2.0,
     ),
     approximate=st.booleans(),
     num_positional_args=helpers.num_positional_args(fn_name="gelu"),
@@ -120,7 +124,9 @@ def test_gelu(
 # tanh
 @handle_cmd_line_args
 @given(
-    dtype_and_x=helpers.dtype_and_values(available_dtypes=ivy_np.valid_float_dtypes),
+    dtype_and_x=helpers.dtype_and_values(
+        available_dtypes=helpers.get_dtypes("float", full=True)
+    ),
     num_positional_args=helpers.num_positional_args(fn_name="tanh"),
 )
 def test_tanh(
@@ -152,7 +158,9 @@ def test_tanh(
 # sigmoid
 @handle_cmd_line_args
 @given(
-    dtype_and_x=helpers.dtype_and_values(available_dtypes=ivy_np.valid_float_dtypes),
+    dtype_and_x=helpers.dtype_and_values(
+        available_dtypes=helpers.get_dtypes("float", full=True)
+    ),
     num_positional_args=helpers.num_positional_args(fn_name="sigmoid"),
 )
 def test_sigmoid(
@@ -185,7 +193,7 @@ def test_sigmoid(
 @handle_cmd_line_args
 @given(
     dtype_and_x=helpers.dtype_and_values(
-        available_dtypes=ivy_np.valid_float_dtypes, min_num_dims=1
+        available_dtypes=helpers.get_dtypes("float", full=True), min_num_dims=1
     ),
     axis=helpers.ints(min_value=-1, max_value=0),
     num_positional_args=helpers.num_positional_args(fn_name="softmax"),
@@ -222,7 +230,7 @@ def test_softmax(
 @handle_cmd_line_args
 @given(
     dtype_and_x=helpers.dtype_and_values(
-        available_dtypes=ivy_np.valid_float_dtypes, min_num_dims=1
+        available_dtypes=helpers.get_dtypes("float", full=True), min_num_dims=1
     ),
     num_positional_args=helpers.num_positional_args(fn_name="softplus"),
 )

--- a/ivy_tests/test_ivy/test_functional/test_nn/test_layers.py
+++ b/ivy_tests/test_ivy/test_functional/test_nn/test_layers.py
@@ -6,7 +6,6 @@ from hypothesis import given, strategies as st, assume
 
 # local
 import ivy_tests.test_ivy.helpers as helpers
-import ivy.functional.backends.numpy as ivy_np
 from ivy_tests.test_ivy.helpers import handle_cmd_line_args
 
 # Linear #
@@ -51,7 +50,7 @@ def x_and_linear(draw, dtypes):
 @handle_cmd_line_args
 @given(
     dtype_x_weight_bias=x_and_linear(
-        dtypes=st.sampled_from(ivy_np.valid_float_dtypes),
+        dtypes=helpers.get_dtypes("float"),
     ),
     with_out=st.booleans(),
     num_positional_args=helpers.num_positional_args(fn_name="linear"),
@@ -99,7 +98,7 @@ def test_linear(
 @handle_cmd_line_args
 @given(
     dtype_and_x=helpers.dtype_and_values(
-        available_dtypes=ivy_np.valid_float_dtypes,
+        available_dtypes=helpers.get_dtypes("float", full=True),
         min_value=0,
         max_value=50,
         allow_inf=False,
@@ -195,7 +194,7 @@ def x_and_scaled_attention(draw, dtypes):
 @handle_cmd_line_args
 @given(
     dtype_q_k_v_mask_scale=x_and_scaled_attention(
-        dtypes=st.sampled_from(ivy_np.valid_float_dtypes),
+        dtypes=helpers.get_dtypes("float"),
     ),
     num_positional_args=helpers.num_positional_args(
         fn_name="scaled_dot_product_attention"
@@ -281,7 +280,7 @@ def x_and_mha(draw, dtypes):
 @handle_cmd_line_args
 @given(
     dtype_mha=x_and_mha(
-        dtypes=st.sampled_from(ivy_np.valid_float_dtypes),
+        dtypes=helpers.get_dtypes("float"),
     ),
 )
 def test_multi_head_attention(
@@ -541,7 +540,7 @@ def _x_and_filters(
 @handle_cmd_line_args
 @given(
     x_f_d_df=_x_and_filters(
-        dtypes=st.sampled_from(ivy_np.valid_float_dtypes),
+        dtypes=helpers.get_dtypes("float"),
         data_format=st.sampled_from(["NWC", "NCW"]),
         padding=st.sampled_from(["VALID", "SAME"]),
         stride_min=1,
@@ -590,7 +589,7 @@ def test_conv1d(
 @handle_cmd_line_args
 @given(
     x_f_d_df=_x_and_filters(
-        dtypes=st.sampled_from(ivy_np.valid_float_dtypes),
+        dtypes=helpers.get_dtypes("float"),
         data_format=st.sampled_from(["NWC", "NCW"]),
         padding=st.sampled_from(["VALID", "SAME"]),
         stride_min=1,
@@ -643,7 +642,7 @@ def test_conv1d_transpose(
 @handle_cmd_line_args
 @given(
     x_f_d_df=_x_and_filters(
-        dtypes=st.sampled_from(ivy_np.valid_float_dtypes),
+        dtypes=helpers.get_dtypes("float"),
         data_format=st.sampled_from(["NHWC", "NCHW"]),
         padding=st.sampled_from(["VALID", "SAME"]),
         stride_min=1,
@@ -690,7 +689,7 @@ def test_conv2d(
 @handle_cmd_line_args
 @given(
     x_f_d_df=_x_and_filters(
-        dtypes=st.sampled_from(ivy_np.valid_float_dtypes),
+        dtypes=helpers.get_dtypes("float"),
         data_format=st.sampled_from(["NHWC", "NCHW"]),
         padding=st.sampled_from(["VALID", "SAME"]),
         stride_min=1,
@@ -744,7 +743,7 @@ def test_conv2d_transpose(
 @handle_cmd_line_args
 @given(
     x_f_d_df=_x_and_filters(
-        dtypes=st.sampled_from(ivy_np.valid_float_dtypes),
+        dtypes=helpers.get_dtypes("float"),
         data_format=st.sampled_from(["NHWC", "NCHW"]),
         padding=st.sampled_from(["VALID", "SAME"]),
         stride_min=1,
@@ -795,7 +794,7 @@ def test_depthwise_conv2d(
 @handle_cmd_line_args
 @given(
     x_f_d_df=_x_and_filters(
-        dtypes=st.sampled_from(ivy_np.valid_float_dtypes),
+        dtypes=helpers.get_dtypes("float"),
         data_format=st.sampled_from(["NDHWC", "NCDHW"]),
         padding=st.sampled_from(["VALID", "SAME"]),
         stride_min=1,
@@ -843,7 +842,7 @@ def test_conv3d(
 @handle_cmd_line_args
 @given(
     x_f_d_df=_x_and_filters(
-        dtypes=st.sampled_from(ivy_np.valid_float_dtypes),
+        dtypes=helpers.get_dtypes("float"),
         data_format=st.sampled_from(["NDHWC", "NCDHW"]),
         padding=st.sampled_from(["VALID", "SAME"]),
         stride_min=1,
@@ -958,7 +957,7 @@ def x_and_lstm(draw, dtypes):
 @handle_cmd_line_args
 @given(
     dtype_lstm=x_and_lstm(
-        dtypes=st.sampled_from(ivy_np.valid_float_dtypes),
+        dtypes=helpers.get_dtypes("float"),
     ),
 )
 def test_lstm_update(

--- a/ivy_tests/test_ivy/test_functional/test_nn/test_losses.py
+++ b/ivy_tests/test_ivy/test_functional/test_nn/test_losses.py
@@ -3,7 +3,6 @@ import numpy as np
 from hypothesis import given
 
 # local
-import ivy.functional.backends.numpy as ivy_np
 import ivy_tests.test_ivy.helpers as helpers
 from ivy_tests.test_ivy.helpers import handle_cmd_line_args
 
@@ -12,7 +11,7 @@ from ivy_tests.test_ivy.helpers import handle_cmd_line_args
 @handle_cmd_line_args
 @given(
     dtype_and_true=helpers.dtype_and_values(
-        available_dtypes=ivy_np.valid_int_dtypes,
+        available_dtypes=helpers.get_dtypes("integer", full=True),
         min_value=0,
         max_value=1,
         allow_inf=False,
@@ -21,7 +20,7 @@ from ivy_tests.test_ivy.helpers import handle_cmd_line_args
         min_dim_size=2,
     ),
     dtype_and_pred=helpers.dtype_and_values(
-        available_dtypes=ivy_np.valid_float_dtypes,
+        available_dtypes=helpers.get_dtypes("float", full=True),
         min_value=1.0013580322265625e-05,
         max_value=1,
         allow_inf=False,
@@ -74,7 +73,7 @@ def test_cross_entropy(
 @handle_cmd_line_args
 @given(
     dtype_and_true=helpers.dtype_and_values(
-        available_dtypes=ivy_np.valid_int_dtypes,
+        available_dtypes=helpers.get_dtypes("integer", full=True),
         min_value=0,
         max_value=1,
         allow_inf=False,
@@ -83,7 +82,7 @@ def test_cross_entropy(
         min_dim_size=2,
     ),
     dtype_and_pred=helpers.dtype_and_values(
-        available_dtypes=ivy_np.valid_float_dtypes,
+        available_dtypes=helpers.get_dtypes("float", full=True),
         min_value=1.0013580322265625e-05,
         max_value=1,
         allow_inf=False,
@@ -132,7 +131,7 @@ def test_binary_cross_entropy(
 @handle_cmd_line_args
 @given(
     dtype_and_true=helpers.dtype_and_values(
-        available_dtypes=ivy_np.valid_int_dtypes,
+        available_dtypes=helpers.get_dtypes("integer", full=True),
         min_value=0,
         max_value=2,
         allow_inf=False,
@@ -141,7 +140,7 @@ def test_binary_cross_entropy(
         min_dim_size=3,
     ),
     dtype_and_pred=helpers.dtype_and_values(
-        available_dtypes=ivy_np.valid_float_dtypes,
+        available_dtypes=helpers.get_dtypes("float", full=True),
         min_value=1.0013580322265625e-05,
         max_value=1,
         allow_inf=False,

--- a/ivy_tests/test_ivy/test_functional/test_nn/test_norms.py
+++ b/ivy_tests/test_ivy/test_functional/test_nn/test_norms.py
@@ -6,7 +6,6 @@ from hypothesis import given, strategies as st
 
 # local
 import ivy
-import ivy.functional.backends.numpy as ivy_np
 import ivy_tests.test_ivy.helpers as helpers
 from ivy_tests.test_ivy.helpers import handle_cmd_line_args
 
@@ -14,7 +13,7 @@ from ivy_tests.test_ivy.helpers import handle_cmd_line_args
 @handle_cmd_line_args
 @given(
     dtype_x_normidxs=helpers.dtype_values_axis(
-        available_dtypes=ivy_np.valid_numeric_dtypes,
+        available_dtypes=helpers.get_dtypes("numeric", full=True),
         allow_inf=False,
         min_num_dims=1,
         min_axis=1,


### PR DESCRIPTION
`get_dtypes` is responsible for backend specific dtype generation with following types-:
1. valid
2. numeric
3. integer
4. float
5. unsigned

All functional tests incorporate this now