### PR TITLE
Ivy Extension task marked open

### DIFF
--- a/docs/partial_source/contributing/4_open_tasks.rst
+++ b/docs/partial_source/contributing/4_open_tasks.rst
@@ -22,6 +22,7 @@ The tasks currently open are:
 
 #. Function Formatting
 #. Frontend APIs
+#. Ivy API Extensions
 
 We try to explain these tasks as clearly as possible, but in cases where things are not
 clear, then please feel free to engage with the `open tasks discussion`_,


### PR DESCRIPTION
Once the task is to be opened, this can be merged to add the task to the list of open tasks.