### PR TITLE
Fix broken import ivy - syntax error

### DIFF
--- a/ivy/container/general.py
+++ b/ivy/container/general.py
@@ -493,7 +493,6 @@ class ContainerWithGeneral(ContainerBase):
             to_apply=to_apply,
             prune_unapplied=prune_unapplied,
             map_sequences=map_sequences,
-            p=p,
             out=out,
         )
 


### PR DESCRIPTION
@djl11 
`import ivy` from the master branch seems to be broken (currently at [fe54364](https://github.com/unifyai/ivy/commit/fe543643954e90250581acedec9ddff7f9fe2f18)): 

```py
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/ivy/ivy/__init__.py", line 372, in <module>
    from .container import conversions as cont_conversions
  File "/ivy/ivy/container/__init__.py", line 14, in <module>
    from .container import ContainerBase, Container  # noqa
  File "/ivy/ivy/container/container.py", line 14, in <module>
    from .general import ContainerWithGeneral
  File "/ivy/ivy/container/general.py", line 496
    p=p,
    ^
SyntaxError: keyword argument repeated
```

This PR removes a duplicated kwarg introduced in a [recent commit](https://github.com/unifyai/ivy/commit/92571f0a43a26d72749e381c1d7f255702ab8ae4#diff-f3a487649a510336c1e94060a1b3b9847f266fdf8a439cead0034b43a1a8d15fR491)