### PR TITLE
modify the matrix_norm function for the torch backend

### DIFF
--- a/ivy/functional/backends/torch/linear_algebra.py
+++ b/ivy/functional/backends/torch/linear_algebra.py
@@ -202,7 +202,8 @@ def matrix_norm(
     out: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
     if isinstance(ord, float):
-        ord = int(ord)
+        if ord != inf and ord != -inf:
+            ord = int(ord)
     return torch.linalg.matrix_norm(x, ord=ord, dim=axis, keepdim=keepdims, out=out)
 
 


### PR DESCRIPTION
Hello,

I find that the inf, -inf value can not be changed to int type in Torch. 
Therefore, it seems like they need to be excluded from type conversion.

Thank you