### PR TITLE
a little fix to the get_axis

### DIFF
--- a/ivy_tests/test_ivy/helpers/hypothesis_helpers/general_helpers.py
+++ b/ivy_tests/test_ivy/helpers/hypothesis_helpers/general_helpers.py
@@ -383,8 +383,12 @@ def get_axis(
 
     axis = draw(st.one_of(*valid_strategies))
     if unique and allow_neg and not isinstance(axis, int):
+        _prev_axis = []
         while not all([ax_i != axes + ax_j for ax_i in axis for ax_j in axis]):
-            axis = draw(st.one_of(*valid_strategies))
+            _prev_axis.append(axis)
+            axis = draw(
+                st.one_of(*valid_strategies).filter(lambda x: x not in _prev_axis)
+            )
 
     if type(axis) == list:
         if sorted:


### PR DESCRIPTION
Sometimes hypothesis generates a particular value many times in a row and due to it in the while loop (inside the if statement) we are waiting for a new axis, but actually the axis array doesn't change, hypothesis raises FailedHealthyCheck exception.
In hypothesis documentation (https://hypothesis.readthedocs.io/en/latest/data.html#composite-strategies) they recommend to use the filter method to avoid that situation of getting identical values in a row.