### PR TITLE
fix `help()` for backend functions

### DIFF
--- a/ivy/func_wrapper.py
+++ b/ivy/func_wrapper.py
@@ -454,7 +454,9 @@ def _wrap_function(key: str, to_wrap: Callable, original: Callable) -> Callable:
                 continue
             setattr(to_wrap, attr, getattr(original, attr))
         # Copy docstring
-        setattr(to_wrap, "__doc__", getattr(original, "__doc__"))
+        docstring_attr = ["__annotations__", "__doc__"]
+        for attr in docstring_attr:
+            setattr(to_wrap, attr, getattr(original, attr))
         # wrap decorators (sequence matters)
         for attr in [
             "infer_device",

--- a/ivy/func_wrapper.py
+++ b/ivy/func_wrapper.py
@@ -453,6 +453,8 @@ def _wrap_function(key: str, to_wrap: Callable, original: Callable) -> Callable:
             if attr.startswith("_") or hasattr(ivy, attr) or attr == "handles_out_arg":
                 continue
             setattr(to_wrap, attr, getattr(original, attr))
+        # Copy docstring
+        setattr(to_wrap, "__doc__", getattr(original, "__doc__"))
         # wrap decorators (sequence matters)
         for attr in [
             "infer_device",


### PR DESCRIPTION
***WIP***
Currently, calling `help(ivy.prod)` before setting the backend, works as expected, showing the correct function signature and the docstring, but this fails after `ivy.set_backend()` is called to set any `backend`.