### PR TITLE
[Fix] Remove reference to `array_or_none()` in torch frontend test

### DIFF
--- a/ivy_tests/test_ivy/test_frontends/test_torch/test_loss_functions.py
+++ b/ivy_tests/test_ivy/test_frontends/test_torch/test_loss_functions.py
@@ -200,16 +200,19 @@ def test_torch_binary_cross_entropy(
     size_average=st.booleans(),
     reduce=st.booleans(),
     reduction=st.sampled_from(["mean", "none", "sum", None]),
-    dtype_and_pos_weight=helpers.array_or_none(
-        array_dtype="float",
-        min_value=0,
-        max_value=10,
-        allow_inf=False,
-        exclude_min=True,
-        exclude_max=True,
-        min_num_dims=1,
-        max_num_dims=1,
-        min_dim_size=2,
+    dtype_and_pos_weight=st.one_of(
+        helpers.dtype_and_values(
+            array_dtype="float",
+            min_value=0,
+            max_value=10,
+            allow_inf=False,
+            exclude_min=True,
+            exclude_max=True,
+            min_num_dims=1,
+            max_num_dims=1,
+            min_dim_size=2,
+        ),
+        st.just([None], [None]),
     ),
 )
 def test_torch_binary_cross_entropy_with_logits(

--- a/ivy_tests/test_ivy/test_frontends/test_torch/test_loss_functions.py
+++ b/ivy_tests/test_ivy/test_frontends/test_torch/test_loss_functions.py
@@ -202,7 +202,7 @@ def test_torch_binary_cross_entropy(
     reduction=st.sampled_from(["mean", "none", "sum", None]),
     dtype_and_pos_weight=st.one_of(
         helpers.dtype_and_values(
-            array_dtype="float",
+            available_dtypes=helpers.get_dtypes("float"),
             min_value=0,
             max_value=10,
             allow_inf=False,
@@ -212,7 +212,7 @@ def test_torch_binary_cross_entropy(
             max_num_dims=1,
             min_dim_size=2,
         ),
-        st.just([None], [None]),
+        st.just([[None], [None]]),
     ),
 )
 def test_torch_binary_cross_entropy_with_logits(


### PR DESCRIPTION
## Context

As discussed in #9440, the torch frontend `test_loss_functions.py` includes a reference to the `helpers.array_or_none()` method, which was removed in commit c8d0524e83f1b09ee8c9b3ec5d4de223e50ea8c4. This has been causing many CI runs to fail due to issues unrelated to the PR itself.

## Solution

The referenced commit introduces a fix via `st.one_of()`. This PR also incorporates this fix to remove the illegal reference to `array_or_none()`. Closes #9440.
