### PR TITLE
pruned func_wrapper traces

### DIFF
--- a/ivy/exceptions.py
+++ b/ivy/exceptions.py
@@ -12,7 +12,7 @@ import traceback as tb
 def _print_new_stack_trace(old_stack_trace):
     print(
         "<func_wrapper.py stack trace is squashed,",
-        "call ivy.set_show_func_wrapper_traces(True) in order to view this>",
+        "call `ivy.set_show_func_wrapper_traces(True)` in order to view this>",
     )
     new_stack_trace = []
     for st in old_stack_trace:

--- a/ivy/exceptions.py
+++ b/ivy/exceptions.py
@@ -10,6 +10,10 @@ import traceback as tb
 
 
 def _print_new_stack_trace(old_stack_trace):
+    print(
+        "<func_wrapper.py stack trace is squashed,",
+        "call ivy.set_show_func_wrapper_traces(True) in order to view this>",
+    )
     new_stack_trace = []
     for st in old_stack_trace:
         if "func_wrapper.py" not in repr(st):
@@ -18,12 +22,18 @@ def _print_new_stack_trace(old_stack_trace):
 
 
 def _custom_exception_handle(type, value, tb_history):
-    _print_new_stack_trace(tb.extract_tb(tb_history))
+    if ivy.get_show_func_wrapper_trace_mode():
+        print("".join(tb.format_tb(tb_history)))
+    else:
+        _print_new_stack_trace(tb.extract_tb(tb_history))
     print(type.__name__ + ":", value)
 
 
 def _print_traceback_history():
-    _print_new_stack_trace(tb.extract_tb(sys.exc_info()[2]))
+    if ivy.get_show_func_wrapper_trace_mode():
+        print("".join(tb.format_tb(sys.exc_info()[2])))
+    else:
+        _print_new_stack_trace(tb.extract_tb(sys.exc_info()[2]))
     print("During the handling of the above exception, another exception occurred:\n")
 
 

--- a/ivy/functional/ivy/general.py
+++ b/ivy/functional/ivy/general.py
@@ -35,6 +35,7 @@ array_mode_stack = list()
 shape_array_mode_stack = list()
 nestable_mode_stack = list()
 exception_trace_mode_stack = list()
+show_func_wrapper_trace_mode_stack = list()
 
 
 def _parse_ellipsis(so, ndims):
@@ -427,6 +428,71 @@ def get_exception_trace_mode() -> bool:
     if not exception_trace_mode_stack:
         return True
     return exception_trace_mode_stack[-1]
+
+
+@handle_exceptions
+def set_show_func_wrapper_trace_mode(mode: bool) -> None:
+    """Set the mode of whether to show the full stack trace with function
+    wrapping traces
+
+    Parameter
+    ---------
+    mode
+        boolean whether to perform ivy.Array conversions
+
+    Examples
+    --------
+    >>> ivy.set_show_func_wrapper_trace_mode(False)
+    >>> ivy.get_show_func_wrapper_trace_mode()
+    False
+
+    >>> ivy.set_show_func_wrapper_trace_mode(True)
+    >>> ivy.get_show_func_wrapper_trace_mode()
+    True
+    """
+    global show_func_wrapper_trace_mode_stack
+    ivy.assertions.check_isinstance(mode, bool)
+    show_func_wrapper_trace_mode_stack.append(mode)
+
+
+@handle_exceptions
+def unset_show_func_wrapper_trace_mode() -> None:
+    """Reset the mode of whether to show the full stack trace with function
+    wrapping traces
+
+    Examples
+    --------
+    >>> ivy.set_show_func_wrapper_trace_mode(False)
+    >>> ivy.get_show_func_wrapper_trace_mode()
+    False
+
+    >>> ivy.unset_show_func_wrapper_trace_mode()
+    >>> ivy.get_show_func_wrapper_trace_mode()
+    True
+    """
+    global show_func_wrapper_trace_mode_stack
+    if show_func_wrapper_trace_mode_stack:
+        show_func_wrapper_trace_mode_stack.pop(-1)
+
+
+@handle_exceptions
+def get_show_func_wrapper_trace_mode() -> bool:
+    """Get the current state of whether to show the full stack trace with function
+    wrapping traces. Default is True (function wrapping traces are shown)
+
+    Examples
+    --------
+    >>> ivy.get_show_func_wrapper_trace_mode()
+    True
+
+    >>> ivy.set_show_func_wrapper_trace_mode(False)
+    >>> ivy.get_show_func_wrapper_trace_mode()
+    False
+    """
+    global show_func_wrapper_trace_mode_stack
+    if not show_func_wrapper_trace_mode_stack:
+        return True
+    return show_func_wrapper_trace_mode_stack[-1]
 
 
 @inputs_to_native_arrays


### PR DESCRIPTION
original:
```
...
During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/julia/Documents/Ivy/ivy/ivy/func_wrapper.py", line 146, in new_fn
    ret = fn(*args, **kwargs)
  File "/Users/julia/Documents/Ivy/ivy/ivy/func_wrapper.py", line 84, in new_fn
    return fn(*new_args, **new_kwargs)
  File "/Users/julia/Documents/Ivy/ivy/ivy/func_wrapper.py", line 360, in new_fn
    return fn(*args, **kwargs)
  File "/Users/julia/Documents/Ivy/ivy/ivy/func_wrapper.py", line 415, in new_fn
    return fn(*args, **kwargs)
  File "/Users/julia/Documents/Ivy/ivy/ivy/exceptions.py", line 66, in new_fn
    raise ivy.exceptions.IvyError(fn.__name__, str(e))
ivy.exceptions.IvyError: numpy: all: axis 1 is out of bounds for array of dimension 1
```

pruned:
```
...
During the handling of the above exception, another exception occurred:

  File "<stdin>", line 1, in <module>
  File "/Users/julia/Documents/Ivy/ivy/ivy/exceptions.py", line 92, in new_fn
    raise ivy.exceptions.IvyError(fn.__name__, str(e))
```