### PR TITLE
add frontend torch rand function

### DIFF
--- a/ivy/functional/frontends/torch/random_sampling.py
+++ b/ivy/functional/frontends/torch/random_sampling.py
@@ -54,3 +54,12 @@ def multinomial(input, num_samples, replacement=False, *, generator=None, out=No
 @to_ivy_arrays_and_back
 def poisson(input, generator=None):
     return ivy.poisson(input, shape=None)
+
+@to_ivy_arrays_and_back
+def rand(size, *, out=None, dtype=None, layout=None, device=None, requires_grad=False, pin_memory=False):
+    return ivy.random_uniform(
+        shape=size,
+        out=out,
+        dtype=dtype,
+        device=device,
+    )

--- a/ivy_tests/test_ivy/test_frontends/test_torch/test_random_sampling.py
+++ b/ivy_tests/test_ivy/test_frontends/test_torch/test_random_sampling.py
@@ -139,3 +139,41 @@ def test_torch_poisson(
     for (u, v) in zip(ret_np, ret_from_np):
         assert u.dtype == v.dtype
         assert u.shape == v.shape
+
+@handle_frontend_test(
+    fn_tree="torch.rand",
+    dtype = helpers.get_dtypes("float", full=False),
+    size = helpers.get_shape(
+        min_num_dims=0,
+        max_num_dims=5,
+        min_dim_size=0,
+        max_dim_size=10,
+        ),
+    # seed=helpers.ints(min_value=0, max_value=100),
+)
+def test_torch_rand(
+    *,
+    dtype,
+    size,
+    as_variable,
+    with_out,
+    num_positional_args,
+    native_array,
+    frontend,
+    fn_tree,
+
+):
+    def call():
+        return helpers.test_frontend_function(
+            input_dtypes=dtype,
+            as_variable_flags=as_variable,
+            num_positional_args=num_positional_args,
+            native_array_flags=native_array,
+            with_out=with_out,
+            frontend=frontend,
+            test_values=False,
+            fn_tree=fn_tree,
+            size=size
+        )
+
+    ret = call()


### PR DESCRIPTION
Close #9686 

Hi, 

Here are my initial attempts to add the torch rand function to the frontend API. My questions are:
- The [docs for rand](https://pytorch.org/docs/stable/generated/torch.rand.html#torch.rand) have some keyword arguments (like requires_grad, pin_memory) that I've included as arguments but haven't used (which I think I've seen happen elsewhere). Is this ok?
- As the function generates random numbers, I've set the test_values flag to False in the call to test_frontend_function. I was looking for a way to compare two different arrays using a manual seed but I don't think this is that straightforward. The other tests are running locally for me - are they sufficient?

Thanks!
Jonny