### PR TITLE
Fixed `ivy.Dtype` validation

### DIFF
--- a/ivy/__init__.py
+++ b/ivy/__init__.py
@@ -72,7 +72,7 @@ class Dtype(str):
             dtype_str = "bool"
         if not isinstance(dtype_str, str):
             raise ivy.exceptions.IvyException("dtype must be type str")
-        if dtype_str not in all_ivy_dtypes_str:
+        if dtype_str not in _all_ivy_dtypes_str:
             raise ivy.exceptions.IvyException(f"{dtype_str} is not supported by ivy")
         return str.__new__(cls, dtype_str)
 
@@ -190,7 +190,7 @@ class IntDtype(Dtype):
             raise ivy.exceptions.IvyException(
                 "dtype must be string and starts with int"
             )
-        if dtype_str not in all_ivy_dtypes_str:
+        if dtype_str not in _all_ivy_dtypes_str:
             raise ivy.exceptions.IvyException(f"{dtype_str} is not supported by ivy")
         return str.__new__(cls, dtype_str)
 
@@ -209,7 +209,7 @@ class FloatDtype(Dtype):
             raise ivy.exceptions.IvyException(
                 "dtype must be string and starts with float"
             )
-        if dtype_str not in all_ivy_dtypes_str:
+        if dtype_str not in _all_ivy_dtypes_str:
             raise ivy.exceptions.IvyException(f"{dtype_str} is not supported by ivy")
         return str.__new__(cls, dtype_str)
 
@@ -226,7 +226,7 @@ class UintDtype(IntDtype):
             raise ivy.exceptions.IvyException(
                 "dtype must be string and starts with uint"
             )
-        if dtype_str not in all_ivy_dtypes_str:
+        if dtype_str not in _all_ivy_dtypes_str:
             raise ivy.exceptions.IvyException(f"{dtype_str} is not supported by ivy")
         return str.__new__(cls, dtype_str)
 
@@ -243,7 +243,7 @@ class ComplexDtype(Dtype):
             raise ivy.exceptions.IvyException(
                 "dtype must be string and starts with complex"
             )
-        if dtype_str not in all_ivy_dtypes_str:
+        if dtype_str not in _all_ivy_dtypes_str:
             raise ivy.exceptions.IvyException(f"{dtype_str} is not supported by ivy")
         return str.__new__(cls, dtype_str)
 
@@ -277,8 +277,9 @@ valid_devices = ("cpu",)
 
 invalid_devices = ("gpu", "tpu")
 
-# supported ivy data types
-all_ivy_dtypes_str = (
+# data types as string (to be used by Dtype classes)
+# any changes here should also be reflected in the data type initialisation underneath
+_all_ivy_dtypes_str = (
     "int8",
     "int16",
     "int32",
@@ -298,6 +299,7 @@ all_ivy_dtypes_str = (
 )
 
 # data types
+# any changes here should also be reflected in the data type string tuple above
 int8 = IntDtype("int8")
 int16 = IntDtype("int16")
 int32 = IntDtype("int32")

--- a/ivy/__init__.py
+++ b/ivy/__init__.py
@@ -71,16 +71,9 @@ class Dtype(str):
         if dtype_str is builtins.bool:
             dtype_str = "bool"
         if not isinstance(dtype_str, str):
-            raise ivy.exceptions.IvyException("dtype_str must be type str")
-        if not (
-            "int" in dtype_str
-            or "float" in dtype_str
-            or "bool" in dtype_str
-            or "complex" in dtype_str
-        ):
-            raise ivy.exceptions.IvyException(
-                "dtype must be string and starts with int, float, complex, or bool"
-            )
+            raise ivy.exceptions.IvyException("dtype must be type str")
+        if dtype_str not in all_ivy_dtypes_str:
+            raise ivy.exceptions.IvyException(f"{dtype_str} is not supported by ivy")
         return str.__new__(cls, dtype_str)
 
     def __ge__(self, other):
@@ -197,6 +190,8 @@ class IntDtype(Dtype):
             raise ivy.exceptions.IvyException(
                 "dtype must be string and starts with int"
             )
+        if dtype_str not in all_ivy_dtypes_str:
+            raise ivy.exceptions.IvyException(f"{dtype_str} is not supported by ivy")
         return str.__new__(cls, dtype_str)
 
     @property
@@ -214,6 +209,8 @@ class FloatDtype(Dtype):
             raise ivy.exceptions.IvyException(
                 "dtype must be string and starts with float"
             )
+        if dtype_str not in all_ivy_dtypes_str:
+            raise ivy.exceptions.IvyException(f"{dtype_str} is not supported by ivy")
         return str.__new__(cls, dtype_str)
 
     @property
@@ -229,6 +226,8 @@ class UintDtype(IntDtype):
             raise ivy.exceptions.IvyException(
                 "dtype must be string and starts with uint"
             )
+        if dtype_str not in all_ivy_dtypes_str:
+            raise ivy.exceptions.IvyException(f"{dtype_str} is not supported by ivy")
         return str.__new__(cls, dtype_str)
 
     @property
@@ -244,6 +243,8 @@ class ComplexDtype(Dtype):
             raise ivy.exceptions.IvyException(
                 "dtype must be string and starts with complex"
             )
+        if dtype_str not in all_ivy_dtypes_str:
+            raise ivy.exceptions.IvyException(f"{dtype_str} is not supported by ivy")
         return str.__new__(cls, dtype_str)
 
 
@@ -276,6 +277,25 @@ valid_devices = ("cpu",)
 
 invalid_devices = ("gpu", "tpu")
 
+# supported ivy data types
+all_ivy_dtypes_str = (
+    "int8",
+    "int16",
+    "int32",
+    "int64",
+    "uint8",
+    "uint16",
+    "uint32",
+    "uint64",
+    "bfloat16",
+    "float16",
+    "float32",
+    "float64",
+    "complex64",
+    "complex128",
+    "complex256",
+    "bool",
+)
 
 # data types
 int8 = IntDtype("int8")

--- a/ivy/functional/backends/jax/data_type.py
+++ b/ivy/functional/backends/jax/data_type.py
@@ -158,7 +158,13 @@ def as_ivy_dtype(dtype_in: Union[jnp.dtype, str, bool, int, float]) -> ivy.Dtype
     if dtype_in is bool:
         return ivy.Dtype("bool")
     if isinstance(dtype_in, str):
-        return ivy.Dtype(dtype_in)
+        if dtype_in in native_dtype_dict:
+            return ivy.Dtype(dtype_in)
+        else:
+            raise ivy.exceptions.IvyException(
+                "Cannot convert to ivy dtype."
+                f" {dtype_in} is not supported by Jax backend."
+            )
     return ivy.Dtype(ivy_dtype_dict[dtype_in])
 
 
@@ -171,7 +177,12 @@ def as_native_dtype(dtype_in: Union[jnp.dtype, str, bool, int, float]) -> jnp.dt
         return jnp.dtype("bool")
     if not isinstance(dtype_in, str):
         return dtype_in
-    return native_dtype_dict[ivy.Dtype(dtype_in)]
+    if dtype_in in native_dtype_dict.values():
+        return native_dtype_dict[ivy.Dtype(dtype_in)]
+    else:
+        raise ivy.exceptions.IvyException(
+            f"Cannot convert to Jax dtype. {dtype_in} is not supported by Jax."
+        )
 
 
 def dtype(x: JaxArray, as_native: bool = False) -> ivy.Dtype:

--- a/ivy/functional/backends/numpy/data_type.py
+++ b/ivy/functional/backends/numpy/data_type.py
@@ -164,7 +164,13 @@ def as_ivy_dtype(dtype_in: Union[np.dtype, str, bool, int, float]) -> ivy.Dtype:
     if dtype_in is bool:
         return ivy.Dtype("bool")
     if isinstance(dtype_in, str):
-        return ivy.Dtype(dtype_in)
+        if dtype_in in native_dtype_dict:
+            return ivy.Dtype(dtype_in)
+        else:
+            raise ivy.exceptions.IvyException(
+                "Cannot convert to ivy dtype."
+                f" {dtype_in} is not supported by NumPy backend."
+            )
     return ivy.Dtype(ivy_dtype_dict[dtype_in])
 
 

--- a/ivy/functional/backends/tensorflow/data_type.py
+++ b/ivy/functional/backends/tensorflow/data_type.py
@@ -207,7 +207,13 @@ def as_ivy_dtype(dtype_in: Union[tf.DType, str, bool, int, float]) -> ivy.Dtype:
     if dtype_in is bool:
         return ivy.Dtype("bool")
     if isinstance(dtype_in, str):
-        return ivy.Dtype(dtype_in)
+        if dtype_in in native_dtype_dict:
+            return ivy.Dtype(dtype_in)
+        else:
+            raise ivy.exceptions.IvyException(
+                "Cannot convert to ivy dtype."
+                f" {dtype_in} is not supported by TensorFlow backend."
+            )
     return ivy.Dtype(ivy_dtype_dict[dtype_in])
 
 
@@ -220,7 +226,13 @@ def as_native_dtype(dtype_in: Union[tf.DType, str, bool, int, float]) -> tf.DTyp
         return tf.bool
     if not isinstance(dtype_in, str):
         return dtype_in
-    return native_dtype_dict[ivy.Dtype(dtype_in)]
+    if dtype_in in native_dtype_dict.keys():
+        return native_dtype_dict[ivy.Dtype(dtype_in)]
+    else:
+        raise ivy.exceptions.IvyException(
+            "Cannot convert to TensorFlow dtype."
+            f" {dtype_in} is not supported by TensorFlow."
+        )
 
 
 def dtype(x: Union[tf.Tensor, tf.Variable], as_native: bool = False) -> ivy.Dtype:

--- a/ivy/functional/backends/torch/data_type.py
+++ b/ivy/functional/backends/torch/data_type.py
@@ -165,7 +165,13 @@ def as_ivy_dtype(dtype_in: Union[torch.dtype, str, bool, int, float]) -> ivy.Dty
     if dtype_in is bool:
         return ivy.Dtype("bool")
     if isinstance(dtype_in, str):
-        return ivy.Dtype(dtype_in)
+        if dtype_in in native_dtype_dict:
+            return ivy.Dtype(dtype_in)
+        else:
+            raise ivy.exceptions.IvyException(
+                "Cannot convert to ivy dtype."
+                f" {dtype_in} is not supported by PyTorch backend."
+            )
     return ivy.Dtype(ivy_dtype_dict[dtype_in])
 
 
@@ -183,7 +189,8 @@ def as_native_dtype(dtype_in: Union[torch.dtype, str, bool, int, float]) -> torc
         return native_dtype_dict[ivy.Dtype(dtype_in)]
     else:
         raise ivy.exceptions.IvyException(
-            f"Cannot convert to PyTorch dtype. {dtype_in} is not supported by PyTorch."
+            "Cannot convert to PyTorch dtype."
+            f" {dtype_in} is not supported by PyTorch."
         )
 
 

--- a/ivy_tests/test_ivy/test_functional/test_core/test_dtype.py
+++ b/ivy_tests/test_ivy/test_functional/test_core/test_dtype.py
@@ -1081,13 +1081,14 @@ def test_function_dtype_versioning_frontend(
 # invalid_dtype
 @handle_test(
     fn_tree="functional.ivy.invalid_dtype",
-    dtype_in=st.sampled_from(ivy.valid_dtypes),
+    dtype_in=helpers.get_dtypes("valid", full=False),
 )
 def test_invalid_dtype(
     *,
     dtype_in,
     backend_fw,
 ):
+    dtype_in = dtype_in[0]
     res = ivy.invalid_dtype(dtype_in)
     fw = backend_fw.current_backend_str()
     fw_invalid_dtypes = {
@@ -1110,12 +1111,13 @@ def test_invalid_dtype(
 # unset_default_dtype
 @handle_test(
     fn_tree="functional.ivy.unset_default_dtype",
-    dtype=st.sampled_from(ivy.valid_dtypes),
+    dtype=helpers.get_dtypes("valid", full=False),
 )
 def test_unset_default_dtype(
     *,
     dtype,
 ):
+    dtype = dtype[0]
     stack_size_before = len(ivy.default_dtype_stack)
     ivy.set_default_dtype(dtype)
     ivy.unset_default_dtype()
@@ -1128,7 +1130,7 @@ def test_unset_default_dtype(
 # unset_default_float_dtype
 @handle_test(
     fn_tree="functional.ivy.unset_default_float_dtype",
-    dtype=st.sampled_from(ivy.valid_float_dtypes),
+    dtype=helpers.get_dtypes("float", full=False),
 )
 def test_unset_default_float_dtype(
     *,
@@ -1138,6 +1140,7 @@ def test_unset_default_float_dtype(
     fn_name,
     on_device,
 ):
+    dtype = dtype[0]
     stack_size_before = len(ivy.default_float_dtype_stack)
     ivy.set_default_float_dtype(dtype)
     ivy.unset_default_float_dtype()
@@ -1150,12 +1153,13 @@ def test_unset_default_float_dtype(
 # unset_default_int_dtype
 @handle_test(
     fn_tree="functional.ivy.unset_default_int_dtype",
-    dtype=st.sampled_from(ivy.valid_int_dtypes),
+    dtype=helpers.get_dtypes("integer", full=False),
 )
 def test_unset_default_int_dtype(
     *,
     dtype,
 ):
+    dtype = dtype[0]
     stack_size_before = len(ivy.default_int_dtype_stack)
     ivy.set_default_int_dtype(dtype)
     ivy.unset_default_int_dtype()
@@ -1168,13 +1172,14 @@ def test_unset_default_int_dtype(
 # valid_dtype
 @handle_test(
     fn_tree="functional.ivy.valid_dtype",
-    dtype_in=st.sampled_from(ivy.valid_dtypes),
+    dtype_in=helpers.get_dtypes("valid", full=False),
 )
 def test_valid_dtype(
     *,
     dtype_in,
     backend_fw,
 ):
+    dtype_in = dtype_in[0]
     res = ivy.valid_dtype(dtype_in)
     fw = backend_fw.current_backend_str()
     fw_valid_dtypes = {

--- a/ivy_tests/test_ivy/test_functional/test_core/test_dtype.py
+++ b/ivy_tests/test_ivy/test_functional/test_core/test_dtype.py
@@ -450,13 +450,14 @@ def test_result_type(
 # as_ivy_dtype
 @handle_test(
     fn_tree="functional.ivy.as_ivy_dtype",
-    input_dtype=st.sampled_from(ivy.valid_dtypes),
+    input_dtype=helpers.get_dtypes("valid", full=False),
 )
 def test_as_ivy_dtype(
     *,
     input_dtype,
     ground_truth_backend,
 ):
+    input_dtype = input_dtype[0]
     res = ivy.as_ivy_dtype(input_dtype)
     if isinstance(input_dtype, str):
         assert isinstance(res, str)
@@ -468,23 +469,10 @@ def test_as_ivy_dtype(
     assert isinstance(res, str), f"result={res!r}, but should be str"
 
 
-_valid_dtype_in_all_frameworks = [
-    "int8",
-    "int16",
-    "int32",
-    "int64",
-    "uint8",
-    "float16",
-    "float32",
-    "float64",
-    "bool",
-]
-
-
 # as_native_dtype
 @handle_test(
     fn_tree="functional.ivy.as_native_dtype",
-    input_dtype=st.sampled_from(_valid_dtype_in_all_frameworks),
+    input_dtype=helpers.get_dtypes("valid", full=False),
 )
 def test_as_native_dtype(
     *,
@@ -495,6 +483,7 @@ def test_as_native_dtype(
     on_device,
     ground_truth_backend,
 ):
+    input_dtype = input_dtype[0]
     res = ivy.as_native_dtype(input_dtype)
     if isinstance(input_dtype, ivy.NativeDtype):
         assert isinstance(res, ivy.NativeDtype)
@@ -511,9 +500,10 @@ def test_as_native_dtype(
 # closest_valid_dtypes
 @handle_test(
     fn_tree="functional.ivy.closest_valid_dtype",
-    input_dtype=st.sampled_from(_valid_dtype_in_all_frameworks),
+    input_dtype=helpers.get_dtypes("valid", full=False),
 )
 def test_closest_valid_dtype(*, input_dtype, with_out, backend_fw, fn_name, on_device):
+    input_dtype = input_dtype[0]
     res = ivy.closest_valid_dtype(input_dtype)
     assert isinstance(input_dtype, ivy.Dtype) or isinstance(input_dtype, str)
     assert isinstance(res, ivy.Dtype) or isinstance(


### PR DESCRIPTION
Fixed `ivy.Dtype` and all `.as_ivy_dtype` backend functions. `ivy.Dtype` can return any valid ivy dtype, `.as_ivy_dtype` returns the respective ivy dtype as long as the backend supports it.