### PR TITLE
Fixed test_activations in TensorFlow frontend

### DIFF
--- a/ivy/functional/backends/jax/activations.py
+++ b/ivy/functional/backends/jax/activations.py
@@ -9,7 +9,10 @@ import jax.numpy as jnp
 from typing import Optional, Union
 
 # local
+from ivy.func_wrapper import with_unsupported_dtypes
 from ivy.functional.backends.jax import JaxArray
+
+from . import backend_version
 
 
 def gelu(
@@ -36,6 +39,7 @@ def sigmoid(x: JaxArray, /, *, out: Optional[JaxArray] = None) -> JaxArray:
     return 1 / (1 + jnp.exp(-x))
 
 
+@with_unsupported_dtypes({"0.3.14 and below": ("float16", "bfloat16")}, backend_version)
 def softmax(
     x: JaxArray, /, *, axis: Optional[int] = None, out: Optional[JaxArray] = None
 ) -> JaxArray:

--- a/ivy/functional/backends/torch/activations.py
+++ b/ivy/functional/backends/torch/activations.py
@@ -51,7 +51,7 @@ def sigmoid(x: torch.Tensor, /, *, out: Optional[torch.Tensor] = None) -> torch.
 sigmoid.support_native_out = True
 
 
-@with_unsupported_dtypes({"1.11.0 and below": ("float16",)}, version)
+@with_unsupported_dtypes({"1.11.0 and below": ("float16", "bfloat16")}, version)
 def softmax(
     x: torch.Tensor,
     /,

--- a/ivy_tests/test_ivy/test_frontends/test_tensorflow/test_activations.py
+++ b/ivy_tests/test_ivy/test_frontends/test_tensorflow/test_activations.py
@@ -83,7 +83,6 @@ def test_tensorflow_sigmoid(
     dtype_x_and_axis=helpers.dtype_values_axis(
         available_dtypes=helpers.get_dtypes("float"),
         min_num_dims=2,
-        max_axes_size=1,
         force_int_axis=True,
         valid_axis=True,
     ),


### PR DESCRIPTION
Fixed tests in `test_activations.py`. Specifically `test_tensorflow_softmax` as is didn't support `float16` nor `bfloat16` in Jax and PyTorch