### PR TITLE
cummax function for jax frontend 

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="VcsDirectoryMappings">
-    <mapping directory="$PROJECT_DIR$" vcs="Git" />
-    <mapping directory="$PROJECT_DIR$/ivy_tests/test_array_api" vcs="Git" />
-    <mapping directory="$PROJECT_DIR$/ivy_tests/test_array_api/array-api" vcs="Git" />
-  </component>
-</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -2,5 +2,7 @@
 <project version="4">
   <component name="VcsDirectoryMappings">
     <mapping directory="$PROJECT_DIR$" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/ivy_tests/test_array_api" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/ivy_tests/test_array_api/array-api" vcs="Git" />
   </component>
 </project>

--- a/ivy/functional/frontends/jax/lax/operators.py
+++ b/ivy/functional/frontends/jax/lax/operators.py
@@ -108,6 +108,27 @@ def cosh(x):
     return ivy.cosh(x)
 
 
+def cummax(operand, axis=0, reverse=False):
+    def make_index(num_dimension, i_pos, i):
+        zeros = [slice(None)] * num_dimension
+        zeros[i_pos] = i
+        return tuple(zeros)
+    dim = len(operand.shape)
+    import numpy as np
+    ret = np.empty(operand.shape)
+    t = -ivy.inf
+    if not reverse:
+        for i in range(operand.shape[axis]):
+            t = ivy.maximum(t, operand[make_index(dim, axis, i)])
+            ret[make_index(dim, axis, i)] = t
+    else:
+        for i in range(operand.shape[axis] - 1, -1, -1):
+            t = ivy.maximum(t, operand[make_index(dim, axis, i)])
+            ret[make_index(dim, axis, i)] = t
+    ret = ivy.array(ret, dtype=operand.dtype)
+    return ret
+
+
 def cumprod(operand, axis=0, reverse=False):
     if reverse:
         return ivy.flip(ivy.cumprod(ivy.flip(operand), axis, dtype=operand.dtype))

--- a/ivy_tests/test_ivy/test_frontends/test_jax/test_jax_lax_operators.py
+++ b/ivy_tests/test_ivy/test_frontends/test_jax/test_jax_lax_operators.py
@@ -1008,6 +1008,46 @@ def test_jax_lax_convert_element_type(
 @handle_cmd_line_args
 @given(
     dtype_x_axis=helpers.dtype_values_axis(
+        available_dtypes=helpers.get_dtypes("float"),
+        min_num_dims=2,
+        min_dim_size=2,
+        valid_axis=True,
+        allow_neg_axes=False,
+        max_axes_size=1,
+        force_int_axis=True,
+    ),
+    num_positional_args=helpers.num_positional_args(
+        fn_name="ivy.functional.frontends.jax.lax.cummax"
+    ),
+    reverse=st.booleans(),
+)
+def test_jax_lax_cummax(
+    dtype_x_axis,
+    as_variable,
+    num_positional_args,
+    native_array,
+    fw,
+    reverse,
+):
+    input_dtype, x, axis = dtype_x_axis
+    helpers.test_frontend_function(
+        input_dtypes=input_dtype,
+        as_variable_flags=as_variable,
+        with_out=False,
+        num_positional_args=num_positional_args,
+        native_array_flags=native_array,
+        fw=fw,
+        frontend="jax",
+        fn_tree="lax.cummax",
+        operand=np.asarray(x, dtype=input_dtype),
+        axis=axis,
+        reverse=reverse,
+    )
+
+
+@handle_cmd_line_args
+@given(
+    dtype_x_axis=helpers.dtype_values_axis(
         available_dtypes=helpers.get_dtypes("numeric"),
         min_num_dims=1,
         max_num_dims=5,


### PR DESCRIPTION
#4575

Can I import the Numpy inside of the frontend function? 

The arbitrary indexing using the slice can be used only in the Numpy backend.