### PR TITLE
numpy frontend logaddexp2

### DIFF
--- a/ivy/functional/frontends/numpy/mathematical_functions/exponents_and_logarithms.py
+++ b/ivy/functional/frontends/numpy/mathematical_functions/exponents_and_logarithms.py
@@ -157,3 +157,24 @@ def logaddexp(
     if ivy.is_array(where):
         ret = ivy.where(where, ret, ivy.default(out, ivy.zeros_like(ret)), out=out)
     return ret
+
+@from_zero_dim_arrays_to_float
+def logaddexp2(
+    x1,
+    x2,
+    /,
+    out=None,
+    *,
+    where=True,
+    casting="same_kind",
+    order="k",
+    dtype=None,
+    subok=True,
+):
+    if dtype:
+        x1 = ivy.astype(ivy.array(x1), ivy.as_ivy_dtype(dtype))
+        x2 = ivy.astype(ivy.array(x2), ivy.as_ivy_dtype(dtype))
+    ret = ivy.log2(ivy.pow(2, x1) + ivy.pow(2, x2), out=out)
+    if ivy.is_array(where):
+        ret = ivy.where(where, ret, ivy.default(out, ivy.zeros_like(ret)), out=out)
+    return ret

--- a/ivy_tests/test_ivy/test_frontends/test_numpy/test_mathematical_functions/test_exponents_and_logarithms.py
+++ b/ivy_tests/test_ivy/test_frontends/test_numpy/test_mathematical_functions/test_exponents_and_logarithms.py
@@ -394,3 +394,47 @@ def test_numpy_logaddexp(
         dtype=dtype,
         subok=True,
     )
+    
+    
+# logaddexp2
+@handle_cmd_line_args
+@given(
+    dtype_and_x=helpers.dtype_and_values(
+        available_dtypes=helpers.get_dtypes("numeric"), num_arrays=2
+    ),
+    dtype=helpers.get_dtypes("float", full=False, none=True),
+    where=np_frontend_helpers.where(),
+    num_positional_args=helpers.num_positional_args(
+        fn_name="ivy.functional.frontends.numpy.logaddexp2"
+    ),
+)
+def test_numpy_logaddexp2(
+    dtype_and_x,
+    dtype,
+    where,
+    as_variable,
+    with_out,
+    num_positional_args,
+    native_array,
+):
+    input_dtype, xs = dtype_and_x
+    where, as_variable, native_array = np_frontend_helpers.handle_where_and_array_bools(
+        where=where,
+        input_dtype=input_dtype,
+        as_variable=as_variable,
+        native_array=native_array,
+    )
+    np_frontend_helpers.test_frontend_function(
+        input_dtypes=input_dtype,
+        as_variable_flags=as_variable,
+        with_out=with_out,
+        num_positional_args=num_positional_args,
+        native_array_flags=native_array,
+        frontend="numpy",
+        fn_tree="logaddexp2",
+        x1=xs[0],
+        x2=xs[1],
+        out=None,
+        where=where,
+        dtype=dtype,
+    )


### PR DESCRIPTION
This merges changes from https://github.com/unifyai/ivy/pull/5442 which had to be reverted due to a wrong version of `array-api` submodule.