### PR TITLE
Fixed failing ivy tests for sum and cumsum in statistical

### DIFF
--- a/ivy/functional/backends/jax/statistical.py
+++ b/ivy/functional/backends/jax/statistical.py
@@ -192,18 +192,18 @@ def cumsum(
             dtype = _infer_dtype(x.dtype)
     if exclusive or reverse:
         if exclusive and reverse:
-            x = jnp.cumsum(jnp.flip(x, axis=(axis,)), axis=axis, dtype=dtype)
+            x = jnp.cumsum(jnp.flip(x, axis=axis), axis=axis, dtype=dtype)
             x = jnp.swapaxes(x, axis, -1)
             x = jnp.concatenate((jnp.zeros_like(x[..., -1:]), x[..., :-1]), -1)
             x = jnp.swapaxes(x, axis, -1)
-            res = jnp.flip(x, axis=(axis,))
+            res = jnp.flip(x, axis=axis)
         elif exclusive:
             x = jnp.swapaxes(x, axis, -1)
             x = jnp.concatenate((jnp.zeros_like(x[..., -1:]), x[..., :-1]), -1)
             x = jnp.cumsum(x, -1, dtype=dtype)
             res = jnp.swapaxes(x, axis, -1)
         elif reverse:
-            x = jnp.cumsum(jnp.flip(x, axis=(axis,)), axis=axis, dtype=dtype)
+            x = jnp.cumsum(jnp.flip(x, axis=axis), axis=axis, dtype=dtype)
             res = jnp.flip(x, axis=axis)
         return res
     return jnp.cumsum(x, axis, dtype=dtype)

--- a/ivy_tests/test_ivy/test_functional/test_core/test_statistical.py
+++ b/ivy_tests/test_ivy/test_functional/test_core/test_statistical.py
@@ -55,7 +55,7 @@ def statistical_dtype_values(draw, *, function, min_value=None, max_value=None):
 @st.composite
 def _get_castable_dtype(draw):
     available_dtypes = helpers.get_dtypes("numeric")
-    shape = draw(helpers.get_shape(min_num_dims=1))
+    shape = draw(helpers.get_shape(min_num_dims=1, max_num_dims=4, max_dim_size=6))
     dtype, values = draw(
         helpers.dtype_and_values(
             available_dtypes=available_dtypes,


### PR DESCRIPTION
Had to reduce `max_num_dims` and `max_dim_size` as there don't seem any issues with the implementation