### PR TITLE
add additional instruction in the Setting Up page

### DIFF
--- a/docs/partial_source/contributing/0_setting_up.rst
+++ b/docs/partial_source/contributing/0_setting_up.rst
@@ -191,6 +191,7 @@ Windows
    b. Going to settings -> project -> Python Interpreter
    c. Clicking add interpreter (currently by clicking the ⚙ icon by the right side) which should open a new window.
    d. Choosing "Docker" from the left panel. Type python3 (with the number) in python interpreter path and press ok.
+   e. Opening "Edit Run/Debug configurations" dialog -> "Edit Configurations..." and making sure that "Working directory" is empty in case of getting the "Can't run process: the working directory '\ivy' is invalid, it needs to be an absolute path" error.
 
 Once these steps are finished, your interpreter should be set up correctly!
 If Docker's latest version causes error,


### PR DESCRIPTION
Solves the issue that I was stuck for quite some time. There are a couple of reports in Discord facing the same issue.
i.e.: https://discord.com/channels/799879767196958751/942114831039856730/1026194766557364347, https://discord.com/channels/799879767196958751/942114831039856730/1027496868348952616


The error: "Error running 'pytest for test.name': Can't run process: the working directory '\ivy' is invalid, it needs to be an absolute path" 