### PR TITLE
Enabled arbitrary nest out argument along with fixing the eigh function

### DIFF
--- a/ivy/container/base.py
+++ b/ivy/container/base.py
@@ -188,7 +188,12 @@ class ContainerBase(dict, abc.ABC):
             and out is not None
         )
         if with_out:
-            conts = arg_conts + kwarg_conts + [out]
+            out_cont_idxs = ivy.nested_argwhere(
+                out, ivy.is_ivy_container, to_ignore=ivy.Container
+            )
+            out_conts = ivy.multi_index_nest(out, out_cont_idxs)
+            num_out_conts = len(out_conts)
+            conts = arg_conts + kwarg_conts + out_conts
         else:
             conts = arg_conts + kwarg_conts
         ivy.assertions.check_exists(conts, message="no containers found in arguments")
@@ -200,8 +205,8 @@ class ContainerBase(dict, abc.ABC):
 
         def map_fn(vals, _):
             if with_out:
-                out = vals[-1]
-                del vals[-1]
+                out = vals[-num_out_conts:]
+                del vals[-num_out_conts:]
             arg_vals = vals[:num_arg_conts]
             a = ivy.copy_nest(args, to_mutable=True)
             ivy.set_nest_at_indices(a, arg_cont_idxs, arg_vals)
@@ -209,6 +214,7 @@ class ContainerBase(dict, abc.ABC):
             kw = ivy.copy_nest(kwargs, to_mutable=True)
             ivy.set_nest_at_indices(kw, kwarg_cont_idxs, kwarg_vals)
             if with_out:
+                out = out[0] if len(out) == 1 else out
                 return fn(*a, out=out, **kw)
             else:
                 return fn(*a, **kw)
@@ -224,16 +230,22 @@ class ContainerBase(dict, abc.ABC):
             prune_unapplied,
             map_nests=map_sequences,
         )
-        if ivy.exists(out):
-            out.inplace_update(ret)
-            ret = out
 
         # Multiple containers for functions returning multiple arrays
-        for values in ret.values():
-            if isinstance(values, list):
-                for v in values:
-                    if ivy.is_ivy_array(v):
-                        return ret.cont_unstack_conts(0)
+        if ivy.is_ivy_container(ret):
+            for values in ret.values():
+                if isinstance(values, (tuple, list)):
+                    for v in values:
+                        if ivy.is_ivy_array(v):
+                            return ret.cont_unstack_conts(0)
+
+        if ivy.exists(out):
+            for out_cont_idx, out_cont in zip(out_cont_idxs, out_conts):
+                out_cont.cont_inplace_update(ivy.index_nest(ret, out_cont_idx))
+            if len(out_conts) == 1:
+                out.cont_inplace_update(ret)
+            ret = out
+
         return ret
 
     @staticmethod
@@ -255,7 +267,7 @@ class ContainerBase(dict, abc.ABC):
 
         """
         if ivy.exists(out):
-            out.inplace_update(ret)
+            out.cont_inplace_update(ret)
             ret = out
         return ret
 

--- a/ivy/container/base.py
+++ b/ivy/container/base.py
@@ -188,11 +188,15 @@ class ContainerBase(dict, abc.ABC):
             and out is not None
         )
         if with_out:
-            out_cont_idxs = ivy.nested_argwhere(
-                out, ivy.is_ivy_container, to_ignore=ivy.Container
-            )
-            out_conts = ivy.multi_index_nest(out, out_cont_idxs)
-            num_out_conts = len(out_conts)
+            out_conts = [out]
+            num_out_conts = 1
+            out_cont_idxs = []
+            if not ivy.is_array(out) and not ivy.is_ivy_container(out):
+                out_cont_idxs = ivy.nested_argwhere(
+                    out, ivy.is_ivy_container, to_ignore=ivy.Container
+                )
+                out_conts = ivy.multi_index_nest(out, out_cont_idxs)
+                num_out_conts = len(out_conts)
             conts = arg_conts + kwarg_conts + out_conts
         else:
             conts = arg_conts + kwarg_conts

--- a/ivy/func_wrapper.py
+++ b/ivy/func_wrapper.py
@@ -396,6 +396,13 @@ def handle_out_argument(fn: Callable) -> Callable:
         # compute return, and then handle the inplace update explicitly
 
         ret = fn(*args, **kwargs)
+        if not ivy.is_array(ret) and not ivy.is_ivy_container(ret):
+            return ivy.nested_multi_map(
+                lambda x, _: ivy.inplace_update(
+                    x[0], ivy.astype(x[1], ivy.dtype(x[0]))
+                ),
+                [out, ret],
+            )
         return ivy.inplace_update(out, ivy.astype(ret, ivy.dtype(out)))
         # return output matches the dtype of the out array to match numpy and torch
 

--- a/ivy/functional/ivy/linear_algebra.py
+++ b/ivy/functional/ivy/linear_algebra.py
@@ -617,9 +617,6 @@ def eigh(
     return current_backend(x).eigh(x, UPLO=UPLO, out=out)
 
 
-eigh.out_index = 1
-
-
 @to_native_arrays_and_back
 @handle_out_argument
 @handle_nestable

--- a/ivy_tests/test_ivy/helpers/function_testing.py
+++ b/ivy_tests/test_ivy/helpers/function_testing.py
@@ -265,15 +265,14 @@ def test_function(
         )
     # assert idx of return if the idx of the out array provided
     if test_flags.with_out:
-        test_ret = ret
-        if isinstance(ret, tuple):
-            assert hasattr(ivy.__dict__[fn_name], "out_index")
-            test_ret = ret[getattr(ivy.__dict__[fn_name], "out_index")]
-        out = ivy.zeros_like(test_ret)
-        if max(container_flags):
-            assert ivy.is_ivy_container(test_ret)
-        else:
-            assert ivy.is_array(test_ret)
+        test_ret = (
+            ret[getattr(ivy.__dict__[fn_name], "out_index")]
+            if hasattr(ivy.__dict__[fn_name], "out_index")
+            else ret
+        )
+        out = ivy.nested_map(
+            test_ret, ivy.zeros_like, to_mutable=True, include_derived=True
+        )
         if instance_method:
             ret, ret_np_flat = get_ret_and_flattened_np_array(
                 instance.__getattribute__(fn_name), *args, **kwargs, out=out
@@ -282,13 +281,23 @@ def test_function(
             ret, ret_np_flat = get_ret_and_flattened_np_array(
                 ivy.__dict__[fn_name], *args, **kwargs, out=out
             )
-        test_ret = ret
-        if isinstance(ret, tuple):
-            test_ret = ret[getattr(ivy.__dict__[fn_name], "out_index")]
-        assert test_ret is out
+        test_ret = (
+            ret[getattr(ivy.__dict__[fn_name], "out_index")]
+            if hasattr(ivy.__dict__[fn_name], "out_index")
+            else ret
+        )
+        assert not ivy.nested_any(
+            ivy.nested_multi_map(lambda x, _: x[0] is x[1], [test_ret, out]),
+            lambda x: not x,
+        )
         if not max(container_flags) and ivy.native_inplace_support:
             # these backends do not always support native inplace updates
-            assert test_ret.data is out.data
+            assert not ivy.nested_any(
+                ivy.nested_multi_map(
+                    lambda x, _: x[0].data is x[1].data, [test_ret, out]
+                ),
+                lambda x: not x,
+            )
     # compute the return with a Ground Truth backend
     ivy.set_backend(ground_truth_backend)
     try:
@@ -309,12 +318,14 @@ def test_function(
             ivy.__dict__[fn_name], *args, **kwargs
         )
         if test_flags.with_out:
-            test_ret_from_gt = ret_from_gt
-            if isinstance(ret_from_gt, tuple):
-                test_ret_from_gt = ret_from_gt[
-                    getattr(ivy.__dict__[fn_name], "out_index")
-                ]
-            out_from_gt = ivy.zeros_like(test_ret_from_gt)
+            test_ret_from_gt = (
+                ret_from_gt[getattr(ivy.__dict__[fn_name], "out_index")]
+                if hasattr(ivy.__dict__[fn_name], "out_index")
+                else ret_from_gt
+            )
+            out_from_gt = ivy.nested_map(
+                test_ret_from_gt, ivy.zeros_like, to_mutable=True, include_derived=True
+            )
             ret_from_gt, ret_np_from_gt_flat = get_ret_and_flattened_np_array(
                 ivy.__dict__[fn_name], *args, **kwargs, out=out_from_gt
             )

--- a/ivy_tests/test_ivy/test_functional/test_core/test_linalg.py
+++ b/ivy_tests/test_ivy/test_functional/test_core/test_linalg.py
@@ -384,7 +384,6 @@ def test_det(
     fn_tree="functional.ivy.eigh",
     dtype_x=_get_dtype_and_matrix(symmetric=True),
     UPLO=st.sampled_from(("L", "U")),
-    test_with_out=st.just(False),
     test_gradients=st.just(False),
 )
 def test_eigh(
@@ -413,11 +412,10 @@ def test_eigh(
     if results is None:
         return
     ret_np_flat, ret_from_np_flat = results
-
     reconstructed_np = None
     for i in range(len(ret_np_flat) // 2):
-        eigenvalue = ret_np_flat[i * 2]
-        eigenvector = ret_np_flat[i * 2 + 1]
+        eigenvalue = ret_np_flat[i]
+        eigenvector = ret_np_flat[len(ret_np_flat) // 2]
         if reconstructed_np is not None:
             reconstructed_np += eigenvalue * np.matmul(
                 eigenvector.reshape(1, -1), eigenvector.reshape(-1, 1)
@@ -429,8 +427,8 @@ def test_eigh(
 
     reconstructed_from_np = None
     for i in range(len(ret_from_np_flat) // 2):
-        eigenvalue = ret_from_np_flat[i * 2]
-        eigenvector = ret_from_np_flat[i * 2 + 1]
+        eigenvalue = ret_from_np_flat[i]
+        eigenvector = ret_from_np_flat[len(ret_np_flat) // 2 + i]
         if reconstructed_from_np is not None:
             reconstructed_from_np += eigenvalue * np.matmul(
                 eigenvector.reshape(1, -1), eigenvector.reshape(-1, 1)


### PR DESCRIPTION
1. Updated the `handle_out_argument` decorator to perform an `inplace_update` for arbitrary nests in the `out` argument.
2. Updated the `test_function` to handle this case.
3. Updated the `multi_map_in_function` method to process arbitrary nests by converting them to a flat list and returning the result with a nest of containers instead of a container of nests.
4. Removed the `out_index` for `eigh` and fixed it to work with a tuple `out` argument, natively supported by `torch`.
5. Fixed the issue where `inplace_update` wasn't renamed to `cont_inplace_update` in a couple of places in the refactor a few weeks ago.