### PR TITLE
Fix used_mem_on_dev() units (GB instead of bytes)

### DIFF
--- a/ivy/functional/ivy/device.py
+++ b/ivy/functional/ivy/device.py
@@ -537,7 +537,7 @@ def used_mem_on_dev(
         return info.used / 1e9
     elif device == "cpu":
         if process_specific:
-            return psutil.Process(os.getpid()).memory_info().rss
+            return psutil.Process(os.getpid()).memory_info().rss / 1e9
         vm = psutil.virtual_memory()
         return (vm.total - vm.available) / 1e9
     else:


### PR DESCRIPTION
When calling `ivy.used_mem_on_dev("cpu", process_specific=True)`, the output value is in bytes, though is expected to be in GB (per ivy docs). See [psutil docs](https://psutil.readthedocs.io/en/latest/index.html?highlight=memory_info#psutil.Process.memory_info): `psutil.Process(...).memory_info().rss` is returned in bytes.

With this PR `ivy.used_mem_on_dev(...)` returns GB units for any argument provided