### PR TITLE
Fix torch.view and close #9665

### DIFF
--- a/ivy/functional/frontends/torch/tensor.py
+++ b/ivy/functional/frontends/torch/tensor.py
@@ -1,8 +1,9 @@
 # local
+import weakref
+
 import ivy
 import ivy.functional.frontends.torch as torch_frontend
 from ivy.func_wrapper import with_unsupported_dtypes
-import weakref
 
 
 class Tensor:
@@ -167,13 +168,15 @@ class Tensor:
         if size and not args:
             size_tup = size
         elif args and not size:
-            if isinstance(args[0], tuple) and len(args)==1:
+            if isinstance(args[0], tuple) and len(args) == 1:
                 size_tup = args[0]
             else:
-                size_tup=args
+                size_tup = args
         else:
-            raise ValueError("View only accepts as argument ints, tuple of ints or "
-                             "the keyword argument size.")
+            raise ValueError(
+                "View only accepts as argument ints, tuple of ints or "
+                "the keyword argument size."
+            )
         return torch_frontend.ViewTensor(weakref.ref(self), size=size_tup)
 
     def float(self, memory_format=None):

--- a/ivy/functional/frontends/torch/tensor.py
+++ b/ivy/functional/frontends/torch/tensor.py
@@ -148,8 +148,8 @@ class Tensor:
     def atan2(self, other):
         return torch_frontend.atan2(self._ivy_array, other)
 
-    def view(self, shape):
-        return torch_frontend.ViewTensor(weakref.ref(self), shape=shape)
+    def view(self, size):
+        return torch_frontend.ViewTensor(weakref.ref(self), size=size)
 
     def float(self, memory_format=None):
         cast_tensor = self.clone()

--- a/ivy/functional/frontends/torch/tensor.py
+++ b/ivy/functional/frontends/torch/tensor.py
@@ -156,6 +156,7 @@ class Tensor:
         possible arguments are either:
             - size
             - tuple of ints
+            - list of ints
             - ints
         Parameters
         ----------
@@ -168,13 +169,13 @@ class Tensor:
         if size and not args:
             size_tup = size
         elif args and not size:
-            if isinstance(args[0], tuple) and len(args) == 1:
+            if (isinstance(args[0], tuple) or isinstance(args[0], list)) and len(args) == 1:
                 size_tup = args[0]
             else:
                 size_tup = args
         else:
             raise ValueError(
-                "View only accepts as argument ints, tuple of ints or "
+                "View only accepts as argument ints, tuple or list of ints or "
                 "the keyword argument size."
             )
         return torch_frontend.ViewTensor(weakref.ref(self), size=size_tup)

--- a/ivy/functional/frontends/torch/tensor.py
+++ b/ivy/functional/frontends/torch/tensor.py
@@ -1,6 +1,8 @@
 # local
 import weakref
 
+import torch
+
 import ivy
 import ivy.functional.frontends.torch as torch_frontend
 from ivy.func_wrapper import with_unsupported_dtypes
@@ -157,6 +159,7 @@ class Tensor:
             - size
             - tuple of ints
             - list of ints
+            - torch.Size object
             - ints
         Parameters
         ----------
@@ -169,9 +172,11 @@ class Tensor:
         if size and not args:
             size_tup = size
         elif args and not size:
-            if (isinstance(args[0], tuple) or isinstance(args[0], list)) and len(
-                args
-            ) == 1:
+            if (
+                isinstance(args[0], tuple)
+                or isinstance(args[0], list)
+                or isinstance(args[0], torch.Size)
+            ) and len(args) == 1:
                 size_tup = args[0]
             else:
                 size_tup = args

--- a/ivy/functional/frontends/torch/tensor.py
+++ b/ivy/functional/frontends/torch/tensor.py
@@ -148,8 +148,33 @@ class Tensor:
     def atan2(self, other):
         return torch_frontend.atan2(self._ivy_array, other)
 
-    def view(self, size):
-        return torch_frontend.ViewTensor(weakref.ref(self), size=size)
+    def view(self, *args, size=None):
+        """
+        Reshape Tensor.
+
+        possible arguments are either:
+            - size
+            - tuple of ints
+            - ints
+        Parameters
+        ----------
+        args:int arguments
+        size: optional size
+
+        Returns reshaped tensor
+        -------
+        """
+        if size and not args:
+            size_tup = size
+        elif args and not size:
+            if isinstance(args[0], tuple) and len(args)==1:
+                size_tup = args[0]
+            else:
+                size_tup=args
+        else:
+            raise ValueError("View only accepts as argument ints, tuple of ints or "
+                             "the keyword argument size.")
+        return torch_frontend.ViewTensor(weakref.ref(self), size=size_tup)
 
     def float(self, memory_format=None):
         cast_tensor = self.clone()

--- a/ivy/functional/frontends/torch/tensor.py
+++ b/ivy/functional/frontends/torch/tensor.py
@@ -185,7 +185,7 @@ class Tensor:
                 "View only accepts as argument ints, tuple or list of ints or "
                 "the keyword argument size."
             )
-        return torch_frontend.ViewTensor(weakref.ref(self), size=size_tup)
+        return torch_frontend.ViewTensor(weakref.ref(self), shape=size_tup)
 
     def float(self, memory_format=None):
         cast_tensor = self.clone()

--- a/ivy/functional/frontends/torch/tensor.py
+++ b/ivy/functional/frontends/torch/tensor.py
@@ -169,7 +169,9 @@ class Tensor:
         if size and not args:
             size_tup = size
         elif args and not size:
-            if (isinstance(args[0], tuple) or isinstance(args[0], list)) and len(args) == 1:
+            if (isinstance(args[0], tuple) or isinstance(args[0], list)) and len(
+                args
+            ) == 1:
                 size_tup = args[0]
             else:
                 size_tup = args

--- a/ivy/functional/frontends/torch/view_tensor.py
+++ b/ivy/functional/frontends/torch/view_tensor.py
@@ -1,10 +1,11 @@
 # local
-import ivy
-import weakref
 import functools
+import weakref
 from typing import Callable
-from ivy.functional.frontends.torch.tensor import Tensor
+
+import ivy
 import ivy.functional.frontends.torch as torch_frontend
+from ivy.functional.frontends.torch.tensor import Tensor
 
 
 def _merge_from_original(method: Callable) -> Callable:

--- a/ivy/functional/frontends/torch/view_tensor.py
+++ b/ivy/functional/frontends/torch/view_tensor.py
@@ -48,7 +48,7 @@ def _merge_to_original(method: Callable) -> Callable:
 
 
 class ViewTensor:
-    def __init__(self, ref, size):
+    def __init__(self, ref, *, size):
         if isinstance(ref(), Tensor):
             self.delegate = torch_frontend.tensor(
                 ivy.reshape(ref().ivy_array, size, copy=True)

--- a/ivy/functional/frontends/torch/view_tensor.py
+++ b/ivy/functional/frontends/torch/view_tensor.py
@@ -48,14 +48,14 @@ def _merge_to_original(method: Callable) -> Callable:
 
 
 class ViewTensor:
-    def __init__(self, ref, *, size):
+    def __init__(self, ref, *, shape):
         if isinstance(ref(), Tensor):
             self.delegate = torch_frontend.tensor(
-                ivy.reshape(ref().ivy_array, size, copy=True)
+                ivy.reshape(ref().ivy_array, shape, copy=True)
             )
         elif isinstance(ref(), ViewTensor):
             self.delegate = torch_frontend.tensor(
-                ivy.reshape(ref().delegate.ivy_array, size, copy=True)
+                ivy.reshape(ref().delegate.ivy_array, shape, copy=True)
             )
         else:
             raise TypeError(

--- a/ivy/functional/frontends/torch/view_tensor.py
+++ b/ivy/functional/frontends/torch/view_tensor.py
@@ -116,8 +116,8 @@ class ViewTensor:
 
     # Class Invariance #
     # ---------------- #
-    def view(self, size):
-        view = ViewTensor(weakref.ref(self), size=size)
+    def view(self, shape):
+        view = ViewTensor(weakref.ref(self), shape=shape)
         return view
 
     def size(self):

--- a/ivy/functional/frontends/torch/view_tensor.py
+++ b/ivy/functional/frontends/torch/view_tensor.py
@@ -47,14 +47,14 @@ def _merge_to_original(method: Callable) -> Callable:
 
 
 class ViewTensor:
-    def __init__(self, ref, *, shape):
+    def __init__(self, ref, *, size):
         if isinstance(ref(), Tensor):
             self.delegate = torch_frontend.tensor(
-                ivy.reshape(ref().ivy_array, shape, copy=True)
+                ivy.reshape(ref().ivy_array, size, copy=True)
             )
         elif isinstance(ref(), ViewTensor):
             self.delegate = torch_frontend.tensor(
-                ivy.reshape(ref().delegate.ivy_array, shape, copy=True)
+                ivy.reshape(ref().delegate.ivy_array, size, copy=True)
             )
         else:
             raise TypeError(
@@ -115,8 +115,8 @@ class ViewTensor:
 
     # Class Invariance #
     # ---------------- #
-    def view(self, shape):
-        view = ViewTensor(weakref.ref(self), shape=shape)
+    def view(self, size):
+        view = ViewTensor(weakref.ref(self), size=size)
         return view
 
     def size(self):

--- a/ivy/functional/frontends/torch/view_tensor.py
+++ b/ivy/functional/frontends/torch/view_tensor.py
@@ -47,7 +47,7 @@ def _merge_to_original(method: Callable) -> Callable:
 
 
 class ViewTensor:
-    def __init__(self, ref, *, size):
+    def __init__(self, ref, size):
         if isinstance(ref(), Tensor):
             self.delegate = torch_frontend.tensor(
                 ivy.reshape(ref().ivy_array, size, copy=True)

--- a/ivy_tests/test_ivy/test_frontends/test_torch/test_view_tensor.py
+++ b/ivy_tests/test_ivy/test_frontends/test_torch/test_view_tensor.py
@@ -29,6 +29,7 @@ def test_view_tensor_no_error(length, dim):
     _ = test_input.view(size=size)
     _ = test_input.view(*size)
     _ = test_input.view(size)
+    _ = test_input.view(list(size))
 
 
 @pytest.mark.parametrize(["test_input"], [[1], [2], [-3]])

--- a/ivy_tests/test_ivy/test_frontends/test_torch/test_view_tensor.py
+++ b/ivy_tests/test_ivy/test_frontends/test_torch/test_view_tensor.py
@@ -1,11 +1,12 @@
 # global
 import pytest
-import ivy
 
+import ivy
+import ivy.functional.frontends.torch as torch_frontend
 # local
 from ivy.functional.frontends.torch import Tensor
 from ivy_tests.test_ivy.helpers.assertions import assert_all_close
-import ivy.functional.frontends.torch as torch_frontend
+
 
 class Database:
     def __init__(self):
@@ -21,15 +22,14 @@ ivy.set_numpy_backend()
 cache = Database()
 
 
-
-
-@pytest.mark.parametrize(["length","dim"], [[4,2],[27,3],[3,1]])
+@pytest.mark.parametrize(["length", "dim"], [[4, 2], [27, 3], [3, 1]])
 def test_view_tensor_no_error(length, dim):
-    size = tuple([int(length**(1/dim))]*dim)
+    size = tuple([int(length ** (1 / dim))] * dim)
     test_input = torch_frontend.arange(length)
     _ = test_input.view(size=size)  # fails
     _ = test_input.view(*size)
     _ = test_input.view(size)
+
 
 @pytest.mark.parametrize(["test_input"], [[1], [2], [-3]])
 def test_view_tensor_add(test_input):

--- a/ivy_tests/test_ivy/test_frontends/test_torch/test_view_tensor.py
+++ b/ivy_tests/test_ivy/test_frontends/test_torch/test_view_tensor.py
@@ -5,7 +5,7 @@ import ivy
 # local
 from ivy.functional.frontends.torch import Tensor
 from ivy_tests.test_ivy.helpers.assertions import assert_all_close
-
+import ivy.functional.frontends.torch as torch_frontend
 
 class Database:
     def __init__(self):
@@ -20,6 +20,16 @@ class Database:
 ivy.set_numpy_backend()
 cache = Database()
 
+
+
+
+@pytest.mark.parametrize(["length","dim"], [[4,2],[27,3],[3,1]])
+def test_view_tensor_no_error(length, dim):
+    size = tuple([int(length**(1/dim))]*dim)
+    test_input = torch_frontend.arange(length)
+    _ = test_input.view(size=size)  # fails
+    _ = test_input.view(*size)
+    _ = test_input.view(size)
 
 @pytest.mark.parametrize(["test_input"], [[1], [2], [-3]])
 def test_view_tensor_add(test_input):

--- a/ivy_tests/test_ivy/test_frontends/test_torch/test_view_tensor.py
+++ b/ivy_tests/test_ivy/test_frontends/test_torch/test_view_tensor.py
@@ -26,7 +26,7 @@ cache = Database()
 def test_view_tensor_no_error(length, dim):
     size = tuple([int(length ** (1 / dim))] * dim)
     test_input = torch_frontend.arange(length)
-    _ = test_input.view(size=size)  # fails
+    _ = test_input.view(size=size)
     _ = test_input.view(*size)
     _ = test_input.view(size)
 


### PR DESCRIPTION
This closes #9665 issue.
Issues:
- keyword shape in torch.view used instead of size
- frontend of view failing

Changes made
- now the view function can take in integers, a tuple of integers or the argument size 
- added a test to verify view works as expected
- removed * from view tensor as not necessary

Further comments:
The confusion shape/size comes from the pytorch documentation (they actually do say the keyword is shape which is wrong) and the fact that the current implementation of view is in C. I found the old one here (https://github.com/pytorch/pytorch/blob/518864a7e094f32044ef4c0de82c0f20f4ed99c2/torch/tensor.py#L178-L217) which is not great.

I am not super happy about this new implementation, but it works. I think the idea of being as restrictive as we can with the inputs to view could help.


