### PR TITLE
refactor test helpers to build flags

### DIFF
--- a/ivy_tests/test_ivy/conftest.py
+++ b/ivy_tests/test_ivy/conftest.py
@@ -4,6 +4,7 @@ import pytest
 from typing import Dict
 
 # local
+import ivy_tests.test_ivy.helpers.test_parameter_flags as pf
 from ivy import DefaultDevice
 from ivy_tests.test_ivy.helpers import globals as test_globals
 from ivy_tests.test_ivy.helpers.available_frameworks import available_frameworks
@@ -141,20 +142,10 @@ def process_cl_flags(config) -> Dict[str, bool]:
             )
         # skipping a test
         if v[0] or no_extra_testing:
-            GENERAL_CONFIG_DICT[k] = False
+            pf.build_flag(k, False)
         # extra testing
         if v[1]:
-            GENERAL_CONFIG_DICT[k] = True
-        # let hypothesis generate it
-        if not v[0] ^ v[1]:
-            if k in ["instance_method", "test_gradients"]:
-                UNSET_TEST_API_CONFIG["flag"].append(k)
-            elif k == "container":
-                UNSET_TEST_API_CONFIG["list"].append("container_flags")
-            elif k == "with_out":
-                UNSET_TEST_CONFIG["flag"].append(k)
-            else:
-                UNSET_TEST_CONFIG["list"].append(k)
+            pf.build_flag(k, True)
 
 
 def pytest_addoption(parser):

--- a/ivy_tests/test_ivy/helpers/test_parameter_flags.py
+++ b/ivy_tests/test_ivy/helpers/test_parameter_flags.py
@@ -1,4 +1,3 @@
-from dataclasses import dataclass
 from hypothesis import strategies as st  # NOQA
 
 
@@ -26,17 +25,12 @@ class AsVariableFlags:
     pass
 
 
-@dataclass(frozen=True)
-class _FlagBuilder:
-    strategy: st.SearchStrategy
-
-
-_BuiltNativeArray = _FlagBuilder(st.lists(st.booleans(), min_size=1, max_size=1))
-_BuiltAsVariable = _FlagBuilder(st.lists(st.booleans(), min_size=1, max_size=1))
-_BuiltContainer = _FlagBuilder(st.booleans())
-_BuiltInstance = _FlagBuilder(st.booleans())
-_BuiltWithOut = _FlagBuilder(st.booleans())
-_BuiltGradient = _FlagBuilder(st.booleans())
+BuiltNativeArrayStrategy = st.lists(st.booleans(), min_size=1, max_size=1)
+BuiltAsVariableStrategy = st.lists(st.booleans(), min_size=1, max_size=1)
+BuiltContainerStrategy = st.booleans()
+BuiltInstanceStrategy = st.booleans()
+BuiltWithOutStrategy = st.booleans()
+BuiltGradientStrategy = st.booleans()
 
 
 flags_mapping = {
@@ -52,4 +46,4 @@ flags_mapping = {
 def build_flag(key: str, value: bool):
     if value is not None:
         value = st.just(value)
-    globals()[flags_mapping[key]] = _FlagBuilder(strategy=value)
+    globals()[flags_mapping[key]] = value

--- a/ivy_tests/test_ivy/helpers/test_parameter_flags.py
+++ b/ivy_tests/test_ivy/helpers/test_parameter_flags.py
@@ -27,7 +27,7 @@ class AsVariableFlags:
 
 BuiltNativeArrayStrategy = st.lists(st.booleans(), min_size=1, max_size=1)
 BuiltAsVariableStrategy = st.lists(st.booleans(), min_size=1, max_size=1)
-BuiltContainerStrategy = st.booleans()
+BuiltContainerStrategy = st.lists(st.booleans(), min_size=1, max_size=1)
 BuiltInstanceStrategy = st.booleans()
 BuiltWithOutStrategy = st.booleans()
 BuiltGradientStrategy = st.booleans()

--- a/ivy_tests/test_ivy/helpers/test_parameter_flags.py
+++ b/ivy_tests/test_ivy/helpers/test_parameter_flags.py
@@ -1,3 +1,7 @@
+from dataclasses import dataclass
+from hypothesis import strategies as st  # NOQA
+
+
 class ContainerFlags:
     pass
 
@@ -20,3 +24,32 @@ class NativeArrayFlags:
 
 class AsVariableFlags:
     pass
+
+
+@dataclass(frozen=True)
+class _FlagBuilder:
+    strategy: st.SearchStrategy
+
+
+_BuiltNativeArray = _FlagBuilder(st.lists(st.booleans(), min_size=1, max_size=1))
+_BuiltAsVariable = _FlagBuilder(st.lists(st.booleans(), min_size=1, max_size=1))
+_BuiltContainer = _FlagBuilder(st.booleans())
+_BuiltInstance = _FlagBuilder(st.booleans())
+_BuiltWithOut = _FlagBuilder(st.booleans())
+_BuiltGradient = _FlagBuilder(st.booleans())
+
+
+flags_mapping = {
+    "as_variable": "_BuiltAsVariable",
+    "native_array": "_BuiltNativeArray",
+    "container": "_BuiltContainer",
+    "with_out": "_BuiltWithOut",
+    "instance_method": "_BuiltInstance",
+    "test_gradients": "_BuiltGradient",
+}
+
+
+def build_flag(key: str, value: bool):
+    if value is not None:
+        value = st.just(value)
+    globals()[flags_mapping[key]] = _FlagBuilder(strategy=value)

--- a/ivy_tests/test_ivy/helpers/testing_helpers.py
+++ b/ivy_tests/test_ivy/helpers/testing_helpers.py
@@ -139,9 +139,9 @@ def _generate_shared_test_flags(
     """
     possible_flags = {
         "num_positional_args": num_positional_args(fn_name=fn_tree),
-        "as_variable": pf._BuiltNativeArray.strategy,
-        "native_array": pf._BuiltNativeArray.strategy,
-        "with_out": pf._BuiltWithOut.strategy,
+        "as_variable": pf.BuiltNativeArrayStrategy,
+        "native_array": pf.BuiltNativeArrayStrategy,
+        "with_out": pf.BuiltWithOutStrategy,
     }
     for k in set(param_names).intersection(possible_flags.keys()):
         _given_kwargs[k] = possible_flags[k]
@@ -196,9 +196,9 @@ def handle_test(
                 param_names, given_kwargs, fn_tree
             )
             possible_flags = {
-                "container": pf._BuiltContainer.strategy,
-                "instance_method": pf._BuiltInstance.strategy,
-                "test_gradients": pf._BuiltGradient.strategy,
+                "container": pf.BuiltContainerStrategy,
+                "instance_method": pf.BuiltInstanceStrategy,
+                "test_gradients": pf.BuiltGradientStrategy,
             }
             for k in set(param_names).intersection(possible_flags.keys()):
                 _given_kwargs[k] = possible_flags[k]

--- a/ivy_tests/test_ivy/helpers/testing_helpers.py
+++ b/ivy_tests/test_ivy/helpers/testing_helpers.py
@@ -8,7 +8,6 @@ from hypothesis import given, strategies as st
 
 # local
 import ivy
-from ivy_tests.test_ivy import conftest as cfg  # TODO temporary
 from .hypothesis_helpers import number_helpers as nh
 from .globals import TestData
 from . import test_parameter_flags as pf
@@ -127,7 +126,9 @@ def _import_fn(fn_tree: str):
 
 
 def _generate_shared_test_flags(
-    param_names: list, _given_kwargs: dict, fn_tree: str, fn: callable
+    param_names: list,
+    _given_kwargs: dict,
+    fn_tree: str,
 ):
     """
     Generates flags that all tests use.
@@ -136,24 +137,14 @@ def _generate_shared_test_flags(
     -------
     shared flags that all tests use.
     """
-    if "num_positional_args" in param_names:
-        _given_kwargs["num_positional_args"] = num_positional_args(fn_name=fn_tree)
-    for flag_key, flag_value in cfg.GENERAL_CONFIG_DICT.items():
-        if flag_key in param_names:
-            _given_kwargs[flag_key] = st.just(flag_value)
-    for flag in cfg.UNSET_TEST_CONFIG["list"]:
-        if flag in param_names:
-            _given_kwargs[flag] = st.lists(st.booleans(), min_size=1, max_size=1)
-    for flag in cfg.UNSET_TEST_CONFIG["flag"]:
-        if flag in param_names:
-            _given_kwargs[flag] = st.booleans()
-    # Override with_out to be compatible
-    if "with_out" in param_names:
-        for k in inspect.signature(fn).parameters.keys():
-            if k.endswith("out"):
-                break
-        else:
-            _given_kwargs["with_out"] = st.just(False)
+    possible_flags = {
+        "num_positional_args": num_positional_args(fn_name=fn_tree),
+        "as_variable": pf._BuiltNativeArray.strategy,
+        "native_array": pf._BuiltNativeArray.strategy,
+        "with_out": pf._BuiltWithOut.strategy,
+    }
+    for k in set(param_names).intersection(possible_flags.keys()):
+        _given_kwargs[k] = possible_flags[k]
     return _given_kwargs
 
 
@@ -202,17 +193,15 @@ def handle_test(
         # No Hypothesis @given is used
         if is_hypothesis_test:
             _given_kwargs = _generate_shared_test_flags(
-                param_names, given_kwargs, fn_tree, callable_fn
+                param_names, given_kwargs, fn_tree
             )
-            for flag in cfg.UNSET_TEST_API_CONFIG["list"]:
-                if flag in param_names:
-                    _given_kwargs[flag] = st.lists(
-                        st.booleans(), min_size=1, max_size=1
-                    )
-            for flag in cfg.UNSET_TEST_API_CONFIG["flag"]:
-                if flag in param_names:
-                    _given_kwargs[flag] = st.booleans()
-
+            possible_flags = {
+                "container": pf._BuiltContainer.strategy,
+                "instance_method": pf._BuiltInstance.strategy,
+                "test_gradients": pf._BuiltGradient.strategy,
+            }
+            for k in set(param_names).intersection(possible_flags.keys()):
+                _given_kwargs[k] = possible_flags[k]
             wrapped_test = given(**_given_kwargs)(test_fn)
             possible_arguments = {
                 "fn_name": fn_name,
@@ -254,7 +243,9 @@ def handle_frontend_test(*, fn_tree: str, **_given_kwargs):
         if is_hypothesis_test:
             param_names = inspect.signature(test_fn).parameters.keys()
             _given_kwargs = _generate_shared_test_flags(
-                param_names, given_kwargs, fn_tree, callable_fn
+                param_names,
+                given_kwargs,
+                fn_tree,
             )
             wrapped_test = given(**_given_kwargs)(test_fn)
             if "fn_tree" in param_names:

--- a/ivy_tests/test_ivy/helpers/testing_helpers.py
+++ b/ivy_tests/test_ivy/helpers/testing_helpers.py
@@ -196,7 +196,7 @@ def handle_test(
                 param_names, given_kwargs, fn_tree
             )
             possible_flags = {
-                "container": pf.BuiltContainerStrategy,
+                "container_flags": pf.BuiltContainerStrategy,
                 "instance_method": pf.BuiltInstanceStrategy,
                 "test_gradients": pf.BuiltGradientStrategy,
             }


### PR DESCRIPTION
## New
- Add pre-built strategies for better readability and faster execution of tests

## Updates
- Remove temporary dependency from `testing_helpers`