### PR TITLE
frontend testing `with_out` support for tuple

### DIFF
--- a/ivy/functional/frontends/torch/reduction_ops.py
+++ b/ivy/functional/frontends/torch/reduction_ops.py
@@ -57,7 +57,7 @@ def var(input, dim, unbiased, keepdim=False, *, out=None):
 def min(input, dim=None, keepdim=False, *, out=None):
     if dim is None:
         return ivy.min(input, axis=dim, keepdims=keepdim, out=out)
-    elif out:
+    elif out is not None:
         ivy.min(input, axis=dim, keepdims=keepdim, out=out[0])
         ivy.argmin(input, axis=dim, keepdims=keepdim, out=out[1])
         return out

--- a/ivy/functional/frontends/torch/reduction_ops.py
+++ b/ivy/functional/frontends/torch/reduction_ops.py
@@ -56,16 +56,14 @@ def var(input, dim, unbiased, keepdim=False, *, out=None):
 
 def min(input, dim=None, keepdim=False, *, out=None):
     if dim is None:
-        ret = ivy.min(input, axis=dim, keepdims=keepdim, out=out)
+        return ivy.min(input, axis=dim, keepdims=keepdim, out=out)
+    elif out:
+        ivy.min(input, axis=dim, keepdims=keepdim, out=out[0])
+        ivy.argmin(input, axis=dim, keepdims=keepdim, out=out[1])
+        return out
     else:
-        if out:
-            ivy.min(input, axis=dim, keepdims=keepdim, out=out[0])
-            ivy.argmin(input, axis=dim, keepdims=keepdim, out=out[1])
-            ret = out
-        else:
-            min_tuple = namedtuple("min", ["values", "indices"])
-            ret = min_tuple(
-                ivy.min(input, axis=dim, keepdims=keepdim),
-                ivy.argmin(input, axis=dim, keepdims=keepdim),
-            )
-    return ret
+        min_tuple = namedtuple("min", ["values", "indices"])
+        return min_tuple(
+            ivy.min(input, axis=dim, keepdims=keepdim),
+            ivy.argmin(input, axis=dim, keepdims=keepdim),
+        )

--- a/ivy/functional/frontends/torch/reduction_ops.py
+++ b/ivy/functional/frontends/torch/reduction_ops.py
@@ -1,6 +1,7 @@
 import ivy
 from collections import namedtuple
 
+
 def dist(input, other, p=2):
     return ivy.vector_norm(ivy.subtract(input, other), ord=p)
 
@@ -51,6 +52,7 @@ def prod(input, dim=None, keepdim=False, *, dtype=None, out=None):
 
 def var(input, dim, unbiased, keepdim=False, *, out=None):
     return ivy.var(input, axis=dim, correction=int(unbiased), keepdims=keepdim, out=out)
+
 
 def min(input, dim=None, keepdim=False, *, out=None):
     if dim is None:

--- a/ivy/functional/frontends/torch/reduction_ops.py
+++ b/ivy/functional/frontends/torch/reduction_ops.py
@@ -1,5 +1,5 @@
 import ivy
-
+from collections import namedtuple
 
 def dist(input, other, p=2):
     return ivy.vector_norm(ivy.subtract(input, other), ord=p)
@@ -51,3 +51,17 @@ def prod(input, dim=None, keepdim=False, *, dtype=None, out=None):
 
 def var(input, dim, unbiased, keepdim=False, *, out=None):
     return ivy.var(input, axis=dim, correction=int(unbiased), keepdims=keepdim, out=out)
+
+def min(input, dim=None, keepdim=False, *, out=None):
+    if dim is None:
+        ret = ivy.min(input, axis=dim, keepdims=keepdim, out=out)
+    else:
+        min_vals = ivy.min(input, axis=dim, keepdims=keepdim, out=out)
+        argmin_vals = ivy.argmin(input, axis=dim, keepdims=keepdim, out=out)
+        if out:
+            assert len(out) == 2
+            ivy.inplace_update(out[0], min_vals)
+            ivy.inplace_update(out[1], argmin_vals)
+        min_tuple = namedtuple("min", ["values", "indices"])
+        ret = min_tuple(min_vals, argmin_vals)
+    return ret

--- a/ivy/functional/frontends/torch/reduction_ops.py
+++ b/ivy/functional/frontends/torch/reduction_ops.py
@@ -58,12 +58,14 @@ def min(input, dim=None, keepdim=False, *, out=None):
     if dim is None:
         ret = ivy.min(input, axis=dim, keepdims=keepdim, out=out)
     else:
-        min_vals = ivy.min(input, axis=dim, keepdims=keepdim, out=out)
-        argmin_vals = ivy.argmin(input, axis=dim, keepdims=keepdim, out=out)
         if out:
-            assert len(out) == 2
-            ivy.inplace_update(out[0], min_vals)
-            ivy.inplace_update(out[1], argmin_vals)
-        min_tuple = namedtuple("min", ["values", "indices"])
-        ret = min_tuple(min_vals, argmin_vals)
+            ivy.min(input, axis=dim, keepdims=keepdim, out=out[0])
+            ivy.argmin(input, axis=dim, keepdims=keepdim, out=out[1])
+            ret = out
+        else:
+            min_tuple = namedtuple("min", ["values", "indices"])
+            ret = min_tuple(
+                ivy.min(input, axis=dim, keepdims=keepdim),
+                ivy.argmin(input, axis=dim, keepdims=keepdim),
+            )
     return ret

--- a/ivy_tests/test_ivy/helpers/function_testing.py
+++ b/ivy_tests/test_ivy/helpers/function_testing.py
@@ -448,6 +448,10 @@ def test_frontend_function(
         optional, return value from the Numpy function
     """
     _assert_dtypes_are_valid(input_dtypes)
+    assert (
+        not with_out or not with_inplace
+    ), "only one of with_out or with_inplace can be set as True"
+
     # split the arguments into their positional and keyword components
     args_np, kwargs_np = kwargs_to_args_n_kwargs(
         num_positional_args=num_positional_args, kwargs=all_as_kwargs_np
@@ -546,21 +550,30 @@ def test_frontend_function(
     copy_kwargs = copy.deepcopy(kwargs)
     copy_args = copy.deepcopy(args)
     ret = frontend_fn(*args, **kwargs)
-    ret = ivy.array(ret) if with_out and not ivy.is_array(ret) else ret
-    out = ret
-    assert (
-        not with_out or not with_inplace
-    ), "only one of with_out or with_inplace can be set as True"
     if with_out:
-        assert not isinstance(ret, tuple)
-        assert ivy.is_array(ret)
+        if not inspect.isclass(ret):
+            is_ret_tuple = issubclass(ret.__class__, tuple)
+        else:
+            is_ret_tuple = issubclass(ret, tuple)
+        if is_ret_tuple:
+            ret = ivy.nested_map(
+                ret,
+                lambda _x: ivy.array(_x) if not ivy.is_array(_x) else _x,
+                include_derived=True,
+            )
+        elif not ivy.is_array(ret):
+            ret = ivy.array(ret)
+        out = ret
         # pass return value to out argument
         # check if passed reference is correctly updated
         kwargs["out"] = out
         ret = frontend_fn(*args, **kwargs)
-        if ivy.native_inplace_support:
-            assert ret.data is out.data
-        assert ret is out
+        flatten_ret = flatten(ret=ret)
+        flatten_out = flatten(ret=out)
+        for ret_array, out_array in zip(flatten_ret, flatten_out):
+            if ivy.native_inplace_support:
+                assert ret_array.data is out_array.data
+            assert ret_array is out_array
     elif with_inplace:
         assert not isinstance(ret, tuple)
         assert ivy.is_array(ret)

--- a/ivy_tests/test_ivy/helpers/function_testing.py
+++ b/ivy_tests/test_ivy/helpers/function_testing.py
@@ -601,16 +601,6 @@ def test_frontend_function(
                 assert ret.data is first_array.data
             assert first_array is ret
             args, kwargs = copy_args, copy_kwargs
-    elif with_out:
-        assert not isinstance(ret, tuple)
-        assert ivy.is_array(ret)
-        # pass return value to out argument
-        # check if passed reference is correctly updated
-        kwargs["out"] = out
-        ret = frontend_fn(*args, **kwargs)
-        if ivy.native_inplace_support:
-            assert ret.data is out.data
-        assert ret is out
 
     # create NumPy args
     args_np = ivy.nested_map(

--- a/ivy_tests/test_ivy/helpers/function_testing.py
+++ b/ivy_tests/test_ivy/helpers/function_testing.py
@@ -568,12 +568,17 @@ def test_frontend_function(
         # check if passed reference is correctly updated
         kwargs["out"] = out
         ret = frontend_fn(*args, **kwargs)
-        flatten_ret = flatten(ret=ret)
-        flatten_out = flatten(ret=out)
-        for ret_array, out_array in zip(flatten_ret, flatten_out):
+        if is_ret_tuple:
+            flatten_ret = flatten(ret=ret)
+            flatten_out = flatten(ret=out)
+            for ret_array, out_array in zip(flatten_ret, flatten_out):
+                if ivy.native_inplace_support:
+                    assert ret_array.data is out_array.data
+                assert ret_array is out_array
+        else:
             if ivy.native_inplace_support:
-                assert ret_array.data is out_array.data
-            assert ret_array is out_array
+                assert ret.data is out.data
+            assert ret is out
     elif with_inplace:
         assert not isinstance(ret, tuple)
         assert ivy.is_array(ret)

--- a/ivy_tests/test_ivy/test_frontends/test_torch/test_reduction_ops.py
+++ b/ivy_tests/test_ivy/test_frontends/test_torch/test_reduction_ops.py
@@ -417,3 +417,42 @@ def test_torch_var(
         keepdim=keepdims,
         out=None,
     )
+
+
+# ToDo, fails for TensorFlow backend, tf.reduce_min doesn't support bool
+# ToDo, fails for torch backend, tf.argmin_cpu doesn't support bool
+@handle_cmd_line_args
+@given(
+    dtype_input_axis=helpers.dtype_values_axis(
+        available_dtypes=helpers.get_dtypes("valid"),
+        min_num_dims=1,
+        valid_axis=True,
+        force_int_axis=True,
+    ),
+    num_positional_args=helpers.num_positional_args(
+        fn_name="ivy.functional.frontends.torch.min"
+    ),
+    keepdim=st.booleans(),
+)
+def test_torch_min(
+    dtype_input_axis,
+    as_variable,
+    num_positional_args,
+    native_array,
+    keepdim,
+    with_out,
+):
+    input_dtype, x, axis = dtype_input_axis
+    helpers.test_frontend_function(
+        input_dtypes=input_dtype,
+        as_variable_flags=as_variable,
+        with_out=with_out,
+        num_positional_args=num_positional_args,
+        native_array_flags=native_array,
+        frontend="torch",
+        fn_tree="min",
+        input=x[0],
+        dim=axis,
+        keepdim=keepdim,
+        out=None,
+    )


### PR DESCRIPTION
### Few comments
* torch have a lot of namedtuple for return, should I refactor the logic inside min to be a decorator for torch frontend?
* torch will return `torch.return_types.min(tensor,tensor)`, but I've made it to return `min(tensor, tensor)`, should i update it to replicate the same name of the torch namedtuple?