### PR TITLE
Better run_tests.sh

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -51,6 +51,7 @@ fi
 
 # Process the arguments to prepend the paths so they will work inside the docker container
 FINAL_ARGS=()
+NUM_TESTS=0
 for ARG in ${RAW_ARGS[@]}; do
     if [[ "${ARG::1}" == "-" ]]; then
         # Copy
@@ -58,8 +59,15 @@ for ARG in ${RAW_ARGS[@]}; do
     else
         # Fix paths to test files
         FINAL_ARGS+=("${IVY_PREFIX}/${ARG}")
+        NUM_TESTS+=1
     fi
 done
+
+# Ensure that empty test specs equals to test everything
+if (( $NUM_TESTS == 0 )); then
+    FINAL_ARGS+=("${IVY_PREFIX}/ivy_tests/")
+    NUM_TESTS+=1
+fi
 
 if (( "${DEBUG}" )); then
     printf -v TMP '%s; ' ${FINAL_ARGS[@]}

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,2 +1,61 @@
-#!/bin/bash -e
-docker run --rm -it -v "$(pwd)":/ivy unifyai/ivy:latest python3 -m pytest ivy/ivy_tests/
+#!/bin/bash
+# Sensure our script doesn't fail silently
+set -efu
+
+# Some basic parameters that should bery rarely change
+IVY_PREFIX="/ivy"
+DOCKER_IMAGE="unifyai/ivy:latest"
+PYTEST_CMD=("python3" "-m" "pytest")
+
+if [[ "-h" == "$1" || "--help" == "$1" ]]; then
+    echo "USAGE: $0 [TESTS..] -- [PYTEST OPTIONS...]"
+    echo "To run all tests pass no options or use -- as the first one"
+    echo "  $0"
+    echo "  $0 --"
+    echo "To run all tests on a specific file, use its path as the first argument"
+    echo "  $0 ivy_tests/test_ivy/test_functional/test_core/test_general.py"
+    echo "To run a specific test on specific file, use its path and function name as the first argument"
+    echo "  $0 ivy_tests/test_ivy/test_functional/test_core/test_general.py::test_array_equal"
+    echo "To run multiple tests just combine them as you would intuitively guess"
+    echo "  $0 ivy_tests/test_ivy/test_functional/test_core/test_general.py::test_array_equal ivy_tests/test_ivy/test_functional/test_core/test_random.py ivy_tests/test_ivy/test_functional/test_core/test_general.py::test_shape"
+    echo "Some examples of pytest options"
+    echo "  --no-header"
+    echo "  --no-summary"
+    echo "  -q same as --quiet"
+    echo "Remember to always use relative paths from the repository root"
+    exit 1
+fi
+
+RAW_ARGS=("$@") # These quotation marks are indispensible to avoid bugs with filenames with spaces
+PYTEST_TESTS=()
+PYTEST_ARGS=()
+ARGS_SPLIT_INDEX=-1 # Holds the position of the '--' argument
+for I in ${!RAW_ARGS[@]}; do
+    if [[ "--" == "${RAW_ARGS[$I]}" ]]; then
+        ARGS_SPLIT_INDEX="${I}"
+        break
+    fi
+done
+for I in ${!RAW_ARGS[@]}; do
+    if (( $I < $ARGS_SPLIT_INDEX || $ARGS_SPLIT_INDEX < 0)); then
+        PYTEST_TESTS+=("${IVY_PREFIX}/${RAW_ARGS[$I]}")
+    elif (( $I > $ARGS_SPLIT_INDEX && $ARGS_SPLIT_INDEX > 0)); then
+        PYTEST_ARGS+=("${RAW_ARGS[$I]}")
+    fi
+done
+
+PWD="$(pwd)"
+set -x
+# These quotation marks are indispensible to avoid bugs with filenames with spaces
+docker run --rm -it -v "${PWD}":"${IVY_PREFIX}" "${DOCKER_IMAGE}" "${PYTEST_CMD[@]}" "${PYTEST_TESTS[@]}" "${PYTEST_ARGS[@]}"
+set +x
+
+exit 0
+
+set -x
+
+if [[ -z "${REQUESTED_TESTS}" || "--" -eq "${REQUESTED_TESTS}" ]]; then
+    docker run --rm -it -v "$(pwd)":/ivy unifyai/ivy:latest python3 -m pytest ivy/ivy_tests/ ${@: 2}
+else
+    docker run --rm -it -v "$(pwd)":/ivy unifyai/ivy:latest python3 -m pytest "ivy/${REQUESTED_TESTS}" ${@: 2}
+fi


### PR DESCRIPTION
I modified the `./run_tests.sh` script to include a help message as well as the possibility of running specific tests and of passing arguments to pytest.

The new interface is compatible with the previous one. That is, calling the script without passing any parameters runs all tests under `ivy_tests/`.