### PR TITLE
Modify parameter for the scatter_nd function of torch backend

### DIFF
--- a/ivy/functional/backends/jax/__init__.py
+++ b/ivy/functional/backends/jax/__init__.py
@@ -94,7 +94,6 @@ valid_numeric_dtypes = (
     ivy.uint16,
     ivy.uint32,
     ivy.uint64,
-    ivy.bfloat16,
     ivy.float16,
     ivy.float32,
     ivy.float64,

--- a/ivy/functional/backends/tensorflow/__init__.py
+++ b/ivy/functional/backends/tensorflow/__init__.py
@@ -67,7 +67,6 @@ valid_numeric_dtypes = (
     ivy.uint16,
     ivy.uint32,
     ivy.uint64,
-    ivy.bfloat16,
     ivy.float16,
     ivy.float32,
     ivy.float64,

--- a/ivy/functional/backends/torch/__init__.py
+++ b/ivy/functional/backends/torch/__init__.py
@@ -55,7 +55,6 @@ valid_numeric_dtypes = (
     ivy.int32,
     ivy.int64,
     ivy.uint8,
-    ivy.bfloat16,
     ivy.float16,
     ivy.float32,
     ivy.float64,

--- a/ivy/functional/backends/torch/general.py
+++ b/ivy/functional/backends/torch/general.py
@@ -365,9 +365,9 @@ def scatter_nd(
             initial_val = min(torch.iinfo(dtype).max, 1e12)
     elif reduction == "max":
         if dtype.is_floating_point:
-            initial_val = max(torch.finfo(dtype).min, 1e-12)
+            initial_val = max(torch.finfo(dtype).min, -1e12)
         else:
-            initial_val = max(torch.iinfo(dtype).min, 1e-12)
+            initial_val = max(torch.iinfo(dtype).min, -1e12)
     else:
         raise ivy.exceptions.IvyException(
             'reduction is {}, but it must be one of "sum", "min" or "max"'.format(


### PR DESCRIPTION
It seems like the result of the scatter_nd function of the Torch backend is not consistent with the outcome of the Tensorflow backend ground-truth.

I need to change the parameter to decide the initial_val when the reduction is max. It is the same value as the Tensorflow backend parameter. 

P.S. I tested it except for the 'bfloat type' which is not directly related to this issue.