### PR TITLE
Added mul and multiply to PyTorch fronend

### DIFF
--- a/ivy/functional/frontends/torch/pointwise_ops.py
+++ b/ivy/functional/frontends/torch/pointwise_ops.py
@@ -194,3 +194,10 @@ def clip(input, min=None, max=None, *, out=None):
     if max is None:
         return ivy.maximum(input, min, out=out)
     return ivy.clip(input, min, max, out=out)
+
+
+def mul(input, other, *, out=None):
+    return ivy.multiply(input, other, out=out)
+
+
+multiply = mul

--- a/ivy_tests/test_ivy/test_frontends/test_torch/test_pointwise_ops.py
+++ b/ivy_tests/test_ivy/test_frontends/test_torch/test_pointwise_ops.py
@@ -1438,7 +1438,7 @@ def test_torch_clip(
 @handle_cmd_line_args
 @given(
     dtype_and_x=helpers.dtype_and_values(
-        available_dtypes=helpers.get_dtypes("float"),
+        available_dtypes=helpers.get_dtypes("numeric"),
         num_arrays=2,
         min_value=-1e04,
         max_value=1e04,

--- a/ivy_tests/test_ivy/test_frontends/test_torch/test_pointwise_ops.py
+++ b/ivy_tests/test_ivy/test_frontends/test_torch/test_pointwise_ops.py
@@ -1432,3 +1432,36 @@ def test_torch_clip(
         max=max,
         out=None,
     )
+
+
+# mul
+@handle_cmd_line_args
+@given(
+    dtype_and_x=helpers.dtype_and_values(
+        available_dtypes=helpers.get_dtypes("float"),
+        num_arrays=2,
+        min_value=-1e04,
+        max_value=1e04,
+        allow_inf=False,
+    ),
+    num_positional_args=helpers.num_positional_args(
+        fn_name="functional.frontends.torch.mul"
+    ),
+)
+def test_torch_mul(
+    dtype_and_x, as_variable, with_out, num_positional_args, native_array, fw
+):
+    input_dtype, x = dtype_and_x
+    helpers.test_frontend_function(
+        input_dtypes=input_dtype,
+        as_variable_flags=as_variable,
+        with_out=with_out,
+        num_positional_args=num_positional_args,
+        native_array_flags=native_array,
+        frontend="torch",
+        fn_tree="mul",
+        rtol=1e-03,
+        input=x[0],
+        other=x[1],
+        out=None,
+    )


### PR DESCRIPTION
Adds mul and its alias multiply to PyTorch frontend. Fixes #5355 and #5354 