### PR TITLE
Fixing jax.numpy.remainder frontend test

### DIFF
--- a/ivy_tests/test_ivy/test_frontends/test_jax/test_jax_numpy_math.py
+++ b/ivy_tests/test_ivy/test_frontends/test_jax/test_jax_numpy_math.py
@@ -1852,7 +1852,7 @@ def test_jax_numpy_remainder(
         fn_tree=fn_tree,
         on_device=on_device,
         x1=x[0],
-        x2=x[0],
+        x2=x[1],
         rtol=1e-2,
         atol=1e-2,
     )

--- a/ivy_tests/test_ivy/test_frontends/test_jax/test_jax_numpy_math.py
+++ b/ivy_tests/test_ivy/test_frontends/test_jax/test_jax_numpy_math.py
@@ -1840,7 +1840,6 @@ def test_jax_numpy_remainder(
 ):
     input_dtype, x = dtype_and_x
 
-    assume(not np.any(np.isclose(x[0], 0)))
     assume(not np.any(np.isclose(x[1], 0)))
 
     helpers.test_frontend_function(


### PR DESCRIPTION
closes #9363 