### PR TITLE
add min and max assertion for clip to all backends.

### DIFF
--- a/ivy/functional/backends/jax/manipulation.py
+++ b/ivy/functional/backends/jax/manipulation.py
@@ -184,6 +184,7 @@ def clip(
     *,
     out: Optional[JaxArray] = None,
 ) -> JaxArray:
+    assert jnp.all(jnp.less(x_min, x_max)), "Min value must be less than max."
     if (
         hasattr(x_min, "dtype")
         and hasattr(x_max, "dtype")

--- a/ivy/functional/backends/numpy/manipulation.py
+++ b/ivy/functional/backends/numpy/manipulation.py
@@ -218,6 +218,7 @@ def clip(
     *,
     out: Optional[np.ndarray] = None,
 ) -> np.ndarray:
+    assert np.all(np.less(x_min, x_max)), "Min value must be less than max."
     ret = np.asarray(np.clip(x, x_min, x_max, out=out), dtype=x.dtype)
     return ret
 

--- a/ivy/functional/backends/tensorflow/manipulation.py
+++ b/ivy/functional/backends/tensorflow/manipulation.py
@@ -290,6 +290,7 @@ def clip(
     *,
     out: Optional[Union[tf.Tensor, tf.Variable]] = None,
 ) -> Union[tf.Tensor, tf.Variable]:
+    assert tf.reduce_all(tf.less(x_min, x_max)), "Min value must be less than max."
     if hasattr(x_min, "dtype") and hasattr(x_max, "dtype"):
         promoted_type = tf.experimental.numpy.promote_types(x.dtype, x_min.dtype)
         promoted_type = tf.experimental.numpy.promote_types(promoted_type, x_max.dtype)

--- a/ivy/functional/backends/torch/manipulation.py
+++ b/ivy/functional/backends/torch/manipulation.py
@@ -266,6 +266,7 @@ def clip(
     *,
     out: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
+    assert torch.all(torch.less(x_min, x_max)), "Min value must be less than max."
     if hasattr(x_min, "dtype"):
         promoted_type = torch.promote_types(x_min.dtype, x_max.dtype)
         promoted_type = torch.promote_types(promoted_type, x.dtype)

--- a/ivy/functional/ivy/manipulation.py
+++ b/ivy/functional/ivy/manipulation.py
@@ -856,7 +856,6 @@ def clip(
     }
 
     """
-    assert ivy.all(ivy.less(x_min, x_max))
     res = current_backend(x).clip(x, x_min, x_max)
     if ivy.exists(out):
         return ivy.inplace_update(out, res)

--- a/ivy_tests/test_ivy/test_functional/test_core/test_manipulation.py
+++ b/ivy_tests/test_ivy/test_functional/test_core/test_manipulation.py
@@ -480,21 +480,33 @@ def test_stack(
 # ------#
 
 
+@st.composite
+def _basic_min_x_max(draw):
+    dtype, value = draw(
+        helpers.dtype_and_values(
+            available_dtypes=helpers.get_dtypes("numeric", full=True),
+        )
+    )
+    min_val = draw(
+        helpers.array_values(dtype=dtype, shape=(), min_value=1, max_value=10)
+    )
+    max_val = draw(
+        helpers.array_values(dtype=dtype, shape=(), min_value=11, max_value=20)
+    )  # TODO remove hardcoded values.
+    return ([dtype] * 3), (value, min_val, max_val)
+
+
 # clip
 @handle_cmd_line_args
 @given(
-    x_min_n_max=helpers.dtype_and_values(
-        available_dtypes=helpers.get_dtypes("numeric", full=True),
-        num_arrays=3,
-        shared_dtype=True,
-    ),
+    dtype_x_min_n_max=_basic_min_x_max(),
     num_positional_args=helpers.num_positional_args(fn_name="clip"),
     data=st.data(),
 )
 def test_clip(
     *,
     data,
-    x_min_n_max,
+    dtype_x_min_n_max,
     as_variable,
     with_out,
     num_positional_args,
@@ -504,11 +516,13 @@ def test_clip(
     device,
     fw,
 ):
-    (x_dtype, min_dtype, max_dtype), (x_list, min_val_list, max_val_list) = x_min_n_max
-    min_val_raw = np.array(min_val_list, dtype=min_dtype)
-    max_val_raw = np.array(max_val_list, dtype=max_dtype)
-    min_val = np.asarray(np.minimum(min_val_raw, max_val_raw))
-    max_val = np.asarray(np.maximum(min_val_raw, max_val_raw))
+    (x_dtype, min_dtype, max_dtype), (
+        x_list,
+        min_val_list,
+        max_val_list,
+    ) = dtype_x_min_n_max
+    min_val = np.array(min_val_list, dtype=min_dtype)
+    max_val = np.array(max_val_list, dtype=max_dtype)
 
     helpers.test_function(
         input_dtypes=[x_dtype, min_dtype, max_dtype],

--- a/ivy_tests/test_ivy/test_functional/test_core/test_manipulation.py
+++ b/ivy_tests/test_ivy/test_functional/test_core/test_manipulation.py
@@ -499,14 +499,14 @@ def _basic_min_x_max(draw):
 # clip
 @handle_cmd_line_args
 @given(
-    dtype_x_min_n_max=_basic_min_x_max(),
+    dtype_x_min_max=_basic_min_x_max(),
     num_positional_args=helpers.num_positional_args(fn_name="clip"),
     data=st.data(),
 )
 def test_clip(
     *,
     data,
-    dtype_x_min_n_max,
+    dtype_x_min_max,
     as_variable,
     with_out,
     num_positional_args,
@@ -516,14 +516,7 @@ def test_clip(
     device,
     fw,
 ):
-    (x_dtype, min_dtype, max_dtype), (
-        x_list,
-        min_val_list,
-        max_val_list,
-    ) = dtype_x_min_n_max
-    min_val = np.array(min_val_list, dtype=min_dtype)
-    max_val = np.array(max_val_list, dtype=max_dtype)
-
+    (x_dtype, min_dtype, max_dtype), (x_list, min_val, max_val) = dtype_x_min_max
     helpers.test_function(
         input_dtypes=[x_dtype, min_dtype, max_dtype],
         as_variable_flags=as_variable,
@@ -535,8 +528,8 @@ def test_clip(
         fw=fw,
         fn_name="clip",
         x=np.asarray(x_list, dtype=x_dtype),
-        x_min=min_val,
-        x_max=max_val,
+        x_min=np.array(min_val, dtype=min_dtype),
+        x_max=np.array(max_val, dtype=max_dtype),
     )
 
 


### PR DESCRIPTION
Assertion is skipped due to implementation in `ivy` wrapper function and not backends. assertion is required as `tensorflow` treats the special case of `min > max` differently.
```python
ivy.clip(ivy.array(0), ivy.array(1), ivy.array(0)) # will fail.
ivy.set_backend("numpy")
ivy.clip(ivy.array([0]), ivy.array([1]), ivy.array([0])) # works fine.
ivy.set_backend("tensorflow")
ivy.clip(ivy.array(0), ivy.array(1), ivy.array(0)) # different results.
```