### PR TITLE
Container deep dive documenration's shared nested example fixed

### DIFF
--- a/docs/partial_source/deep_dive/6_containers.rst
+++ b/docs/partial_source/deep_dive/6_containers.rst
@@ -294,7 +294,7 @@ are shared but not identical.
 
 .. code-block:: python
 
-    x = ivy.Container(a={'b': 2, 'c': 4}, d={'e': 6, 'f': 8})
+    x = ivy.Container(a={'b': 2, 'c': 4}, d={'e': 6, 'f': 9})
     y = ivy.Container(a=2, d=3)
 
 The shared key chains (chains of keys, used for indexing the container)
@@ -314,12 +314,12 @@ It's helpful to look at an example:
     print(x / y)
     {
         a: {
-          b: 1,
-          c: 2
+          b: 1.0,
+          c: 2.0
         },
         d: {
-          e: 3,
-          f: 2.67
+          e: 2.0,
+          f: 3.0
         }
     }
 


### PR DESCRIPTION
PR for issue #4531

Along with `d.e ` value fix

1.  Output container print values converted to float instead of integer (which is inline with current ivy execution of example) 
2.  f parameter updated from 8 to 9 since 8/3 was returning 2.6666666666666665, now it will return 3.0 which is more clean.