### PR TITLE
Improved inputs_to_native_arrays.

### DIFF
--- a/ivy/func_wrapper.py
+++ b/ivy/func_wrapper.py
@@ -105,6 +105,8 @@ def inputs_to_native_arrays(fn: Callable) -> Callable:
         -------
             The return of the function, with native arrays passed in the arguments.
         """
+        if not ivy.get_array_mode():
+            return fn(*args, **kwargs)
         if not any(isinstance(arg, ivy.Array) for arg in args) and not any(isinstance(arg, ivy.Array) for arg in kwargs.values()):
             return fn(*args, **kwargs)
         # use pop on out from keywords 

--- a/ivy/func_wrapper.py
+++ b/ivy/func_wrapper.py
@@ -105,23 +105,16 @@ def inputs_to_native_arrays(fn: Callable) -> Callable:
         -------
             The return of the function, with native arrays passed in the arguments.
         """
-        if not ivy.get_array_mode():
+        if not any(isinstance(arg, ivy.Array) for arg in args) and not any(isinstance(arg, ivy.Array) for arg in kwargs.values()):
             return fn(*args, **kwargs)
-        # check if kwargs contains an out argument, and if so, remove it
-        has_out = False
-        out = None
-        if "out" in kwargs:
-            out = kwargs["out"]
-            del kwargs["out"]
-            has_out = True
+        # use pop on out from keywords 
+        out = kwargs.pop("out", None)
         # convert all arrays in the inputs to ivy.NativeArray instances
-        new_args, new_kwargs = ivy.args_to_native(
-            *args, **kwargs, include_derived={tuple: True}
-        )
+        args, kwargs = ivy.args_to_native(*args, **kwargs, include_derived={tuple: True},cache=array_cache)
         # add the original out argument back to the keyword arguments
-        if has_out:
-            new_kwargs["out"] = out
-        return fn(*new_args, **new_kwargs)
+        if out is not None:
+            kwargs["out"] = out
+        return fn(*args, **kwargs)
 
     new_fn.inputs_to_native_arrays = True
     return new_fn


### PR DESCRIPTION
Added additional check in the beginning of the inputs_to_native_arrays function to see if any of the arguments are instances of ivy.Array.If none of the arguments are instances of ivy arrays, the function is called as usual and the conversion to ivy.NativeArray is skipped.Also changed del to pop both are linear complexity and added a cache register.