### PR TITLE
Added `less`, `lt`, `not_equal`, and `ne` to torch frontend

### DIFF
--- a/ivy/functional/frontends/torch/comparison_ops.py
+++ b/ivy/functional/frontends/torch/comparison_ops.py
@@ -141,3 +141,17 @@ def less_equal(input, other, *, out=None):
 
 
 le = less_equal
+
+
+def less(input, other, *, out=None):
+    return ivy.less(input, other, out=out)
+
+
+lt = less
+
+
+def not_equal(input, other, *, out=None):
+    return ivy.not_equal(input, other, out=out)
+
+
+ne = not_equal

--- a/ivy_tests/test_ivy/test_frontends/test_torch/test_comparison_ops.py
+++ b/ivy_tests/test_ivy/test_frontends/test_torch/test_comparison_ops.py
@@ -580,7 +580,6 @@ def test_torch_less_equal(
             ),
         ),
         num_arrays=2,
-        allow_inf=False,
         shared_dtype=True,
     ),
     num_positional_args=helpers.num_positional_args(
@@ -621,7 +620,6 @@ def test_torch_less(
             ),
         ),
         num_arrays=2,
-        allow_inf=False,
         shared_dtype=True,
     ),
     num_positional_args=helpers.num_positional_args(

--- a/ivy_tests/test_ivy/test_frontends/test_torch/test_comparison_ops.py
+++ b/ivy_tests/test_ivy/test_frontends/test_torch/test_comparison_ops.py
@@ -568,3 +568,85 @@ def test_torch_less_equal(
         other=np.asarray(inputs[1], dtype=input_dtype[1]),
         out=None,
     )
+
+
+# less
+@handle_cmd_line_args
+@given(
+    dtype_and_inputs=helpers.dtype_and_values(
+        available_dtypes=tuple(
+            set(ivy_np.valid_numeric_dtypes).intersection(
+                set(ivy_torch.valid_numeric_dtypes)
+            ),
+        ),
+        num_arrays=2,
+        allow_inf=False,
+        shared_dtype=True,
+    ),
+    num_positional_args=helpers.num_positional_args(
+        fn_name="ivy.functional.frontends.torch.less"
+    ),
+)
+def test_torch_less(
+    dtype_and_inputs,
+    as_variable,
+    with_out,
+    num_positional_args,
+    native_array,
+    fw,
+):
+    input_dtype, inputs = dtype_and_inputs
+    helpers.test_frontend_function(
+        input_dtypes=input_dtype,
+        as_variable_flags=as_variable,
+        with_out=with_out,
+        num_positional_args=num_positional_args,
+        native_array_flags=native_array,
+        fw=fw,
+        frontend="torch",
+        fn_tree="less",
+        input=np.asarray(inputs[0], dtype=input_dtype[0]),
+        other=np.asarray(inputs[1], dtype=input_dtype[1]),
+        out=None,
+    )
+
+
+# not_equal
+@handle_cmd_line_args
+@given(
+    dtype_and_inputs=helpers.dtype_and_values(
+        available_dtypes=tuple(
+            set(ivy_np.valid_numeric_dtypes).intersection(
+                set(ivy_torch.valid_numeric_dtypes)
+            ),
+        ),
+        num_arrays=2,
+        allow_inf=False,
+        shared_dtype=True,
+    ),
+    num_positional_args=helpers.num_positional_args(
+        fn_name="ivy.functional.frontends.torch.not_equal"
+    ),
+)
+def test_torch_not_equal(
+    dtype_and_inputs,
+    as_variable,
+    with_out,
+    num_positional_args,
+    native_array,
+    fw,
+):
+    input_dtype, inputs = dtype_and_inputs
+    helpers.test_frontend_function(
+        input_dtypes=input_dtype,
+        as_variable_flags=as_variable,
+        with_out=with_out,
+        num_positional_args=num_positional_args,
+        native_array_flags=native_array,
+        fw=fw,
+        frontend="torch",
+        fn_tree="not_equal",
+        input=np.asarray(inputs[0], dtype=input_dtype[0]),
+        other=np.asarray(inputs[1], dtype=input_dtype[1]),
+        out=None,
+    )


### PR DESCRIPTION
Hi James

This PR resolves issues #3869 #3870 #3872 and #3873

I added `less` an alias of `lt` and `not_equal` an alias of `ne` to the torch frontend.

Thanks