### PR TITLE
Triangular_solve function for the Jax frontend

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -2,5 +2,7 @@
 <project version="4">
   <component name="VcsDirectoryMappings">
     <mapping directory="$PROJECT_DIR$" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/ivy_tests/test_array_api" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/ivy_tests/test_array_api/array-api" vcs="Git" />
   </component>
 </project>

--- a/ivy/functional/frontends/jax/lax/linalg.py
+++ b/ivy/functional/frontends/jax/lax/linalg.py
@@ -10,3 +10,40 @@ def cholesky(x, /, *, symmetrize_input=True):
         x = symmetrize(x)
 
     return ivy.cholesky(x)
+
+
+def triangular_solve(a, b, *,
+                     left_side=False, lower=False, transpose_a=False,
+                     conjugate_a=False, unit_diagonal=False):
+    def solveUpperTriangularMatrix(R, b):
+        fR, fb = [], []
+        for x, line in enumerate(R):
+            fLine = []
+            for y, el in enumerate(line):
+                value = el
+                fLine.append(value)
+            fR.append(fLine)
+        for el in b:
+            fb.append(el)
+        x = [0] * len(b)
+        for step in range(len(b) - 1, 0 - 1, -1):
+            if fR[step][step] == 0:
+                if fb[step] != 0:
+                    return "No solution"
+                else:
+                    return "Infinity solutions"
+            else:
+                x[step] = fb[step] / fR[step][step]
+            for row in range(step - 1, 0 - 1, -1):
+                fb[row] -= fR[row][step] * x[step]
+        return x
+
+    a_list = []
+    for a_1 in list(a):
+        a_list.append(list(a_1))
+    result_temp = solveUpperTriangularMatrix(a_list, list(b))
+    result_list = []
+    for result in result_temp:
+        result_list.append(float(result))
+    ret = ivy.array(result_list, dtype=result.dtype)
+    return ret

--- a/ivy_tests/test_ivy/test_frontends/test_jax/test_jax_lax_linalg.py
+++ b/ivy_tests/test_ivy/test_frontends/test_jax/test_jax_lax_linalg.py
@@ -50,3 +50,54 @@ def test_jax_lax_cholesky(
         x=x,
         symmetrize_input=symmetrize_input,
     )
+
+
+# triangular_solve
+@handle_cmd_line_args
+@given(
+    dtype_and_x=helpers.dtype_and_values(
+        available_dtypes=helpers.get_dtypes("float"),
+        min_value=1,
+        max_value=10,
+        shape=helpers.ints(min_value=2, max_value=5).map(lambda x: tuple([x, x])),
+        num_arrays=1,
+    ),
+    as_variable=helpers.array_bools(num_arrays=2),
+    num_positional_args=helpers.num_positional_args(
+        fn_name="ivy.functional.frontends.jax.lax.linalg.triangular_solve"
+    ),
+)
+def test_jax_lax_linalg_triangular_solve(
+    dtype_and_x,
+    as_variable,
+    native_array,
+    num_positional_args,
+    fw,
+):
+    dtype, x = dtype_and_x
+    num_positional_args = 2
+    # make a triangular matrix
+    mask = np.asarray(x, dtype=dtype) * 0.0
+    iu = np.tril_indices(mask.shape[0])
+    mask[iu] = 1.0
+    a = x * mask
+    # make a right-hand side matrix in a x = b
+    b = x[0]
+    helpers.test_frontend_function(
+        input_dtypes=[dtype],
+        as_variable_flags=as_variable,
+        with_out=False,
+        num_positional_args=num_positional_args,
+        native_array_flags=native_array,
+        fw=fw,
+        frontend="jax",
+        fn_tree="lax.linalg.triangular_solve",
+        atol=1e-06,
+        a=np.array(a, dtype=dtype),
+        b=np.array(b, dtype=dtype),
+        left_side=False,
+        lower=False,
+        transpose_a=False,
+        conjugate_a=False,
+        unit_diagonal=False
+    )


### PR DESCRIPTION
https://github.com/unifyai/ivy/issues/4385

I need to manually set the num_positional_args argument as 2 to make them pass the test. I put the argument of the frontend function as like the [official document](https://jax.readthedocs.io/en/latest/_autosummary/jax.lax.linalg.triangular_solve.html).