### PR TITLE
optimise promote_types_of_inputs and handle int/float inputs accurately

### DIFF
--- a/ivy/functional/ivy/data_type.py
+++ b/ivy/functional/ivy/data_type.py
@@ -2007,25 +2007,19 @@ def promote_types_of_inputs(
     as inputs only for those functions that expect an array-like or tensor-like objects,
     otherwise it might give unexpected results.
     """
-    if hasattr(x1, "dtype") and hasattr(x2, "dtype"):
-        if x1.dtype != x2.dtype:
-            promoted = promote_types(
-                x1.dtype, x2.dtype, array_api_promotion=array_api_promotion
-            )
-            x1 = ivy.asarray(x1, dtype=promoted)
-            x2 = ivy.asarray(x2, dtype=promoted)
-    elif hasattr(x1, "dtype"):
-        x1 = ivy.asarray(x1)
-        x2 = ivy.asarray(x2, dtype=x1.dtype)
-    elif hasattr(x2, "dtype"):
-        x1 = ivy.asarray(x1, dtype=x2.dtype)
+    if hasattr(x1, "dtype") and not hasattr(x2, "dtype"):
         x2 = ivy.asarray(x2)
-    else:
+    elif hasattr(x2, "dtype") and not hasattr(x1, "dtype"):
+        x1 = ivy.asarray(x1)
+    elif not (hasattr(x1, "dtype") or hasattr(x2, "dtype")):
         x1 = ivy.asarray(x1)
         x2 = ivy.asarray(x2)
+
+    if x1.dtype != x2.dtype:
         promoted = promote_types(
             x1.dtype, x2.dtype, array_api_promotion=array_api_promotion
         )
         x1 = ivy.asarray(x1, dtype=promoted)
         x2 = ivy.asarray(x2, dtype=promoted)
+
     return ivy.to_native(x1), ivy.to_native(x2)


### PR DESCRIPTION
Currently the dtype function promotes `Number` (non-array) entries to their counterpart array. This can sometime leade to down promote like if the array is of `int` type and number of `float`. For example take `ivy.pow` function.
This code produces the wrong result.
```python
>>> x = ivy.array([2,3])
>>> ivy.pow(x, 2.3)
ivy.array([4, 9])
```
Whereas torch gives the mathematically accurate result.

```python
>>> x = torch.tensor([2,3])
>>> torch.pow(x, 2.3)
tensor([ 4.9246, 12.5135])
```

After this change the result will be
```python
>>> x = ivy.array([2,3])
>>> ivy.pow(x, 2.3)
ivy.array([ 4.92457771, 12.51350212])
```

Also the function had some extra needless calls to ivy.asarray and duplicated logic which was removed. Just needs approval before merge as its quite a funcdamental function.
