### PR TITLE
Removing MXNet from backend options

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -44,7 +44,6 @@ body:
         - label: TensorFlow
         - label: PyTorch
         - label: JAX
-        - label: MXNet
   - type: input
     id: device
     attributes:

--- a/README.rst
+++ b/README.rst
@@ -77,7 +77,7 @@ Contents
 Overview
 --------
 
-Ivy is an ML framework that currently supports JAX, TensorFlow, PyTorch, Numpy and MXNet.
+Ivy is an ML framework that currently supports JAX, TensorFlow, PyTorch, and Numpy.
 We’re very excited for you to try it out!
 
 Next on our roadmap is to support automatic code conversions between all frameworks 🔄,

--- a/README.rst
+++ b/README.rst
@@ -77,7 +77,7 @@ Contents
 Overview
 --------
 
-Ivy is an ML framework that currently supports JAX, TensorFlow, PyTorch, and Numpy.
+Ivy is an ML framework that currently supports JAX, TensorFlow, PyTorch, MXNet and Numpy.
 We’re very excited for you to try it out!
 
 Next on our roadmap is to support automatic code conversions between all frameworks 🔄,

--- a/README.rst
+++ b/README.rst
@@ -77,7 +77,7 @@ Contents
 Overview
 --------
 
-Ivy is an ML framework that currently supports JAX, TensorFlow, PyTorch, MXNet and Numpy.
+Ivy is an ML framework that currently supports JAX, TensorFlow, PyTorch, Numpy and MXNet.
 We’re very excited for you to try it out!
 
 Next on our roadmap is to support automatic code conversions between all frameworks 🔄,


### PR DESCRIPTION
Adding 'MXNet' in code line 80 of README.rst if IVY supports this framework.
                                                                           OR
Removing the MXNet option from the backend option (https://github.com/rohini-ranjanR/ivy/blob/master/.github/ISSUE_TEMPLATE/bug_report.yml) as this framework is not mentioned in README.rst (https://github.com/rohini-ranjanR/ivy/blob/master/README.rst) means the IVY ML framework doesn't support the MXNet framework.

