### PR TITLE
update experimental dashboards and workflows

### DIFF
--- a/.github/workflows/test-ivy-experimental-core.yml
+++ b/.github/workflows/test-ivy-experimental-core.yml
@@ -1,4 +1,4 @@
-name: test-experimental-ivy
+name: test-ivy-experimental-core
 on:
   push:
   pull_request:

--- a/.github/workflows/test-ivy-experimental-core.yml
+++ b/.github/workflows/test-ivy-experimental-core.yml
@@ -1,0 +1,102 @@
+name: test-experimental-ivy
+on:
+  push:
+  pull_request:
+    types: [labeled, opened, synchronize, reopened, review_requested]
+permissions:
+  actions: read
+jobs:
+   run-nightly-tests:
+     if: ${{(github.event_name == 'push') || contains(github.event.pull_request.labels.*.name, 'Exhaustive CI') || contains(github.event.pull_request.labels.*.name, 'Ivy API Experimental')}}
+     strategy:
+       matrix:
+         backends :  [numpy, torch, jax, tensorflow]
+         submodules: [creation, device, dtype, elementwise, general, gradients, linalg,
+                     manipulation, meta, nest, random, searching, set, sorting, statistical,
+                     utility]
+     continue-on-error: true
+     runs-on: ubuntu-latest
+     steps:
+       - name: Checkout 🛎️Ivy
+         uses: actions/checkout@v2
+         with:
+           path: ivy
+           persist-credentials: false
+           submodules: "recursive"
+           fetch-depth: 2
+
+       - name: Download artifact
+         uses: dawidd6/action-download-artifact@v2
+         if: github.event_name == 'pull_request'
+         with:
+           github_token: ${{secrets.GITHUB_TOKEN}}
+           workflow: test-ivy-experimental.yml
+           workflow_conclusion: ""
+           search_artifacts: true
+           name: hypothesis_${{ matrix.backends }}_test_experimental_zip
+           path: |
+             ivy/.hypothesis/
+         continue-on-error: true
+
+       - name: Unzip Hypothesis Examples
+         id: unzip
+         if: github.event_name == 'pull_request'
+         run: |
+           cd ivy/.hypothesis
+           unzip examples.zip
+           rm examples.zip
+         continue-on-error: true
+
+       - name: Create Hypothesis Directory
+         if: github.event_name == 'pull_request'
+         run: |
+           cd ivy
+           mkdir -p .hypothesis
+           cd .hypothesis
+           mkdir -p examples
+         continue-on-error: true
+
+       - name: Run Experimental Test
+         id: tests
+         run: |
+           cd ivy
+           ./run_tests_CLI/test_experimental_core.sh ${{ matrix.backends }} test_${{ matrix.submodules }} ${{ secrets.REDIS_CONNECTION_URL }} ${{ secrets.REDIS_PASSWORD}}
+         continue-on-error: true
+
+       - name: Zip Hypothesis Examples
+         if: github.event_name == 'pull_request'
+         run: |
+           cd ivy/.hypothesis
+           zip -r examples.zip examples
+         continue-on-error: true
+
+       - name: Upload hypothesis
+         uses: actions/upload-artifact@v3
+         if: github.event_name == 'pull_request'
+         with:
+           name: hypothesis_${{ matrix.backends }}_test_${{ matrix.submodules }}_zip
+           path: |
+             ivy/.hypothesis/examples.zip
+         continue-on-error: true
+
+       - name: Install Mongo Python Client
+         if:  github.event_name == 'push' && github.ref == 'refs/heads/master'
+         uses: BSFishy/pip-action@v1
+         with:
+             packages: |
+               pymongo[srv]
+
+       - name: Update Database
+         if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+         env:
+             MONGODB_PASSWORD: ${{ secrets.MONGODB_PASSWORD }}
+         run: |
+             cd ivy/automation_tools/dashboard_automation/
+             python3 update_db.py "$MONGODB_PASSWORD" ${{ github.workflow }} "${{ matrix.backends }}-experimental-${{ matrix.submodules }}" ${{ steps.tests.outcome }} ${{ github.run_id }}
+         continue-on-error: true
+
+
+       - name: Check on failures
+         if: steps.tests.outcome != 'success'
+         run: exit 1
+

--- a/.github/workflows/test-ivy-experimental-core.yml
+++ b/.github/workflows/test-ivy-experimental-core.yml
@@ -1,4 +1,4 @@
-name: test-ivy-experimental-core
+name: test-experimental-core-ivy
 on:
   push:
   pull_request:

--- a/.github/workflows/test-ivy-experimental-nn.yml
+++ b/.github/workflows/test-ivy-experimental-nn.yml
@@ -1,4 +1,4 @@
-name: test-experimental-ivy
+name: test-ivy-experimental-nn
 on:
   push:
   pull_request:

--- a/.github/workflows/test-ivy-experimental-nn.yml
+++ b/.github/workflows/test-ivy-experimental-nn.yml
@@ -1,4 +1,4 @@
-name: test-ivy-experimental-nn
+name: test-experimental-nn-ivy
 on:
   push:
   pull_request:

--- a/.github/workflows/test-ivy-experimental-nn.yml
+++ b/.github/workflows/test-ivy-experimental-nn.yml
@@ -11,6 +11,7 @@ jobs:
      strategy:
        matrix:
          backends :  [numpy, torch, jax, tensorflow]
+         submodules: [activations, layers, losses, norms]
      continue-on-error: true
      runs-on: ubuntu-latest
      steps:
@@ -57,7 +58,7 @@ jobs:
          id: tests
          run: |
            cd ivy
-           docker run --rm --env REDIS_URL=${{secrets.REDIS_CONNECTION_URL}} --env REDIS_PASSWD=${{secrets.REDIS_PASSWORD}} -v "$(pwd)":/ivy -v "$(pwd)"/.hypothesis:/.hypothesis unifyai/ivy:latest python3 -m pytest --backend ${{matrix.backends}} ivy_tests/test_ivy/test_functional/test_experimental --tb=short
+           ./run_tests_CLI/test_experimental_nn.sh ${{ matrix.backends }} test_${{ matrix.submodules }} ${{ secrets.REDIS_CONNECTION_URL }} ${{ secrets.REDIS_PASSWORD}}
          continue-on-error: true
 
        - name: Zip Hypothesis Examples
@@ -89,7 +90,7 @@ jobs:
              MONGODB_PASSWORD: ${{ secrets.MONGODB_PASSWORD }}
          run: |
              cd ivy/automation_tools/dashboard_automation/
-             python3 update_db.py "$MONGODB_PASSWORD" ${{ github.workflow }} "${{ matrix.backends }}-experimental" ${{ steps.tests.outcome }} ${{ github.run_id }}
+             python3 update_db.py "$MONGODB_PASSWORD" ${{ github.workflow }} "${{ matrix.backends }}-experimental-${{ matrix.submodules }}" ${{ steps.tests.outcome }} ${{ github.run_id }}
          continue-on-error: true
 
 

--- a/automation_tools/dashboard_automation/update_db.py
+++ b/automation_tools/dashboard_automation/update_db.py
@@ -12,7 +12,8 @@ test_configs = {
     "test-frontend-numpy-push": ["numpy_frontend", 5],
     "test-frontend-jax-push": ["jax_frontend", 6],
     "test-frontend-torch-push": ["torch_frontend", 7],
-    "test-experimental-ivy": ["experimental", 8],
+    "test-experimental-core-ivy": ["experimental_core", 8],
+    "test-experimental-core-nn": ["experimental_nn", 9],
 }
 result_config = {
     "success": "https://img.shields.io/badge/-success-success",

--- a/run_tests_CLI/test_experimental_core.sh
+++ b/run_tests_CLI/test_experimental_core.sh
@@ -1,0 +1,2 @@
+#!/bin/bash -e
+docker run --rm --env REDIS_URL="$3" --env REDIS_PASSWD="$4" -v "$(pwd)":/ivy -v "$(pwd)"/.hypothesis:/.hypothesis unifyai/ivy:latest python3 -m pytest --backend "$1" ivy_tests/test_ivy/test_functional/test_experimental/test_core/"$2".py --tb=short

--- a/run_tests_CLI/test_experimental_nn.sh
+++ b/run_tests_CLI/test_experimental_nn.sh
@@ -1,0 +1,2 @@
+#!/bin/bash -e
+docker run --rm --env REDIS_URL="$3" --env REDIS_PASSWD="$4" -v "$(pwd)":/ivy -v "$(pwd)"/.hypothesis:/.hypothesis unifyai/ivy:latest python3 -m pytest --backend "$1" ivy_tests/test_ivy/test_functional/test_experimental/test_nn/"$2".py --tb=short


### PR DESCRIPTION
Since we divided the experimental API into multiple submodules and it essentially became a mirror of the functional API, it would make sense to have two separate dashboards and workflows for `experimental-core` and `experimental-nn` , and for the dashboards to have the same appearance as the functional dashboards.