### PR TITLE
frontends.torch.Tensor: add support for arccos

### DIFF
--- a/ivy_tests/test_ivy/test_frontends/test_torch/test_tensor.py
+++ b/ivy_tests/test_ivy/test_frontends/test_torch/test_tensor.py
@@ -2152,7 +2152,7 @@ def test_torch_instance_add_(dtype_and_x, as_variable, native_array):
     dtype_and_x=helpers.dtype_and_values(
         min_value=-1.0,
         max_value=1.0,
-        available_dtypes=helpers.get_dtypes("float"),
+        available_dtypes=helpers.get_dtypes("float", index=1),
     ),
 )
 def test_torch_instance_arccos_(dtype_and_x, as_variable, native_array):
@@ -2182,7 +2182,7 @@ def test_torch_instance_arccos_(dtype_and_x, as_variable, native_array):
     dtype_and_x=helpers.dtype_and_values(
         min_value=-1.0,
         max_value=1.0,
-        available_dtypes=helpers.get_dtypes("float"),
+        available_dtypes=helpers.get_dtypes("float", index=1),
     ),
 )
 def test_torch_instance_arccos(dtype_and_x, as_variable, native_array):


### PR DESCRIPTION
I was assigned to add support for `arccos` instance method to PyTorch frontend as seen from [here](https://github.com/unifyai/ivy/issues/3612) and [here](https://github.com/unifyai/ivy/issues/6560) but someone else went ahead and added the method before me. However, the tests for both `arccos` and `arccos_` were failing with the following error against a **torch** backend with the following execption:

> **ivy.exceptions.IvyBackendException: torch: asarray: can't convert np.ndarray of type bfloat16. The only supported types are: float64, float32, float16, complex64, complex128, int64, int32, int16, int8, uint8, and bool.**

Hence, I have initiated this pull request in response to my original [task](https://github.com/unifyai/ivy/issues/6560) to add support for `arccos` while fixing the tests for both `arccos` and `arccos_`. 