### PR TITLE
Adding `isfinite` and `isinf` torch frontend

### DIFF
--- a/ivy/functional/frontends/torch/comparison_ops.py
+++ b/ivy/functional/frontends/torch/comparison_ops.py
@@ -97,3 +97,11 @@ def isclose(input, other, rtol=1e-05, atol=1e-08, equal_nan=False):
 
 
 isclose.unsupported_dtypes = ("float16",)
+
+
+def isfinite(input):
+    return ivy.isfinite(input)
+
+
+def isinf(input):
+    return ivy.isinf(input)

--- a/ivy_tests/test_ivy/test_frontends/test_torch/test_comparison_ops.py
+++ b/ivy_tests/test_ivy/test_frontends/test_torch/test_comparison_ops.py
@@ -300,3 +300,75 @@ def test_torch_isclose(
         atol=1e-08,
         equal_nan=equal_nan,
     )
+
+
+# isifinite
+@handle_cmd_line_args
+@given(
+    dtype_and_input=helpers.dtype_and_values(
+        available_dtypes=tuple(
+            set(ivy_np.valid_numeric_dtypes).intersection(
+                set(ivy_torch.valid_numeric_dtypes)
+            ),
+        ),
+        allow_inf=True,
+    ),
+    num_positional_args=helpers.num_positional_args(
+        fn_name="ivy.functional.frontends.torch.isfinite"
+    ),
+)
+def test_torch_isfinite(
+    dtype_and_input,
+    as_variable,
+    num_positional_args,
+    native_array,
+    fw,
+):
+    input_dtype, input = dtype_and_input
+    helpers.test_frontend_function(
+        input_dtypes=input_dtype,
+        as_variable_flags=as_variable,
+        with_out=False,
+        num_positional_args=num_positional_args,
+        native_array_flags=native_array,
+        fw=fw,
+        frontend="torch",
+        fn_tree="isfinite",
+        input=np.asarray(input, dtype=input_dtype),
+    )
+
+
+# isinf
+@handle_cmd_line_args
+@given(
+    dtype_and_input=helpers.dtype_and_values(
+        available_dtypes=tuple(
+            set(ivy_np.valid_numeric_dtypes).intersection(
+                set(ivy_torch.valid_numeric_dtypes)
+            ),
+        ),
+        allow_inf=True,
+    ),
+    num_positional_args=helpers.num_positional_args(
+        fn_name="ivy.functional.frontends.torch.isinf"
+    ),
+)
+def test_torch_isinf(
+    dtype_and_input,
+    as_variable,
+    num_positional_args,
+    native_array,
+    fw,
+):
+    input_dtype, input = dtype_and_input
+    helpers.test_frontend_function(
+        input_dtypes=input_dtype,
+        as_variable_flags=as_variable,
+        with_out=False,
+        num_positional_args=num_positional_args,
+        native_array_flags=native_array,
+        fw=fw,
+        frontend="torch",
+        fn_tree="isinf",
+        input=np.asarray(input, dtype=input_dtype),
+    )


### PR DESCRIPTION
Hi James,

This PR resolves issues #3728 and #3729 
Added `torch.isfinite` and `torch.isinf` to the torch frontend.

Thanks.