### PR TITLE
chore: change base image to ubuntu:latest

### DIFF
--- a/.github/workflows/dockerfile-image.yml
+++ b/.github/workflows/dockerfile-image.yml
@@ -11,7 +11,7 @@ jobs:
 
   build:
     if: ${{(github.event_name == 'push') || contains(github.event.pull_request.labels.*.name, 'Exhaustive CI') || contains(github.event.pull_request.labels.*.name, 'Build Docker Files')}}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/dockerfile-push.yml
+++ b/.github/workflows/dockerfile-push.yml
@@ -10,7 +10,7 @@ jobs:
 
   build:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
     - 

--- a/.github/workflows/dockerfilecopsim-image.yml
+++ b/.github/workflows/dockerfilecopsim-image.yml
@@ -11,7 +11,7 @@ jobs:
 
   build:
     if: ${{(github.event_name == 'push') || contains(github.event.pull_request.labels.*.name, 'Exhaustive CI') || contains(github.event.pull_request.labels.*.name, 'Build Docker Files')}}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/dockerfilecopsim-push.yml
+++ b/.github/workflows/dockerfilecopsim-push.yml
@@ -9,7 +9,7 @@ jobs:
 
   build:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
     - 

--- a/.github/workflows/dockerfilegpu-image.yml
+++ b/.github/workflows/dockerfilegpu-image.yml
@@ -11,7 +11,7 @@ jobs:
 
   build:
     if: ${{(github.event_name == 'push') || contains(github.event.pull_request.labels.*.name, 'Exhaustive CI') || contains(github.event.pull_request.labels.*.name, 'Build Docker Files')}}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/dockerfilegpu-push.yml
+++ b/.github/workflows/dockerfilegpu-push.yml
@@ -9,7 +9,7 @@ jobs:
 
   build:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
     - 


### PR DESCRIPTION
"The `ubuntu:latest` tag points to the "latest LTS", since that's the version recommended for general use."