### PR TITLE
Modity the linspace function of tensorflow backend for endpoint argument

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -2,5 +2,7 @@
 <project version="4">
   <component name="VcsDirectoryMappings">
     <mapping directory="$PROJECT_DIR$" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/ivy_tests/test_array_api" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/ivy_tests/test_array_api/array-api" vcs="Git" />
   </component>
 </project>

--- a/ivy/functional/backends/tensorflow/creation.py
+++ b/ivy/functional/backends/tensorflow/creation.py
@@ -262,7 +262,15 @@ def linspace(
         start = tf.constant(start, dtype=dtype)
         stop = tf.constant(stop, dtype=dtype)
         if not endpoint:
-            ans = tf.linspace(start, stop, num + 1, axis=axis)[:-1]
+            ans = tf.linspace(start, stop, num + 1, axis=axis)
+            begin = []
+            size = []
+            for i in range(0, len(ans.shape)):
+                begin.append(0)
+            for shape in list(ans.shape):
+                size.append(shape)
+            size[axis] -= 1
+            ans = tf.slice(ans, begin=begin, size=size)
         else:
             ans = tf.linspace(start, stop, num, axis=axis)
         ans = tf.cast(ans, dtype)

--- a/ivy_tests/test_ivy/test_functional/test_core/test_creation.py
+++ b/ivy_tests/test_ivy/test_functional/test_core/test_creation.py
@@ -70,6 +70,7 @@ def test_native_array(
     ),
     num=helpers.ints(min_value=1, max_value=5),
     axis=st.none(),
+    endpoint=st.booleans(),
     num_positional_args=helpers.num_positional_args(fn_name="linspace"),
 )
 def test_linspace(
@@ -77,6 +78,7 @@ def test_linspace(
     dtype_and_start_stop,
     num,
     axis,
+    endpoint,
     device,
     num_positional_args,
     fw,
@@ -98,6 +100,7 @@ def test_linspace(
         stop=start_stop[1],
         num=num,
         axis=axis,
+        endpoint=endpoint,
         device=device,
         dtype=dtype[0],
     )


### PR DESCRIPTION
Hello,

There is an error in processing the endpoint argument in the linspace function of the Tensorflow backend.
It can only deal with a specific array shape. I change it to a more general form.

Thank you

