### PR TITLE
Instance method testing import update

### DIFF
--- a/ivy/functional/frontends/numpy/ndarray/ndarray.py
+++ b/ivy/functional/frontends/numpy/ndarray/ndarray.py
@@ -6,10 +6,10 @@ import ivy.functional.frontends.numpy as np_frontend
 
 
 class ndarray:
-    def __init__(self, data):
-        if ivy.is_native_array(data):
-            data = ivy.Array(data)
-        self.data = data
+    def __init__(self, object):
+        if ivy.is_native_array(object):
+            object = ivy.Array(object)
+        self.object = object
 
     # Instance Methoods #
     # -------------------#
@@ -25,35 +25,35 @@ class ndarray:
     ):
 
         return np_frontend.argmax(
-            self.data,
+            self.object,
             axis=axis,
             out=out,
             keepdims=keepdims,
         )
 
     def reshape(self, shape, order="C"):
-        return np_frontend.reshape(self.data, shape)
+        return np_frontend.reshape(self.object, shape)
 
     def transpose(self, /, axes=None):
-        return np_frontend.transpose(self.data, axes=axes)
+        return np_frontend.transpose(self.object, axes=axes)
 
     def add(
         self,
         value,
     ):
         return np_frontend.add(
-            self.data,
+            self.object,
             value,
         )
 
     def squeeze(self, axis=None):
-        return np_frontend.squeeze(self.data, axis)
+        return np_frontend.squeeze(self.object, axis)
 
     def all(self, axis=None, out=None, keepdims=False, *, where=True):
-        return np_frontend.all(self.data, axis, out, keepdims, where=where)
+        return np_frontend.all(self.object, axis, out, keepdims, where=where)
 
     def any(self, axis=None, out=None, keepdims=False, *, where=True):
-        return np_frontend.any(self.data, axis, out, keepdims, where=where)
+        return np_frontend.any(self.object, axis, out, keepdims, where=where)
 
     def argsort(self, *, axis=-1, kind=None, order=None):
-        return np_frontend.argsort(self.data, axis, kind, order)
+        return np_frontend.argsort(self.object, axis, kind, order)

--- a/ivy/functional/frontends/tensorflow/tensor.py
+++ b/ivy/functional/frontends/tensorflow/tensor.py
@@ -21,7 +21,7 @@ class Tensor:
         return y.__radd__(self.data)
 
     def __div__(self, x, name="div"):
-        return tf_frontend.math.divide(x, self.data, name=name)
+        return tf_frontend.math.divide(self.data, x, name=name)
 
     def __and__(self, y, name="and"):
         return y.__rand__(self.data)
@@ -58,7 +58,7 @@ class Tensor:
         return tf_frontend.raw_ops.Greater(x=self.data, y=y.data, name=name)
 
     def __invert__(self, name="invert"):
-        return tf_frontend.Invert(x=self.data, name=name)
+        return tf_frontend.raw_ops.Invert(x=self.data, name=name)
 
     def __le__(self, y, name="le"):
         return tf_frontend.raw_ops.LessEqual(x=self.data, y=y.data, name=name)

--- a/ivy/functional/frontends/torch/Tensor.py
+++ b/ivy/functional/frontends/torch/Tensor.py
@@ -40,7 +40,7 @@ class Tensor:
         return self.data
 
     def float(self, memory_format=torch.preserve_format):
-        return self.data.__float__()
+        return ivy.astype(self.data, ivy.float32)
 
     def tan(self, *, out=None):
         return torch_frontend.tan(self.data, out=out)

--- a/ivy/functional/frontends/torch/Tensor.py
+++ b/ivy/functional/frontends/torch/Tensor.py
@@ -40,7 +40,7 @@ class Tensor:
         return self.data
 
     def float(self, memory_format=torch.preserve_format):
-        return ivy.astype(self.data, ivy.float32)
+        return self.data.__float__()
 
     def tan(self, *, out=None):
         return torch_frontend.tan(self.data, out=out)

--- a/ivy_tests/test_ivy/test_frontends/test_numpy/test_ndarray/test_ndarray.py
+++ b/ivy_tests/test_ivy/test_frontends/test_numpy/test_ndarray/test_ndarray.py
@@ -13,33 +13,29 @@ import ivy_tests.test_ivy.test_frontends.test_numpy.helpers as np_frontend_helpe
 @given(
     dtype_and_x=helpers.dtype_and_values(
         available_dtypes=helpers.get_dtypes("valid"),
-        num_arrays=2,
     ),
 )
 def test_numpy_ndarray_argmax(
     dtype_and_x,
     as_variable,
     native_array,
-    fw,
 ):
     input_dtype, x = dtype_and_x
     helpers.test_frontend_method(
-        input_dtype_init=input_dtype,
+        input_dtypes_init=input_dtype,
         as_variable_flags_init=as_variable,
         num_positional_args_init=0,
         native_array_flags_init=native_array,
         all_as_kwargs_np_init={
-            "data": x[0],
+            "object": x[0],
         },
-        input_dtypes_method=[input_dtype[1]],
+        input_dtypes_method=[input_dtype[0]],
         as_variable_flags_method=as_variable,
         num_positional_args_method=0,
         native_array_flags_method=native_array,
-        all_as_kwargs_np_method={
-            "value": x[1],
-        },
-        fw=fw,
+        all_as_kwargs_np_method={},
         frontend="numpy",
+        module_name="ndarray",
         class_name="ndarray",
         method_name="argmax",
     )
@@ -80,7 +76,7 @@ def test_numpy_ndarray_reshape(
         num_positional_args_init=0,
         native_array_flags_init=native_array,
         all_as_kwargs_np_init={
-            "data": x[0],
+            "object": x[0],
         },
         input_dtypes_method=[],
         as_variable_flags_method=as_variable,
@@ -90,6 +86,7 @@ def test_numpy_ndarray_reshape(
             "shape": shape,
         },
         frontend="numpy",
+        module_name="ndarray",
         class_name="ndarray",
         method_name="reshape",
     )
@@ -115,7 +112,7 @@ def test_numpy_ndarray_add(
         num_positional_args_init=0,
         native_array_flags_init=native_array,
         all_as_kwargs_np_init={
-            "data": x[0],
+            "object": x[0],
         },
         input_dtypes_method=[input_dtype[1]],
         as_variable_flags_method=as_variable,
@@ -125,6 +122,7 @@ def test_numpy_ndarray_add(
             "value": x[1],
         },
         frontend="numpy",
+        module_name="ndarray",
         class_name="ndarray",
         method_name="add",
     )
@@ -155,7 +153,7 @@ def test_numpy_ndarray_squeeze(
         num_positional_args_init=0,
         native_array_flags_init=native_array,
         all_as_kwargs_np_init={
-            "data": np.array(x, dtype=input_dtype),
+            "object": np.array(x, dtype=input_dtype),
         },
         input_dtypes_method=[],
         as_variable_flags_method=as_variable,
@@ -166,6 +164,7 @@ def test_numpy_ndarray_squeeze(
         },
         fw=fw,
         frontend="numpy",
+        module_name="ndarray",
         class_name="ndarray",
         method_name="squeeze",
     )
@@ -197,7 +196,7 @@ def test_numpy_ndarray_transpose(
         num_positional_args_init=num_positional_args,
         native_array_flags_init=native_array,
         all_as_kwargs_np_init={
-            "data": np.array(array),
+            "object": np.array(array),
         },
         input_dtypes_method=dtype,
         as_variable_flags_method=as_variable,
@@ -207,6 +206,7 @@ def test_numpy_ndarray_transpose(
             "axes": axes,
         },
         frontend="numpy",
+        module_name="ndarray",
         class_name="ndarray",
         method_name="transpose",
     )
@@ -253,7 +253,7 @@ def test_numpy_ndarray_any(
         num_positional_args_init=num_positional_args,
         native_array_flags_init=native_array,
         all_as_kwargs_np_init={
-            "data": x[0],
+            "object": x[0],
         },
         input_dtypes_method=input_dtype,
         as_variable_flags_method=as_variable,
@@ -266,6 +266,7 @@ def test_numpy_ndarray_any(
             "where": where,
         },
         frontend="numpy",
+        module_name="ndarray",
         class_name="ndarray",
         method_name="any",
     )
@@ -316,7 +317,7 @@ def test_numpy_ndarray_all(
         as_variable_flags_method=as_variable,
         native_array_flags_method=native_array,
         all_as_kwargs_np_init={
-            "data": x[0],
+            "object": x[0],
         },
         all_as_kwargs_np_method={
             "axis": axis,
@@ -325,6 +326,7 @@ def test_numpy_ndarray_all(
             "where": where,
         },
         frontend="numpy",
+        module_name="ndarray",
         class_name="ndarray",
         method_name="all",
     )
@@ -359,6 +361,7 @@ def test_numpy_instance_argsort(
         native_array_flags=native_array,
         fw=fw,
         frontend="numpy",
+        module_name="ndarray",
         frontend_class=np.ndarray,
         fn_tree="ndarray.argsort",
         x=x[0],

--- a/ivy_tests/test_ivy/test_frontends/test_tensorflow/test_tensor.py
+++ b/ivy_tests/test_ivy/test_frontends/test_tensorflow/test_tensor.py
@@ -35,6 +35,7 @@ def test_tensorflow_instance_add(dtype_and_x, as_variable, native_array):
             "y": x[1],
         },
         frontend="tensorflow",
+        module_name="tensor",
         class_name="Tensor",
         method_name="__add__",
     )
@@ -67,6 +68,7 @@ def test_tensorflow_instance_div(dtype_and_x, as_variable, native_array, fw):
             "y": x[1],
         },
         frontend="tensorflow",
+        module_name="tensor",
         class_name="Tensor",
         method_name="__div__",
     )
@@ -97,6 +99,7 @@ def test_tensorflow_instance_get_shape(dtype_and_x, as_variable, native_array):
         native_array_flags_method=[],
         all_as_kwargs_np_method={},
         frontend="tensorflow",
+        module_name="tensor",
         class_name="Tensor",
         method_name="get_shape",
     )
@@ -128,6 +131,7 @@ def test_tensorflow_instance_eq(dtype_and_x, as_variable, native_array):
             "other": x[1],
         },
         frontend="tensorflow",
+        module_name="tensor",
         class_name="Tensor",
         method_name="__eq__",
     )
@@ -160,6 +164,7 @@ def test_tensorflow_instance_floordiv(dtype_and_x, as_variable, native_array):
             "y": x[1],
         },
         frontend="tensorflow",
+        module_name="tensor",
         class_name="Tensor",
         method_name="__floordiv__",
     )
@@ -192,6 +197,7 @@ def test_tensorflow_instance_ge(dtype_and_x, as_variable, native_array):
             "y": x[1],
         },
         frontend="tensorflow",
+        module_name="tensor",
         class_name="Tensor",
         method_name="__ge__",
     )
@@ -224,6 +230,7 @@ def test_tensorflow_instance_gt(dtype_and_x, as_variable, native_array):
             "y": x[1],
         },
         frontend="tensorflow",
+        module_name="tensor",
         class_name="Tensor",
         method_name="__gt__",
     )
@@ -256,6 +263,7 @@ def test_tensorflow_instance_le(dtype_and_x, as_variable, native_array):
             "y": x[1],
         },
         frontend="tensorflow",
+        module_name="tensor",
         class_name="Tensor",
         method_name="__le__",
     )
@@ -288,6 +296,7 @@ def test_tensorflow_instance_lt(dtype_and_x, as_variable, native_array):
             "y": x[1],
         },
         frontend="tensorflow",
+        module_name="tensor",
         class_name="Tensor",
         method_name="__lt__",
     )
@@ -320,6 +329,7 @@ def test_tensorflow_instance_mul(dtype_and_x, as_variable, native_array, fw):
             "y": x[1],
         },
         frontend="tensorflow",
+        module_name="tensor",
         class_name="Tensor",
         method_name="__mul__",
     )
@@ -354,6 +364,7 @@ def test_tensorflow_instance_sub(dtype_and_x, as_variable, native_array):
             "y": x[1],
         },
         frontend="tensorflow",
+        module_name="tensor",
         class_name="Tensor",
         method_name="__sub__",
     )
@@ -385,6 +396,7 @@ def test_tensorflow_instance_ne(dtype_and_x, as_variable, native_array):
             "other": x[1],
         },
         frontend="tensorflow",
+        module_name="tensor",
         class_name="Tensor",
         method_name="__ne__",
     )
@@ -417,6 +429,7 @@ def test_tensorflow_instance_radd(dtype_and_x, as_variable, native_array):
             "x": x[1],
         },
         frontend="tensorflow",
+        module_name="tensor",
         class_name="Tensor",
         method_name="__radd__",
     )
@@ -449,6 +462,7 @@ def test_tensorflow_instance_rfloordiv(dtype_and_x, as_variable, native_array):
             "x": x[1],
         },
         frontend="tensorflow",
+        module_name="tensor",
         class_name="Tensor",
         method_name="__rfloordiv__",
     )
@@ -481,6 +495,7 @@ def test_tensorflow_instance_rsub(dtype_and_x, as_variable, native_array):
             "x": x[1],
         },
         frontend="tensorflow",
+        module_name="tensor",
         class_name="Tensor",
         method_name="__rsub__",
     )
@@ -513,6 +528,7 @@ def test_tensorflow_instance_and(dtype_and_x, as_variable, native_array):
             "y": x[1],
         },
         frontend="tensorflow",
+        module_name="tensor",
         class_name="Tensor",
         method_name="__and__",
     )
@@ -545,6 +561,7 @@ def test_tensorflow_instance_rand(dtype_and_x, as_variable, native_array):
             "x": x[1],
         },
         frontend="tensorflow",
+        module_name="tensor",
         class_name="Tensor",
         method_name="__rand__",
     )
@@ -577,6 +594,7 @@ def test_tensorflow_instance_or(dtype_and_x, as_variable, native_array):
             "y": x[1],
         },
         frontend="tensorflow",
+        module_name="tensor",
         class_name="Tensor",
         method_name="__or__",
     )
@@ -609,6 +627,7 @@ def test_tensorflow_instance_ror(dtype_and_x, as_variable, native_array):
             "x": x[1],
         },
         frontend="tensorflow",
+        module_name="tensor",
         class_name="Tensor",
         method_name="__ror__",
     )
@@ -641,6 +660,7 @@ def test_tensorflow_instance_truediv(dtype_and_x, as_variable, native_array):
             "y": x[1],
         },
         frontend="tensorflow",
+        module_name="tensor",
         class_name="Tensor",
         method_name="__truediv__",
     )
@@ -673,6 +693,7 @@ def test_tensorflow_instance_rtruediv(dtype_and_x, as_variable, native_array):
             "x": x[1],
         },
         frontend="tensorflow",
+        module_name="tensor",
         class_name="Tensor",
         method_name="__rtruediv__",
     )
@@ -702,6 +723,7 @@ def test_tensorflow_instance_bool(dtype_and_x, as_variable, native_array, fw):
         native_array_flags_method=[],
         all_as_kwargs_np_method={},
         frontend="tensorflow",
+        module_name="tensor",
         class_name="Tensor",
         method_name="__bool__",
     )
@@ -731,6 +753,7 @@ def test_tensorflow_instance_nonzero(dtype_and_x, as_variable, native_array, fw)
         native_array_flags_method=[],
         all_as_kwargs_np_method={},
         frontend="tensorflow",
+        module_name="tensor",
         class_name="Tensor",
         method_name="__nonzero__",
     )
@@ -766,6 +789,7 @@ def test_tensorflow_instance_neg(dtype_and_x, as_variable, native_array, fw):
         native_array_flags_method=[],
         all_as_kwargs_np_method={},
         frontend="tensorflow",
+        module_name="tensor",
         class_name="Tensor",
         method_name="__neg__",
     )
@@ -798,6 +822,7 @@ def test_tensorflow_instance_rxor(dtype_and_x, as_variable, native_array, fw):
             "x": x[1],
         },
         frontend="tensorflow",
+        module_name="tensor",
         class_name="Tensor",
         method_name="__rxor__",
     )
@@ -830,6 +855,7 @@ def test_tensorflow_instance_xor(dtype_and_x, as_variable, native_array, fw):
             "y": x[1],
         },
         frontend="tensorflow",
+        module_name="tensor",
         class_name="Tensor",
         method_name="__xor__",
     )
@@ -869,6 +895,7 @@ def test_tensorflow_instance_matmul(dtype_and_x, as_variable, native_array, fw):
             "y": x[1],
         },
         frontend="tensorflow",
+        module_name="tensor",
         class_name="Tensor",
         method_name="__matmul__",
     )
@@ -908,6 +935,7 @@ def test_tensorflow_instance_rmatmul(dtype_and_x, as_variable, native_array, fw)
             "x": x[1],
         },
         frontend="tensorflow",
+        module_name="tensor",
         class_name="Tensor",
         method_name="__rmatmul__",
     )
@@ -936,6 +964,7 @@ def test_tensorflow_instance_array(dtype_and_x, as_variable, native_array, fw):
         native_array_flags_method=[],
         all_as_kwargs_np_method={},
         frontend="tensorflow",
+        module_name="tensor",
         class_name="Tensor",
         method_name="__array__",
     )
@@ -964,6 +993,7 @@ def test_tensorflow_instance_invert(dtype_and_x, as_variable, native_array, fw):
         native_array_flags_method=[],
         all_as_kwargs_np_method={},
         frontend="tensorflow",
+        module_name="tensor",
         class_name="Tensor",
         method_name="__invert__",
     )

--- a/ivy_tests/test_ivy/test_frontends/test_torch/test_tensor.py
+++ b/ivy_tests/test_ivy/test_frontends/test_torch/test_tensor.py
@@ -4,6 +4,7 @@ from hypothesis import assume, given, strategies as st
 
 # local
 import ivy_tests.test_ivy.helpers as helpers
+from ivy.functional.frontends.torch.Tensor import Tensor
 from ivy_tests.test_ivy.helpers import handle_cmd_line_args
 
 
@@ -268,33 +269,24 @@ def test_torch_instance_view(
 @given(
     dtype_x=helpers.dtype_and_values(
         available_dtypes=helpers.get_dtypes("valid", full=True),
+        max_num_dims=0,
     ),
 )
 def test_torch_instance_float(
     dtype_x,
-    as_variable,
-    native_array,
 ):
-    input_dtype, x = dtype_x
-    helpers.test_frontend_method(
-        input_dtypes_init=input_dtype,
-        as_variable_flags_init=as_variable,
-        num_positional_args_init=1,
-        native_array_flags_init=native_array,
-        all_as_kwargs_np_init={
-            "data": x[0],
-        },
-        input_dtypes_method=input_dtype,
-        as_variable_flags_method=as_variable,
-        num_positional_args_method=0,
-        native_array_flags_method=native_array,
-        all_as_kwargs_np_method={
-            "memory_format": torch.preserve_format,
-        },
-        frontend="torch",
-        class_name="tensor",
-        method_name="float",
-    )
+    _, x = dtype_x
+    data = Tensor(x[0])
+    ret = data.float()
+    ret_gt = torch.from_numpy(x[0]).float()
+    ret = helpers.flatten_and_to_np(ret=ret)
+    ret_gt = helpers.flatten_and_to_np(ret=ret_gt)
+    for (_, _) in zip(ret, ret_gt):
+        helpers.value_test(
+            ret_np_flat=ret,
+            ret_np_from_gt_flat=ret_gt,
+            ground_truth_backend="torch",
+        )
 
 
 # tan

--- a/ivy_tests/test_ivy/test_frontends/test_torch/test_tensor.py
+++ b/ivy_tests/test_ivy/test_frontends/test_torch/test_tensor.py
@@ -4,7 +4,6 @@ from hypothesis import assume, given, strategies as st
 
 # local
 import ivy_tests.test_ivy.helpers as helpers
-from ivy.functional.frontends.torch.Tensor import Tensor
 from ivy_tests.test_ivy.helpers import handle_cmd_line_args
 
 
@@ -45,6 +44,7 @@ def test_torch_instance_add(
             "alpha": alpha,
         },
         frontend="torch",
+        module_name="Tensor",
         class_name="tensor",
         method_name="add",
     )
@@ -84,6 +84,7 @@ def test_torch_instance_reshape(
             "shape": shape,
         },
         frontend="torch",
+        module_name="Tensor",
         class_name="tensor",
         method_name="reshape",
     )
@@ -118,6 +119,7 @@ def test_torch_instance_sin(
         native_array_flags_method=native_array,
         all_as_kwargs_np_method={},
         frontend="torch",
+        module_name="Tensor",
         class_name="tensor",
         method_name="sin",
     )
@@ -152,6 +154,7 @@ def test_torch_instance_sin_(
         native_array_flags_method=native_array,
         all_as_kwargs_np_method={},
         frontend="torch",
+        module_name="Tensor",
         class_name="tensor",
         method_name="sin_",
     )
@@ -186,6 +189,7 @@ def test_torch_instance_sinh(
         native_array_flags_method=native_array,
         all_as_kwargs_np_method={},
         frontend="torch",
+        module_name="Tensor",
         class_name="tensor",
         method_name="sinh",
     )
@@ -220,6 +224,7 @@ def test_torch_instance_sinh_(
         native_array_flags_method=native_array,
         all_as_kwargs_np_method={},
         frontend="torch",
+        module_name="Tensor",
         class_name="tensor",
         method_name="sinh_",
     )
@@ -260,6 +265,7 @@ def test_torch_instance_view(
             "shape": shape,
         },
         frontend="torch",
+        module_name="Tensor",
         class_name="tensor",
         method_name="view",
     )
@@ -269,24 +275,34 @@ def test_torch_instance_view(
 @given(
     dtype_x=helpers.dtype_and_values(
         available_dtypes=helpers.get_dtypes("valid", full=True),
-        max_num_dims=0,
     ),
 )
 def test_torch_instance_float(
     dtype_x,
+    as_variable,
+    native_array,
 ):
-    _, x = dtype_x
-    data = Tensor(x[0])
-    ret = data.float()
-    ret_gt = torch.from_numpy(x[0]).float()
-    ret = helpers.flatten_and_to_np(ret=ret)
-    ret_gt = helpers.flatten_and_to_np(ret=ret_gt)
-    for (_, _) in zip(ret, ret_gt):
-        helpers.value_test(
-            ret_np_flat=ret,
-            ret_np_from_gt_flat=ret_gt,
-            ground_truth_backend="torch",
-        )
+    input_dtype, x = dtype_x
+    helpers.test_frontend_method(
+        input_dtypes_init=input_dtype,
+        as_variable_flags_init=as_variable,
+        num_positional_args_init=1,
+        native_array_flags_init=native_array,
+        all_as_kwargs_np_init={
+            "data": x[0],
+        },
+        input_dtypes_method=input_dtype,
+        as_variable_flags_method=as_variable,
+        num_positional_args_method=0,
+        native_array_flags_method=native_array,
+        all_as_kwargs_np_method={
+            "memory_format": torch.preserve_format,
+        },
+        frontend="torch",
+        module_name="Tensor",
+        class_name="tensor",
+        method_name="float",
+    )
 
 
 # tan
@@ -318,6 +334,7 @@ def test_torch_instance_tan(
         native_array_flags_method=native_array,
         all_as_kwargs_np_method={},
         frontend="torch",
+        module_name="Tensor",
         class_name="tensor",
         method_name="tan",
     )


### PR DESCRIPTION
Hey,
Referring to the current way we are doing the testing it appeared that we were not importing actual classes and object instantiation was resulting in an `ivy.Array` object instead of the instance object being invoked. I updated the `test_frontend_method` helper to fully import the instance class object. But I think still for `ndarray` instance method we need some kind of generalization because the value test is giving an error the `ndarray` object has no `dtype` atribute.