### PR TITLE
Fixed failing ivy test for conv2d

### DIFF
--- a/ivy/functional/backends/tensorflow/layers.py
+++ b/ivy/functional/backends/tensorflow/layers.py
@@ -82,8 +82,6 @@ def conv2d(
     dilations: Optional[Union[int, Tuple[int, int]]] = 1,
     out: Optional[Union[tf.Tensor, tf.Variable]] = None,
 ) -> Union[tf.Tensor, tf.Variable]:
-    if not isinstance(strides, int):
-        strides = strides[0]
     if data_format == "NCHW":
         x = tf.transpose(x, (0, 2, 3, 1))
     res = tf.nn.conv2d(x, filters, strides, padding, "NHWC", dilations)


### PR DESCRIPTION
 by removing logic without which the function still works for the additional test cases added in https://github.com/unifyai/ivy/commit/0dc5fb9f82877ac034fc65e2a6a167c3e081f3f2