### PR TITLE
add additional information to data promotion chapter

### DIFF
--- a/docs/partial_source/deep_dive/data_types.rst
+++ b/docs/partial_source/deep_dive/data_types.rst
@@ -134,7 +134,7 @@ return new type promoted values, respectively.
 For an example of how some of these functions are used,
 the implementations for :func:`ivy.add` in each backend framework are as follows:
 
-# JAX
+JAX:
 
 .. code-block:: python
 
@@ -148,7 +148,7 @@ the implementations for :func:`ivy.add` in each backend framework are as follows
         x1, x2 = ivy.promote_types_of_inputs(x1, x2)
         return jnp.add(x1, x2)
 
-# NumPy
+NumPy:
 
 .. code-block:: python
 
@@ -163,7 +163,7 @@ the implementations for :func:`ivy.add` in each backend framework are as follows
         x1, x2 = ivy.promote_types_of_inputs(x1, x2)
         return np.add(x1, x2, out=out)
 
-# TensorFlow
+TensorFlow:
 
 .. code-block:: python
 
@@ -177,7 +177,7 @@ the implementations for :func:`ivy.add` in each backend framework are as follows
         x1, x2 = ivy.promote_types_of_inputs(x1, x2)
         return tf.experimental.numpy.add(x1, x2)
 
-# PyTorch
+PyTorch:
 
 .. code-block:: python
 
@@ -203,6 +203,22 @@ data types should be promoted, and their own type promoting functions
 in :mod:`ivy/functional/frontends/frontend_name/__init__.py`.
 We should always use these functions in any frontend implementation,
 to ensure we follow exactly the same promotion rules as the frontend framework uses.
+
+It should be noted that data type promotion is only used for unifying data types of inputs
+to a common one for performing various operations.
+Examples shown above demonstrate the usage of ``add`` operation.
+As different data types cannot be simply summed, they are promoted to a least common type,
+according to the presented promotion table.
+This ensures that functions always return specific and expected values,
+independently of the specified backend.
+
+However, data promotion is never used for increasing the accuracy or precision of the computations.
+For example, if two ``float32`` values are divided, the produced result will still be a ``float32``,
+even though the result's precision can be improved by promoting it to a ``float64``.
+Therefore, Ivy does not upcast specific values to improve the stability or precision of the computation.
+User expects a specific behavior and memory constraints whenever they specify and use concrete data types,
+and those decisions should be respcted.
+
 
 Arguments in other Functions
 ----------------------------

--- a/docs/partial_source/deep_dive/data_types.rst
+++ b/docs/partial_source/deep_dive/data_types.rst
@@ -205,27 +205,27 @@ We should always use these functions in any frontend implementation,
 to ensure we follow exactly the same promotion rules as the frontend framework uses.
 
 It should be noted that data type promotion is only used for unifying data types of inputs
-to a common one for performing various mathemtaical operations.
-Examples shown above demonstrate the usage of ``add`` operation.
-As different data types cannot be simply summed, they are promoted to a least common type,
+to a common one for performing various mathematical operations.
+Examples shown above demonstrate the usage of the ``add`` operation.
+As different data types cannot be simply summed, they are promoted to the least common type,
 according to the presented promotion table.
 This ensures that functions always return specific and expected values,
 independently of the specified backend.
 
 However, data promotion is never used for increasing the accuracy or precision of computations.
-This is a required condition for all operations, even if the upcasting can help to avoid numerical instabilites casused by
+This is a required condition for all operations, even if the upcasting can help to avoid numerical instabilities caused by
 underflow or overflow.
 
 Assume that an algorithm is required to compute an inverse of a nearly singular matrix, that is defined in
 ``float32`` data type. 
 It is likely that this operation can produce numerical instabilities and generate ``inf`` or ``nan`` values.
 Temporary upcasting the input matrix to ``float64`` for computing an inverse and then downcasting the matrix
-back to ``float32`` may help to produce stable result.
-However, the temporary upcasting and subsequnet downcasting can not performed as this is not expected by the user.
-Whenever the user defines a data with specific data type, they expect a certain memory footprint.
+back to ``float32`` may help to produce a stable result.
+However, temporary upcasting and subsequent downcasting can not be performed as this is not expected by the user.
+Whenever the user defines data with a specific data type, they expect a certain memory footprint.
 
-User expects a specific behavior and memory constraints whenever they specify and use concrete data types,
-and those decisions should be respcted.
+The user expects a specific behaviour and memory constraints whenever they specify and use concrete data types,
+and those decisions should be respected.
 Therefore, Ivy does not upcast specific values to improve the stability or precision of the computation.
 
 

--- a/docs/partial_source/deep_dive/data_types.rst
+++ b/docs/partial_source/deep_dive/data_types.rst
@@ -224,7 +224,7 @@ back to ``float32`` may help to produce a stable result.
 However, temporary upcasting and subsequent downcasting can not be performed as this is not expected by the user.
 Whenever the user defines data with a specific data type, they expect a certain memory footprint.
 
-The user expects a specific behaviour and memory constraints whenever they specify and use concrete data types,
+The user expects specific behaviour and memory constraints whenever they specify and use concrete data types,
 and those decisions should be respected.
 Therefore, Ivy does not upcast specific values to improve the stability or precision of the computation.
 

--- a/docs/partial_source/deep_dive/data_types.rst
+++ b/docs/partial_source/deep_dive/data_types.rst
@@ -205,19 +205,28 @@ We should always use these functions in any frontend implementation,
 to ensure we follow exactly the same promotion rules as the frontend framework uses.
 
 It should be noted that data type promotion is only used for unifying data types of inputs
-to a common one for performing various operations.
+to a common one for performing various mathemtaical operations.
 Examples shown above demonstrate the usage of ``add`` operation.
 As different data types cannot be simply summed, they are promoted to a least common type,
 according to the presented promotion table.
 This ensures that functions always return specific and expected values,
 independently of the specified backend.
 
-However, data promotion is never used for increasing the accuracy or precision of the computations.
-For example, if two ``float32`` values are divided, the produced result will still be a ``float32``,
-even though the result's precision can be improved by promoting it to a ``float64``.
-Therefore, Ivy does not upcast specific values to improve the stability or precision of the computation.
+However, data promotion is never used for increasing the accuracy or precision of computations.
+This is a required condition for all operations, even if the upcasting can help to avoid numerical instabilites casused by
+underflow or overflow.
+
+Assume that an algorithm is required to compute an inverse of a nearly singular matrix, that is defined in
+``float32`` data type. 
+It is likely that this operation can produce numerical instabilities and generate ``inf`` or ``nan`` values.
+Temporary upcasting the input matrix to ``float64`` for computing an inverse and then downcasting the matrix
+back to ``float32`` may help to produce stable result.
+However, the temporary upcasting and subsequnet downcasting can not performed as this is not expected by the user.
+Whenever the user defines a data with specific data type, they expect a certain memory footprint.
+
 User expects a specific behavior and memory constraints whenever they specify and use concrete data types,
 and those decisions should be respcted.
+Therefore, Ivy does not upcast specific values to improve the stability or precision of the computation.
 
 
 Arguments in other Functions


### PR DESCRIPTION
Adds explanations to the data promotion chapter to clarify that type upcasting is not to be used for improving accuracy and precision.