### PR TITLE
Softmax fix on keyword argument

### DIFF
--- a/ivy/functional/ivy/activations.py
+++ b/ivy/functional/ivy/activations.py
@@ -305,7 +305,7 @@ def softmax(
     ivy.array([0.422, 0.155, 0.422])
 
     """
-    return current_backend(x).softmax(x, axis, out=out)
+    return current_backend(x).softmax(x, axis=axis, out=out)
 
 
 @to_native_arrays_and_back


### PR DESCRIPTION
The softmax was failing on the default backend providing this error log.
```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/workspaces/ivy/ivy/func_wrapper.py", line 189, in new_fn
    ret = fn(*args, **kwargs)
  File "/workspaces/ivy/ivy/func_wrapper.py", line 127, in new_fn
    return fn(*new_args, **new_kwargs)
  File "/workspaces/ivy/ivy/func_wrapper.py", line 383, in new_fn
    return fn(*args, **kwargs)
  File "/workspaces/ivy/ivy/func_wrapper.py", line 438, in new_fn
    return fn(*args, **kwargs)
  File "/workspaces/ivy/ivy/functional/ivy/activations.py", line 308, in softmax
    return current_backend(x).softmax(x, axis, out=out)
TypeError: softmax() takes 1 positional argument but 2 positional arguments (and 1 keyword-only argument) were given
```