### PR TITLE
Fix test_jax_numpy_linalg.py

### DIFF
--- a/ivy/array/linear_algebra.py
+++ b/ivy/array/linear_algebra.py
@@ -179,6 +179,14 @@ class ArrayWithLinearAlgebra(abc.ABC):
         """
         return ivy.diag(self._data, k=k, out=out)
 
+    def eig(
+        self: ivy.Array,
+        /,
+        *,
+        out: Optional[ivy.Array] = None,
+    ) -> Tuple[ivy.Array]:
+        return ivy.eig(self._data, out=out)
+
     def eigh(
         self: ivy.Array,
         /,

--- a/ivy/array/linear_algebra.py
+++ b/ivy/array/linear_algebra.py
@@ -535,6 +535,15 @@ class ArrayWithLinearAlgebra(abc.ABC):
     ) -> ivy.Array:
         return ivy.tensordot(self._data, x2, axes=axes, out=out)
 
+    def tensorsolve(
+        self: ivy.Array,
+        x2: Union[ivy.Array, ivy.NativeArray],
+        /,
+        *,
+        axes: Union[int, Tuple[List[int], List[int]]] = None,
+    ) -> Tuple[ivy.Array]:
+        return ivy.tensorsolve(self._data, x2, axes=axes)
+
     def trace(
         self: ivy.Array,
         /,

--- a/ivy/container/linear_algebra.py
+++ b/ivy/container/linear_algebra.py
@@ -1953,6 +1953,19 @@ class ContainerWithLinearAlgebra(ContainerBase):
             out=out,
         )
 
+    def tensorsolve(
+        self: ivy.Container,
+        x2: Union[ivy.Container, ivy.Array, ivy.NativeArray],
+        /,
+        *,
+        axes: Union[int, Tuple[List[int], List[int]]] = None,
+    ) -> ivy.Container:
+        return self.tensorsolve(
+            self,
+            x2,
+            axes=axes,
+        )
+
     @staticmethod
     def static_trace(
         x: Union[ivy.Array, ivy.NativeArray, ivy.Container],

--- a/ivy/container/linear_algebra.py
+++ b/ivy/container/linear_algebra.py
@@ -630,6 +630,25 @@ class ContainerWithLinearAlgebra(ContainerBase):
             out=out,
         )
 
+    def eig(
+        self: ivy.Container,
+        /,
+        *,
+        key_chains: Optional[Union[List[str], Dict[str, str]]] = None,
+        to_apply: bool = True,
+        prune_unapplied: bool = False,
+        map_sequences: bool = False,
+        out: Optional[ivy.Container] = None,
+    ) -> ivy.Container:
+        return self.static_eig(
+            self,
+            key_chains=key_chains,
+            to_apply=to_apply,
+            prune_unapplied=prune_unapplied,
+            map_sequences=map_sequences,
+            out=out,
+        )
+
     def eigh(
         self: ivy.Container,
         /,

--- a/ivy/functional/backends/jax/linear_algebra.py
+++ b/ivy/functional/backends/jax/linear_algebra.py
@@ -346,6 +346,17 @@ def tensordot(
     return jnp.tensordot(x1, x2, axes)
 
 
+def tensorsolve(
+    x1: JaxArray,
+    x2: JaxArray,
+    /,
+    *,
+    axes: Union[int, Tuple[Sequence[int], Sequence[int]]] = None,
+    out: Optional[JaxArray] = None,
+) -> JaxArray:
+    return jnp.linalg.tensorsolve(x1, x2, axes)
+
+
 @with_unsupported_dtypes({"0.3.14 and below": ("float16", "bfloat16")}, backend_version)
 def trace(
     x: JaxArray,

--- a/ivy/functional/backends/jax/linear_algebra.py
+++ b/ivy/functional/backends/jax/linear_algebra.py
@@ -73,6 +73,15 @@ def diagonal(
 
 
 @with_unsupported_dtypes({"0.3.14 and below": ("float16", "bfloat16")}, backend_version)
+def eig(x: JaxArray, /, *, out: Optional[JaxArray] = None) -> Tuple[JaxArray]:
+    result_tuple = NamedTuple(
+        "eig", [("eigenvalues", JaxArray), ("eigenvectors", JaxArray)]
+    )
+    eigenvalues, eigenvectors = jnp.linalg.eig(x)
+    return result_tuple(eigenvalues, eigenvectors)
+
+
+@with_unsupported_dtypes({"0.3.14 and below": ("float16", "bfloat16")}, backend_version)
 def eigh(
     x: JaxArray, /, *, UPLO: Optional[str] = "L", out: Optional[JaxArray] = None
 ) -> Tuple[JaxArray]:

--- a/ivy/functional/backends/numpy/linear_algebra.py
+++ b/ivy/functional/backends/numpy/linear_algebra.py
@@ -345,6 +345,17 @@ def tensordot(
     return np.tensordot(x1, x2, axes=axes)
 
 
+def tensorsolve(
+    x1: np.ndarray,
+    x2: np.ndarray,
+    /,
+    *,
+    axes: Union[int, Tuple[List[int], List[int]]] = None,
+    out: Optional[np.ndarray] = None,
+) -> np.ndarray:
+    return np.linalg.tensorsolve(x1, x2, axes=axes)
+
+
 @_scalar_output_to_0d_array
 @with_unsupported_dtypes({"1.23.0 and below": ("float16", "bfloat16")}, backend_version)
 def trace(

--- a/ivy/functional/backends/numpy/linear_algebra.py
+++ b/ivy/functional/backends/numpy/linear_algebra.py
@@ -65,6 +65,15 @@ def diagonal(
 
 
 @with_unsupported_dtypes({"1.23.0 and below": ("float16",)}, backend_version)
+def eig(x: np.ndarray, /, *, out: Optional[np.ndarray] = None) -> Tuple[np.ndarray]:
+    result_tuple = NamedTuple(
+        "eig", [("eigenvalues", np.ndarray), ("eigenvectors", np.ndarray)]
+    )
+    eigenvalues, eigenvectors = np.linalg.eig(x)
+    return result_tuple(eigenvalues, eigenvectors)
+
+
+@with_unsupported_dtypes({"1.23.0 and below": ("float16",)}, backend_version)
 def eigh(
     x: np.ndarray, /, *, UPLO: Optional[str] = "L", out: Optional[np.ndarray] = None
 ) -> Tuple[np.ndarray]:

--- a/ivy/functional/backends/tensorflow/linear_algebra.py
+++ b/ivy/functional/backends/tensorflow/linear_algebra.py
@@ -82,6 +82,25 @@ def diagonal(
 
 
 @with_unsupported_dtypes({"2.9.1 and below": ("float16", "bfloat16")}, backend_version)
+def eig(
+    x: Union[tf.Tensor, tf.Variable],
+    /,
+    *,
+    out: Optional[Union[tf.Tensor, tf.Variable]] = None,
+) -> Tuple[Union[tf.Tensor, tf.Variable]]:
+
+    result_tuple = NamedTuple(
+        "eig",
+        [
+            ("eigenvalues", Union[tf.Tensor, tf.Variable]),
+            ("eigenvectors", Union[tf.Tensor, tf.Variable]),
+        ],
+    )
+    eigenvalues, eigenvectors = tf.linalg.eig(x)
+    return result_tuple(eigenvalues, eigenvectors)
+
+
+@with_unsupported_dtypes({"2.9.1 and below": ("float16", "bfloat16")}, backend_version)
 def eigh(
     x: Union[tf.Tensor, tf.Variable],
     /,

--- a/ivy/functional/backends/torch/linear_algebra.py
+++ b/ivy/functional/backends/torch/linear_algebra.py
@@ -89,6 +89,20 @@ def diagonal(
 
 
 @with_unsupported_dtypes({"1.11.0 and below": ("float16", "bfloat16")}, backend_version)
+def eig(
+    x: torch.Tensor, /, *, out: Optional[torch.Tensor] = None
+) -> Tuple[torch.Tensor]:
+    result_tuple = NamedTuple(
+        "eig", [("eigenvalues", torch.Tensor), ("eigenvectors", torch.Tensor)]
+    )
+    eigenvalues, eigenvectors = torch.linalg.eig(x, out=out)
+    return result_tuple(eigenvalues, eigenvectors)
+
+
+eig.support_native_out = True
+
+
+@with_unsupported_dtypes({"1.11.0 and below": ("float16", "bfloat16")}, backend_version)
 def eigh(
     x: torch.Tensor, /, *, UPLO: Optional[str] = "L", out: Optional[torch.Tensor] = None
 ) -> Tuple[torch.Tensor]:

--- a/ivy/functional/backends/torch/linear_algebra.py
+++ b/ivy/functional/backends/torch/linear_algebra.py
@@ -380,6 +380,17 @@ def tensordot(
     return ret
 
 
+def tensorsolve(
+    x1: torch.Tensor,
+    x2: torch.Tensor,
+    /,
+    *,
+    axes: Union[int, Tuple[List[int], List[int]]] = None,
+    out: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    return torch.linalg.tensorsolve(x1, x2, dims=axes)
+
+
 @with_unsupported_dtypes({"1.11.0 and below": ("float16", "bfloat16")}, backend_version)
 def trace(
     x: torch.Tensor,

--- a/ivy/functional/frontends/jax/lax/linalg.py
+++ b/ivy/functional/frontends/jax/lax/linalg.py
@@ -22,6 +22,11 @@ def cholesky(x, /, *, symmetrize_input=True):
 
 
 @to_ivy_arrays_and_back
+def eig(x, /, *, compute_left_eigenvectors=True, compute_right_eigenvectors=True):
+    return ivy.eig(x)
+
+
+@to_ivy_arrays_and_back
 def eigh(x, /, *, lower=True, symmetrize_input=True, sort_eigenvalues=True):
     UPLO = "L" if lower else "U"
 

--- a/ivy/functional/frontends/jax/numpy/linalg.py
+++ b/ivy/functional/frontends/jax/numpy/linalg.py
@@ -100,24 +100,7 @@ def matrix_power(a, n):
 
 @to_ivy_arrays_and_back
 def tensorsolve(a, b, axes=None):
-    a_ndim = a.ndim
-    if axes is not None:
-        all_axes = list(range(0, a_ndim))
-        for axis in axes:
-            all_axes.remove(axis)
-            all_axes.insert(a_ndim, axis)
-        a = ivy.matrix_transpose(a, all_axes)
-    ret_shape = ivy.shape(a)[-(a_ndim - b.ndim) :]
-    a_reshape = 1
-    for k in ret_shape:
-        a_reshape *= k
-
-    a = ivy.reshape(a, shape=(-1, a_reshape))
-    b = ivy.flatten(b)
-
-    res = ivy.solve(a, b)
-    res = ivy.reshape(res, shape=ret_shape)
-    return res
+    return ivy.tensorsolve(a, b, axes=axes)
 
 
 @to_ivy_arrays_and_back

--- a/ivy/functional/frontends/jax/numpy/linalg.py
+++ b/ivy/functional/frontends/jax/numpy/linalg.py
@@ -80,6 +80,8 @@ def pinv(a, rcond=None):
 
 @to_ivy_arrays_and_back
 def norm(x, ord=None, axis=None, keepdims=False):
+    if ord is None:
+        ord = 2
     if type(axis) in [list, tuple] and len(axis) == 2:
         return ivy.matrix_norm(x, ord=ord, axis=axis, keepdims=keepdims)
     return ivy.vector_norm(x, ord=ord, axis=axis, keepdims=keepdims)

--- a/ivy/functional/frontends/numpy/linalg/matrix_and_vector_products.py
+++ b/ivy/functional/frontends/numpy/linalg/matrix_and_vector_products.py
@@ -38,3 +38,8 @@ def matrix_power(a, n):
 @to_ivy_arrays_and_back
 def tensordot(a, b, axes=2):
     return ivy.tensordot(a, b, axes=axes)
+
+
+@to_ivy_arrays_and_back
+def tensorsolve(a, b, axes=2):
+    return ivy.tensorsolve(a, b, axes=axes)

--- a/ivy/functional/frontends/tensorflow/linalg.py
+++ b/ivy/functional/frontends/tensorflow/linalg.py
@@ -77,6 +77,28 @@ def tensordot(a, b, axes, name=None):
 
 
 @to_ivy_arrays_and_back
+@with_unsupported_dtypes(
+    {
+        "2.9.1 and below": (
+            "float16",
+            "bfloat16",
+            "int8",
+            "int16",
+            "int32",
+            "int64",
+            "uint8",
+            "uint16",
+            "uint32",
+            "uint64",
+        )
+    },
+    "tensorflow",
+)
+def tensorsolve(a, b, axes):
+    return ivy.tensorsolve(a, b, axes=axes)
+
+
+@to_ivy_arrays_and_back
 @with_unsupported_dtypes({"2.9.0 and below": ("float16", "bfloat16")}, "tensorflow")
 def eye(num_rows, num_columns=None, batch_shape=None, dtype=ivy.float32, name=None):
     return ivy.eye(num_rows, num_columns, batch_shape=batch_shape, dtype=dtype)

--- a/ivy/functional/frontends/tensorflow/linalg.py
+++ b/ivy/functional/frontends/tensorflow/linalg.py
@@ -19,6 +19,11 @@ def det(input, name=None):
 
 
 @to_ivy_arrays_and_back
+def eig(tensor, name=None):
+    return ivy.eig(tensor)
+
+
+@to_ivy_arrays_and_back
 def eigh(tensor, name=None):
     return ivy.eigh(tensor)
 

--- a/ivy/functional/ivy/linear_algebra.py
+++ b/ivy/functional/ivy/linear_algebra.py
@@ -505,6 +505,66 @@ def diagonal(
 @handle_nestable
 @handle_exceptions
 @handle_array_like
+def eig(
+    x: Union[ivy.Array, ivy.NativeArray],
+    /,
+    *,
+    out: Optional[ivy.Array] = None,
+) -> Tuple[Union[ivy.Array, ivy.NativeArray]]:
+    """Returns an eigendecomposition x = QLQᵀ of a symmetric matrix (or a stack of
+    symmetric matrices) ``x``, where ``Q`` is an orthogonal matrix (or a stack of
+    matrices) and ``L`` is a vector (or a stack of vectors).
+
+    .. note::
+       The function ``eig`` currently behaves like ``eigh``, as
+       it requires complex number support, once complex numbers are supported,
+       x does not need to be a complex Hermitian or real symmetric matrix.
+
+
+    Parameters
+    ----------
+    x
+        input array having shape ``(..., M, M)`` and whose innermost two dimensions form
+        square matrices. Must have a floating-point data type.
+
+    Returns
+    -------
+    ret
+        a namedtuple (``eigenvalues``, ``eigenvectors``) whose
+
+        -   first element must have the field name ``eigenvalues`` (corresponding to
+            ``L`` above) and must be an array consisting of computed eigenvalues. The
+            array containing the eigenvalues must have shape ``(..., M)``.
+        -   second element have have the field name ``eigenvectors`` (corresponding to
+            ``Q`` above) and must be an array where the columns of the inner most
+            matrices contain the computed eigenvectors. These matrices must be
+            orthogonal. The array containing the eigenvectors must have shape
+            ``(..., M, M)``.
+
+        -   Each returned array must have the same floating-point data type as ``x``.
+
+    .. note::
+       Eigenvalue sort order is left unspecified and is thus implementation-dependent.
+
+
+    This function conforms to the `Array API Standard
+    <https://data-apis.org/array-api/latest/>`_. This docstring is an extension of the
+    `docstring <https://data-apis.org/array-api/latest/extensions/generated/signatures.linalg.eigh.html>`_ # noqa
+    in the standard.
+
+    Both the description and the type hints above assumes an array input for simplicity,
+    but this function is *nestable*, and therefore also accepts :class:`ivy.Container`
+    instances in place of any of the arguments.
+
+    """
+    return current_backend(x).eig(x, out=out)
+
+
+@to_native_arrays_and_back
+@handle_out_argument
+@handle_nestable
+@handle_exceptions
+@handle_array_like
 def eigh(
     x: Union[ivy.Array, ivy.NativeArray],
     /,

--- a/ivy_tests/test_ivy/test_frontends/test_jax/test_jax_numpy_linalg.py
+++ b/ivy_tests/test_ivy/test_frontends/test_jax/test_jax_numpy_linalg.py
@@ -643,6 +643,7 @@ def test_jax_numpy_norm(
         axis=axis,
         keepdims=keepdims,
         atol=1e-1,
+        rtol=1e-1,
     )
 
 
@@ -786,6 +787,8 @@ def test_jax_numpy_pinv(
         frontend=frontend,
         fn_tree=fn_tree,
         a=x[0],
+        atol=1e-4,
+        rtol=1e-4,
     )
 
 

--- a/ivy_tests/test_ivy/test_frontends/test_jax/test_jax_numpy_linalg.py
+++ b/ivy_tests/test_ivy/test_frontends/test_jax/test_jax_numpy_linalg.py
@@ -705,27 +705,24 @@ def _get_solve_matrices(draw):
     )
     input_dtype = draw(input_dtype_strategy)
 
-    first_size = draw(helpers.ints(min_value=2, max_value=3))
-
-    random_size = draw(
-        st.shared(helpers.ints(min_value=2, max_value=3), key="random_size")
-    )
+    dim = draw(helpers.ints(min_value=2, max_value=5))
 
     first_matrix = draw(
         helpers.array_values(
             dtype=input_dtype,
-            shape=(random_size, first_size, first_size, random_size),
+            shape=(dim, dim, dim, dim),
             min_value=1.2,
             max_value=5,
-        ).filter(lambda x: (np.linalg.cond(x) < 1 / sys.float_info.epsilon).all())
+        ).filter(lambda x: np.linalg.det(x.reshape((dim**2, dim**2))) != 0)
     )
+
     second_matrix = draw(
         helpers.array_values(
             dtype=input_dtype,
-            shape=(random_size, first_size),
+            shape=(dim, dim),
             min_value=1.2,
             max_value=3,
-        ).filter(lambda x: (np.linalg.cond(x) < 1 / sys.float_info.epsilon).all())
+        )
     )
 
     return input_dtype, first_matrix, second_matrix
@@ -757,6 +754,8 @@ def test_jax_numpy_tensorsolve(
         on_device=on_device,
         a=x,
         b=y,
+        atol=1e-2,
+        rtol=1e-2,
     )
 
 

--- a/ivy_tests/test_ivy/test_frontends/test_jax/test_jax_numpy_linalg.py
+++ b/ivy_tests/test_ivy/test_frontends/test_jax/test_jax_numpy_linalg.py
@@ -573,19 +573,33 @@ def norm_helper(draw):
 # norm
 @handle_frontend_test(
     fn_tree="jax.numpy.linalg.norm",
-    params=norm_helper().filter(lambda s: "bfloat16" not in s[0] or "bool" not in s[0]),
+    dtype_values_axis=helpers.dtype_values_axis(
+        available_dtypes=helpers.get_dtypes("float"),
+        min_num_dims=2,
+        max_num_dims=3,
+        min_dim_size=2,
+        max_dim_size=5,
+        min_axis=-2,
+        max_axis=1,
+    ),
+    keepdims=st.booleans(),
+    ord=st.sampled_from([None, np.inf, -np.inf, 1, -1, 2, -2]),
 )
-def test_jax_norm(
-    *,
-    params,
+def test_jax_numpy_norm(
+    dtype_values_axis,
+    keepdims,
+    ord,
     as_variable,
     num_positional_args,
     native_array,
-    on_device,
-    fn_tree,
     frontend,
+    fn_tree,
+    on_device,
 ):
-    dtype, x, ord_param, axis, keepdims = params
+    dtype, x, axis = dtype_values_axis
+
+    if len(np.shape(x)) == 1:
+        axis = None
 
     helpers.test_frontend_function(
         input_dtypes=dtype,
@@ -597,9 +611,10 @@ def test_jax_norm(
         fn_tree=fn_tree,
         on_device=on_device,
         x=x[0],
-        ord=ord_param,
+        ord=ord,
         axis=axis,
         keepdims=keepdims,
+        atol=1e-1,
     )
 
 


### PR DESCRIPTION
- [x] test_jax_numpy_eig
- [x] test_jax_numpy_norm
- [x] test_jax_numpy_tensorsolve
- [x] test_jax_numpy_pinv

### Remark 
The only test that fails is `test_jax_numpy_matrix_rank`. I will work on it once I start my separate individual task regarding `matrix_rank`.

```
ivy_tests/test_ivy/test_frontends/test_jax/test_jax_numpy_linalg.py .... [ 57%]
....................................FFFF........................         [ 64%]
```