### PR TITLE
[Fix] Remove white space in `sqrt` to enable AST parsing

### DIFF
--- a/ivy/functional/frontends/torch/tensor.py
+++ b/ivy/functional/frontends/torch/tensor.py
@@ -492,15 +492,7 @@ class Tensor:
             return torch_frontend.tensor(ivy.array(self._ivy_array).full_like(max))
         return torch_frontend.clamp(self._ivy_array, min=min, max=max, out=out)
 
-    @with_unsupported_dtypes(
-        {
-            "1.11.0 and below": (
-                "float16",
-                "bfloat16",
-            )
-        },
-        "torch",
-    )
+    @with_unsupported_dtypes({"1.11.0 and below": ("float16", "bfloat16")}, "torch")
     def sqrt(self):
         return torch_frontend.sqrt(self._ivy_array)
 


### PR DESCRIPTION
## Context

As discussed in #9449, the torch tensor frontend tests are falling due to a failure associated with AST parsing. Specifically, the `torch.Tensor.sqrt()` function is the cause of the error.

## Solution

Upon inspection, I realized that the `sqrt()` function has a lengthy decorator that "looks" different from other functions. Simply removing all white space to conform to other function decorators in the file resolved the issue. I haven't looked into AST to see how the input is being parsed, but the hypothesis that extraneous white space was causing an issue with parsing seems reasonable. Closes #9449.