### PR TITLE
add triu function to the jax.numpy namespace functions

### DIFF
--- a/ivy/functional/frontends/jax/numpy/name_space_functions.py
+++ b/ivy/functional/frontends/jax/numpy/name_space_functions.py
@@ -565,3 +565,7 @@ def max(a, axis=None, out=None, keepdims=False, where=None):
 
 
 amax = max
+
+@to_ivy_arrays_and_back
+def ones(shape, dtype=None):
+    return ivy.ones(shape, dtype=dtype)

--- a/ivy/functional/frontends/jax/numpy/name_space_functions.py
+++ b/ivy/functional/frontends/jax/numpy/name_space_functions.py
@@ -539,6 +539,11 @@ def equal(x1, x2):
 
 
 @to_ivy_arrays_and_back
+def triu(m, k=0):
+    return ivy.triu(m, k=k)
+
+
+@to_ivy_arrays_and_back
 def min(a, axis=None, out=None, keepdims=False, where=None):
     ret = ivy.min(a, axis=axis, out=out, keepdims=keepdims)
     if ivy.is_array(where):

--- a/ivy_tests/test_ivy/test_frontends/test_jax/test_jax_numpy_namespace_functions.py
+++ b/ivy_tests/test_ivy/test_frontends/test_jax/test_jax_numpy_namespace_functions.py
@@ -3007,3 +3007,40 @@ def test_jax_numpy_triu(
         m=x[0],
         k=k,
     )
+
+# ones    
+@handle_frontend_test(
+    fn_tree="jax.numpy.ones",
+    shape=helpers.get_shape(
+        allow_none=False,
+        min_num_dims=1,
+        max_num_dims=5,
+        min_dim_size=1,
+        max_dim_size=10,
+    ),
+    dtypes=helpers.get_dtypes("numeric", full=False),
+)
+def test_jax_numpy_ones(
+        *,
+        dtypes,
+        shape,
+        num_positional_args,
+        as_variable,
+        native_array,
+        on_device,
+        fn_tree,
+        frontend,
+    ):
+    helpers.test_frontend_function(
+        input_dtypes=dtypes,
+        as_variable_flags=as_variable,
+        with_out=False,
+        num_positional_args=num_positional_args,
+        native_array_flags=native_array,
+        frontend=frontend,
+        fn_tree=fn_tree,
+        on_device=on_device,
+        shape=shape,
+        dtype=dtypes[0],
+    )
+   

--- a/ivy_tests/test_ivy/test_frontends/test_jax/test_jax_numpy_namespace_functions.py
+++ b/ivy_tests/test_ivy/test_frontends/test_jax/test_jax_numpy_namespace_functions.py
@@ -2969,3 +2969,41 @@ def test_jax_numpy_max(
         keepdims=keepdims,
         where=where,
     )
+    
+    
+# triu    
+@handle_frontend_test(
+    fn_tree="jax.numpy.triu",
+    dtype_and_x=helpers.dtype_and_values(
+        available_dtypes=helpers.get_dtypes("numeric"),
+        num_arrays=1,
+        min_num_dims=2,
+        max_num_dims=5,
+        min_dim_size=1,
+        max_dim_size=5,
+    ),
+    k=helpers.ints(min_value=-10, max_value=10),
+)
+def test_jax_numpy_triu(
+    dtype_and_x,
+    k,
+    as_variable,
+    num_positional_args,
+    native_array,
+    frontend,
+    fn_tree,
+    on_device,
+):
+    dtype, x = dtype_and_x
+    helpers.test_frontend_function(
+        input_dtypes=dtype,
+        as_variable_flags=as_variable,
+        with_out=False,
+        num_positional_args=num_positional_args,
+        native_array_flags=native_array,
+        frontend=frontend,
+        fn_tree=fn_tree,
+        on_device=on_device,
+        m=x[0],
+        k=k,
+    )


### PR DESCRIPTION
I added triu function to jax.numpy and previously I got all test passed but when I got the latest commits I get the error and 75% tests passed. It looks like its related to the jax device class(I put screenshots on the discord server in ivy-frontend-tests section). Is it related to the latest version or there's something wrong with the test function?🤔