### PR TITLE
Partial Solution

### DIFF
--- a/ivy/functional/backends/jax/statistical.py
+++ b/ivy/functional/backends/jax/statistical.py
@@ -210,3 +210,12 @@ def einsum(
     equation: str, *operands: JaxArray, out: Optional[JaxArray] = None
 ) -> JaxArray:
     return jnp.einsum(equation, *operands)
+
+
+def unravel_index(
+        indices: jnp.dtype,
+        shape: jnp.dtype,
+        /,
+        *,
+) -> jnp.dtype:
+    return jnp.asarray(jnp.unravel_index(indices, shape))

--- a/ivy/functional/backends/numpy/statistical.py
+++ b/ivy/functional/backends/numpy/statistical.py
@@ -236,3 +236,18 @@ def einsum(
 
 
 einsum.support_native_out = True
+
+def unravel_index(
+    indices: np.ndarray,
+    shape: np.ndarray,
+    /,
+    *,
+) -> np.ndarray:
+    max_value = np.prod(shape)
+    for i in range(len(indices)):
+        if indices[i] > max_value:
+            indices[i] = max_value
+
+        # TODO if negative value in indices
+
+    return np.asarray(np.unravel_index(indices, shape))

--- a/ivy/functional/backends/tensorflow/statistical.py
+++ b/ivy/functional/backends/tensorflow/statistical.py
@@ -197,3 +197,12 @@ def einsum(
     dtype = _get_promoted_type_of_operands(operands)
     operands = (tf.cast(operand, tf.float32) for operand in operands)
     return tf.cast(tf.einsum(equation, *operands), dtype)
+
+
+def unravel_index(
+        indices: tf.Tensor,
+        shape: tf.Tensor,
+        /,
+        *,
+) -> tf.Tensor:
+    return tf.cast(tf.unravel_index(indices, shape))

--- a/ivy/functional/backends/torch/statistical.py
+++ b/ivy/functional/backends/torch/statistical.py
@@ -296,3 +296,21 @@ def einsum(
     dtype = _get_promoted_type_of_operands(operands)
     operands = (operand.to(torch.float32) for operand in operands)
     return torch.einsum(equation, *operands).to(dtype)
+
+def unravel_index(
+        indices: torch.Tensor,
+        shape: torch.Tensor,
+        /,
+        *,
+) -> torch.Tensor:
+    if indices.shape == torch.Size([1]):
+        max_value = torch.prod(shape)
+        if indices > max_value: # clip output to valid range
+            return torch.Tensor(shape)
+        output = []
+        for dim in reversed(shape):
+            output.append(indices % dim)
+            indices = indices // dim
+        return torch.Tensor(reversed(output))
+    else:
+        return torch.Tensor([torch.unravel_index(index) for index in indices])

--- a/ivy/functional/extensions/statistical.py
+++ b/ivy/functional/extensions/statistical.py
@@ -53,3 +53,13 @@ def median(
     ivy.array([6.5, 4.5, 2.5])
     """
     return ivy.current_backend().median(input, axis=axis, keepdims=keepdims, out=out)
+
+def unravel_index(
+    indices: ivy.Array,
+    shape: ivy.Array,
+    /,
+    *,
+    order: Optional[str]='C'
+) -> ivy.Array:
+
+    return ivy.current_backend().unravel_index(indices, shape)


### PR DESCRIPTION
Hello,

I have committed a partial solution that I have not tested yet but just wanted to clarify a few things beforehand. I am working on the unravel_index function and wanted to make sure I understood what needs to be done / confirm below observations are correct.

1. NumPy takes arguments: indices, shape, and optional order. JAX and TensorFlow take indices, shape arguments. Torch has no implementation. Order will not be part of the superset argument since it is under the hood non mathematical stuff?
2. Torch has no implementation and therefore needs to be implemented from scatch without use of any NumPy (or other framework) functions?
3. JAX allows indices inputs that can either be negative or out-of-bounds (and corresponding returned value should be clipped). Therefore, the NumPy, Torch and TF implementations need to be adjusted to also allow such inputs?

Thank you for your time.