### PR TITLE
add the None type to the ord argument of the vector_norm backend

### DIFF
--- a/ivy/functional/backends/tensorflow/linear_algebra.py
+++ b/ivy/functional/backends/tensorflow/linear_algebra.py
@@ -576,7 +576,9 @@ def vector_norm(
     *,
     out: Optional[Union[tf.Tensor, tf.Variable]] = None,
 ) -> Union[tf.Tensor, tf.Variable]:
-    if ord == -float("inf"):
+    if ord == None:
+        tn_normalized_vector = tf.linalg.norm(tensor=x, axis=axis, keepdims=keepdims)
+    elif ord == -float("inf"):
         tn_normalized_vector = tf.reduce_min(tf.abs(x), axis, keepdims)
     elif ord == -2:
         tn_normalized_vector = 1.0 / tf.sqrt(

--- a/ivy/functional/backends/torch/linear_algebra.py
+++ b/ivy/functional/backends/torch/linear_algebra.py
@@ -399,7 +399,11 @@ def vector_norm(
     *,
     out: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
-    py_normalized_vector = torch.linalg.vector_norm(x, ord, axis, keepdims, out=out)
+    if ord == None:
+        py_normalized_vector = torch.linalg.vector_norm(x, dim=axis, keepdim=keepdims, out=out)
+    else:
+        py_normalized_vector = torch.linalg.vector_norm(x, ord, axis, keepdims, out=out)
+
     if py_normalized_vector.shape == ():
         ret = torch.unsqueeze(py_normalized_vector, 0)
     else:

--- a/ivy/functional/frontends/numpy/__init__.py
+++ b/ivy/functional/frontends/numpy/__init__.py
@@ -39,4 +39,10 @@ from .linalg.matrix_and_vector_products import (
     # kron,
 )
 
-# from .linalg.norms_and_other_numbers import trace
+
+from .linalg.norms_and_other_numbers import (
+    norm,
+    matrix_rank,
+    det,
+    slogdet
+)

--- a/ivy/functional/frontends/numpy/linalg/norms_and_other_numbers.py
+++ b/ivy/functional/frontends/numpy/linalg/norms_and_other_numbers.py
@@ -3,7 +3,7 @@ import ivy
 
 
 def norm(x, ord=None, axis=None, keepdims=False):
-    ret = ivy.vector_norm(x, axis, keepdims, ord)
+    ret = ivy.vector_norm(x, axis=axis, keepdims=keepdims, ord=ord)
     if axis is None:
         return ret[0]
     return ret

--- a/ivy_tests/test_ivy/test_frontends/test_numpy/test_linear_algebra/test_norms_and_other_numbers.py
+++ b/ivy_tests/test_ivy/test_frontends/test_numpy/test_linear_algebra/test_norms_and_other_numbers.py
@@ -21,13 +21,14 @@ from ivy_tests.test_ivy.test_functional.test_core.test_linalg import (
         min_axis=-2,
         max_axis=1,
     ),
+    ord=helpers.ints(min_value=1, max_value=2) | st.none(),
     keepdims=st.booleans(),
     num_positional_args=helpers.num_positional_args(
         fn_name="ivy.functional.frontends.numpy.linalg.norm"
     ),
 )
-def test_numpy_norm(
-    dtype_values_axis, keepdims, as_variable, native_array, num_positional_args, fw
+def test_numpy_linalg_norm(
+    dtype_values_axis, ord, keepdims, as_variable, native_array, num_positional_args, fw
 ):
     dtype, x, axis = dtype_values_axis
     if len(np.shape(x)) == 1:
@@ -42,7 +43,7 @@ def test_numpy_norm(
         frontend="numpy",
         fn_tree="linalg.norm",
         x=x[0],
-        ord=None,
+        ord=ord,
         axis=axis,
         keepdims=keepdims,
     )


### PR DESCRIPTION
The issue is that the default of the ord argument of the **jax.numpy.linalg.norm** function is None.

Another framework usually has an int-type value for that. 

Therefore, it looks like a good idea to add a condition for dealing with the None value for the norm of all backend.

I also add the None type for the test function to ensure that.