### PR TITLE
Another fix to mixed function handling

### DIFF
--- a/ivy/func_wrapper.py
+++ b/ivy/func_wrapper.py
@@ -519,25 +519,21 @@ def _wrap_function(
         for attr in docstring_attr:
             setattr(to_wrap, attr, getattr(original, attr))
         # wrap decorators
-        to_replace, additional_wrappers = {}, {}
-        if not compositional:
+        mixed = hasattr(original, "mixed_function")
+        if mixed:
             to_replace = {
-                "inputs_to_ivy_arrays": [
+                True: ["inputs_to_ivy_arrays"],
+                False: [
                     "outputs_to_ivy_arrays",
                     "inputs_to_native_arrays",
-                ]
+                ],
             }
-            additional_wrappers = {"handle_nestable", "handle_out_argument"}
+            for attr in to_replace[compositional]:
+                setattr(original, attr, True)
+
         for attr in FN_DECORATORS:
             if hasattr(original, attr) and not hasattr(to_wrap, attr):
-                if compositional and attr in additional_wrappers:
-                    continue
-                if attr in to_replace:
-                    attrs = to_replace[attr]
-                    for attr in attrs:
-                        to_wrap = getattr(ivy, attr)(to_wrap)
-                else:
-                    to_wrap = getattr(ivy, attr)(to_wrap)
+                to_wrap = getattr(ivy, attr)(to_wrap)
     return to_wrap
 
 

--- a/ivy/functional/experimental/manipulation.py
+++ b/ivy/functional/experimental/manipulation.py
@@ -21,7 +21,6 @@ from ivy.backend_handler import current_backend
 from ivy.exceptions import handle_exceptions
 
 
-@to_native_arrays_and_back
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
@@ -164,6 +163,9 @@ def flatten(
     for i in range(end_dim + 1, len(x.shape)):
         lst.insert(i, x.shape[i])
     return ivy.reshape(x, tuple(lst), order=order)
+
+
+flatten.mixed_function = True
 
 
 @to_native_arrays_and_back

--- a/ivy/functional/ivy/elementwise.py
+++ b/ivy/functional/ivy/elementwise.py
@@ -5374,7 +5374,6 @@ def rad2deg(
     return ivy.current_backend(x).rad2deg(x, out=out)
 
 
-@to_native_arrays_and_back
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
@@ -5417,6 +5416,9 @@ def trunc_divide(
     ivy.array([ 0., -1., 14.])
     """
     return ivy.trunc(ivy.divide(x1, x2), out=out)
+
+
+trunc_divide.mixed_function = True
 
 
 @to_native_arrays_and_back


### PR DESCRIPTION
Had to make some changes to the mixed function wrapping considering the fact that there are some primary functions which also require the `inputs_to_ivy_arrays` decorator such as `inplace_increment`, `inplace_decrement` so a direct replacement of `inputs_to_ivy_arrays` by `inputs_to_native_arrays` followed by `outputs_to_ivy_arrays` is not possible. This time I've added a `mixed_function` attribute which can be set for any function so that only mixed functions will follow this conversion. Finally, the function which is marked as mixed should not have any array conversion decorators as demonstrated for the `flatten` function. 
@djl11 and @mattbarrett98 please let me know if there's a better approach to handle this, thanks 🙂