### PR TITLE
Fixed a bug regarding unsupported dtypes with einops_repeat

### DIFF
--- a/ivy/functional/ivy/data_type.py
+++ b/ivy/functional/ivy/data_type.py
@@ -83,6 +83,8 @@ def _get_function_list(func):
     for node in ast.walk(tree):
         if isinstance(node, ast.Call):
             nodef = node.func
+            if nodef.value.id != "ivy":
+                continue
             if isinstance(nodef, ast.Name):
                 names[nodef.id] = getattr(
                     func,


### PR DESCRIPTION
The issue was that we were adding functions from other modules into the `names` dict, after which those names were being fetched from the `ivy.__dict__` and when there was a name conflict (e.g. `einops.repeat` and `ivy.repeat`), the functions had the wrong reference