### PR TITLE
vmap for all backends and the test

### DIFF
--- a/ivy/functional/backends/jax/general.py
+++ b/ivy/functional/backends/jax/general.py
@@ -9,7 +9,7 @@ from numbers import Number
 from operator import mul
 from functools import reduce
 from jaxlib.xla_extension import Buffer
-from typing import Iterable, Optional, Union, Sequence, List
+from typing import Iterable, Optional, Union, Sequence, List, Callable
 import multiprocessing as _multiprocessing
 from haiku._src.data_structures import FlatMapping
 
@@ -383,6 +383,14 @@ def inplace_increment(
     else:
         x = ivy.Array(val_native)
     return x
+
+
+def vmap(func: Callable,
+         in_axes: Union[int, Sequence[int], Sequence[None]] = 0,
+         out_axes: Optional[int] = 0) -> Callable:
+    return ivy.to_native_arrays_and_back(jax.vmap(func,
+                                                  in_axes=in_axes,
+                                                  out_axes=out_axes))
 
 
 current_backend_str = lambda: "jax"

--- a/ivy/functional/backends/numpy/general.py
+++ b/ivy/functional/backends/numpy/general.py
@@ -1,7 +1,7 @@
 """Collection of Numpy general functions, wrapped to fit Ivy syntax and signature."""
 
 # global
-from typing import Optional, Union, Sequence, List
+from typing import Optional, Union, Sequence, List, Callable
 import numpy as np
 from operator import mul
 from functools import reduce
@@ -369,3 +369,85 @@ def get_num_dims(x, as_tensor=False):
 
 def current_backend_str():
     return "numpy"
+
+
+def vmap(
+    func: Callable,
+    in_axes: Union[int, Sequence[int], Sequence[None]] = 0,
+    out_axes: Optional[int] = 0,
+) -> Callable:
+    @ivy.to_native_arrays_and_back
+    def _vmap(*args):
+
+        # convert args tuple to list to allow mutability using moveaxis ahead.
+        args = list(args)
+
+        # if in_axis is a non-integer, its length should be equal to pos args.
+        if isinstance(in_axes, (list, tuple)):
+            try:
+                assert (len(args)) == len(in_axes)
+            except AssertionError:
+                raise Exception(
+                    """The in_axes should have length equivalent to the 
+                number of positional arguments to the function being vectorized
+                or it should be an integer."""
+                )
+
+        # checking uniqueness of axis_size
+        axis_size = set()
+
+        if isinstance(in_axes, int):
+            for arg in args:
+                axis_size.add(arg.shape[in_axes])
+        elif isinstance(in_axes, (list, tuple)):
+            for (arg, axis) in zip(args, in_axes):
+                if axis is not None:
+                    axis_size.add(arg.shape[axis])
+
+        if len(axis_size) > 1:
+            raise ValueError(
+                """Inconsistent sizes. All mapped axes should have the same size"""
+            )
+
+        # Making sure not all in_axes are None
+        if isinstance(in_axes, (list, tuple)):
+            assert not all(
+                ax is None for ax in in_axes
+            ), "At least one of the axes should be specified (not None)"
+        else:
+            assert not (in_axes is None), "single value in_axes should not be None"
+
+        # Handling None in in_axes by broadcasting the axis_size
+        if isinstance(in_axes, (tuple, list)) and None in in_axes:
+            none_axis_index = list()
+            for index, axis in enumerate(in_axes):
+                if axis is None:
+                    none_axis_index.append(index)
+
+            for none_mapped_axis in none_axis_index:
+                args[none_mapped_axis] = np.broadcast_to(
+                    args[none_mapped_axis],
+                    (tuple(axis_size) + args[none_mapped_axis].shape),
+                )
+
+        # set up the axis to be mapped to index zero.
+        if isinstance(in_axes, (tuple, list)):
+            for i in range(len(in_axes)):
+                if in_axes[i] is not None:
+                    args[i] = np.moveaxis(args[i], in_axes[i], 0)
+        elif isinstance(in_axes, int):
+            args[0] = np.moveaxis(args[0], in_axes, 0)
+
+        # vectorisation. To be optimized.
+        arr_results = []
+        for arrays in zip(*args):
+            single_op = func(*arrays)
+            arr_results.append(single_op)
+        res = np.stack(arr_results)
+
+        if out_axes:
+            res = np.moveaxis(res, 0, out_axes)
+
+        return res
+
+    return _vmap

--- a/ivy/functional/backends/tensorflow/general.py
+++ b/ivy/functional/backends/tensorflow/general.py
@@ -3,7 +3,7 @@ signature.
 """
 
 # global
-from typing import Optional, Union, Sequence, List
+from typing import Optional, Union, Sequence, List, Callable
 
 
 _round = round
@@ -488,3 +488,85 @@ def shape(
 
 def get_num_dims(x, as_tensor=False):
     return tf.shape(tf.shape(x))[0] if as_tensor else int(tf.shape(tf.shape(x)))
+
+
+def vmap(
+    func: Callable,
+    in_axes: Union[int, Sequence[int], Sequence[None]] = 0,
+    out_axes: Optional[int] = 0,
+) -> Callable:
+    @ivy.to_native_arrays_and_back
+    def _vmap(*args, **kwargs):
+
+        # convert args tuple to list to allow mutability using moveaxis ahead.
+        args = list(args)
+
+        # if in_axis is a non-integer, its length should be equal to pos args.
+        if isinstance(in_axes, (list, tuple)):
+            try:
+                assert (len(args)) == len(in_axes)
+            except AssertionError:
+                raise Exception(
+                    """The in_axes should have length equivalent to the 
+                number of positional arguments to the function being vectorized
+                or it should be an integer."""
+                )
+
+        # checking axis_size consistency
+        axis_size = set()
+
+        if isinstance(in_axes, int):
+            for arg in args:
+                axis_size.add(arg.shape[in_axes])
+        elif isinstance(in_axes, (list, tuple)):
+            for arg, axis in zip(args, in_axes):
+                if axis is not None:
+                    axis_size.add(arg.shape[axis])
+
+        if len(axis_size) > 1:
+            raise ValueError(
+                """Inconsistent sizes. All mapped axes should have the same size"""
+            )
+
+        # Making sure not all in_axes are None
+        if isinstance(in_axes, (list, tuple)):
+            assert not all(
+                ax is None for ax in in_axes
+            ), "At least one of the axes should be specified (not None)."
+        else:
+            assert not (in_axes is None), "single value in_axes should not be None."
+
+        # Handling None in in_axes by broadcasting the axis_size
+        if isinstance(in_axes, (tuple, list)) and None in in_axes:
+            none_axis_index = list()
+            for index, axis in enumerate(in_axes):
+                if axis is None:
+                    none_axis_index.append(index)
+
+            for none_mapped_axis in none_axis_index:
+                args[none_mapped_axis] = tf.broadcast_to(
+                    args[none_mapped_axis],
+                    (tuple(axis_size) + args[none_mapped_axis].shape),
+                )
+
+        # set up the axis to be mapped
+        if isinstance(in_axes, (tuple, list)):
+            for i in range(len(in_axes)):
+                args[i] = tf.experimental.numpy.moveaxis(args[i], in_axes[i], 0)
+        elif isinstance(in_axes, int):
+            args[0] = tf.experimental.numpy.moveaxis(args[0], in_axes, 0)
+
+        # vectorisation - applying map_fn if only one arg provided as reduce requires
+        # two elements to begin with.
+        arr_results = []
+        for arrays in zip(*args):
+            single_op = func(*arrays)
+            arr_results.append(single_op)
+        res = ivy.stack(arr_results)
+
+        if out_axes:
+            res = tf.experimental.numpy.moveaxis(res, 0, out_axes)
+
+        return res
+
+    return _vmap

--- a/ivy/functional/ivy/general.py
+++ b/ivy/functional/ivy/general.py
@@ -7,7 +7,7 @@ import gc
 import inspect
 import math
 from numbers import Number
-from typing import Callable, Any, Union, List, Tuple, Dict, Iterable, Optional
+from typing import Callable, Any, Union, List, Tuple, Dict, Iterable, Optional, Sequence
 import einops
 import numpy as np
 
@@ -3954,3 +3954,52 @@ def function_unsupported_devices_and_dtypes(fn: Callable, recurse=True) -> Dict:
         )
 
     return unsupported_devices_dtype
+
+
+def vmap(func: Callable,
+         in_axes: Union[int, Sequence[int], Sequence[None]] = 0,
+         out_axes: Optional[int] = 0) -> Callable:
+    """Vectorizing map. Creates a function which maps func over argument axes.
+    Parameters
+    ----------
+    func
+        Function to be mapped over additional axes.
+    in_axes
+       An integer, None, or (nested) standard Python container
+       (tuple/list) thereof specifying which input array
+       axes to map over.If each positional argument to fun
+       is an array, then in_axes can be an integer, a None,
+       or a tuple of integers and Nones with length equal
+       to the number of positional arguments to fun. An
+       integer or None indicates which array axis to map
+       over for all arguments (with None indicating not to map any axis),
+       and a tuple indicates which axis to map for each
+       corresponding positional argument. Axis integers must
+       be in the range [-ndim, ndim) for each array,
+       where ndim is the number of dimensions (axes) of the
+       corresponding input array.
+    out_axes
+        An integer indicating where the mapped axis should appear in the output.
+    Returns
+    -------
+    ret
+        Batched/vectorized version of func with arguments
+        that correspond to those of func, but with extra
+        array axes at positions indicated by in_axes,
+        and a return value that corresponds
+        to that of fun, but with extra array axes
+        at positions indicated by out_axes.
+    This docstring is a summarised version of the
+    `docstring <https://jax.readthedocs.io/en/latest/_autosummary/jax.vmap.html#jax-vmap>`_ for  # noqa
+    vmap from JAX documentation.
+    Examples
+    --------
+    With :code:`ivy.matmul` func and :code:`ivy.Array` input:
+    >>> x = ivy.array(ivy.arange(60).reshape((3, 5, 4)))
+    >>> y = ivy.array(ivy.arange(40).reshape((5, 4, 2)))
+    >>> z = ivy.vmap(ivy.matmul, (1, 0), 1)(x, y)
+    >>> print(z.shape)
+    (3, 5, 2)
+    """
+    # TODO: optimize in the numpy and tensorflow backends and extend functionality
+    return current_backend().vmap(func, in_axes, out_axes)

--- a/ivy_tests/test_ivy/helpers.py
+++ b/ivy_tests/test_ivy/helpers.py
@@ -3314,3 +3314,36 @@ def statistical_dtype_values(draw, *, function):
 @st.composite
 def seed(draw):
     return draw(st.integers(min_value=0, max_value=2**8 - 1))
+
+
+@st.composite
+def arrays_and_axes(draw,
+                    allow_none=False,
+                    min_num_dims=0,
+                    max_num_dims=5,
+                    min_dim_size=1,
+                    max_dim_size=10,
+                    num=2):
+    shapes = list()
+    for _ in range(num):
+        shape = draw(get_shape(allow_none=False,
+                               min_num_dims=min_num_dims,
+                               max_num_dims=max_num_dims,
+                               min_dim_size=min_dim_size,
+                               max_dim_size=max_dim_size))
+        shapes.append(shape)
+    arrays = list()
+    for shape in shapes:
+        arrays.append(draw(array_values(dtype="int32",
+                                        shape=shape,
+                                        min_value=-200,
+                                        max_value=200)))
+    all_axes_ranges = list()
+    for shape in shapes:
+        if None in all_axes_ranges:
+            all_axes_ranges.append(st.integers(0, len(shape) - 1))
+        else:
+            all_axes_ranges.append(st.one_of(st.none(),
+                                             st.integers(0, len(shape) - 1)))
+    axes = draw(st.tuples(*all_axes_ranges))
+    return arrays, axes

--- a/ivy_tests/test_ivy/test_functional/test_core/test_general.py
+++ b/ivy_tests/test_ivy/test_functional/test_core/test_general.py
@@ -1985,3 +1985,66 @@ def test_assert_supports_inplace(
 @handle_cmd_line_args
 def test_arg_info():
     return
+
+
+def _fn1(x, y):
+    return ivy.matmul(x, y)
+
+
+def _fn2(x, y):
+    return ivy.vecdot(x, y)
+
+
+def _fn3(x, y):
+    ivy.add(x, y)
+
+
+@given(func=st.sampled_from([_fn1, _fn2, _fn3]),
+       arrays_and_axes=helpers.arrays_and_axes(allow_none=False,
+                                               min_num_dims=2,
+                                               max_num_dims=5,
+                                               min_dim_size=2,
+                                               max_dim_size=10,
+                                               num=2),
+       in_axes_as_cont=st.booleans())
+def test_vmap(func, arrays_and_axes, in_axes_as_cont):
+
+    generated_arrays, in_axes = arrays_and_axes
+    arrays = [ivy.native_array(array) for array in generated_arrays]
+
+    if in_axes_as_cont:
+        vmapped_func = ivy.vmap(func, in_axes=in_axes, out_axes=0)
+    else:
+        vmapped_func = ivy.vmap(func, in_axes=0, out_axes=0)
+
+    assert callable(vmapped_func)
+
+    try:
+        fw_res = vmapped_func(*arrays)
+    except Exception:
+        fw_res = None
+
+    ivy.set_backend("jax")
+    arrays = [ivy.native_array(array) for array in generated_arrays]
+    if in_axes_as_cont:
+        jax_vmapped_func = ivy.vmap(func, in_axes=in_axes, out_axes=0)
+    else:
+        jax_vmapped_func = ivy.vmap(func, in_axes=0, out_axes=0)
+
+    assert callable(jax_vmapped_func)
+
+    try:
+        jax_res = jax_vmapped_func(*arrays)
+    except Exception:
+        jax_res = None
+
+    ivy.unset_backend()
+
+    if fw_res is not None and jax_res is not None:
+        assert np.allclose(fw_res, jax_res),\
+            f"Results from {ivy.current_backend_str()} and jax are not equal"
+
+    elif fw_res is None and jax_res is None:
+        pass
+    else:
+        assert False, "One of the results is None while other isn't"


### PR DESCRIPTION
`ivy.vmap` implementations inspired by `jax.vmap`. 
The `test_vmap` is passing for the backends `[numpy, tensorflow, jax, torch]`. Checked with a max of 500 hypothesis generated examples and made sure its hitting actual examples and not passing for the wrong reasons.

The implementation will be improved using optimized vectorisation functions by the host frameworks and extended/adding more functionality/control but this is the first iteration and has the essential working components.

Here is a list of additions.
 - vmap in ivy
 - vmap for all ivy backends
 - vmap test
 - helper function arrays_and_axes