### PR TITLE
safety factor linalg

### DIFF
--- a/ivy_tests/test_ivy/helpers/hypothesis_helpers/general_helpers.py
+++ b/ivy_tests/test_ivy/helpers/hypothesis_helpers/general_helpers.py
@@ -8,65 +8,40 @@ import numpy as np
 from . import array_helpers, number_helpers, dtype_helpers
 
 
-def safety_factor_linalg(
-    matrix,
-    *,
-    condition_index="high",
-):
+def matrix_is_stable(x, cond_limit=30):
     """
-    Applies safety factor to the condition of a matrix to avoid numerical
-    instabilities in further calculations.
+    Used to avoid numerical instabilities in further computationally heavy
+    calculations.
 
     Parameters
     ----------
     matrix
         The original matrix whose condition number is to be determined.
     condition_index
-        When a condition_index of "high" is used we are testing for a less
-        ill-conditioned matrix which is not too much prone to numerical
-        instabilities.
-
-        When a condition_index of "low" is used we are testing for a
-        well-conditioned matrices.
+        The greater the condition number, the more ill-conditioned the matrix 
+        will be, the more it will be prone to numerical instabilities. 
 
         There is no rule of thumb for what the exact condition number
         should be to consider a matrix ill-conditioned(prone to numerical errors).
-        If the condition number is "1", the matrix is perfectly said to be a
-        well-conditioned matrix which will not be prone to any numerical type
-        of instabilities in further calculations, but that would probably be a
+        But, if the condition number is "1", the matrix is perfectly said to be a
+        well-conditioned matrix which will not be prone to any type of numerical
+        instabilities in further calculations, but that would probably be a
         very simple matrix.
 
-        The "low" condition index checks from "1" till "10" as a matrix can
-        be considered well-condition in this range. This should be used for
-        a very high numerical computational function because it strictly
-        limits the type of matrices we generate.
+        The cond_limit should start with "30", gradually decreasing it according 
+        to our use, lower cond_limit would result in more numerically stable 
+        matrices but more simple matrices.
 
-        The "high" condition index checks from "10" till "30", in this range
-        the matrix is close to multicollinearity and can be considered a
-        little ill-conditioned, going above 30 leads to strong multicollinearity
-        which leads to singularity.
+        The limit should always be in the range "1-30", greater the number greater 
+        the computational instability. Should not increase 30, it leads to strong
+        multicollinearity which leads to singularity.
 
     Returns
     -------
     A bool, either True or False. Which tells whether the matrix is suitable for
     further numerical computations or not.
     """
-    type_casted_matrix = matrix.astype('float64')
-    if condition_index == "high":
-        if np.linalg.cond(type_casted_matrix) == float("inf"):
-            return False
-        elif round(np.linalg.cond(type_casted_matrix)) >= 10 and \
-                round(np.linalg.cond(type_casted_matrix)) <= 30:
-            return True
-        else:
-            return False
-    if condition_index == "low":
-        if np.linalg.cond(type_casted_matrix) == float("inf"):
-            return False
-        elif round(np.linalg.cond(type_casted_matrix)) <= 10:
-            return True
-        else:
-            return False
+    return np.linalg.cond(x.astype('float64')) <= cond_limit
 
 
 def apply_safety_factor(

--- a/ivy_tests/test_ivy/helpers/hypothesis_helpers/general_helpers.py
+++ b/ivy_tests/test_ivy/helpers/hypothesis_helpers/general_helpers.py
@@ -51,8 +51,10 @@ def safety_factor_linalg(
     A bool, either True or False. Which tells whether the matrix is suitable for
     further numerical computations or not.
     """
-    assert condition_index != "high", "wrong condition index given, can either be (high) or (low)"
-    assert condition_index != "low", "wrong condition index given, can either be (high) or (low)"
+    assert condition_index != "high", \
+        "wrong condition index given, can either be (high) or (low)"
+    assert condition_index != "low", \
+        "wrong condition index given, can either be (high) or (low)"
 
     type_casted_matrix = matrix.astype('float64')
     if condition_index == "high":

--- a/ivy_tests/test_ivy/helpers/hypothesis_helpers/general_helpers.py
+++ b/ivy_tests/test_ivy/helpers/hypothesis_helpers/general_helpers.py
@@ -64,7 +64,7 @@ def safety_factor_linalg(
         else:
             return False
     if condition_index == "low":
-        if np.linalg.cond(type_casted_matrix) <= 10:
+        if round(np.linalg.cond(type_casted_matrix)) <= 10:
             return True
         else:
             return False

--- a/ivy_tests/test_ivy/helpers/hypothesis_helpers/general_helpers.py
+++ b/ivy_tests/test_ivy/helpers/hypothesis_helpers/general_helpers.py
@@ -11,7 +11,7 @@ from . import array_helpers, number_helpers, dtype_helpers
 def safety_factor_linalg(
     matrix,
     *,
-    condition_index='high',
+    condition_index="high",
 ):
     """
     Applies safety factor to the condition of a matrix to avoid numerical instabilities in further calculations.
@@ -21,17 +21,29 @@ def safety_factor_linalg(
     matrix
         The original matrix whose condition number is to be determined.
     condition_index
+        When a condition_index of "high" is used we are testing for a little
+        ill-conditioned matrices which are not too much prone to numerical
+        instabilities.
+
+        When a condition_index of "low" is used we are testing for a little
+        well-conditioned matrices.
+
         There is no rule of thumb for what the exact condition number
         should be to consider a matrix ill-conditioned(prone to numerical errors).
         If the condition number is "1", the matrix is perfectly said to be a
-        well-conditioned matrix which will not be prone to any numerical zzinstabilities in further
-        calculations, but that would probably be a very simple matrix.
+        well-conditioned matrix which will not be prone to any numerical
+        instabilities in further calculations, but that would probably be a very
+        simple matrix.
 
         The "low" condition index checks from "1" till "10" as a matrix can
-        be considered well-condition in this range.
+        be considered well-condition in this range. This should be used for
+        a very high numerical computational function because it strictly
+        limits the type of matrices we generate.
 
         The "high" condition index checks from "10" till "30", in this range
-        the matrix is considered to be ill-conditioned but still
+        the matrix is close to multicollinearity and can be considered a
+        little ill-conditioned, going above 30 leads to strong multicollinearity
+        which leads t singularity.
 
     Returns
     -------
@@ -39,12 +51,13 @@ def safety_factor_linalg(
     absolute smallest representable value (only for float dtypes).
     """
     type_casted_matrix = matrix.astype('float64')
-    if condition_index == 'high':
-        if np.linalg.cond(type_casted_matrix) >= 10 and np.linalg.cond(type_casted_matrix) <= 30:
+    if condition_index == "high":
+        assume(round(np.linalg.det(x_i.astype("float64")), 1) != 0.0)
+        if round(np.linalg.cond(type_casted_matrix)) >= 10 and round(np.linalg.cond(type_casted_matrix)) <= 30:
             return True
         else:
             return False
-    if condition_index == 'low':
+    if condition_index == "low":
         if np.linalg.cond(type_casted_matrix) <= 10:
             return True
         else:

--- a/ivy_tests/test_ivy/helpers/hypothesis_helpers/general_helpers.py
+++ b/ivy_tests/test_ivy/helpers/hypothesis_helpers/general_helpers.py
@@ -51,11 +51,6 @@ def safety_factor_linalg(
     A bool, either True or False. Which tells whether the matrix is suitable for
     further numerical computations or not.
     """
-    assert condition_index != "high", \
-        "wrong condition index given, can either be (high) or (low)"
-    assert condition_index != "low", \
-        "wrong condition index given, can either be (high) or (low)"
-
     type_casted_matrix = matrix.astype('float64')
     if condition_index == "high":
         if np.linalg.cond(type_casted_matrix) == float("inf"):

--- a/ivy_tests/test_ivy/helpers/hypothesis_helpers/general_helpers.py
+++ b/ivy_tests/test_ivy/helpers/hypothesis_helpers/general_helpers.py
@@ -4,7 +4,51 @@ import math
 
 # local
 import ivy
+import numpy as np
 from . import array_helpers, number_helpers, dtype_helpers
+
+
+def safety_factor_linalg(
+    matrix,
+    *,
+    condition_index='high',
+):
+    """
+    Applies safety factor to the condition of a matrix to avoid numerical instabilities in further calculations.
+
+    Parameters
+    ----------
+    matrix
+        The original matrix whose condition number is to be determined.
+    condition_index
+        There is no rule of thumb for what the exact condition number
+        should be to consider a matrix ill-conditioned(prone to numerical errors).
+        If the condition number is "1", the matrix is perfectly said to be a
+        well-conditioned matrix which will not be prone to any numerical zzinstabilities in further
+        calculations, but that would probably be a very simple matrix.
+
+        The "low" condition index checks from "1" till "10" as a matrix can
+        be considered well-condition in this range.
+
+        The "high" condition index checks from "10" till "30", in this range
+        the matrix is considered to be ill-conditioned but still
+
+    Returns
+    -------
+    the result of applying safety scaling to minimum value, maximum value and
+    absolute smallest representable value (only for float dtypes).
+    """
+    type_casted_matrix = matrix.astype('float64')
+    if condition_index == 'high':
+        if np.linalg.cond(type_casted_matrix) >= 10 and np.linalg.cond(type_casted_matrix) <= 30:
+            return True
+        else:
+            return False
+    if condition_index == 'low':
+        if np.linalg.cond(type_casted_matrix) <= 10:
+            return True
+        else:
+            return False
 
 
 def apply_safety_factor(

--- a/ivy_tests/test_ivy/helpers/hypothesis_helpers/general_helpers.py
+++ b/ivy_tests/test_ivy/helpers/hypothesis_helpers/general_helpers.py
@@ -14,26 +14,27 @@ def safety_factor_linalg(
     condition_index="high",
 ):
     """
-    Applies safety factor to the condition of a matrix to avoid numerical instabilities in further calculations.
+    Applies safety factor to the condition of a matrix to avoid numerical
+    instabilities in further calculations.
 
     Parameters
     ----------
     matrix
         The original matrix whose condition number is to be determined.
     condition_index
-        When a condition_index of "high" is used we are testing for a little
-        ill-conditioned matrices which are not too much prone to numerical
+        When a condition_index of "high" is used we are testing for a less
+        ill-conditioned matrix which is not too much prone to numerical
         instabilities.
 
-        When a condition_index of "low" is used we are testing for a little
+        When a condition_index of "low" is used we are testing for a
         well-conditioned matrices.
 
         There is no rule of thumb for what the exact condition number
         should be to consider a matrix ill-conditioned(prone to numerical errors).
         If the condition number is "1", the matrix is perfectly said to be a
-        well-conditioned matrix which will not be prone to any numerical
-        instabilities in further calculations, but that would probably be a very
-        simple matrix.
+        well-conditioned matrix which will not be prone to any numerical type
+        of instabilities in further calculations, but that would probably be a
+        very simple matrix.
 
         The "low" condition index checks from "1" till "10" as a matrix can
         be considered well-condition in this range. This should be used for
@@ -43,17 +44,20 @@ def safety_factor_linalg(
         The "high" condition index checks from "10" till "30", in this range
         the matrix is close to multicollinearity and can be considered a
         little ill-conditioned, going above 30 leads to strong multicollinearity
-        which leads t singularity.
+        which leads to singularity.
 
     Returns
     -------
-    the result of applying safety scaling to minimum value, maximum value and
-    absolute smallest representable value (only for float dtypes).
+    A bool, either True or False. Which tells whether the matrix is suitable for
+    further numerical computations or not.
     """
+    assert condition_index != "high", "wrong condition index given, can either be (high) or (low)"
+    assert condition_index != "low", "wrong condition index given, can either be (high) or (low)"
+
     type_casted_matrix = matrix.astype('float64')
     if condition_index == "high":
-        assume(round(np.linalg.det(x_i.astype("float64")), 1) != 0.0)
-        if round(np.linalg.cond(type_casted_matrix)) >= 10 and round(np.linalg.cond(type_casted_matrix)) <= 30:
+        if round(np.linalg.cond(type_casted_matrix)) >= 10 and \
+                round(np.linalg.cond(type_casted_matrix)) <= 30:
             return True
         else:
             return False

--- a/ivy_tests/test_ivy/helpers/hypothesis_helpers/general_helpers.py
+++ b/ivy_tests/test_ivy/helpers/hypothesis_helpers/general_helpers.py
@@ -58,13 +58,17 @@ def safety_factor_linalg(
 
     type_casted_matrix = matrix.astype('float64')
     if condition_index == "high":
-        if round(np.linalg.cond(type_casted_matrix)) >= 10 and \
+        if np.linalg.cond(type_casted_matrix) == float("inf"):
+            return False
+        elif round(np.linalg.cond(type_casted_matrix)) >= 10 and \
                 round(np.linalg.cond(type_casted_matrix)) <= 30:
             return True
         else:
             return False
     if condition_index == "low":
-        if round(np.linalg.cond(type_casted_matrix)) <= 10:
+        if np.linalg.cond(type_casted_matrix) == float("inf"):
+            return False
+        elif round(np.linalg.cond(type_casted_matrix)) <= 10:
             return True
         else:
             return False


### PR DESCRIPTION
We still have to use `assume()` in the tests, there is no other way around where we can generate a numerically stable matrix(well-conditioned). The `condition` number of the matrix is checked and then the matrix is re-generated if the `condition` number is high. 
There is one other way around, we can make that matrix a little well-conditioned from ill-conditioned, reducing it's condition number, but that would be by something known as diagonal scaling, it would be numerically expensive and the original matrix would also be changed as well, it still doesn't make sure that to what extent it would be reducing the numerical instabilities.
The best approach would be to re-generate the matrix if the condition number is high as it leads to singularity.
Do let me know if this solution doesn't seem suitable.
 