### PR TITLE
adding `__array_api_version__` attribute

### DIFF
--- a/ivy/array/array.py
+++ b/ivy/array/array.py
@@ -236,10 +236,6 @@ class Array(
     def __array_namespace__(self, api_version=None):
         return ivy
 
-    def __array_api_version__(self):
-        api_version = "2021.12"
-        return api_version
-
     def __repr__(self):
         sig_fig = ivy.array_significant_figures()
         dec_vals = ivy.array_decimal_values()

--- a/ivy/array/array.py
+++ b/ivy/array/array.py
@@ -236,6 +236,9 @@ class Array(
     def __array_namespace__(self, api_version=None):
         return ivy
 
+    def __array_api_version__(self, api_version="2021.12"):
+        return api_version
+
     def __repr__(self):
         sig_fig = ivy.array_significant_figures()
         dec_vals = ivy.array_decimal_values()

--- a/ivy/array/array.py
+++ b/ivy/array/array.py
@@ -236,7 +236,8 @@ class Array(
     def __array_namespace__(self, api_version=None):
         return ivy
 
-    def __array_api_version__(self, api_version="2021.12"):
+    def __array_api_version__(self):
+        api_version = "2021.12"
         return api_version
 
     def __repr__(self):


### PR DESCRIPTION
Addressing issue:
```
hypothesis.errors.InvalidArgument: Array module ivy.functional.backends.numpy has no attribute __array_api_version__, which is required when inferring api_version. If you believe ivy.functional.backends.numpy is indeed an Array API module, try explicitly passing an api_version.
```