### PR TITLE
softplus_superset

### DIFF
--- a/ivy/array/activations.py
+++ b/ivy/array/activations.py
@@ -1,6 +1,6 @@
 # global
 import abc
-from typing import Optional
+from typing import Optional, Union
 
 # local
 import ivy
@@ -103,7 +103,12 @@ class ArrayWithActivations(abc.ABC):
         """
         return ivy.softmax(self._data, axis=axis, out=out)
 
-    def softplus(self: ivy.Array, /, *, out: Optional[ivy.Array] = None) -> ivy.Array:
+    def softplus(self: ivy.Array,
+                 /,
+                 *,
+                 beta: Optional[Union[int, float]] = 1,
+                 out: Optional[ivy.Array] = None
+                 ) -> ivy.Array:
         """
         ivy.Array instance method variant of ivy.softplus. This method simply wraps the
         function, and so the docstring for ivy.softplus also applies to this method
@@ -116,4 +121,4 @@ class ArrayWithActivations(abc.ABC):
         >>> print(y)
         ivy.array([0.535, 0.42 ])
         """
-        return ivy.softplus(self._data, out=out)
+        return ivy.softplus(self._data, beta=beta, out=out)

--- a/ivy/array/activations.py
+++ b/ivy/array/activations.py
@@ -107,6 +107,7 @@ class ArrayWithActivations(abc.ABC):
                  /,
                  *,
                  beta: Optional[Union[int, float]] = 1,
+                 threshold: Optional[Union[int, float]] = 20,
                  out: Optional[ivy.Array] = None
                  ) -> ivy.Array:
         """
@@ -120,5 +121,16 @@ class ArrayWithActivations(abc.ABC):
         >>> y = x.softplus()
         >>> print(y)
         ivy.array([0.535, 0.42 ])
+
+        >>> x = ivy.array([-0.3461, -0.6491])
+        >>> x.softplus(beta=0.5)
+        >>> print(y)
+        ivy.array([1.22, 1.09])
+
+        >>> ivy.array([1.31, 2.  , 2.  ])
+        >>> x.softplus(threshold=2)
+        >>> print(y)
+        ivy.array([1.31, 2.  , 2.  ])
+
         """
-        return ivy.softplus(self._data, beta=beta, out=out)
+        return ivy.softplus(self._data, beta=beta, threshold=threshold, out=out)

--- a/ivy/array/activations.py
+++ b/ivy/array/activations.py
@@ -127,10 +127,10 @@ class ArrayWithActivations(abc.ABC):
         >>> print(y)
         ivy.array([1.22, 1.09])
 
-        >>> ivy.array([1.31, 2.  , 2.  ])
+        >>> ivy.array([1.31, 2., 2.])
         >>> x.softplus(threshold=2)
         >>> print(y)
-        ivy.array([1.31, 2.  , 2.  ])
+        ivy.array([2.15, 2.63, 2.63])
 
         """
         return ivy.softplus(self._data, beta=beta, threshold=threshold, out=out)

--- a/ivy/array/activations.py
+++ b/ivy/array/activations.py
@@ -106,8 +106,8 @@ class ArrayWithActivations(abc.ABC):
     def softplus(self: ivy.Array,
                  /,
                  *,
-                 beta: Optional[Union[int, float]] = 1,
-                 threshold: Optional[Union[int, float]] = 20,
+                 beta: Optional[Union[int, float]] = None,
+                 threshold: Optional[Union[int, float]] = None,
                  out: Optional[ivy.Array] = None
                  ) -> ivy.Array:
         """

--- a/ivy/container/activations.py
+++ b/ivy/container/activations.py
@@ -620,8 +620,8 @@ class ContainerWithActivations(ContainerBase):
         x: Union[ivy.Array, ivy.NativeArray, ivy.Container],
         /,
         *,
-        beta: Optional[Union[int, float]] = 1,
-        threshold: Optional[Union[int, float]] = 20,
+        beta: Optional[Union[int, float]] = None,
+        threshold: Optional[Union[int, float]] = None,
         key_chains: Optional[Union[List[str], Dict[str, str]]] = None,
         to_apply: bool = True,
         prune_unapplied: bool = False,
@@ -638,7 +638,9 @@ class ContainerWithActivations(ContainerBase):
         x
             input container.
         beta
-            the beta value of the softplus formation. Default is 1.
+            The beta value for the softplus formation. Default: None.
+        threshold
+            values above this revert to a linear function. Default: None.
         key_chains
             The key-chains to apply or not apply the method to. Default is None.
         to_apply
@@ -690,8 +692,8 @@ class ContainerWithActivations(ContainerBase):
         self: ivy.Container,
         /,
         *,
-        beta: Optional[Union[int, float]] = 1,
-        threshold: Optional[Union[int, float]] = 20,
+        beta: Optional[Union[int, float]] = None,
+        threshold: Optional[Union[int, float]] = None,
         key_chains: Optional[Union[List[str], Dict[str, str]]] = None,
         to_apply: bool = True,
         prune_unapplied: bool = False,
@@ -708,7 +710,9 @@ class ContainerWithActivations(ContainerBase):
         self
             input container.
         beta
-            the beta value of the softplus formation. Default is 1.
+            The beta value for the softplus formation. Default: None.
+        threshold
+            values above this revert to a linear function. Default: None.
         key_chains
             The key-chains to apply or not apply the method to. Default is None.
         to_apply

--- a/ivy/container/activations.py
+++ b/ivy/container/activations.py
@@ -671,7 +671,7 @@ class ContainerWithActivations(ContainerBase):
         >>> y = ivy.Container.static_softplus(x, beta=0.5, threshold=2)
         >>> print(y)
         {
-            a: ivy.array([0.948, 2., 2.])
+            a: ivy.array([0.948, 2.63, 4.25])
         }
         """
         return ContainerBase.multi_map_in_static_method(
@@ -741,7 +741,7 @@ class ContainerWithActivations(ContainerBase):
         >>> y = x.softplus(beta=0.5, threshold=2)
         >>> print(y)
         {
-            a: ivy.array([0.948, 2., 2.])
+            a: ivy.array([0.948, 2.63, 4.25])
         }
         """
         return self.static_softplus(

--- a/ivy/container/activations.py
+++ b/ivy/container/activations.py
@@ -621,6 +621,7 @@ class ContainerWithActivations(ContainerBase):
         /,
         *,
         beta: Optional[Union[int, float]] = 1,
+        threshold: Optional[Union[int, float]] = 20,
         key_chains: Optional[Union[List[str], Dict[str, str]]] = None,
         to_apply: bool = True,
         prune_unapplied: bool = False,
@@ -666,11 +667,18 @@ class ContainerWithActivations(ContainerBase):
             a: ivy.array([0.535, 0.42])
         }
 
+        >>> x = ivy.Container(a=ivy.array([-1., 2., 4.]))
+        >>> y = ivy.Container.static_softplus(x, beta=0.5, threshold=2)
+        >>> print(y)
+        {
+            a: ivy.array([0.948, 2., 2.])
+        }
         """
         return ContainerBase.multi_map_in_static_method(
             "softplus",
             x,
             beta=beta,
+            threshold=threshold,
             key_chains=key_chains,
             to_apply=to_apply,
             prune_unapplied=prune_unapplied,
@@ -683,6 +691,7 @@ class ContainerWithActivations(ContainerBase):
         /,
         *,
         beta: Optional[Union[int, float]] = 1,
+        threshold: Optional[Union[int, float]] = 20,
         key_chains: Optional[Union[List[str], Dict[str, str]]] = None,
         to_apply: bool = True,
         prune_unapplied: bool = False,
@@ -728,10 +737,17 @@ class ContainerWithActivations(ContainerBase):
             a: ivy.array([0.535, 0.42])
         }
 
+        >>> x = ivy.Container(a=ivy.array([-1., 2., 4.]))
+        >>> y = x.softplus(beta=0.5, threshold=2)
+        >>> print(y)
+        {
+            a: ivy.array([0.948, 2., 2.])
+        }
         """
         return self.static_softplus(
             self,
             beta=beta,
+            threshold=threshold,
             key_chains=key_chains,
             to_apply=to_apply,
             prune_unapplied=prune_unapplied,

--- a/ivy/container/activations.py
+++ b/ivy/container/activations.py
@@ -620,6 +620,7 @@ class ContainerWithActivations(ContainerBase):
         x: Union[ivy.Array, ivy.NativeArray, ivy.Container],
         /,
         *,
+        beta: Optional[Union[int, float]] = 1,
         key_chains: Optional[Union[List[str], Dict[str, str]]] = None,
         to_apply: bool = True,
         prune_unapplied: bool = False,
@@ -635,6 +636,8 @@ class ContainerWithActivations(ContainerBase):
         ----------
         x
             input container.
+        beta
+            the beta value of the softplus formation. Default is 1.
         key_chains
             The key-chains to apply or not apply the method to. Default is None.
         to_apply
@@ -667,6 +670,7 @@ class ContainerWithActivations(ContainerBase):
         return ContainerBase.multi_map_in_static_method(
             "softplus",
             x,
+            beta=beta,
             key_chains=key_chains,
             to_apply=to_apply,
             prune_unapplied=prune_unapplied,
@@ -678,6 +682,7 @@ class ContainerWithActivations(ContainerBase):
         self: ivy.Container,
         /,
         *,
+        beta: Optional[Union[int, float]] = 1,
         key_chains: Optional[Union[List[str], Dict[str, str]]] = None,
         to_apply: bool = True,
         prune_unapplied: bool = False,
@@ -693,6 +698,8 @@ class ContainerWithActivations(ContainerBase):
         ----------
         self
             input container.
+        beta
+            the beta value of the softplus formation. Default is 1.
         key_chains
             The key-chains to apply or not apply the method to. Default is None.
         to_apply
@@ -724,6 +731,7 @@ class ContainerWithActivations(ContainerBase):
         """
         return self.static_softplus(
             self,
+            beta=beta,
             key_chains=key_chains,
             to_apply=to_apply,
             prune_unapplied=prune_unapplied,

--- a/ivy/functional/backends/jax/activations.py
+++ b/ivy/functional/backends/jax/activations.py
@@ -48,4 +48,4 @@ def softplus(x: JaxArray,
              threshold: Optional[Union[int, float]] = 20,
              out: Optional[JaxArray] = None) -> JaxArray:
     res = (jnp.log1p(jnp.exp(-jnp.abs(x * beta))) + jnp.maximum(x * beta, 0)) / beta
-    return jnp.where(res < threshold, res, float(threshold))
+    return jnp.where(x*beta > threshold, x*beta, res)

--- a/ivy/functional/backends/jax/activations.py
+++ b/ivy/functional/backends/jax/activations.py
@@ -48,4 +48,4 @@ def softplus(x: JaxArray,
              threshold: Optional[Union[int, float]] = 20,
              out: Optional[JaxArray] = None) -> JaxArray:
     res = (jnp.log1p(jnp.exp(-jnp.abs(x * beta))) + jnp.maximum(x * beta, 0)) / beta
-    return jnp.where(x*beta > threshold, x, res)
+    return jnp.where(x * beta > threshold, x, res)

--- a/ivy/functional/backends/jax/activations.py
+++ b/ivy/functional/backends/jax/activations.py
@@ -3,7 +3,7 @@
 # global
 import jax
 import jax.numpy as jnp
-from typing import Optional
+from typing import Optional, Union
 
 # local
 from ivy.functional.backends.jax import JaxArray
@@ -41,5 +41,9 @@ def softmax(
     return jax.nn.softmax(x, axis)
 
 
-def softplus(x: JaxArray, /, *, out: Optional[JaxArray] = None) -> JaxArray:
-    return jnp.log1p(jnp.exp(-jnp.abs(x))) + jnp.maximum(x, 0)
+def softplus(x: JaxArray,
+             /,
+             *,
+             beta: Optional[Union[int, float]] = 1,
+             out: Optional[JaxArray] = None) -> JaxArray:
+    return (jnp.log1p(jnp.exp(-jnp.abs(x * beta))) + jnp.maximum(x * beta, 0)) / beta

--- a/ivy/functional/backends/jax/activations.py
+++ b/ivy/functional/backends/jax/activations.py
@@ -44,14 +44,24 @@ def softmax(
 def softplus(x: JaxArray,
              /,
              *,
-             beta: Optional[Union[int, float, None]] = None,
-             threshold: Optional[Union[int, float]] = 20,
+             beta: Optional[Union[int, float]] = None,
+             threshold: Optional[Union[int, float]] = None,
              out: Optional[JaxArray] = None) -> JaxArray:
 
     if beta is not None and beta != 1:
-        res = (jnp.log1p(jnp.exp(-jnp.abs(x * beta)))
-               + jnp.maximum(x * beta, 0)) / beta
-        return np.where(x * beta > threshold, x, res)
+        x_beta = x * beta
+        res = (jnp.add(
+            jnp.log1p(jnp.exp(-jnp.abs(x_beta))),
+            jnp.maximum(x_beta, 0, dtype=x.dtype),
+            out=out
+        )) / beta
     else:
-        res = (jnp.log1p(jnp.exp(-jnp.abs(x))) + jnp.maximum(x, 0))
-        return np.where(x > threshold, x, res)
+        x_beta = x
+        res = (jnp.add(
+            jnp.log1p(jnp.exp(-jnp.abs(x_beta))),
+            jnp.maximum(x_beta, 0, dtype=x.dtype),
+            out=out
+        ))
+    if threshold is not None:
+        return jnp.where(x_beta > threshold, x, res)
+    return res

--- a/ivy/functional/backends/jax/activations.py
+++ b/ivy/functional/backends/jax/activations.py
@@ -45,5 +45,7 @@ def softplus(x: JaxArray,
              /,
              *,
              beta: Optional[Union[int, float]] = 1,
+             threshold: Optional[Union[int, float]] = 20,
              out: Optional[JaxArray] = None) -> JaxArray:
-    return (jnp.log1p(jnp.exp(-jnp.abs(x * beta))) + jnp.maximum(x * beta, 0)) / beta
+    res = (jnp.log1p(jnp.exp(-jnp.abs(x * beta))) + jnp.maximum(x * beta, 0)) / beta
+    return jnp.where(res < threshold, res, float(threshold))

--- a/ivy/functional/backends/jax/activations.py
+++ b/ivy/functional/backends/jax/activations.py
@@ -44,8 +44,14 @@ def softmax(
 def softplus(x: JaxArray,
              /,
              *,
-             beta: Optional[Union[int, float]] = 1,
+             beta: Optional[Union[int, float, None]] = None,
              threshold: Optional[Union[int, float]] = 20,
              out: Optional[JaxArray] = None) -> JaxArray:
-    res = (jnp.log1p(jnp.exp(-jnp.abs(x * beta))) + jnp.maximum(x * beta, 0)) / beta
-    return jnp.where(x * beta > threshold, x, res)
+
+    if beta is not None and beta != 1:
+        res = (jnp.log1p(jnp.exp(-jnp.abs(x * beta)))
+               + jnp.maximum(x * beta, 0)) / beta
+        return np.where(x * beta > threshold, x, res)
+    else:
+        res = (jnp.log1p(jnp.exp(-jnp.abs(x))) + jnp.maximum(x, 0))
+        return np.where(x > threshold, x, res)

--- a/ivy/functional/backends/jax/activations.py
+++ b/ivy/functional/backends/jax/activations.py
@@ -48,4 +48,4 @@ def softplus(x: JaxArray,
              threshold: Optional[Union[int, float]] = 20,
              out: Optional[JaxArray] = None) -> JaxArray:
     res = (jnp.log1p(jnp.exp(-jnp.abs(x * beta))) + jnp.maximum(x * beta, 0)) / beta
-    return jnp.where(x*beta > threshold, x*beta, res)
+    return jnp.where(x*beta > threshold, x, res)

--- a/ivy/functional/backends/numpy/activations.py
+++ b/ivy/functional/backends/numpy/activations.py
@@ -70,7 +70,7 @@ def softplus(x: np.ndarray,
         np.maximum(x * beta, 0, dtype=x.dtype),
         out=out
     )) / beta
-    return np.where(res < threshold, res, float(threshold))
+    return np.where(x*beta > threshold, x*beta, res)
 
 
 softplus.support_native_out = True

--- a/ivy/functional/backends/numpy/activations.py
+++ b/ivy/functional/backends/numpy/activations.py
@@ -84,4 +84,5 @@ def softplus(x: np.ndarray,
         return np.where(x_beta > threshold, x, res)
     return res
 
+
 softplus.support_native_out = True

--- a/ivy/functional/backends/numpy/activations.py
+++ b/ivy/functional/backends/numpy/activations.py
@@ -61,16 +61,23 @@ softmax.support_native_out = True
 def softplus(x: np.ndarray,
              /,
              *,
-             beta: Optional[Union[int, float]] = 1,
+             beta: Optional[Union[int, float, None]] = None,
              threshold: Optional[Union[int, float]] = 20,
              out: Optional[np.ndarray] = None
              ) -> np.ndarray:
-    res = (np.add(
-        np.log1p(np.exp(-np.abs(x * beta))),
-        np.maximum(x * beta, 0, dtype=x.dtype),
-        out=out
-    )) / beta
-    return np.where(x * beta > threshold, x, res)
+    if beta is not None and beta != 1:
+        res = (np.add(
+            np.log1p(np.exp(-np.abs(x * beta))),
+            np.maximum(x * beta, 0, dtype=x.dtype),
+            out=out
+        )) / beta
+        return np.where(x * beta > threshold, x, res)
+    else:
+        res = (np.add(
+            np.log1p(np.exp(-np.abs(x))),
+            np.maximum(x, 0, dtype=x.dtype),
+            out=out))
+        return np.where(x > threshold, x, res)
 
 
 softplus.support_native_out = True

--- a/ivy/functional/backends/numpy/activations.py
+++ b/ivy/functional/backends/numpy/activations.py
@@ -62,13 +62,15 @@ def softplus(x: np.ndarray,
              /,
              *,
              beta: Optional[Union[int, float]] = 1,
+             threshold: Optional[Union[int, float]] = 20,
              out: Optional[np.ndarray] = None
              ) -> np.ndarray:
-    return (np.add(
+    res = (np.add(
         np.log1p(np.exp(-np.abs(x * beta))),
         np.maximum(x * beta, 0, dtype=x.dtype),
         out=out
     )) / beta
+    return np.where(res < threshold, res, float(threshold))
 
 
 softplus.support_native_out = True

--- a/ivy/functional/backends/numpy/activations.py
+++ b/ivy/functional/backends/numpy/activations.py
@@ -1,6 +1,6 @@
 """Collection of Numpy activation functions, wrapped to fit Ivy syntax and signature."""
 
-from typing import Optional
+from typing import Optional, Union
 
 # global
 import numpy as np
@@ -58,10 +58,17 @@ softmax.support_native_out = True
 
 
 @_handle_0_dim_output
-def softplus(x: np.ndarray, /, *, out: Optional[np.ndarray] = None) -> np.ndarray:
-    return np.add(
-        np.log1p(np.exp(-np.abs(x))), np.maximum(x, 0, dtype=x.dtype), out=out
-    )
+def softplus(x: np.ndarray,
+             /,
+             *,
+             beta: Optional[Union[int, float]] = 1,
+             out: Optional[np.ndarray] = None
+             ) -> np.ndarray:
+    return (np.add(
+        np.log1p(np.exp(-np.abs(x * beta))),
+        np.maximum(x * beta, 0, dtype=x.dtype),
+        out=out
+    )) / beta
 
 
 softplus.support_native_out = True

--- a/ivy/functional/backends/numpy/activations.py
+++ b/ivy/functional/backends/numpy/activations.py
@@ -70,7 +70,7 @@ def softplus(x: np.ndarray,
         np.maximum(x * beta, 0, dtype=x.dtype),
         out=out
     )) / beta
-    return np.where(x*beta > threshold, x*beta, res)
+    return np.where(x*beta > threshold, x, res)
 
 
 softplus.support_native_out = True

--- a/ivy/functional/backends/numpy/activations.py
+++ b/ivy/functional/backends/numpy/activations.py
@@ -61,23 +61,27 @@ softmax.support_native_out = True
 def softplus(x: np.ndarray,
              /,
              *,
-             beta: Optional[Union[int, float, None]] = None,
-             threshold: Optional[Union[int, float]] = 20,
+             beta: Optional[Union[int, float]] = None,
+             threshold: Optional[Union[int, float]] = None,
              out: Optional[np.ndarray] = None
              ) -> np.ndarray:
+
     if beta is not None and beta != 1:
+        x_beta = x * beta
         res = (np.add(
-            np.log1p(np.exp(-np.abs(x * beta))),
-            np.maximum(x * beta, 0, dtype=x.dtype),
+            np.log1p(np.exp(-np.abs(x_beta))),
+            np.maximum(x_beta, 0, dtype=x.dtype),
             out=out
         )) / beta
-        return np.where(x * beta > threshold, x, res)
     else:
+        x_beta = x
         res = (np.add(
-            np.log1p(np.exp(-np.abs(x))),
-            np.maximum(x, 0, dtype=x.dtype),
-            out=out))
-        return np.where(x > threshold, x, res)
-
+            np.log1p(np.exp(-np.abs(x_beta))),
+            np.maximum(x_beta, 0, dtype=x.dtype),
+            out=out
+        ))
+    if threshold is not None:
+        return np.where(x_beta > threshold, x, res)
+    return res
 
 softplus.support_native_out = True

--- a/ivy/functional/backends/numpy/activations.py
+++ b/ivy/functional/backends/numpy/activations.py
@@ -70,7 +70,7 @@ def softplus(x: np.ndarray,
         np.maximum(x * beta, 0, dtype=x.dtype),
         out=out
     )) / beta
-    return np.where(x*beta > threshold, x, res)
+    return np.where(x * beta > threshold, x, res)
 
 
 softplus.support_native_out = True

--- a/ivy/functional/backends/tensorflow/activations.py
+++ b/ivy/functional/backends/tensorflow/activations.py
@@ -47,4 +47,4 @@ def softplus(x: Tensor,
              threshold: Optional[Union[int, float]] = 20,
              out: Optional[Tensor] = None) -> Tensor:
     res = (tf.nn.softplus(x * beta)) / beta
-    return tf.where(x*beta > threshold, x, res)
+    return tf.where(x * beta > threshold, x, res)

--- a/ivy/functional/backends/tensorflow/activations.py
+++ b/ivy/functional/backends/tensorflow/activations.py
@@ -47,4 +47,4 @@ def softplus(x: Tensor,
              threshold: Optional[Union[int, float]] = 20,
              out: Optional[Tensor] = None) -> Tensor:
     res = (tf.nn.softplus(x * beta)) / beta
-    return tf.where(res < threshold, res, float(threshold))
+    return tf.where(x*beta > threshold, x*beta, res)

--- a/ivy/functional/backends/tensorflow/activations.py
+++ b/ivy/functional/backends/tensorflow/activations.py
@@ -43,8 +43,14 @@ def softmax(
 def softplus(x: Tensor,
              /,
              *,
-             beta: Optional[Union[int, float]] = 1,
+             beta: Optional[Union[int, float, None]] = None,
              threshold: Optional[Union[int, float]] = 20,
              out: Optional[Tensor] = None) -> Tensor:
-    res = (tf.nn.softplus(x * beta)) / beta
-    return tf.where(x * beta > threshold, x, res)
+    if beta is not None and beta != 1:
+        x_beta = x * beta
+        res = (tf.nn.softplus(x_beta)) / beta
+        return tf.where(x_beta > threshold, x, res)
+    else:
+        res = tf.nn.softplus(x)
+        return tf.where(x > threshold, x, res)
+

--- a/ivy/functional/backends/tensorflow/activations.py
+++ b/ivy/functional/backends/tensorflow/activations.py
@@ -47,4 +47,4 @@ def softplus(x: Tensor,
              threshold: Optional[Union[int, float]] = 20,
              out: Optional[Tensor] = None) -> Tensor:
     res = (tf.nn.softplus(x * beta)) / beta
-    return tf.where(x*beta > threshold, x*beta, res)
+    return tf.where(x*beta > threshold, x, res)

--- a/ivy/functional/backends/tensorflow/activations.py
+++ b/ivy/functional/backends/tensorflow/activations.py
@@ -47,13 +47,12 @@ def softplus(x: Tensor,
              threshold: Optional[Union[int, float]] = None,
              out: Optional[Tensor] = None) -> Tensor:
 
-        if beta is not None and beta != 1:
-            x_beta = x * beta
-            res = (tf.nn.softplus(x_beta)) / beta
-        else:
-            x_beta = x
-            res = tf.nn.softplus(x)
-        if threshold is not None:
-            return tf.where(x_beta > threshold, x, res)
-        return res
-
+    if beta is not None and beta != 1:
+        x_beta = x * beta
+        res = (tf.nn.softplus(x_beta)) / beta
+    else:
+        x_beta = x
+        res = tf.nn.softplus(x)
+    if threshold is not None:
+        return tf.where(x_beta > threshold, x, res)
+    return res

--- a/ivy/functional/backends/tensorflow/activations.py
+++ b/ivy/functional/backends/tensorflow/activations.py
@@ -44,5 +44,7 @@ def softplus(x: Tensor,
              /,
              *,
              beta: Optional[Union[int, float]] = 1,
+             threshold: Optional[Union[int, float]] = 20,
              out: Optional[Tensor] = None) -> Tensor:
-    return (tf.nn.softplus(x * beta)) / beta
+    res = (tf.nn.softplus(x * beta)) / beta
+    return tf.where(res < threshold, res, float(threshold))

--- a/ivy/functional/backends/tensorflow/activations.py
+++ b/ivy/functional/backends/tensorflow/activations.py
@@ -2,7 +2,7 @@
 signature.
 """
 
-from typing import Optional
+from typing import Optional, Union
 
 # global
 import tensorflow as tf
@@ -40,5 +40,9 @@ def softmax(
     return tf.nn.softmax(x, axis)
 
 
-def softplus(x: Tensor, /, *, out: Optional[Tensor] = None) -> Tensor:
-    return tf.nn.softplus(x)
+def softplus(x: Tensor,
+             /,
+             *,
+             beta: Optional[Union[int, float]] = 1,
+             out: Optional[Tensor] = None) -> Tensor:
+    return (tf.nn.softplus(x * beta)) / beta

--- a/ivy/functional/backends/tensorflow/activations.py
+++ b/ivy/functional/backends/tensorflow/activations.py
@@ -43,14 +43,17 @@ def softmax(
 def softplus(x: Tensor,
              /,
              *,
-             beta: Optional[Union[int, float, None]] = None,
-             threshold: Optional[Union[int, float]] = 20,
+             beta: Optional[Union[int, float]] = None,
+             threshold: Optional[Union[int, float]] = None,
              out: Optional[Tensor] = None) -> Tensor:
-    if beta is not None and beta != 1:
-        x_beta = x * beta
-        res = (tf.nn.softplus(x_beta)) / beta
-        return tf.where(x_beta > threshold, x, res)
-    else:
-        res = tf.nn.softplus(x)
-        return tf.where(x > threshold, x, res)
+
+        if beta is not None and beta != 1:
+            x_beta = x * beta
+            res = (tf.nn.softplus(x_beta)) / beta
+        else:
+            x_beta = x
+            res = tf.nn.softplus(x)
+        if threshold is not None:
+            return tf.where(x_beta > threshold, x, res)
+        return res
 

--- a/ivy/functional/backends/torch/activations.py
+++ b/ivy/functional/backends/torch/activations.py
@@ -76,14 +76,8 @@ def softplus(x: torch.Tensor,
              beta: Optional[Union[int, float]] = None,
              threshold: Optional[Union[int, float]] = None,
              out: Optional[torch.Tensor] = None) -> torch.Tensor:
-    if beta is None and threshold is None:
-        return torch.nn.functional.softplus(x)
-    elif beta is None:
-        return torch.nn.functional.softplus(x, threshold=threshold)
-    elif threshold is None:
-        return torch.nn.functional.softplus(x, beta=beta)
-
-    return torch.nn.functional.softplus(x, beta=beta, threshold=threshold)
+    kwargs = {k: v for k, v in {"beta": beta, "threshold": threshold}.items() if v is not None}
+    return torch.nn.functional.softplus(x, **kwargs)
 
 
 softplus.unsupported_dtypes = ("float16", "bfloat16")

--- a/ivy/functional/backends/torch/activations.py
+++ b/ivy/functional/backends/torch/activations.py
@@ -76,7 +76,9 @@ def softplus(x: torch.Tensor,
              beta: Optional[Union[int, float]] = None,
              threshold: Optional[Union[int, float]] = None,
              out: Optional[torch.Tensor] = None) -> torch.Tensor:
-    kwargs = {k: v for k, v in {"beta": beta, "threshold": threshold}.items() if v is not None}
+    kwargs = {k: v for k, v in {"beta": beta,
+                                "threshold": threshold}.items()
+              if v is not None}
     return torch.nn.functional.softplus(x, **kwargs)
 
 

--- a/ivy/functional/backends/torch/activations.py
+++ b/ivy/functional/backends/torch/activations.py
@@ -74,12 +74,16 @@ def softplus(x: torch.Tensor,
              /,
              *,
              beta: Optional[Union[int, float]] = None,
-             threshold: Optional[Union[int, float]] = 20,
+             threshold: Optional[Union[int, float]] = None,
              out: Optional[torch.Tensor] = None) -> torch.Tensor:
-    if beta is None:
-        return torch.nn.functional.softplus(x, threshold)
-    else:
-        return torch.nn.functional.softplus(x, beta=beta, threshold=threshold)
+    if beta is None and threshold is None:
+        return torch.nn.functional.softplus(x)
+    elif beta is None:
+        return torch.nn.functional.softplus(x, threshold=threshold)
+    elif threshold is None:
+        return torch.nn.functional.softplus(x, beta=beta)
+
+    return torch.nn.functional.softplus(x, beta=beta, threshold=threshold)
 
 
 softplus.unsupported_dtypes = ("float16", "bfloat16")

--- a/ivy/functional/backends/torch/activations.py
+++ b/ivy/functional/backends/torch/activations.py
@@ -1,7 +1,7 @@
 """Collection of PyTorch activation functions, wrapped to fit Ivy syntax and
 signature.
 """
-from typing import Optional
+from typing import Optional, Union
 
 # global
 import numpy as np
@@ -70,8 +70,12 @@ def softmax(
 softmax.unsupported_dtypes = ("float16",)
 
 
-def softplus(x: torch.Tensor, /, *, out: Optional[torch.Tensor] = None) -> torch.Tensor:
-    return torch.nn.functional.softplus(x)
+def softplus(x: torch.Tensor,
+             /,
+             *,
+             beta: Optional[Union[int, float]] = 1,
+             out: Optional[torch.Tensor] = None) -> torch.Tensor:
+    return torch.nn.functional.softplus(x, beta=beta)
 
 
 softplus.unsupported_dtypes = ("float16", "bfloat16")

--- a/ivy/functional/backends/torch/activations.py
+++ b/ivy/functional/backends/torch/activations.py
@@ -74,8 +74,9 @@ def softplus(x: torch.Tensor,
              /,
              *,
              beta: Optional[Union[int, float]] = 1,
+             threshold: Optional[Union[int, float]] = 20,
              out: Optional[torch.Tensor] = None) -> torch.Tensor:
-    return torch.nn.functional.softplus(x, beta=beta)
+    return torch.nn.functional.softplus(x, beta=beta, threshold=threshold)
 
 
 softplus.unsupported_dtypes = ("float16", "bfloat16")

--- a/ivy/functional/backends/torch/activations.py
+++ b/ivy/functional/backends/torch/activations.py
@@ -73,10 +73,13 @@ softmax.unsupported_dtypes = ("float16",)
 def softplus(x: torch.Tensor,
              /,
              *,
-             beta: Optional[Union[int, float]] = 1,
+             beta: Optional[Union[int, float]] = None,
              threshold: Optional[Union[int, float]] = 20,
              out: Optional[torch.Tensor] = None) -> torch.Tensor:
-    return torch.nn.functional.softplus(x, beta=beta, threshold=threshold)
+    if beta is None:
+        return torch.nn.functional.softplus(x, threshold)
+    else:
+        return torch.nn.functional.softplus(x, beta=beta, threshold=threshold)
 
 
 softplus.unsupported_dtypes = ("float16", "bfloat16")

--- a/ivy/functional/frontends/jax/nn/non_linear_activations.py
+++ b/ivy/functional/frontends/jax/nn/non_linear_activations.py
@@ -160,9 +160,9 @@ def softmax(x, /, *, axis=-1):
     return ret.astype(dtype)
 
 
-def softplus(x, /, *, beta=1):
+def softplus(x):
     x = _type_conversion(x)
-    return ivy.softplus(x, beta=beta).astype(x.dtype)
+    return ivy.softplus(x).astype(x.dtype)
 
 
 def log_sigmoid(x):

--- a/ivy/functional/frontends/jax/nn/non_linear_activations.py
+++ b/ivy/functional/frontends/jax/nn/non_linear_activations.py
@@ -160,9 +160,9 @@ def softmax(x, /, *, axis=-1):
     return ret.astype(dtype)
 
 
-def softplus(x):
+def softplus(x, /, *, beta=1):
     x = _type_conversion(x)
-    return ivy.softplus(x).astype(x.dtype)
+    return ivy.softplus(x, beta=beta).astype(x.dtype)
 
 
 def log_sigmoid(x):

--- a/ivy/functional/ivy/activations.py
+++ b/ivy/functional/ivy/activations.py
@@ -316,7 +316,7 @@ def softplus(
     /,
     *,
     beta: Optional[Union[int, float]] = None,
-    threshold: Optional[Union[int, float]] = 20,
+    threshold: Optional[Union[int, float]] = None,
     out: Optional[ivy.Array] = None
 ) -> ivy.Array:
     """Applies the softplus function element-wise.
@@ -328,7 +328,7 @@ def softplus(
     beta
         The beta value for the softplus formation. Default: None.
     threshold
-        values above this revert to a linear function. Default: 20
+        values above this revert to a linear function. Default: None.
     out
         optional output array, for writing the result to. It must have a shape that the
         inputs broadcast to.

--- a/ivy/functional/ivy/activations.py
+++ b/ivy/functional/ivy/activations.py
@@ -316,6 +316,7 @@ def softplus(
     /,
     *,
     beta: Optional[Union[int, float]] = 1,
+    threshold: Optional[Union[int, float]] = 20,
     out: Optional[ivy.Array] = None
 ) -> ivy.Array:
     """Applies the softplus function element-wise.
@@ -325,7 +326,9 @@ def softplus(
     x
         input array.
     beta
-        The beta value for the softplus formation. The default is 1.
+        The beta value for the softplus formation. Default: 1.
+    threshold
+        values above this revert to a linear function. Default: 20
     out
         optional output array, for writing the result to. It must have a shape that the
         inputs broadcast to.
@@ -345,6 +348,15 @@ def softplus(
     >>> print(y)
     ivy.array([0.535,0.42])
 
+    >>> x = ivy.array([-0.3461, -0.6491])
+    >>> y = ivy.softplus(x, beta=0.5)
+    >>> print(y)
+    ivy.array([1.22, 1.09])
+
+    >>> x = ivy.array([1., 2., 3.])
+    >>> y = ivy.softplus(x, threshold=2)
+    >>> print(y)
+    ivy.array([1.31, 2.  , 2.  ])
 
     With :code: `ivy.NativeArray` input:
 
@@ -365,4 +377,4 @@ def softplus(
     ivy.array([0.535,0.42])
 
     """
-    return current_backend(x).softplus(x, beta=beta, out=out)
+    return current_backend(x).softplus(x, beta=beta, threshold=threshold, out=out)

--- a/ivy/functional/ivy/activations.py
+++ b/ivy/functional/ivy/activations.py
@@ -312,7 +312,11 @@ def softmax(
 @handle_out_argument
 @handle_nestable
 def softplus(
-    x: Union[ivy.Array, ivy.NativeArray], /, *, out: Optional[ivy.Array] = None
+    x: Union[ivy.Array, ivy.NativeArray],
+    /,
+    *,
+    beta: Optional[Union[int, float]] = 1,
+    out: Optional[ivy.Array] = None
 ) -> ivy.Array:
     """Applies the softplus function element-wise.
 
@@ -320,6 +324,8 @@ def softplus(
     ----------
     x
         input array.
+    beta
+        The beta value for the softplus formation. The default is 1.
     out
         optional output array, for writing the result to. It must have a shape that the
         inputs broadcast to.
@@ -359,4 +365,4 @@ def softplus(
     ivy.array([0.535,0.42])
 
     """
-    return current_backend(x).softplus(x, out=out)
+    return current_backend(x).softplus(x, beta=beta, out=out)

--- a/ivy/functional/ivy/activations.py
+++ b/ivy/functional/ivy/activations.py
@@ -315,7 +315,7 @@ def softplus(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
     *,
-    beta: Optional[Union[int, float]] = 1,
+    beta: Optional[Union[int, float]] = None,
     threshold: Optional[Union[int, float]] = 20,
     out: Optional[ivy.Array] = None
 ) -> ivy.Array:
@@ -326,7 +326,7 @@ def softplus(
     x
         input array.
     beta
-        The beta value for the softplus formation. Default: 1.
+        The beta value for the softplus formation. Default: None.
     threshold
         values above this revert to a linear function. Default: 20
     out

--- a/ivy/functional/ivy/activations.py
+++ b/ivy/functional/ivy/activations.py
@@ -356,7 +356,7 @@ def softplus(
     >>> x = ivy.array([1., 2., 3.])
     >>> y = ivy.softplus(x, threshold=2)
     >>> print(y)
-    ivy.array([1.31, 2.  , 2.  ])
+    ivy.array([1.31, 2.13, 3.  ])
 
     With :code: `ivy.NativeArray` input:
 

--- a/ivy_tests/test_ivy/helpers.py
+++ b/ivy_tests/test_ivy/helpers.py
@@ -672,7 +672,6 @@ def ints_or_floats(draw, *, min_value=None, max_value=None, safety_factor=0.95):
         ))
 
 
-
 def assert_all_close(
     ret_np, ret_from_gt_np, rtol=1e-05, atol=1e-08, ground_truth_backend="TensorFlow"
 ):

--- a/ivy_tests/test_ivy/helpers.py
+++ b/ivy_tests/test_ivy/helpers.py
@@ -635,6 +635,44 @@ def ints(draw, *, min_value=None, max_value=None, safety_factor=0.95):
     return draw(st.integers(min_value, max_value))
 
 
+@st.composite
+def ints_or_floats(draw, *, min_value=None, max_value=None, safety_factor=0.95):
+    """Draws an arbitrarily sized list of integers or floats with a safety factor
+    applied to values.
+
+    Parameters
+    ----------
+    draw
+        special function that draws data randomly (but is reproducible) from a given
+        data-set (ex. list).
+    min_value
+        minimum value of integers generated.
+    max_value
+        maximum value of integers generated.
+    safety_factor
+        default = 0.95. Only values which are 95% or less than the edge of
+        the limit for a given dtype are generated.
+
+    Returns
+    -------
+    ret
+        integer or float.
+    """
+    if draw(st.booleans()):
+        return draw(ints(
+            min_value=min_value,
+            max_value=max_value,
+            safety_factor=safety_factor,
+        ))
+    else:
+        return draw(floats(
+            min_value=min_value,
+            max_value=max_value,
+            safety_factor=safety_factor,
+        ))
+
+
+
 def assert_all_close(
     ret_np, ret_from_gt_np, rtol=1e-05, atol=1e-08, ground_truth_backend="TensorFlow"
 ):

--- a/ivy_tests/test_ivy/helpers.py
+++ b/ivy_tests/test_ivy/helpers.py
@@ -637,7 +637,7 @@ def ints(draw, *, min_value=None, max_value=None, safety_factor=0.95):
 
 @st.composite
 def ints_or_floats(draw, *, min_value=None, max_value=None, safety_factor=0.95):
-    """Draws an arbitrarily sized list of integers or floats with a safety factor
+    """Draws integers or floats with a safety factor
     applied to values.
 
     Parameters

--- a/ivy_tests/test_ivy/helpers.py
+++ b/ivy_tests/test_ivy/helpers.py
@@ -660,8 +660,8 @@ def ints_or_floats(draw, *, min_value=None, max_value=None, safety_factor=0.95):
     """
     if draw(st.booleans()):
         return draw(ints(
-            min_value=min_value,
-            max_value=max_value,
+            min_value=int(min_value),
+            max_value=int(max_value),
             safety_factor=safety_factor,
         ))
     else:

--- a/ivy_tests/test_ivy/helpers.py
+++ b/ivy_tests/test_ivy/helpers.py
@@ -658,18 +658,15 @@ def ints_or_floats(draw, *, min_value=None, max_value=None, safety_factor=0.95):
     ret
         integer or float.
     """
-    if draw(st.booleans()):
-        return draw(ints(
-            min_value=int(min_value),
-            max_value=int(max_value),
-            safety_factor=safety_factor,
-        ))
-    else:
-        return draw(floats(
-            min_value=min_value,
-            max_value=max_value,
-            safety_factor=safety_factor,
-        ))
+
+    return draw(
+        ints(min_value=int(min_value),
+             max_value=int(max_value),
+             safety_factor=safety_factor)
+        | floats(min_value=min_value,
+                 max_value=max_value,
+                 safety_factor=safety_factor)
+    )
 
 
 def assert_all_close(

--- a/ivy_tests/test_ivy/test_functional/test_nn/test_activations.py
+++ b/ivy_tests/test_ivy/test_functional/test_nn/test_activations.py
@@ -197,7 +197,8 @@ def test_softmax(
         available_dtypes=helpers.get_dtypes("float"), min_num_dims=1
     ),
     num_positional_args=helpers.num_positional_args(fn_name="softplus"),
-    beta=helpers.ints_or_floats(min_value=0.1, max_value=10),
+    beta=st.one_of([helpers.ints_or_floats(min_value=0.1,
+                                           max_value=10), st.none()]),
     threshold=helpers.ints_or_floats(min_value=0.1, max_value=30),
 )
 def test_softplus(

--- a/ivy_tests/test_ivy/test_functional/test_nn/test_activations.py
+++ b/ivy_tests/test_ivy/test_functional/test_nn/test_activations.py
@@ -199,7 +199,8 @@ def test_softmax(
     num_positional_args=helpers.num_positional_args(fn_name="softplus"),
     beta=st.one_of([helpers.ints_or_floats(min_value=0.1,
                                            max_value=10), st.none()]),
-    threshold=helpers.ints_or_floats(min_value=0.1, max_value=30),
+    threshold=st.one_of([helpers.ints_or_floats(min_value=0.1, max_value=30),
+                         st.none()]),
 )
 def test_softplus(
     *,

--- a/ivy_tests/test_ivy/test_functional/test_nn/test_activations.py
+++ b/ivy_tests/test_ivy/test_functional/test_nn/test_activations.py
@@ -197,10 +197,12 @@ def test_softmax(
         available_dtypes=helpers.get_dtypes("float"), min_num_dims=1
     ),
     num_positional_args=helpers.num_positional_args(fn_name="softplus"),
+    beta = st.sampled_from([1, 10]),
 )
 def test_softplus(
     *,
     dtype_and_x,
+    beta,
     as_variable,
     with_out,
     num_positional_args,
@@ -223,4 +225,5 @@ def test_softplus(
         rtol_=1e-02,
         atol_=1e-02,
         x=np.asarray(x, dtype=dtype),
+        beta=beta,
     )

--- a/ivy_tests/test_ivy/test_functional/test_nn/test_activations.py
+++ b/ivy_tests/test_ivy/test_functional/test_nn/test_activations.py
@@ -197,7 +197,7 @@ def test_softmax(
         available_dtypes=helpers.get_dtypes("float"), min_num_dims=1
     ),
     num_positional_args=helpers.num_positional_args(fn_name="softplus"),
-    beta = st.sampled_from([1, 10]),
+    beta=helpers.ints_or_floats(min_value=1, max_value=10),
 )
 def test_softplus(
     *,

--- a/ivy_tests/test_ivy/test_functional/test_nn/test_activations.py
+++ b/ivy_tests/test_ivy/test_functional/test_nn/test_activations.py
@@ -197,12 +197,14 @@ def test_softmax(
         available_dtypes=helpers.get_dtypes("float"), min_num_dims=1
     ),
     num_positional_args=helpers.num_positional_args(fn_name="softplus"),
-    beta=helpers.ints_or_floats(min_value=1, max_value=10),
+    beta=helpers.ints_or_floats(min_value=0.1, max_value=10),
+    threshold=helpers.ints_or_floats(min_value=0.1, max_value=30),
 )
 def test_softplus(
     *,
     dtype_and_x,
     beta,
+    threshold,
     as_variable,
     with_out,
     num_positional_args,
@@ -226,4 +228,5 @@ def test_softplus(
         atol_=1e-02,
         x=np.asarray(x, dtype=dtype),
         beta=beta,
+        threshold=threshold,
     )


### PR DESCRIPTION
Based on the additional arguments in [torch softplus](https://pytorch.org/docs/stable/generated/torch.nn.functional.softplus.html).

This just requires that the `x` is `x * beta` and that the final results is multiplied by `1/beta` as clear from the formula.

`torch` takes this as arg while for other backends it is done manually. Test passing.

Should we consider adding the argument `threshold` also from [torch softplus](https://pytorch.org/docs/stable/generated/torch.nn.functional.softplus.html)**?** 