### PR TITLE
Fix numpy.nanmin Frontend

### DIFF
--- a/ivy/functional/frontends/numpy/mathematical_functions/extrema_finding.py
+++ b/ivy/functional/frontends/numpy/mathematical_functions/extrema_finding.py
@@ -145,6 +145,13 @@ def nanmin(
         else:
             a = ivy.concat([a, header], axis=0)
     res = ivy.min(a, axis=axis, keepdims=keepdims, out=out)
+    if nan_mask is not None:
+        nan_mask = ivy.all(nan_mask, axis=axis, keepdims=keepdims, out=out)
+        if ivy.any(nan_mask):
+            res = ivy.where(ivy.logical_not(nan_mask),
+                            res,
+                            initial if initial is not None else ivy.nan,
+                            out=out)
     if where_mask is not None and ivy.any(where_mask):
         res = ivy.where(ivy.logical_not(where_mask), res, ivy.nan, out=out)
     return res

--- a/ivy_tests/test_ivy/test_frontends/test_numpy/test_mathematical_functions/test_extrema_finding.py
+++ b/ivy_tests/test_ivy/test_frontends/test_numpy/test_mathematical_functions/test_extrema_finding.py
@@ -182,6 +182,8 @@ def test_numpy_amax(
         force_int_axis=True,
         large_abs_safety_factor=2,
         safety_factor_scale="log",
+        allow_nan=True,
+        allow_inf=True,
     ),
     initial=st.one_of(st.floats(min_value=-1000, max_value=1000), st.none()),
     keepdims=st.booleans(),


### PR DESCRIPTION
Added a condition because it was causing an issue of not replacing inf with nan back after compute the max while putting initial with None value.