### PR TITLE
Add CSC format to ivy.SparseArray

### DIFF
--- a/ivy/functional/backends/jax/experimental/__init__.py
+++ b/ivy/functional/backends/jax/experimental/__init__.py
@@ -37,6 +37,8 @@ from . import set
 from .set import *
 from . import sorting
 from .sorting import *
+from . import sparse_array
+from .sparse_array import *
 from . import statistical
 from .statistical import *
 from . import utility

--- a/ivy/functional/backends/jax/experimental/sparse_array.py
+++ b/ivy/functional/backends/jax/experimental/sparse_array.py
@@ -1,9 +1,11 @@
 import logging
 import ivy
-from ivy.functional.ivy.experimental.sparse_array import (
+from ivy.functional.experimental.sparse_array import (
     _verify_coo_components,
     _verify_csr_components,
-    _is_coo_not_csr,
+    _verify_csc_components,
+    _is_coo,
+    _is_csr,
 )
 
 
@@ -18,6 +20,8 @@ def native_sparse_array(
     coo_indices=None,
     csr_crow_indices=None,
     csr_col_indices=None,
+    csc_ccol_indices=None,
+    csc_row_indices=None,
     values=None,
     dense_shape=None,
 ):
@@ -26,16 +30,37 @@ def native_sparse_array(
         inverse=True,
         message="data cannot be specified, Jax does not support sparse array natively",
     )
-    if _is_coo_not_csr(
-        coo_indices, csr_crow_indices, csr_col_indices, values, dense_shape
+    if _is_coo(
+        coo_indices,
+        csr_crow_indices,
+        csr_col_indices,
+        csc_ccol_indices,
+        csc_row_indices,
+        values,
+        dense_shape,
     ):
         _verify_coo_components(
             indices=coo_indices, values=values, dense_shape=dense_shape
         )
-    else:
+    elif _is_csr(
+        coo_indices,
+        csr_crow_indices,
+        csr_col_indices,
+        csc_ccol_indices,
+        csc_row_indices,
+        values,
+        dense_shape,
+    ):
         _verify_csr_components(
             crow_indices=csr_crow_indices,
             col_indices=csr_col_indices,
+            values=values,
+            dense_shape=dense_shape,
+        )
+    else:
+        _verify_csc_components(
+            ccol_indices=csc_ccol_indices,
+            row_indices=csc_row_indices,
             values=values,
             dense_shape=dense_shape,
         )

--- a/ivy/functional/backends/numpy/experimental/__init__.py
+++ b/ivy/functional/backends/numpy/experimental/__init__.py
@@ -35,6 +35,8 @@ from . import set
 from .set import *
 from . import sorting
 from .sorting import *
+from . import sparse_array
+from .sparse_array import *
 from . import statistical
 from .statistical import *
 from . import utility

--- a/ivy/functional/backends/numpy/experimental/sparse_array.py
+++ b/ivy/functional/backends/numpy/experimental/sparse_array.py
@@ -3,10 +3,12 @@ import logging
 
 # local
 import ivy
-from ivy.functional.ivy.experimental.sparse_array import (
+from ivy.functional.experimental.sparse_array import (
     _verify_coo_components,
     _verify_csr_components,
-    _is_coo_not_csr,
+    _verify_csc_components,
+    _is_coo,
+    _is_csr,
 )
 
 
@@ -21,6 +23,8 @@ def native_sparse_array(
     coo_indices=None,
     csr_crow_indices=None,
     csr_col_indices=None,
+    csc_ccol_indices=None,
+    csc_row_indices=None,
     values=None,
     dense_shape=None,
 ):
@@ -32,16 +36,37 @@ def native_sparse_array(
             " natively"
         ),
     )
-    if _is_coo_not_csr(
-        coo_indices, csr_crow_indices, csr_col_indices, values, dense_shape
+    if _is_coo(
+        coo_indices,
+        csr_crow_indices,
+        csr_col_indices,
+        csc_ccol_indices,
+        csc_row_indices,
+        values,
+        dense_shape,
     ):
         _verify_coo_components(
             indices=coo_indices, values=values, dense_shape=dense_shape
         )
-    else:
+    elif _is_csr(
+        coo_indices,
+        csr_crow_indices,
+        csr_col_indices,
+        csc_ccol_indices,
+        csc_row_indices,
+        values,
+        dense_shape,
+    ):
         _verify_csr_components(
             crow_indices=csr_crow_indices,
             col_indices=csr_col_indices,
+            values=values,
+            dense_shape=dense_shape,
+        )
+    else:
+        _verify_csc_components(
+            ccol_indices=csc_ccol_indices,
+            row_indices=csc_row_indices,
             values=values,
             dense_shape=dense_shape,
         )

--- a/ivy/functional/backends/tensorflow/experimental/__init__.py
+++ b/ivy/functional/backends/tensorflow/experimental/__init__.py
@@ -29,6 +29,8 @@ from . import set
 from .set import *
 from . import sorting
 from .sorting import *
+from . import sparse_array
+from .sparse_array import *
 from . import statistical
 from .statistical import *
 from . import utility

--- a/ivy/functional/backends/tensorflow/experimental/sparse_array.py
+++ b/ivy/functional/backends/tensorflow/experimental/sparse_array.py
@@ -4,11 +4,13 @@ import logging
 
 # local
 import ivy
-from ivy.functional.ivy.experimental.sparse_array import (
+from ivy.functional.experimental.sparse_array import (
     _verify_coo_components,
     _verify_csr_components,
+    _verify_csc_components,
     _is_data_not_indices_values_and_shape,
-    _is_coo_not_csr,
+    _is_coo,
+    _is_csr,
 )
 
 
@@ -22,18 +24,33 @@ def native_sparse_array(
     coo_indices=None,
     csr_crow_indices=None,
     csr_col_indices=None,
+    csc_ccol_indices=None,
+    csc_row_indices=None,
     values=None,
     dense_shape=None,
 ):
     if _is_data_not_indices_values_and_shape(
-        data, coo_indices, csr_crow_indices, csr_col_indices, values, dense_shape
+        data,
+        coo_indices,
+        csr_crow_indices,
+        csr_col_indices,
+        csc_ccol_indices,
+        csc_row_indices,
+        values,
+        dense_shape,
     ):
         ivy.assertions.check_true(
             ivy.is_native_sparse_array(data), message="not a sparse array"
         )
         return data
-    elif _is_coo_not_csr(
-        coo_indices, csr_crow_indices, csr_col_indices, values, dense_shape
+    elif _is_coo(
+        coo_indices,
+        csr_crow_indices,
+        csr_col_indices,
+        csc_ccol_indices,
+        csc_row_indices,
+        values,
+        dense_shape,
     ):
         _verify_coo_components(
             indices=coo_indices, values=values, dense_shape=dense_shape
@@ -46,7 +63,15 @@ def native_sparse_array(
         return tf.SparseTensor(
             indices=all_coordinates, values=values, dense_shape=dense_shape
         )
-    else:
+    elif _is_csr(
+        coo_indices,
+        csr_crow_indices,
+        csr_col_indices,
+        csc_ccol_indices,
+        csc_row_indices,
+        values,
+        dense_shape,
+    ):
         _verify_csr_components(
             crow_indices=csr_crow_indices,
             col_indices=csr_col_indices,
@@ -56,10 +81,20 @@ def native_sparse_array(
         logging.warning(
             "Tensorflow does not support CSR sparse array natively. None is returned."
         )
-        return None
+    else:
+        _verify_csc_components(
+            ccol_indices=csc_ccol_indices,
+            row_indices=csc_row_indices,
+            values=values,
+            dense_shape=dense_shape,
+        )
+        logging.warning(
+            "Tensorflow does not support CSC sparse array natively. None is returned."
+        )
+    return None
 
 
 def native_sparse_array_to_indices_values_and_shape(x):
     if isinstance(x, tf.SparseTensor):
-        return x.indices, x.values, x.dense_shape
+        return {"indices": x.indices}, x.values, x.dense_shape
     raise ivy.exceptions.IvyException("not a SparseTensor")

--- a/ivy/functional/backends/torch/experimental/__init__.py
+++ b/ivy/functional/backends/torch/experimental/__init__.py
@@ -31,6 +31,8 @@ from . import set
 from .set import *
 from . import sorting
 from .sorting import *
+from . import sparse_array
+from .sparse_array import *
 from . import statistical
 from .statistical import *
 from . import utility

--- a/ivy/functional/backends/torch/experimental/sparse_array.py
+++ b/ivy/functional/backends/torch/experimental/sparse_array.py
@@ -1,15 +1,17 @@
 import ivy
-from ivy.functional.ivy.experimental.sparse_array import (
+from ivy.functional.experimental.sparse_array import (
     _verify_coo_components,
     _verify_csr_components,
+    _verify_csc_components,
     _is_data_not_indices_values_and_shape,
-    _is_coo_not_csr,
+    _is_coo,
+    _is_csr,
 )
 import torch
 
 
 def is_native_sparse_array(x):
-    return x.layout in [torch.sparse_coo, torch.sparse_csr]
+    return x.layout in [torch.sparse_coo, torch.sparse_csr, torch.sparse_csc]
 
 
 def native_sparse_array(
@@ -18,18 +20,33 @@ def native_sparse_array(
     coo_indices=None,
     csr_crow_indices=None,
     csr_col_indices=None,
+    csc_ccol_indices=None,
+    csc_row_indices=None,
     values=None,
     dense_shape=None,
 ):
     if _is_data_not_indices_values_and_shape(
-        data, coo_indices, csr_crow_indices, csr_col_indices, values, dense_shape
+        data,
+        coo_indices,
+        csr_crow_indices,
+        csr_col_indices,
+        csc_ccol_indices,
+        csc_row_indices,
+        values,
+        dense_shape,
     ):
         ivy.assertions.check_true(
             ivy.is_native_sparse_array(data), message="not a sparse array"
         )
         return data
-    elif _is_coo_not_csr(
-        coo_indices, csr_crow_indices, csr_col_indices, values, dense_shape
+    elif _is_coo(
+        coo_indices,
+        csr_crow_indices,
+        csr_col_indices,
+        csc_ccol_indices,
+        csc_row_indices,
+        values,
+        dense_shape,
     ):
         _verify_coo_components(
             indices=coo_indices, values=values, dense_shape=dense_shape
@@ -37,7 +54,15 @@ def native_sparse_array(
         return torch.sparse_coo_tensor(
             indices=coo_indices, values=values, size=dense_shape
         )
-    else:
+    elif _is_csr(
+        coo_indices,
+        csr_crow_indices,
+        csr_col_indices,
+        csc_ccol_indices,
+        csc_row_indices,
+        values,
+        dense_shape,
+    ):
         _verify_csr_components(
             crow_indices=csr_crow_indices,
             col_indices=csr_col_indices,
@@ -50,12 +75,35 @@ def native_sparse_array(
             values=values,
             size=dense_shape,
         )
+    else:
+        _verify_csc_components(
+            ccol_indices=csc_ccol_indices,
+            row_indices=csc_row_indices,
+            values=values,
+            dense_shape=dense_shape,
+        )
+        return torch.sparse_csc_tensor(
+            ccol_indices=csc_ccol_indices,
+            row_indices=csc_row_indices,
+            values=values,
+            size=dense_shape,
+        )
 
 
 def native_sparse_array_to_indices_values_and_shape(x):
     if x.layout == torch.sparse_coo:
         x = x.coalesce()
-        return x.indices(), x.values(), x.size()
+        return {"indices": x.indices()}, x.values(), x.size()
     elif x.layout == torch.sparse_csr:
-        return [x.crow_indices(), x.col_indices()], x.values(), x.size()
-    raise ivy.exceptions.IvyException("not a sparse COO/CSR Tensor")
+        return (
+            {"crow_indices": x.crow_indices(), "col_indices": x.col_indices()},
+            x.values(),
+            x.size(),
+        )
+    elif x.layout == torch.sparse_csc:
+        return (
+            {"ccol_indices": x.ccol_indices(), "row_indices": x.row_indices()},
+            x.values(),
+            x.size(),
+        )
+    raise ivy.exceptions.IvyException("not a sparse COO/CSR/CSC Tensor")

--- a/ivy/functional/experimental/sparse_array.py
+++ b/ivy/functional/experimental/sparse_array.py
@@ -82,11 +82,59 @@ def _verify_csr_components(
     )
 
 
+def _verify_csc_components(
+    *, ccol_indices=None, row_indices=None, values=None, dense_shape=None
+):
+    ivy.assertions.check_all_or_any_fn(
+        ccol_indices,
+        row_indices,
+        values,
+        dense_shape,
+        fn=ivy.exists,
+        type="all",
+        message="ccol_indices, row_indices, values and dense_shape must all \
+        be specified",
+    )
+    ivy.assertions.check_equal(
+        len(ivy.shape(ccol_indices)), 1, message="ccol_indices must be 1D"
+    )
+    ivy.assertions.check_equal(
+        len(ivy.shape(row_indices)), 1, message="row_indices must be 1D"
+    )
+    ivy.assertions.check_equal(len(ivy.shape(values)), 1, message="values must be 1D")
+    ivy.assertions.check_equal(
+        len(dense_shape),
+        2,
+        message="only 2D arrays can be converted to CSC sparse arrays",
+    )
+    # number of intervals must be equal to y in shape (x, y)
+    ivy.assertions.check_equal(ivy.shape(ccol_indices)[0] - 1, dense_shape[1])
+    # index in row_indices must not exceed x in shape (x, y)
+    ivy.assertions.check_less(
+        row_indices, dense_shape[0], message="index in row_indices does not match shape"
+    )
+    # number of values must match number of coordinates
+    ivy.assertions.check_equal(
+        ivy.shape(row_indices)[0],
+        ivy.shape(values)[0],
+        message="values and row_indices do not match",
+    )
+    # index in ccol_indices must not exceed length of row_indices
+    ivy.assertions.check_less(
+        ccol_indices,
+        ivy.shape(row_indices)[0],
+        allow_equal=True,
+        message="index in ccol_indices does not match the number of row_indices",
+    )
+
+
 def _is_data_not_indices_values_and_shape(
     data=None,
     coo_indices=None,
     csr_crow_indices=None,
     csr_col_indices=None,
+    csc_ccol_indices=None,
+    csc_row_indices=None,
     values=None,
     dense_shape=None,
 ):
@@ -95,23 +143,28 @@ def _is_data_not_indices_values_and_shape(
             coo_indices,
             csr_crow_indices,
             csr_col_indices,
+            csc_ccol_indices,
+            csc_row_indices,
             values,
             dense_shape,
             fn=ivy.exists,
             type="any",
             limit=[0],
-            message="only specify either data, all coo components (coo_indices, values \
+            message="only specify data, all coo components (coo_indices, values \
             and dense_shape), or all csr components (csr_crow_indices, \
-            csr_col_indices, values and dense_shape)",
+            csr_col_indices, values and dense_shape), or all csc components \
+                (csc_ccol_indices, csc_row_indices, values and dense_shape).",
         )
         return True
     return False
 
 
-def _is_coo_not_csr(
+def _is_coo(
     coo_indices=None,
     csr_crow_indices=None,
     csr_col_indices=None,
+    csc_ccol_indices=None,
+    csc_row_indices=None,
     values=None,
     dense_shape=None,
 ):
@@ -121,22 +174,57 @@ def _is_coo_not_csr(
         and ivy.exists(dense_shape)
         and csr_crow_indices is None
         and csr_col_indices is None
+        and csc_ccol_indices is None
+        and csc_row_indices is None
     ):
         return True
-    elif (
+    return False
+
+
+def _is_csr(
+    coo_indices=None,
+    csr_crow_indices=None,
+    csr_col_indices=None,
+    csc_ccol_indices=None,
+    csc_row_indices=None,
+    values=None,
+    dense_shape=None,
+):
+    if (
         ivy.exists(csr_crow_indices)
         and ivy.exists(csr_col_indices)
         and ivy.exists(values)
         and ivy.exists(dense_shape)
         and coo_indices is None
+        and csc_ccol_indices is None
+        and csc_row_indices is None
     ):
-        return False
-    else:
-        raise ivy.exceptions.IvyException(
-            "specify either all coo components (coo_indices, values \
-            and dense_shape), or all csr components (csr_crow_indices, \
-            csr_col_indices, values and dense_shape)"
-        )
+        return True
+
+    return False
+
+
+def _is_csc(
+    coo_indices=None,
+    csr_crow_indices=None,
+    csr_col_indices=None,
+    csc_ccol_indices=None,
+    csc_row_indices=None,
+    values=None,
+    dense_shape=None,
+):
+    if (
+        ivy.exists(csc_ccol_indices)
+        and ivy.exists(csc_row_indices)
+        and ivy.exists(values)
+        and ivy.exists(dense_shape)
+        and coo_indices is None
+        and csr_crow_indices is None
+        and csr_col_indices is None
+    ):
+        return True
+
+    return False
 
 
 class SparseArray:
@@ -147,20 +235,62 @@ class SparseArray:
         coo_indices=None,
         csr_crow_indices=None,
         csr_col_indices=None,
+        csc_ccol_indices=None,
+        csc_row_indices=None,
         values=None,
         dense_shape=None,
     ):
         if _is_data_not_indices_values_and_shape(
-            data, coo_indices, csr_crow_indices, csr_col_indices, values, dense_shape
+            data,
+            coo_indices,
+            csr_crow_indices,
+            csr_col_indices,
+            csc_ccol_indices,
+            csc_row_indices,
+            values,
+            dense_shape,
         ):
             self._init_data(data)
-        elif _is_coo_not_csr(
-            coo_indices, csr_crow_indices, csr_col_indices, values, dense_shape
+        elif _is_coo(
+            coo_indices,
+            csr_crow_indices,
+            csr_col_indices,
+            csc_ccol_indices,
+            csc_row_indices,
+            values,
+            dense_shape,
         ):
             self._init_coo_components(coo_indices, values, dense_shape)
-        else:
+        elif _is_csr(
+            coo_indices,
+            csr_crow_indices,
+            csr_col_indices,
+            csc_ccol_indices,
+            csc_row_indices,
+            values,
+            dense_shape,
+        ):
             self._init_csr_components(
                 csr_crow_indices, csr_col_indices, values, dense_shape
+            )
+        elif _is_csc(
+            coo_indices,
+            csr_crow_indices,
+            csr_col_indices,
+            csc_ccol_indices,
+            csc_row_indices,
+            values,
+            dense_shape,
+        ):
+            self._init_csc_components(
+                csc_ccol_indices, csc_row_indices, values, dense_shape
+            )
+        else:
+            raise ivy.exceptions.IvyException(
+                "specify all coo components (coo_indices, values \
+            and dense_shape), or all csr components (csr_crow_indices, \
+            csr_col_indices, values and dense_shape), or all csc components \
+                (csc_ccol_indices, csc_row_indices, values and dense_shape)."
             )
 
     def _init_data(self, data):
@@ -169,6 +299,8 @@ class SparseArray:
             self._coo_indices = data.coo_indices
             self._csr_crow_indices = data.csr_crow_indices
             self._csr_col_indices = data.csr_col_indices
+            self._csc_ccol_indices = data.csc_ccol_indices
+            self._csc_row_indices = data.csc_row_indices
             self._values = data.values
             self._dense_shape = data.dense_shape
         else:
@@ -182,14 +314,26 @@ class SparseArray:
         indices, values, shape = ivy.native_sparse_array_to_indices_values_and_shape(
             self._data
         )
-        if isinstance(indices, list):
-            self._csr_crow_indices = ivy.array(indices[0], dtype="int64")
-            self._csr_col_indices = ivy.array(indices[1], dtype="int64")
-            self._coo_indices = None
-        else:
-            self._coo_indices = ivy.array(indices, dtype="int64")
+
+        if "indices" in indices:
+            self._coo_indices = ivy.array(indices["indices"], dtype="int64")
             self._csr_crow_indices = None
             self._csr_col_indices = None
+            self._csc_ccol_indices = None
+            self._csc_row_indices = None
+        elif "crow_indices" in indices and "col_indices" in indices:
+            self._csr_crow_indices = ivy.array(indices["crow_indices"], dtype="int64")
+            self._csr_col_indices = ivy.array(indices["col_indices"], dtype="int64")
+            self._coo_indices = None
+            self._csc_ccol_indices = None
+            self._csc_row_indices = None
+        else:
+            self._csc_ccol_indices = ivy.array(indices["ccol_indices"], dtype="int64")
+            self._csc_row_indices = ivy.array(indices["row_indices"], dtype="int64")
+            self._coo_indices = None
+            self._csr_crow_indices = None
+            self._csr_col_indices = None
+
         self._values = ivy.array(values)
         self._dense_shape = ivy.Shape(shape)
 
@@ -205,6 +349,8 @@ class SparseArray:
         self._dense_shape = shape
         self._csr_crow_indices = None
         self._csr_col_indices = None
+        self._csc_ccol_indices = None
+        self._csc_row_indices = None
 
     def _init_csr_components(self, csr_crow_indices, csr_col_indices, values, shape):
         csr_crow_indices = ivy.array(csr_crow_indices, dtype="int64")
@@ -222,6 +368,27 @@ class SparseArray:
         self._values = values
         self._dense_shape = shape
         self._coo_indices = None
+        self._csc_ccol_indices = None
+        self._csc_row_indices = None
+
+    def _init_csc_components(self, csc_ccol_indices, csc_row_indices, values, shape):
+        csc_ccol_indices = ivy.array(csc_ccol_indices, dtype="int64")
+        csc_row_indices = ivy.array(csc_row_indices, dtype="int64")
+        values = ivy.array(values)
+        shape = ivy.Shape(shape)
+        self._data = ivy.native_sparse_array(
+            csc_ccol_indices=csc_ccol_indices,
+            csc_row_indices=csc_row_indices,
+            values=values,
+            dense_shape=shape,
+        )
+        self._csc_ccol_indices = csc_ccol_indices
+        self._csc_row_indices = csc_row_indices
+        self._values = values
+        self._dense_shape = shape
+        self._coo_indices = None
+        self._csr_crow_indices = None
+        self._csr_col_indices = None
 
     # Properties #
     # -----------#
@@ -241,6 +408,14 @@ class SparseArray:
     @property
     def csr_col_indices(self):
         return self._csr_col_indices
+
+    @property
+    def csc_ccol_indices(self):
+        return self._csc_ccol_indices
+
+    @property
+    def csc_row_indices(self):
+        return self._csc_row_indices
 
     @property
     def values(self):
@@ -287,6 +462,28 @@ class SparseArray:
         )
         self._csr_col_indices = indices
 
+    @csc_ccol_indices.setter
+    def csc_ccol_indices(self, indices):
+        indices = ivy.array(indices, dtype="int64")
+        _verify_csc_components(
+            ccol_indices=indices,
+            row_indices=self._csc_row_indices,
+            values=self._values,
+            dense_shape=self._dense_shape,
+        )
+        self._csc_ccol_indices = indices
+
+    @csc_row_indices.setter
+    def csc_row_indices(self, indices):
+        indices = ivy.array(indices, dtype="int64")
+        _verify_csc_components(
+            ccol_indices=self._csc_ccol_indices,
+            row_indices=indices,
+            values=self._values,
+            dense_shape=self._dense_shape,
+        )
+        self._csc_row_indices = indices
+
     @values.setter
     def values(self, values):
         values = ivy.array(values)
@@ -308,23 +505,32 @@ class SparseArray:
 
     def to_dense_array(self, *, native=False):
         all_coordinates = []
+        print(self._coo_indices)
         if self._coo_indices is not None:
             # COO sparse array
             for i in range(self._values.shape[0]):
                 coordinate = ivy.gather(self._coo_indices, ivy.array([[i]]))
                 coordinate = ivy.reshape(coordinate, (self._coo_indices.shape[0],))
                 all_coordinates.append(coordinate.to_list())
-        else:
+        elif self._csr_crow_indices is not None and self._csr_col_indices is not None:
             # CSR sparse array
-            row = 0
             total_rows = self._dense_shape[0]
             all_cols = self._csr_col_indices.to_list()
             all_rows = self._csr_crow_indices.to_list()
-            while row < total_rows:
+            for row in range(total_rows):
                 cols = all_cols[all_rows[row] : all_rows[row + 1]]
                 for col in cols:
                     all_coordinates.append([row, col])
-                row += 1
+        else:
+            # CSC sparse array
+            total_cols = self._dense_shape[1]
+            all_rows = self._csc_row_indices.to_list()
+            all_cols = self._csc_ccol_indices.to_list()
+            for col in range(total_cols):
+                rows = all_rows[all_cols[col] : all_cols[col + 1]]
+                for row in rows:
+                    all_coordinates.append([row, col])
+
         # make dense array
         ret = ivy.scatter_nd(
             ivy.array(all_coordinates), self._values, ivy.array(self._dense_shape)
@@ -354,6 +560,8 @@ def native_sparse_array(
     coo_indices=None,
     csr_crow_indices=None,
     csr_col_indices=None,
+    csc_ccol_indices=None,
+    csc_row_indices=None,
     values=None,
     dense_shape=None,
 ):
@@ -362,6 +570,8 @@ def native_sparse_array(
         coo_indices=coo_indices,
         csr_crow_indices=csr_crow_indices,
         csr_col_indices=csr_col_indices,
+        csc_ccol_indices=csc_ccol_indices,
+        csc_row_indices=csc_row_indices,
         values=values,
         dense_shape=dense_shape,
     )

--- a/ivy/functional/experimental/sparse_array.py
+++ b/ivy/functional/experimental/sparse_array.py
@@ -505,7 +505,7 @@ class SparseArray:
 
     def to_dense_array(self, *, native=False):
         all_coordinates = []
-        print(self._coo_indices)
+
         if self._coo_indices is not None:
             # COO sparse array
             for i in range(self._values.shape[0]):

--- a/ivy_tests/test_ivy/test_functional/test_experimental/test_core/test_sparse_array.py
+++ b/ivy_tests/test_ivy/test_functional/test_experimental/test_core/test_sparse_array.py
@@ -60,6 +60,36 @@ def _sparse_csr_indices_values_shape(draw):
     return crow_indices, col_indices, value_dtype, values, shape
 
 
+@st.composite
+def _sparse_csc_indices_values_shape(draw):
+    num_elem = draw(helpers.ints(min_value=2, max_value=8))
+    dim1 = draw(helpers.ints(min_value=5, max_value=10))
+    dim2 = draw(helpers.ints(min_value=2, max_value=5))
+    value_dtype = draw(helpers.get_dtypes("numeric", full=False))[0]
+    values = draw(helpers.array_values(dtype=value_dtype, shape=(num_elem,)))
+    row_indices = draw(
+        helpers.array_values(
+            dtype="int64",
+            shape=(num_elem,),
+            min_value=0,
+            max_value=dim1,
+            exclude_min=False,
+        )
+    )
+    indices = draw(
+        helpers.array_values(
+            dtype="int64",
+            shape=(dim2 - 1,),
+            min_value=0,
+            max_value=num_elem,
+            exclude_min=False,
+        )
+    )
+    ccol_indices = [0] + sorted(indices) + [num_elem]
+    shape = (dim1, dim2)
+    return ccol_indices, row_indices, value_dtype, values, shape
+
+
 # coo - to_dense_array
 @handle_method(
     method_tree="SparseArray.to_dense_array",
@@ -119,6 +149,43 @@ def test_sparse_csr(
         init_all_as_kwargs_np={
             "csr_crow_indices": crow_indices,
             "csr_col_indices": col_indices,
+            "values": values,
+            "dense_shape": shape,
+        },
+        method_input_dtypes=[],
+        method_as_variable_flags=[],
+        method_num_positional_args=0,
+        method_native_array_flags=[],
+        method_container_flags=[False],
+        method_all_as_kwargs_np={},
+        class_name=class_name,
+        method_name=method_name,
+    )
+
+
+# csc - to_dense_array
+@handle_method(
+    method_tree="SparseArray.to_dense_array",
+    sparse_data=_sparse_csc_indices_values_shape(),
+)
+def test_sparse_csc(
+    sparse_data,
+    init_as_variable_flags: pf.AsVariableFlags,
+    init_native_array_flags: pf.NativeArrayFlags,
+    class_name,
+    method_name,
+    ground_truth_backend,
+):
+    ccol_indices, row_indices, value_dtype, values, shape = sparse_data
+    helpers.test_method(
+        ground_truth_backend=ground_truth_backend,
+        init_input_dtypes=["int64", "int64", value_dtype],
+        init_as_variable_flags=init_as_variable_flags,
+        init_num_positional_args=0,
+        init_native_array_flags=init_native_array_flags,
+        init_all_as_kwargs_np={
+            "csc_ccol_indices": ccol_indices,
+            "csc_row_indices": row_indices,
             "values": values,
             "dense_shape": shape,
         },


### PR DESCRIPTION
- [x] Support CSC format for the torch backend
- [x] Debug previous tests
- [x] Add a test case for the CSC format

### Remark

Previous tests, namely [test_sparse_coo](https://github.com/unifyai/ivy/blob/4b7498f3b9eb771d086ccae5ee134b5b4bcc48f9/ivy_tests/test_ivy/test_functional/test_experimental/test_core/test_sparse_array.py#L68) and [test_sparse_csr](https://github.com/unifyai/ivy/blob/4b7498f3b9eb771d086ccae5ee134b5b4bcc48f9/ivy_tests/test_ivy/test_functional/test_experimental/test_core/test_sparse_array.py#L104) failed. Then, I needed to update `__init__.py` of each backend so that it imports the `sparse_array` module and all functions in it. After this change, I got `Segmentation Fault` while running tests. I'm not really sure why it was the case (It might come from M1 chip but I don't know) but I tackled with it by uninstalling functorch. Therefore, I wanted to share the versions of libraries and frameworks for the future reference. 

```
# Name                    Version                   Build  Channel
absl-py                   1.3.0                    pypi_0    pypi
astunparse                1.6.3                    pypi_0    pypi
async-timeout             4.0.2                    pypi_0    pypi
attrs                     22.1.0                   pypi_0    pypi
black                     22.10.0                  pypi_0    pypi
blas                      1.0                    openblas  
c-ares                    1.18.1               h1a28f6b_0  
ca-certificates           2022.10.11           hca03da5_0  
cachetools                5.2.0                    pypi_0    pypi
certifi                   2022.9.24        py38hca03da5_0  
cffi                      1.15.1           py38h80987f9_2  
cfgv                      3.3.1                    pypi_0    pypi
charset-normalizer        2.1.1                    pypi_0    pypi
click                     8.1.3                    pypi_0    pypi
cloudpickle               2.2.0                    pypi_0    pypi
colorama                  0.4.5                    pypi_0    pypi
cycler                    0.11.0                   pypi_0    pypi
decorator                 5.1.1                    pypi_0    pypi
distlib                   0.3.6                    pypi_0    pypi
dm-haiku                  0.0.6                    pypi_0    pypi
dm-tree                   0.1.7                    pypi_0    pypi
einops                    0.4.1                    pypi_0    pypi
etils                     0.9.0                    pypi_0    pypi
exceptiongroup            1.0.4                    pypi_0    pypi
filelock                  3.8.0                    pypi_0    pypi
flake8                    6.0.0                    pypi_0    pypi
flatbuffers               1.12                     pypi_0    pypi
fonttools                 4.38.0                   pypi_0    pypi
gast                      0.4.0                    pypi_0    pypi
google-auth               2.14.1                   pypi_0    pypi
google-auth-oauthlib      0.4.6                    pypi_0    pypi
google-pasta              0.2.0                    pypi_0    pypi
grpcio                    1.42.0           py38h95c9599_0  
h5py                      3.7.0                    pypi_0    pypi
hdf5                      1.12.1               h160e8cb_2  
hypothesis                6.48.2                   pypi_0    pypi
identify                  2.5.9                    pypi_0    pypi
idna                      3.4                      pypi_0    pypi
importlib-metadata        5.1.0                    pypi_0    pypi
importlib-resources       5.10.0                   pypi_0    pypi
iniconfig                 1.1.1                    pypi_0    pypi
ivy-core                  1.1.9                    pypi_0    pypi
jax                       0.3.14                   pypi_0    pypi
jaxlib                    0.3.14                   pypi_0    pypi
jmp                       0.0.2                    pypi_0    pypi
keras                     2.9.0                    pypi_0    pypi
keras-preprocessing       1.1.2                    pypi_0    pypi
kiwisolver                1.4.4                    pypi_0    pypi
krb5                      1.19.2               h3b8d789_0  
libblas                   3.9.0           16_osxarm64_openblas    conda-forge
libcblas                  3.9.0           16_osxarm64_openblas    conda-forge
libclang                  14.0.6                   pypi_0    pypi
libcurl                   7.86.0               h0f1d93c_0  
libcxx                    14.0.6               h848a8c0_0  
libedit                   3.1.20210910         h1a28f6b_0  
libev                     4.33                 h1a28f6b_1  
libffi                    3.4.2                hca03da5_6  
libgfortran               5.0.0           11_3_0_hca03da5_28  
libgfortran5              11.3.0              h009349e_28  
liblapack                 3.9.0           16_osxarm64_openblas    conda-forge
libnghttp2                1.46.0               h95c9599_0  
libopenblas               0.3.21               h269037a_0  
libprotobuf               3.21.10              hb5ab8b9_0    conda-forge
libssh2                   1.10.0               hf27765b_0  
libzlib                   1.2.13               h03a7124_4    conda-forge
llvm-openmp               14.0.6               hc6e5704_0  
markdown                  3.4.1                    pypi_0    pypi
markupsafe                2.1.1                    pypi_0    pypi
matplotlib                3.5.2                    pypi_0    pypi
mccabe                    0.7.0                    pypi_0    pypi
mypy-extensions           0.4.3                    pypi_0    pypi
ncurses                   6.3                  h1a28f6b_3  
networkx                  2.8.4                    pypi_0    pypi
ninja                     1.10.2               hca03da5_5  
ninja-base                1.10.2               h525c30c_5  
nodeenv                   1.7.0                    pypi_0    pypi
numpy                     1.23.0                   pypi_0    pypi
numpy-base                1.22.3           py38h974a1f5_0  
nvidia-ml-py              11.495.46                pypi_0    pypi
oauthlib                  3.2.2                    pypi_0    pypi
opencv-python             4.6.0.66                 pypi_0    pypi
openssl                   1.1.1s               h1a28f6b_0  
opt-einsum                3.3.0                    pypi_0    pypi
packaging                 21.3                     pypi_0    pypi
pathspec                  0.10.2                   pypi_0    pypi
pillow                    9.3.0                    pypi_0    pypi
pip                       22.2.2           py38hca03da5_0  
platformdirs              2.5.4                    pypi_0    pypi
pluggy                    1.0.0                    pypi_0    pypi
pre-commit                2.20.0                   pypi_0    pypi
protobuf                  3.19.4                   pypi_0    pypi
psutil                    5.9.1                    pypi_0    pypi
py                        1.11.0                   pypi_0    pypi
pyasn1                    0.4.8                    pypi_0    pypi
pyasn1-modules            0.2.8                    pypi_0    pypi
pycodestyle               2.10.0                   pypi_0    pypi
pycparser                 2.21               pyhd3eb1b0_0  
pyflakes                  3.0.1                    pypi_0    pypi
pyparsing                 3.0.9                    pypi_0    pypi
pytest                    7.1.2                    pypi_0    pypi
python                    3.8.10          hab31e5c_2_cpython    conda-forge
python-dateutil           2.8.2                    pypi_0    pypi
python_abi                3.8                      3_cp38    conda-forge
pytorch                   1.12.1          cpu_py38hfb32b02_1    conda-forge
pytorch_scatter           2.0.9           cpu_py38h99447b9_0    conda-forge
pyyaml                    6.0                      pypi_0    pypi
readline                  8.2                  h1a28f6b_0  
redis                     4.3.5                    pypi_0    pypi
requests                  2.28.1                   pypi_0    pypi
requests-oauthlib         1.3.1                    pypi_0    pypi
rsa                       4.9                      pypi_0    pypi
scipy                     1.8.1                    pypi_0    pypi
setuptools                65.5.0           py38hca03da5_0  
six                       1.16.0             pyhd3eb1b0_1  
sleef                     3.5.1                hf27765b_1  
sortedcontainers          2.4.0                    pypi_0    pypi
sqlite                    3.40.0               h7a7dc30_0  
tabulate                  0.9.0                    pypi_0    pypi
tensorboard               2.9.1                    pypi_0    pypi
tensorboard-data-server   0.6.1                    pypi_0    pypi
tensorboard-plugin-wit    1.8.1                    pypi_0    pypi
tensorflow-addons         0.17.1                   pypi_0    pypi
tensorflow-deps           2.9.0                         0    apple
tensorflow-estimator      2.9.0                    pypi_0    pypi
tensorflow-macos          2.9.1                    pypi_0    pypi
tensorflow-probability    0.17.0                   pypi_0    pypi
termcolor                 1.1.0                    pypi_0    pypi
tk                        8.6.12               hb8d0fd4_0  
toml                      0.10.2                   pypi_0    pypi
tomli                     2.0.1                    pypi_0    pypi
torch                     1.13.0                   pypi_0    pypi
typeguard                 2.13.3                   pypi_0    pypi
typing_extensions         4.3.0            py38hca03da5_0  
urllib3                   1.26.13                  pypi_0    pypi
virtualenv                20.16.7                  pypi_0    pypi
werkzeug                  2.2.2                    pypi_0    pypi
wheel                     0.37.1             pyhd3eb1b0_0  
wrapt                     1.14.1                   pypi_0    pypi
xz                        5.2.6                h1a28f6b_0  
zipp                      3.11.0                   pypi_0    pypi
zlib                      1.2.13               h03a7124_4    conda-forge
```