### PR TITLE
fixed test frontends issue

### DIFF
--- a/ivy_tests/test_ivy/helpers/function_testing.py
+++ b/ivy_tests/test_ivy/helpers/function_testing.py
@@ -562,7 +562,7 @@ def test_frontend_function(
     ret = frontend_fn(*args, **kwargs)
     # since the return from the frontend functions is now
     # a frontend tensor or array object
-    ret = ret.data
+    # ret = ret.data
     if with_out:
         if not inspect.isclass(ret):
             is_ret_tuple = issubclass(ret.__class__, tuple)
@@ -1534,6 +1534,7 @@ def flatten(*, ret):
 
 def flatten_and_to_np(*, ret):
     # flatten the return
+    ret = ivy.to_ivy(ret)
     ret_flat = flatten(ret=ret)
     return [ivy.to_numpy(x) for x in ret_flat]
 


### PR DESCRIPTION
I ran into a problem running the tests. All the jax tests failed because of a problem with test_frontend_function.
The flatten function found in ivy/ivy_tests/test_ivy/helpers/function_testing.py returns an empty array, when I pass it an array.
I think the error occurs when ivy.nested_argwhere is called in the flatten function., since if ret is a numpy.ndarray, when ivy.is_ivy_array is used in ivy.nested_argwhere, it returns an empty array, because there is no ivy.Array, but a numpy.ndarray.
I think adding ret = ivy.to_ivy(ret) and commenting ret = ret.data, fixed this issue.

Anyway I wonder, Is that flatten function made to receive another type of data than ivy.Array? For example, numpy.ndarray?