### PR TITLE
fixing allclose failing tests in Experimental API

### DIFF
--- a/ivy/functional/backends/numpy/experimental/elementwise.py
+++ b/ivy/functional/backends/numpy/experimental/elementwise.py
@@ -292,6 +292,7 @@ def diff(
 diff.support_native_out = False
 
 
+@_scalar_output_to_0d_array
 def allclose(
     x1: np.ndarray,
     x2: np.ndarray,
@@ -302,10 +303,10 @@ def allclose(
     equal_nan: Optional[bool] = False,
     out: Optional[np.ndarray] = None,
 ) -> bool:
-    return np.array(np.allclose(x1, x2, rtol=rtol, atol=atol, equal_nan=equal_nan))
+    return np.allclose(x1, x2, rtol=rtol, atol=atol, equal_nan=equal_nan)
 
 
-isclose.support_native_out = False
+allclose.support_native_out = False
 
 
 def fix(

--- a/ivy_tests/test_ivy/test_functional/test_experimental/test_core/test_elementwise.py
+++ b/ivy_tests/test_ivy/test_functional/test_experimental/test_core/test_elementwise.py
@@ -702,6 +702,7 @@ def test_logaddexp2(
     atol=st.floats(min_value=1e-5, max_value=1e-5),
     equal_nan=st.booleans(),
     test_gradients=st.just(False),
+    test_with_out=st.just(False),
 )
 def test_allclose(
     dtype_and_x,


### PR DESCRIPTION
Allclose doesn't support any out argument as it returns 0-D array