### PR TITLE
fix `KeyError: 'NamedTuple'`

### DIFF
--- a/ivy/func_wrapper.py
+++ b/ivy/func_wrapper.py
@@ -445,7 +445,7 @@ def _wrap_function(key: str, to_wrap: Callable, original: Callable) -> Callable:
         for linalg_k, linalg_v in to_wrap.__dict__.items():
             if (
                 isinstance(linalg_v, FunctionType)
-                and linalg_k != "namedtuple"
+                and linalg_k.lower() != "namedtuple"
                 and linalg_k != "with_unsupported_dtypes"
                 and not linalg_k.startswith("_")
             ):


### PR DESCRIPTION
This fixes the [following bug](https://github.com/unifyai/ivy/issues/4500#issuecomment-1288535900):

```
import ivy
ivy.set_backend("tensorflow")
```
