### PR TITLE
torch tensors are instantiated using `torch.tensor` not `torch.Tensor`

### DIFF
--- a/ivy/functional/frontends/torch/__init__.py
+++ b/ivy/functional/frontends/torch/__init__.py
@@ -2,7 +2,7 @@
 
 from . import nn
 from . import tensor
-from .tensor import Tensor
+from .tensor import tensor
 from . import blas_and_lapack_ops
 from .blas_and_lapack_ops import *
 from . import comparison_ops


### PR DESCRIPTION
When `torch.Tensor` class is called it creates the same tensor as `torch.empty` function so to have instantiated class we need to call `torch.tensor` which is able to store the data value. 
And from the [Documentation](https://pytorch.org/docs/stable/tensors.html). Tensor objects are instantiated using `torch.tensor`