### PR TITLE
Fix for bug where frontend tests ignore unsupported_dtypes flag

### DIFF
--- a/ivy/functional/frontends/torch/miscellaneous_ops.py
+++ b/ivy/functional/frontends/torch/miscellaneous_ops.py
@@ -21,7 +21,7 @@ def cumsum(input, dim, *, dtype=None, out=None):
 def tril_indices(row, col, offset=0, *, dtype="int64", device="cpu", layout=None):
     sample_matrix = ivy.tril(ivy.ones((row, col), device=device), k=offset)
     return ivy.stack(ivy.nonzero(sample_matrix)).astype(dtype)
-  
+
 
 def cumprod(input, dim, *, dtype=None, out=None):
     return ivy.cumprod(input, axis=dim, dtype=dtype, out=out)
@@ -33,3 +33,16 @@ def diagonal(input, offset=0, dim1=0, dim2=1):
 
 def triu(input, diagonal=0, *, out=None):
     return ivy.triu(input, k=diagonal, out=out)
+
+
+# THIS SHOULD NOT BE COMMITTED AS PART OF THE FRONTEND_TEST_TYPE_DETECTION BRANCH
+# ITS JUST HERE TO TEST THE FIXES IN THAT BRANCH
+# IT SHOULD BE COMMITTED FROM THE TRACE BRANCH
+def trace(input):
+    if "int" in input.dtype:
+        input = input.astype("int64")
+    target_type = "int64" if "int" in input.dtype else input.dtype
+    return ivy.astype(ivy.trace(input), target_type)
+
+
+trace.unsupported_dtypes = ("float16",)

--- a/ivy/functional/ivy/data_type.py
+++ b/ivy/functional/ivy/data_type.py
@@ -122,7 +122,7 @@ def _get_dtypes(fn, complement=True):
     # We only care about getting dtype info from the base function
     # if we do need to at some point use dtype information from the parent function
     # we can comment out the following condition
-    if "backend" not in fn.__module__:
+    if "backend" not in fn.__module__ and "frontend" not in fn.__module__:
         if complement:
             supported = set(ivy.all_dtypes).difference(supported)
         return supported

--- a/ivy_tests/test_ivy/test_frontends/test_torch/test_miscellaneous_ops.py
+++ b/ivy_tests/test_ivy/test_frontends/test_torch/test_miscellaneous_ops.py
@@ -341,3 +341,46 @@ def test_torch_tril_indices(
         offset=offset,
         dtype=dtype_result,
     )
+
+
+# THIS SHOULD NOT BE COMMITTED AS PART OF THE FRONTEND_TEST_TYPE_DETECTION BRANCH
+# ITS JUST HERE TO TEST THE FIXES IN THAT BRANCH
+# IT SHOULD BE COMMITTED FROM THE TRACE BRANCH
+@handle_cmd_line_args
+@given(
+    dtype_and_values=helpers.dtype_and_values(
+        available_dtypes=helpers.get_dtypes("float"),
+        shape=st.shared(helpers.get_shape(min_num_dims=2, max_num_dims=2), key="shape"),
+    ),
+    num_positional_args=helpers.num_positional_args(
+        fn_name="ivy.functional.frontends.torch.trace"
+    ),
+)
+def test_torch_trace(
+    dtype_and_values,
+    as_variable,
+    num_positional_args,
+    with_out,
+    native_array,
+    fw,
+):
+    dtype, value = dtype_and_values
+
+    if "float16" in dtype:
+        print("float16 was drawn")
+
+    # assume("float16" not in dtype)
+
+    value = np.asarray(value, dtype=dtype)
+
+    helpers.test_frontend_function(
+        input_dtypes=dtype,
+        as_variable_flags=as_variable,
+        with_out=with_out,
+        num_positional_args=num_positional_args,
+        native_array_flags=native_array,
+        fw=fw,
+        frontend="torch",
+        fn_tree="trace",
+        input=value,
+    )


### PR DESCRIPTION
I've had a quick chat with Ved about this bug, this fixes the issue where it's ignored in the frontend tests. I've added in the `trace` test from another PR just to reproduce the error more easily, I'll remove that before anything gets merged. By running the test you can see (if you get good enough luck for `float16` to be drawn) that the value is nicely skipped.

I'm wondering if there's any reason to keep the `if "backend" not in fn.__module__ and "frontend" not in fn.__module__:` line and associated block at all, in my very quick testing nothing seems to actually meet this criteria. 

Also how should I go about testing that this doesn't break anything, I'm going to run all of the frontend tests and see if they agree with the master branch but I'm wondering if this is sufficient.