### PR TITLE
added jax.numpy.linalg.tensorinv with tests

### DIFF
--- a/ivy/functional/frontends/jax/numpy/linalg.py
+++ b/ivy/functional/frontends/jax/numpy/linalg.py
@@ -115,3 +115,19 @@ def tensorsolve(a, b, axes=None):
     res = ivy.solve(a, b)
     res = ivy.reshape(res, shape=ret_shape)
     return res
+
+
+@to_ivy_arrays_and_back
+def tensorinv(a, ind=2):
+    old_shape = ivy.shape(a)
+    prod = 1
+    if ind > 0:
+        invshape = old_shape[ind:] + old_shape[:ind]
+        for k in old_shape[ind:]:
+            prod *= k
+    else:
+        raise ValueError("Invalid ind argument.")
+    a = ivy.reshape(a, shape=(prod, -1))
+    ia = ivy.inv(a)
+    new_shape = tuple([*invshape])
+    return ivy.reshape(ia, shape=new_shape)

--- a/ivy_tests/test_ivy/test_frontends/test_jax/test_jax_numpy_linalg.py
+++ b/ivy_tests/test_ivy/test_frontends/test_jax/test_jax_numpy_linalg.py
@@ -745,3 +745,64 @@ def test_jax_numpy_pinv(
         fn_tree=fn_tree,
         a=x[0],
     )
+
+
+# tensorinv
+@st.composite
+def _get_inv_square_matrices(draw):
+
+    dim_size = draw(helpers.ints(min_value=1, max_value=10))
+
+    batch_shape = draw(st.sampled_from([2, 4, 6, 8, 10]))
+
+    shape = (dim_size,) * batch_shape
+    input_dtype = draw(helpers.get_dtypes("float", index=1, full=False))
+    invertible = False
+    while not invertible:
+        a = draw(
+            helpers.array_values(
+                dtype=input_dtype[0],
+                shape=shape,
+                min_value=-100,
+                max_value=100,
+            )
+        )
+        try:
+            np.linalg.inv(a)
+            invertible = True
+        except np.linalg.LinAlgError:
+            pass
+
+    ind = int(np.floor(len(shape) / 2))
+
+    return input_dtype, a, ind
+
+
+@handle_frontend_test(
+    fn_tree="jax.numpy.linalg.tensorinv", params=_get_inv_square_matrices()
+)
+def test_jax_numpy_tensorinv(
+    *,
+    params,
+    as_variable,
+    num_positional_args,
+    native_array,
+    on_device,
+    fn_tree,
+    frontend,
+):
+    dtype, x, ind = params
+    helpers.test_frontend_function(
+        input_dtypes=dtype,
+        as_variable_flags=as_variable,
+        with_out=False,
+        num_positional_args=num_positional_args,
+        native_array_flags=native_array,
+        rtol=1e-01,
+        atol=1e-01,
+        frontend=frontend,
+        fn_tree=fn_tree,
+        on_device=on_device,
+        a=x[0],
+        ind=ind,
+    )


### PR DESCRIPTION
Close #7387

Added `jax.numpy.linalg.tensorinv` frontend function through copying [the original implementation](https://github.com/google/jax/blob/71edfc7422eeff1ec91cff6711a91685270bb192/jax/_src/third_party/numpy/linalg.py#L65) and replacing the appropriate functions with ivy functions.

Added `test_jax_numpy_tensorinv`  and  `_get_inv_square_matrices` in test_jax_numpy_linalg.py by closely following the test in [the original implementation](https://github.com/google/jax/blob/c1e1d64e66a7850281420bf029b025ec79de5681/tests/linalg_test.py#L765)

Notes:

- We needed to implement a helper function `_get_inv_square_matrices` because `tensorinv` requires invertible matrices that have a "square" shape as per [the documentation](https://jax.readthedocs.io/en/latest/_autosummary/jax.numpy.linalg.tensorinv.html). Namely, 

> a (array_like) – Tensor to ‘invert’. Its shape must be ‘square’, i. e., prod(a.shape[:ind]) == prod(a.shape[ind:]).



Things I'm not sure about:

- Whether `input_dtype` needs to be filtered to exclude `float16` and `bfloat16` dtypes.
- Whether  `while not invertible` is the best way to ensure the generated matrix is non-invertible (this is how it's implemented in the original testing code)
