### PR TITLE
 add matplotlib dependency

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -5,3 +5,4 @@ termcolor==1.1.0
 colorama==0.4.5
 packaging==21.3
 nvidia-ml-py<=11.495.46 # mod_name=pynvml
+matplotlib==3.5.2


### PR DESCRIPTION
In reference to this issue #9441 added matplotlib version 3.5.2 as part of the dependencies required during the installation of ivy. 