### PR TITLE
dirichlet extension

### DIFF
--- a/ivy/array/extensions/random.py
+++ b/ivy/array/extensions/random.py
@@ -45,11 +45,11 @@ class ArrayWithRandomExtensions(abc.ABC):
         Examples
         --------
         >>> alpha = ivy.array([1.0, 2.0, 3.0])
-        >>> ivy.dirichlet(alpha)
+        >>> alpha.dirichlet()
         ivy.array([0.10598304, 0.21537054, 0.67864642])
 
         >>> alpha = ivy.array([1.0, 2.0, 3.0])
-        >>> ivy.dirichlet(alpha, size = (2,3))
+        >>> alpha.dirichlet(size = (2,3))
         ivy.array([[[0.48006698, 0.07472073, 0.44521229],
             [0.55479872, 0.05426367, 0.39093761],
             [0.19531053, 0.51675832, 0.28793114]],

--- a/ivy/array/extensions/random.py
+++ b/ivy/array/extensions/random.py
@@ -1,6 +1,61 @@
 # global
 import abc
+from typing import Optional, Union
+
+# local
+import ivy
 
 
 class ArrayWithRandomExtensions(abc.ABC):
-    pass
+    # dirichlet
+    def dirichlet(
+        self: ivy.Array,
+        /,
+        *,
+        size: Optional[Union[ivy.Shape, ivy.NativeShape]] = None,
+        dtype: Optional[Union[ivy.Dtype, ivy.NativeDtype]] = None,
+        seed: Optional[int] = None,
+        out: Optional[ivy.Array] = None,
+    ) -> ivy.Array:
+        """ivy.Array instance method variant of ivy.dirichlet. This method simply
+        wraps the function, and so the docstring for ivy.shuffle also applies to
+        this method with minimal changes.
+
+        Parameters
+        ----------
+        alpha
+            Sequence of floats of length k
+        size
+            optional int or tuple of ints, Output shape. If the given shape is,
+            e.g., (m, n), then m * n * k samples are drawn. Default is None,
+            in which case a vector of length k is returned.
+        dtype
+            output array data type. If ``dtype`` is ``None``, the output array data
+            type will be the default floating-point data type. Default ``None``
+        seed
+            A python integer. Used to create a random seed distribution
+        out
+            optional output array, for writing the result to.
+
+        Returns
+        -------
+        ret
+            The drawn samples, of shape (size, k).
+
+        Examples
+        --------
+        >>> alpha = ivy.array([1.0, 2.0, 3.0])
+        >>> ivy.dirichlet(alpha)
+        ivy.array([0.10598304, 0.21537054, 0.67864642])
+
+        >>> alpha = ivy.array([1.0, 2.0, 3.0])
+        >>> ivy.dirichlet(alpha, size = (2,3))
+        ivy.array([[[0.48006698, 0.07472073, 0.44521229],
+            [0.55479872, 0.05426367, 0.39093761],
+            [0.19531053, 0.51675832, 0.28793114]],
+
+        [[0.12315625, 0.29823365, 0.5786101 ],
+            [0.15564976, 0.50542368, 0.33892656],
+            [0.1325352 , 0.44439589, 0.42306891]]])
+        """
+        return ivy.dirichlet(self, size=size, dtype=dtype, seed=seed, out=out)

--- a/ivy/container/extensions/random.py
+++ b/ivy/container/extensions/random.py
@@ -1,5 +1,141 @@
+# global
+from typing import Optional, Union, List, Dict
+
+# local
+import ivy
 from ivy.container.base import ContainerBase
 
 
 class ContainerWithRandomExtensions(ContainerBase):
-    pass
+    # dirichlet
+    @staticmethod
+    def static_dirichlet(
+        alpha: ivy.Container,
+        /,
+        *,
+        key_chains: Optional[Union[List[str], Dict[str, str]]] = None,
+        to_apply: bool = True,
+        prune_unapplied: bool = False,
+        map_sequences: bool = False,
+        size: Optional[Union[ivy.Shape, ivy.NativeShape, ivy.Container]] = None,
+        dtype: Optional[Union[ivy.Dtype, ivy.NativeDtype]] = None,
+        seed: Optional[int] = None,
+        out: Optional[ivy.Container] = None,
+    ) -> ivy.Container:
+        """ivy.Container static method variant of ivy.dirichlet. This method
+        simply wraps the function, and so the docstring for ivy.dirichlet also
+        applies to this method with minimal changes.
+
+        Parameters
+        ----------
+        alpha
+            Sequence of floats of length k 
+        size
+            optional container including ints or tuple of ints, 
+            Output shape for the arrays in the input container. 
+        dtype
+            output container array data type. If ``dtype`` is ``None``, the output data
+            type will be the default floating-point data type. Default ``None``
+        seed
+            A python integer. Used to create a random seed distribution
+        out
+            optional output container, for writing the result to.
+
+        Returns
+        -------
+        ret
+            container including the drawn samples.
+
+        Examples
+        --------
+        >>> alpha = ivy.Container(a=ivy.array([7,6,5]), \
+                                  b=ivy.array([8,9,4]))
+        >>> size = ivy.Container(a=3, b=5)
+        >>> ivy.Container.static_dirichlet(alpha, size)
+        {
+            a: ivy.array(
+                [[0.43643127, 0.32325703, 0.24031169],
+                 [0.34251311, 0.31692529, 0.3405616 ],
+                 [0.5319725 , 0.22458365, 0.24344385]]
+                ),
+            b: ivy.array(
+                [[0.26588406, 0.61075421, 0.12336174],
+                 [0.51142915, 0.25041268, 0.23815817],
+                 [0.64042903, 0.25763214, 0.10193883],
+                 [0.31624692, 0.46567987, 0.21807321],
+                 [0.37677699, 0.39914594, 0.22407707]]
+                )
+        }
+        """
+        return ContainerBase.multi_map_in_static_method(
+            "dirichlet",
+            alpha,
+            key_chains=key_chains,
+            to_apply=to_apply,
+            prune_unapplied=prune_unapplied,
+            map_sequences=map_sequences,
+            size=size,
+            dtype=dtype,
+            out=out,
+        )
+
+    def dirichlet(
+        self: ivy.Container,
+        /,
+        *,
+        size: Optional[Union[ivy.Shape, ivy.NativeShape, ivy.Container]] = None,
+        dtype: Optional[Union[ivy.Dtype, ivy.NativeDtype, ivy.Container]] = None,
+        seed: Optional[int] = None,
+        out: Optional[ivy.Container] = None,
+    ) -> ivy.Container:
+        """ivy.Container instance method variant of ivy.dirichlet. This method
+        simply wraps the function, and so the docstring for ivy.shuffle also
+        applies to this method with minimal changes.
+
+        Parameters
+        ----------
+        self
+            Sequence of floats of length k 
+        size
+            optional container including ints or tuple of ints, 
+            Output shape for the arrays in the input container. 
+        dtype
+            output container array data type. If ``dtype`` is ``None``, the output data
+            type will be the default floating-point data type. Default ``None``
+        seed
+            A python integer. Used to create a random seed distribution
+        out
+            optional output container, for writing the result to.
+
+        Returns
+        -------
+        ret
+            container including the drawn samples.
+
+        Examples
+        --------
+        >>> alpha = ivy.Container(a=ivy.array([7,6,5]), \
+                                  b=ivy.array([8,9,4]))
+        >>> size = ivy.Container(a=3, b=5)
+        >>> alpha.dirichlet(size)
+        {
+            a: ivy.array(
+                [[0.43643127, 0.32325703, 0.24031169],
+                 [0.34251311, 0.31692529, 0.3405616 ],
+                 [0.5319725 , 0.22458365, 0.24344385]]
+                ),
+            b: ivy.array(
+                [[0.26588406, 0.61075421, 0.12336174],
+                 [0.51142915, 0.25041268, 0.23815817],
+                 [0.64042903, 0.25763214, 0.10193883],
+                 [0.31624692, 0.46567987, 0.21807321],
+                 [0.37677699, 0.39914594, 0.22407707]]
+                )
+        }
+        """
+        return self.static_dirichlet(
+            self,
+            size=size,
+            dtype=dtype,
+            out=out,
+        )

--- a/ivy/functional/backends/jax/extensions/random.py
+++ b/ivy/functional/backends/jax/extensions/random.py
@@ -1,0 +1,45 @@
+from typing import Optional, Union, Sequence
+from ivy.functional.backends.jax import JaxArray
+import jax.numpy as jnp
+import jax
+import ivy
+
+# Extra #
+# ------#
+
+
+class RNGWrapper:
+    def __init__(self):
+        self.key = jax.random.PRNGKey(0)
+
+
+RNG = RNGWrapper()
+
+
+def _setRNG(key):
+    global RNG
+    RNG.key = key
+
+
+def _getRNG():
+    global RNG
+    return RNG.key
+
+
+# dirichlet
+def dirichlet(
+    alpha: Union[JaxArray, float, Sequence[float]],
+    /,
+    *,
+    size: Optional[Union[ivy.NativeShape, Sequence[int]]] = None,
+    dtype: Optional[jnp.dtype] = None,
+    seed: Optional[int] = None,
+    out: Optional[JaxArray] = None,
+) -> JaxArray:
+    RNG, rng_input = jax.random.split(_getRNG())
+    if seed is not None:
+        rng_input = jax.random.PRNGKey(seed)
+    else:
+        RNG_, rng_input = jax.random.split(_getRNG())
+        _setRNG(RNG_)
+    return jax.random.dirichlet(rng_input, alpha, shape=size, dtype=dtype)

--- a/ivy/functional/backends/numpy/extensions/random.py
+++ b/ivy/functional/backends/numpy/extensions/random.py
@@ -13,8 +13,8 @@ def dirichlet(
     seed: Optional[int] = None,
     out: Optional[np.ndarray] = None,
 ) -> np.ndarray:
-    size = size if not None else len(alpha)
-    dtype = dtype if not None else np.float64
+    size = size if size is not None else len(alpha)
+    dtype = dtype if dtype is not None else np.float64
     if seed is not None:
         np.random.seed(seed)
     return np.asarray(np.random.dirichlet(alpha, size=size), dtype=dtype)

--- a/ivy/functional/backends/numpy/extensions/random.py
+++ b/ivy/functional/backends/numpy/extensions/random.py
@@ -1,0 +1,23 @@
+from typing import Optional, Union, Sequence
+import numpy as np
+import ivy
+
+
+# dirichlet
+def dirichlet(
+    alpha: Union[np.ndarray, float, Sequence[float]],
+    /,
+    *,
+    size: Optional[Union[ivy.NativeShape, Sequence[int]]] = None,
+    dtype: Optional[np.dtype] = None,
+    seed: Optional[int] = None,
+    out: Optional[np.ndarray] = None,
+) -> np.ndarray:
+    size = size if not None else len(alpha)
+    dtype = dtype if not None else np.float64
+    if seed is not None:
+        np.random.seed(seed)
+    return np.asarray(np.random.dirichlet(alpha, size=size), dtype=dtype)
+
+
+dirichlet.support_native_out = False

--- a/ivy/functional/backends/tensorflow/extensions/random.py
+++ b/ivy/functional/backends/tensorflow/extensions/random.py
@@ -21,7 +21,8 @@ def dirichlet(
     seed: Optional[int] = None,
     dtype: Optional[tf.Tensor] = None,
 ) -> Union[tf.Tensor, tf.Variable]:
-    size = size if not None else len(alpha)
+    size = size if size is not None else len(alpha)
+    size = tf.constant(size, dtype=tf.int32)
     if dtype is None:
         dtype = tf.float64
     else:

--- a/ivy/functional/backends/tensorflow/extensions/random.py
+++ b/ivy/functional/backends/tensorflow/extensions/random.py
@@ -22,7 +22,7 @@ def dirichlet(
     dtype: Optional[tf.Tensor] = None,
 ) -> Union[tf.Tensor, tf.Variable]:
     size = size if size is not None else len(alpha)
-    size = tf.constant(size, dtype=tf.int32)
+
     if dtype is None:
         dtype = tf.float64
     else:

--- a/ivy/functional/backends/tensorflow/extensions/random.py
+++ b/ivy/functional/backends/tensorflow/extensions/random.py
@@ -1,0 +1,40 @@
+from typing import Union, Optional, Sequence
+import tensorflow as tf
+import ivy
+from .. import backend_version
+from tensorflow_probability import distributions as tfd
+ 
+# local
+from ivy.func_wrapper import with_unsupported_dtypes
+
+
+# dirichlet
+@with_unsupported_dtypes(
+    {"2.9.1 and below": ("blfoat16", "float16")}, backend_version
+)
+def dirichlet(
+    alpha: Union[tf.Tensor, tf.Variable, float, Sequence[float]],
+    /,
+    *,
+    size: Optional[Union[ivy.NativeShape, Sequence[int]]] = None,
+    out: Optional[Union[tf.Tensor, tf.Variable]] = None,
+    seed: Optional[int] = None,
+    dtype: Optional[tf.Tensor] = None,
+) -> Union[tf.Tensor, tf.Variable]:
+    size = size if not None else len(alpha)
+    if dtype is None:
+        dtype = tf.float64
+    else:
+        dtype = dtype
+    if seed is not None:
+        tf.random.set_seed(seed)
+    return tf.cast(
+        tfd.Dirichlet(
+            concentration=alpha,
+            validate_args=False,
+            allow_nan_stats=True,
+            force_probs_to_zero_outside_support=False,
+            name="Dirichlet",
+        ).sample(size),
+        dtype=dtype,
+    )

--- a/ivy/functional/backends/torch/extensions/random.py
+++ b/ivy/functional/backends/torch/extensions/random.py
@@ -19,9 +19,9 @@ def dirichlet(
     seed: Optional[int] = None,
     dtype: Optional[torch.dtype] = None,
 ) -> torch.Tensor:
-    size = size if not None else len(alpha)
+    size = size if size is not None else len(alpha)
     if seed is not None:
         torch.manual_seed(seed)
-    return torch.Tensor(
-        torch.distributions.dirichlet.Dirichlet(alpha).sample(size), dtype=dtype
+    return torch.tensor(
+        torch.distributions.dirichlet.Dirichlet(alpha).rsample(sample_shape=size), dtype=dtype
     )

--- a/ivy/functional/backends/torch/extensions/random.py
+++ b/ivy/functional/backends/torch/extensions/random.py
@@ -23,5 +23,6 @@ def dirichlet(
     if seed is not None:
         torch.manual_seed(seed)
     return torch.tensor(
-        torch.distributions.dirichlet.Dirichlet(alpha).rsample(sample_shape=size), dtype=dtype
+        torch.distributions.dirichlet.Dirichlet(alpha).rsample(sample_shape=size),
+        dtype=dtype
     )

--- a/ivy/functional/backends/torch/extensions/random.py
+++ b/ivy/functional/backends/torch/extensions/random.py
@@ -1,0 +1,27 @@
+# global
+from typing import Optional, Union, Sequence
+import torch
+import ivy
+
+# local
+from ivy.func_wrapper import with_unsupported_dtypes
+from .. import backend_version
+
+
+# dirichlet
+@with_unsupported_dtypes({"1.11.0 and below": ("float16",)}, backend_version)
+def dirichlet(
+    alpha: Union[torch.tensor, float, Sequence[float]],
+    /,
+    *,
+    size: Optional[Union[ivy.NativeShape, Sequence[int]]] = None,
+    out: Optional[torch.Tensor] = None,
+    seed: Optional[int] = None,
+    dtype: Optional[torch.dtype] = None,
+) -> torch.Tensor:
+    size = size if not None else len(alpha)
+    if seed is not None:
+        torch.manual_seed(seed)
+    return torch.Tensor(
+        torch.distributions.dirichlet.Dirichlet(alpha).sample(size), dtype=dtype
+    )

--- a/ivy/functional/extensions/random.py
+++ b/ivy/functional/extensions/random.py
@@ -1,0 +1,75 @@
+# local
+from typing import Optional, Union, Sequence
+import ivy
+from ivy.func_wrapper import (
+    handle_out_argument,
+    to_native_arrays_and_back,
+    handle_nestable,
+)
+from ivy.exceptions import handle_exceptions
+
+
+# dirichlet
+@to_native_arrays_and_back
+@handle_out_argument
+@handle_nestable
+@handle_exceptions
+def dirichlet(
+    alpha: Union[ivy.Array, ivy.NativeArray, float, Sequence[float]],
+    /,
+    *,
+    size: Optional[Union[ivy.Shape, ivy.NativeShape]] = None,
+    dtype: Optional[Union[ivy.Dtype, ivy.NativeDtype]] = None,
+    seed: Optional[int] = None,
+    out: Optional[ivy.Array] = None,
+) -> ivy.Array:
+    """Draw size samples of dimension k from a Dirichlet distribution.
+    A Dirichlet-distributed random variable can be seen as a multivariate
+    generalization of a Beta distribution. The Dirichlet distribution is
+    a conjugate prior of a multinomial distribution in Bayesian inference.
+
+    Parameters
+    ----------
+    alpha
+        Sequence of floats of length k
+    size
+        optional int or tuple of ints, Output shape. If the given shape is,
+        e.g., (m, n), then m * n * k samples are drawn. Default is None,
+        in which case a vector of length k is returned.
+    dtype
+        output array data type. If ``dtype`` is ``None``, the output array data
+        type will be the default floating-point data type. Default ``None``
+    seed
+        A python integer. Used to create a random seed distribution
+    out
+        optional output array, for writing the result to.
+
+    Returns
+    -------
+    ret
+        The drawn samples, of shape (size, k).
+
+    Functional Examples
+    -------------------
+
+    >>> alpha = [1.0, 2.0, 3.0]
+    >>> ivy.dirichlet(alpha)
+    ivy.array([0.10598304, 0.21537054, 0.67864642])
+
+    >>> alpha = [1.0, 2.0, 3.0]
+    >>> ivy.dirichlet(alpha, size = (2,3))
+    ivy.array([[[0.48006698, 0.07472073, 0.44521229],
+        [0.55479872, 0.05426367, 0.39093761],
+        [0.19531053, 0.51675832, 0.28793114]],
+
+       [[0.12315625, 0.29823365, 0.5786101 ],
+        [0.15564976, 0.50542368, 0.33892656],
+        [0.1325352 , 0.44439589, 0.42306891]]])
+    """
+    return ivy.current_backend().dirichlet(
+        alpha,
+        size=size,
+        dtype=dtype,
+        seed=seed,
+        out=out,
+    )

--- a/ivy_tests/test_ivy/test_functional/test_extensions/test_core/test_random.py
+++ b/ivy_tests/test_ivy/test_functional/test_extensions/test_core/test_random.py
@@ -16,7 +16,7 @@ import numpy as np
 @handle_cmd_line_args
 @given(
     dtype_and_alpha=helpers.dtype_and_values(
-        available_dtypes=helpers.get_dtypes("float", index=1),
+        available_dtypes=helpers.get_dtypes("float", index=2),
         shape=st.tuples(
             st.integers(min_value=2, max_value=5),
         ),

--- a/ivy_tests/test_ivy/test_functional/test_extensions/test_core/test_random.py
+++ b/ivy_tests/test_ivy/test_functional/test_extensions/test_core/test_random.py
@@ -68,6 +68,7 @@ def test_dirichlet(
     ret = helpers.flatten_and_to_np(ret=ret)
     ret_gt = helpers.flatten_and_to_np(ret=ret_gt)
     for (u, v) in zip(ret, ret_gt):
+        u, v = ivy.array(u), ivy.array(v)
         assert ivy.all(ivy.sum(u, axis=-1) == ivy.sum(v, axis=-1))
         assert ivy.all(u >= 0) and ivy.all(u <= 1)
         assert ivy.all(v >= 0) and ivy.all(v <= 1)

--- a/ivy_tests/test_ivy/test_functional/test_extensions/test_core/test_random.py
+++ b/ivy_tests/test_ivy/test_functional/test_extensions/test_core/test_random.py
@@ -1,0 +1,73 @@
+# global
+from hypothesis import given, strategies as st
+
+# local
+import ivy_tests.test_ivy.helpers as helpers
+from ivy_tests.test_ivy.helpers import handle_cmd_line_args
+import ivy
+import numpy as np
+
+
+# Helpers #
+# ------- #
+
+
+# dirichlet
+@handle_cmd_line_args
+@given(
+    dtype_and_alpha=helpers.dtype_and_values(
+        available_dtypes=helpers.get_dtypes("float", index=1),
+        shape=st.tuples(
+            st.integers(min_value=2, max_value=5),
+        ),
+        min_value=0,
+        max_value=100,
+        exclude_min=True,
+    ),
+    size=st.tuples(
+        st.integers(min_value=2, max_value=5), st.integers(min_value=2, max_value=5)
+    ),
+    seed=helpers.ints(min_value=0, max_value=100),
+    num_positional_args=helpers.num_positional_args(fn_name="dirichlet"),
+)
+def test_dirichlet(
+    dtype_and_alpha,
+    size,
+    seed,
+    with_out,
+    as_variable,
+    num_positional_args,
+    native_array,
+    container,
+    instance_method,
+    fw,
+):
+    dtype, alpha = dtype_and_alpha
+
+    def call():
+        return helpers.test_function(
+            input_dtypes=dtype,
+            as_variable_flags=as_variable,
+            with_out=with_out,
+            num_positional_args=num_positional_args,
+            native_array_flags=native_array,
+            container_flags=container,
+            instance_method=instance_method,
+            test_values=False,
+            fw=fw,
+            fn_name="dirichlet",
+            alpha=np.asarray(alpha[0], dtype=dtype[0]),
+            size=size,
+            seed=seed,
+        )
+
+    ret, ret_gt = call()
+    if seed:
+        ret1, ret_gt1 = call()
+        assert ivy.any(ret == ret1)
+    ret = helpers.flatten_and_to_np(ret=ret)
+    ret_gt = helpers.flatten_and_to_np(ret=ret_gt)
+    for (u, v) in zip(ret, ret_gt):
+        assert ivy.all(ivy.sum(u, axis=-1) == ivy.sum(v, axis=-1))
+        assert ivy.all(u >= 0) and ivy.all(u <= 1)
+        assert ivy.all(v >= 0) and ivy.all(v <= 1)


### PR DESCRIPTION
Throws the following error for all back-ends except numpy: 

`>       ret, ret_gt = call()`
`E       TypeError: cannot unpack non-iterable NoneType object`