### PR TITLE
Fixed array like handing by fixing problem with `handle_array_like` w…

### DIFF
--- a/ivy/func_wrapper.py
+++ b/ivy/func_wrapper.py
@@ -1,10 +1,11 @@
+import numbers
+
 import ivy
 import functools
 import logging
 from types import FunctionType
 from typing import Callable
 import inspect
-import typing
 
 
 # for wrapping (sequence matters)
@@ -21,7 +22,7 @@ FN_DECORATORS = [
     "handle_exceptions",
     "with_unsupported_dtypes",
     "handle_nans",
-    "handle_array_like",
+    "handle_array_like_without_promotion",
 ]
 
 
@@ -51,39 +52,38 @@ def _get_first_array(*args, **kwargs):
 # ---------------#
 
 
-def handle_array_like(fn: Callable) -> Callable:
+def handle_array_like_without_promotion(fn: Callable) -> Callable:
     @functools.wraps(fn)
     def new_fn(*args, **kwargs):
+        args = list(args)
+        num_args = len(args)
         try:
-            signature = inspect.signature(fn)
-            type_hints = typing.get_type_hints(fn)
+            type_hints = inspect.signature(fn).parameters
         except (TypeError, ValueError):
             return fn(*args, **kwargs)
-        has_out = False
-        out = None
-        if "out" in kwargs:
-            out = kwargs["out"]
-            del kwargs["out"]
-            has_out = True
-        params = signature.parameters
-        for name, param in params.items():
-            if param.kind in (param.POSITIONAL_OR_KEYWORD, param.KEYWORD_ONLY):
-                annotation = type_hints.get(name)
-                if annotation is not None:
-                    annotation_str = str(annotation)
-                    if "Array" in annotation_str and all(
-                        sq not in annotation_str for sq in ["Sequence", "List", "Tuple"]
-                    ):
-                        if param.kind == param.POSITIONAL_OR_KEYWORD:
-                            if param.name in kwargs:
-                                if isinstance(kwargs[param.name], (list, tuple)):
-                                    kwargs[param.name] = ivy.array(kwargs[param.name])
-                        elif param.kind == param.KEYWORD_ONLY:
-                            if param.name in kwargs:
-                                if isinstance(kwargs[param.name], (list, tuple)):
-                                    kwargs[param.name] = ivy.array(kwargs[param.name])
-        if has_out:
-            kwargs["out"] = out
+        parameters = list(type_hints.keys())
+        annotations = [param.annotation for param in type_hints.values()]
+
+        for i, (annotation, parameter, arg) in enumerate(
+            zip(annotations, parameters, args)
+        ):
+            annotation_str = str(annotation)
+            if (
+                ("rray" in annotation_str or "Tensor" in annotation_str)
+                and parameter != "out"
+                and all(
+                    sq not in annotation_str for sq in ["Sequence", "List", "Tuple"]
+                )
+            ):
+
+                if i < num_args:
+                    if isinstance(arg, (list, tuple, numbers.Number)):
+                        args[i] = ivy.native_array(arg)
+                elif parameters in kwargs:
+                    kwarg = kwargs[parameter]
+                    if isinstance(kwarg, (list, tuple, numbers.Number)):
+                        kwargs[parameter] = ivy.native_array(kwarg)
+
         return fn(*args, **kwargs)
 
     new_fn.handle_array_like = True

--- a/ivy/func_wrapper.py
+++ b/ivy/func_wrapper.py
@@ -86,7 +86,7 @@ def handle_array_like_without_promotion(fn: Callable) -> Callable:
 
         return fn(*args, **kwargs)
 
-    new_fn.handle_array_like = True
+    new_fn.handle_array_like_without_promotion = True
     return new_fn
 
 

--- a/ivy/functional/backends/jax/experimental/elementwise.py
+++ b/ivy/functional/backends/jax/experimental/elementwise.py
@@ -1,6 +1,8 @@
 import operator
 from typing import Optional, Union, Tuple, List
 from numbers import Number
+
+from ivy import promote_types_of_inputs, default_float_dtype, is_float_dtype
 from ivy.functional.backends.jax import JaxArray
 import jax.numpy as jnp
 import jax.scipy as js
@@ -9,6 +11,7 @@ jax_ArrayLike = Union[JaxArray, Number]
 
 
 def lcm(x1: JaxArray, x2: JaxArray, /, *, out: Optional[JaxArray] = None) -> JaxArray:
+    x1, x2 = promote_types_of_inputs(x1, x2)
     return jnp.lcm(x1, x2)
 
 
@@ -23,6 +26,7 @@ def fmod(
     *,
     out: Optional[JaxArray] = None,
 ) -> JaxArray:
+    x1, x2 = promote_types_of_inputs(x1, x2)
     return jnp.fmod(x1, x2)
 
 
@@ -33,6 +37,7 @@ def fmax(
     *,
     out: Optional[JaxArray] = None,
 ) -> JaxArray:
+    x1, x2 = promote_types_of_inputs(x1, x2)
     return jnp.fmax(x1, x2)
 
 
@@ -84,6 +89,10 @@ def copysign(
     *,
     out: Optional[JaxArray] = None,
 ) -> JaxArray:
+    x1, x2 = promote_types_of_inputs(x1, x2)
+    if not is_float_dtype(x1):
+        x1 = x1.astype(default_float_dtype(as_native=True))
+        x2 = x2.astype(default_float_dtype(as_native=True))
     return jnp.copysign(x1, x2)
 
 
@@ -122,6 +131,7 @@ def gcd(
     *,
     out: Optional[JaxArray] = None,
 ) -> JaxArray:
+    x1, x2 = promote_types_of_inputs(x1, x2)
     return jnp.gcd(x1, x2)
 
 
@@ -158,6 +168,10 @@ def logaddexp2(
     *,
     out: Optional[JaxArray] = None,
 ) -> JaxArray:
+    x1, x2 = promote_types_of_inputs(x1, x2)
+    if not is_float_dtype(x1):
+        x1 = x1.astype(default_float_dtype(as_native=True))
+        x2 = x2.astype(default_float_dtype(as_native=True))
     return jnp.logaddexp2(x1, x2)
 
 
@@ -478,6 +492,7 @@ def gradient(
 
 
 def xlogy(x: JaxArray, y: JaxArray, /, *, out: Optional[JaxArray] = None) -> JaxArray:
+    x, y = promote_types_of_inputs(x, y)
     return js.special.xlogy(x, y)
 
 

--- a/ivy/functional/backends/numpy/experimental/elementwise.py
+++ b/ivy/functional/backends/numpy/experimental/elementwise.py
@@ -1,6 +1,9 @@
 from typing import Optional, Union, Tuple, List
 import numpy as np
 import numpy.typing as npt
+
+import ivy
+from ivy import promote_types_of_inputs
 from ivy.functional.backends.numpy.helpers import _scalar_output_to_0d_array
 from ivy.func_wrapper import with_unsupported_dtypes
 from . import backend_version
@@ -20,6 +23,7 @@ def lcm(
     *,
     out: Optional[np.ndarray] = None,
 ) -> np.ndarray:
+    x1, x2 = promote_types_of_inputs(x1, x2)
     return np.abs(
         np.lcm(
             x1,
@@ -40,6 +44,7 @@ def fmod(
     *,
     out: Optional[np.ndarray] = None,
 ) -> np.ndarray:
+    x1, x2 = promote_types_of_inputs(x1, x2)
     return np.fmod(
         x1,
         x2,
@@ -58,6 +63,7 @@ def fmax(
     *,
     out: Optional[np.ndarray] = None,
 ) -> np.ndarray:
+    x1, x2 = promote_types_of_inputs(x1, x2)
     return np.fmax(
         x1,
         x2,
@@ -81,6 +87,7 @@ def fmin(
     *,
     out: Optional[np.ndarray] = None,
 ) -> np.ndarray:
+    x1, x2 = promote_types_of_inputs(x1, x2)
     return np.fmin(
         x1,
         x2,
@@ -145,6 +152,10 @@ def copysign(
     *,
     out: Optional[np.ndarray] = None,
 ) -> np.ndarray:
+    x1, x2 = promote_types_of_inputs(x1, x2)
+    if not ivy.is_float_dtype(x1):
+        x1 = x1.astype(ivy.default_float_dtype(as_native=True))
+        x2 = x2.astype(ivy.default_float_dtype(as_native=True))
     return np.copysign(x1, x2, out=out)
 
 
@@ -194,6 +205,7 @@ def gcd(
     *,
     out: Optional[np.ndarray] = None,
 ) -> np.ndarray:
+    x1, x2 = promote_types_of_inputs(x1, x2)
     return np.gcd(x1, x2, out=out)
 
 
@@ -269,6 +281,10 @@ def logaddexp2(
     *,
     out: Optional[np.ndarray] = None,
 ) -> np.ndarray:
+    x1, x2 = promote_types_of_inputs(x1, x2)
+    if not ivy.is_float_dtype(x1):
+        x1 = x1.astype(ivy.default_float_dtype(as_native=True))
+        x2 = x2.astype(ivy.default_float_dtype(as_native=True))
     return np.logaddexp2(x1, x2, out=out)
 
 
@@ -390,6 +406,7 @@ def gradient(
 def xlogy(
     x: np.ndarray, y: np.ndarray, /, *, out: Optional[np.ndarray] = None
 ) -> np.ndarray:
+    x, y = promote_types_of_inputs(x, y)
     if (x == 0).all():
         return 0.0
     else:

--- a/ivy/functional/backends/tensorflow/experimental/elementwise.py
+++ b/ivy/functional/backends/tensorflow/experimental/elementwise.py
@@ -2,6 +2,8 @@ import operator
 from typing import Union, Optional, Tuple, List
 from numbers import Number
 import tensorflow as tf
+
+from ivy import promote_types_of_inputs
 from .. import backend_version
 
 
@@ -29,6 +31,7 @@ def lcm(
     *,
     out: Optional[Union[tf.Tensor, tf.Variable]] = None,
 ) -> Union[tf.Tensor, tf.Variable]:
+    x1, x2 = promote_types_of_inputs(x1, x2)
     return tf.math.abs(tf.experimental.numpy.lcm(x1, x2))
 
 
@@ -43,6 +46,7 @@ def fmod(
     *,
     out: Optional[Union[tf.Tensor, tf.Variable]] = None,
 ) -> Union[tf.Tensor, tf.Variable]:
+    x1, x2 = promote_types_of_inputs(x1, x2)
     res = tf.experimental.numpy.remainder(tf.math.abs(x1), tf.math.abs(x2))
     return tf.where(x1 < 0, -res, res)
 
@@ -55,8 +59,7 @@ def fmax(
     out: Optional[Union[tf.Tensor, tf.Variable]] = None,
 ) -> Union[tf.Tensor, tf.Variable]:
     temp = tf.constant(float("nan"))
-    tf.dtypes.cast(x1, tf.float64)
-    tf.dtypes.cast(x2, tf.float64)
+    x1, x2 = promote_types_of_inputs(x1, x2)
     x1 = tf.where(tf.math.is_nan(x1, temp), x2, x1)
     x2 = tf.where(tf.math.is_nan(x2, temp), x1, x2)
     ret = tf.experimental.numpy.maximum(x1, x2)
@@ -71,8 +74,7 @@ def fmin(
     out: Optional[Union[tf.Tensor, tf.Variable]] = None,
 ) -> Union[tf.Tensor, tf.Variable]:
     temp = tf.constant(float("nan"))
-    tf.dtypes.cast(x1, tf.float64)
-    tf.dtypes.cast(x2, tf.float64)
+    x1, x2 = promote_types_of_inputs(x1, x2)
     x1 = tf.where(tf.math.is_nan(x1, temp), x2, x1)
     x2 = tf.where(tf.math.is_nan(x2, temp), x1, x2)
     ret = tf.experimental.numpy.minimum(x1, x2)
@@ -117,19 +119,16 @@ def copysign(
     *,
     out: Optional[tf.Tensor] = None,
 ) -> Union[tf.Tensor, tf.Variable]:
-    # Cast our inputs to float64 to match numpy behaviour
-    tensor_x2 = tf.convert_to_tensor(x2)
-    # Cast our inputs to float64 if needed to match numpy behaviour
-    if not tensor_x2.dtype.is_floating:
-        tensor_x2 = tf.cast(tensor_x2, tf.float64)
-    tensor_x1 = tf.convert_to_tensor(x1)
-    if not tensor_x1.dtype.is_floating:
-        tensor_x1 = tf.cast(tensor_x1, tf.float64)
+    x1, x2 = promote_types_of_inputs(x1, x2)
+    # Cast our inputs to float to match numpy behaviour
+    if not ivy.is_float_dtype(x1):
+        x1 = tf.cast(x1, ivy.default_float_dtype(as_native=True))
+        x2 = tf.cast(x2, ivy.default_float_dtype(as_native=True))
     # Replace any zero values with 1/the value, since tf.math.sign always
     # returns 0 for positive or negative zero
-    signable_x2 = tf.where(tf.equal(tensor_x2, 0), tf.math.divide(1, x2), tensor_x2)
+    signable_x2 = tf.where(tf.equal(x2, 0), tf.math.divide(1, x2), x2)
     signs = tf.math.sign(signable_x2)
-    return tf.math.multiply(tf.math.abs(tensor_x1), signs)
+    return tf.math.multiply(tf.math.abs(x1), signs)
 
 
 def count_nonzero(
@@ -170,6 +169,7 @@ def gcd(
     *,
     out: Optional[Union[tf.Tensor, tf.Variable]] = None,
 ) -> Union[tf.Tensor, tf.Variable]:
+    x1, x2 = promote_types_of_inputs(x1, x2)
     return tf.experimental.numpy.gcd(x1, x2)
 
 
@@ -232,11 +232,11 @@ def logaddexp2(
     *,
     out: Optional[Union[tf.Tensor, tf.Variable]] = None,
 ) -> Union[tf.Tensor, tf.Variable]:
-    x1, x2 = ivy.promote_types_of_inputs(x1, x2)
-    dtype = x1.dtype
-    x1 = tf.cast(x1, tf.float64)
-    x2 = tf.cast(x2, tf.float64)
-    return ivy.log2(ivy.exp2(x1) + ivy.exp2(x2)).astype(dtype)
+    x1, x2 = promote_types_of_inputs(x1, x2)
+    if not ivy.is_float_dtype(x1):
+        x1 = tf.cast(x1, ivy.default_float_dtype(as_native=True))
+        x2 = tf.cast(x2, ivy.default_float_dtype(as_native=True))
+    return ivy.log2(ivy.exp2(x1) + ivy.exp2(x2))
 
 
 def signbit(
@@ -581,6 +581,7 @@ def xlogy(
     *,
     out: Optional[Union[tf.Tensor, tf.Variable]] = None,
 ) -> Union[tf.Tensor, tf.Variable]:
+    x, y = promote_types_of_inputs(x, y)
     return tf.math.xlogy(x, y)
 
 

--- a/ivy/functional/backends/torch/experimental/elementwise.py
+++ b/ivy/functional/backends/torch/experimental/elementwise.py
@@ -6,6 +6,7 @@ import torch
 
 # local
 import ivy
+from ivy import promote_types_of_inputs
 from ivy.functional.backends.torch.elementwise import _cast_for_unary_op
 from ivy.func_wrapper import with_unsupported_dtypes
 from .. import backend_version
@@ -19,6 +20,7 @@ def lcm(
     *,
     out: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
+    x1, x2 = promote_types_of_inputs(x1, x2)
     return torch.abs(torch.lcm(x1, x2, out=out))
 
 
@@ -32,6 +34,7 @@ def fmod(
     *,
     out: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
+    x1, x2 = promote_types_of_inputs(x1, x2)
     return torch.fmod(x1, x2, out=None)
 
 
@@ -46,6 +49,7 @@ def fmax(
     *,
     out: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
+    x1, x2 = promote_types_of_inputs(x1, x2)
     return torch.fmax(x1, x2, out=None)
 
 
@@ -131,6 +135,10 @@ def copysign(
     *,
     out: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
+    x1, x2 = promote_types_of_inputs(x1, x2)
+    if not ivy.is_float_dtype(x1):
+        x1 = x1.type(ivy.default_float_dtype(as_native=True))
+        x2 = x2.type(ivy.default_float_dtype(as_native=True))
     return torch.copysign(torch.as_tensor(x1), x2, out=out)
 
 
@@ -193,8 +201,7 @@ def gcd(
     *,
     out: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
-    x1 = x1 if type(x1) == torch.Tensor else torch.Tensor(x1)
-    x2 = x2 if type(x2) == torch.Tensor else torch.Tensor(x2)
+    x1, x2 = promote_types_of_inputs(x1, x2)
     return torch.gcd(x1, x2, out=out)
 
 
@@ -272,8 +279,10 @@ def logaddexp2(
     *,
     out: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
-    x1 = x1 if type(x1) == torch.Tensor else torch.Tensor(x1)
-    x2 = x2 if type(x2) == torch.Tensor else torch.Tensor(x2)
+    x1, x2 = promote_types_of_inputs(x1, x2)
+    if not ivy.is_float_dtype(x1):
+        x1 = x1.type(ivy.default_float_dtype(as_native=True))
+        x2 = x2.type(ivy.default_float_dtype(as_native=True))
     return torch.logaddexp2(x1, x2, out=out)
 
 
@@ -395,6 +404,7 @@ def gradient(
 def xlogy(
     x: torch.tensor, y: torch.tensor, /, *, out: Optional[torch.tensor] = None
 ) -> torch.tensor:
+    x, y = promote_types_of_inputs(x, y)
     return torch.xlogy(x, y, out=out)
 
 

--- a/ivy/functional/ivy/activations.py
+++ b/ivy/functional/ivy/activations.py
@@ -11,7 +11,7 @@ from ivy.func_wrapper import (
     to_native_arrays_and_back,
     handle_nestable,
     integer_arrays_to_float,
-    handle_array_like,
+    handle_array_like_without_promotion,
 )
 from ivy.exceptions import handle_exceptions
 
@@ -99,7 +99,7 @@ ACTIVATION_FUNCTIONS = [
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def gelu(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -206,7 +206,7 @@ def get(
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def leaky_relu(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -270,7 +270,7 @@ def leaky_relu(
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def log_softmax(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -340,7 +340,7 @@ def log_softmax(
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def relu(
     x: Union[ivy.Array, ivy.NativeArray], /, *, out: Optional[ivy.Array] = None
 ) -> ivy.Array:
@@ -393,7 +393,7 @@ def relu(
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def sigmoid(
     x: Union[ivy.Array, ivy.NativeArray], /, *, out: Optional[ivy.Array] = None
 ) -> ivy.Array:
@@ -434,7 +434,7 @@ def sigmoid(
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def softmax(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -482,7 +482,7 @@ def softmax(
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def softplus(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -538,7 +538,7 @@ def softplus(
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def mish(
     x: Union[ivy.Array, ivy.NativeArray], /, *, out: Optional[ivy.Array] = None
 ) -> ivy.Array:

--- a/ivy/functional/ivy/control_flow_ops.py
+++ b/ivy/functional/ivy/control_flow_ops.py
@@ -1,6 +1,6 @@
 from ivy.backend_handler import current_backend
 from ivy.func_wrapper import (
-    handle_array_like,
+    handle_array_like_without_promotion,
     to_native_arrays_and_back,
     to_ivy_arrays_and_back,
 )
@@ -15,7 +15,7 @@ def IfElse(cond, body_fn, orelse_fn, vars):
 
 
 @to_native_arrays_and_back
-@handle_array_like
+@handle_array_like_without_promotion
 def if_else(cond, body_fn, orelse_fn, vars):
     return current_backend().if_else(cond, body_fn, orelse_fn, vars)
 
@@ -29,6 +29,6 @@ def WhileLoop(test_fn, body_fn, vars):
 
 
 @to_native_arrays_and_back
-@handle_array_like
+@handle_array_like_without_promotion
 def while_loop(test_fn, body_fn, vars):
     return current_backend().while_loop(test_fn, body_fn, vars)

--- a/ivy/functional/ivy/creation.py
+++ b/ivy/functional/ivy/creation.py
@@ -17,7 +17,7 @@ from ivy.func_wrapper import (
     outputs_to_ivy_arrays,
     to_native_arrays_and_back,
     handle_nestable,
-    handle_array_like,
+    handle_array_like_without_promotion,
 )
 
 # Helpers #
@@ -428,7 +428,7 @@ def ones(
 @infer_dtype
 @handle_nestable
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def full_like(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -533,7 +533,7 @@ def full_like(
 @infer_device
 @handle_nestable
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def ones_like(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -650,7 +650,7 @@ def ones_like(
 @infer_device
 @handle_nestable
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def zeros_like(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -765,7 +765,7 @@ def zeros_like(
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def tril(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -813,7 +813,7 @@ def tril(
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def triu(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -910,7 +910,7 @@ def empty(
 @infer_device
 @handle_nestable
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def empty_like(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -1105,7 +1105,7 @@ def eye(
 @infer_device
 @handle_nestable
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def linspace(
     start: Union[ivy.Array, ivy.NativeArray, float],
     stop: Union[ivy.Array, ivy.NativeArray, float],
@@ -1614,7 +1614,7 @@ def native_array(
 @infer_device
 @handle_nestable
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def one_hot(
     indices: Union[ivy.Array, ivy.NativeArray],
     depth: int,
@@ -1727,7 +1727,7 @@ def one_hot(
 @infer_device
 @handle_nestable
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def logspace(
     start: Union[ivy.Array, ivy.NativeArray, float],
     stop: Union[ivy.Array, ivy.NativeArray, float],

--- a/ivy/functional/ivy/creation.py
+++ b/ivy/functional/ivy/creation.py
@@ -1105,7 +1105,6 @@ def eye(
 @infer_device
 @handle_nestable
 @handle_exceptions
-@handle_array_like_without_promotion
 def linspace(
     start: Union[ivy.Array, ivy.NativeArray, float],
     stop: Union[ivy.Array, ivy.NativeArray, float],

--- a/ivy/functional/ivy/data_type.py
+++ b/ivy/functional/ivy/data_type.py
@@ -15,7 +15,7 @@ from ivy.func_wrapper import (
     to_native_arrays_and_back,
     inputs_to_native_arrays,
     handle_nestable,
-    handle_array_like,
+    handle_array_like_without_promotion,
     inputs_to_ivy_arrays,
 )
 from ivy.exceptions import handle_exceptions
@@ -222,7 +222,7 @@ Iinfo = None
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def astype(
     x: Union[ivy.Array, ivy.NativeArray],
     dtype: Union[ivy.Dtype, ivy.NativeDtype],
@@ -404,7 +404,7 @@ def broadcast_arrays(*arrays: Union[ivy.Array, ivy.NativeArray]) -> List[ivy.Arr
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def broadcast_to(
     x: Union[ivy.Array, ivy.NativeArray],
     /,

--- a/ivy/functional/ivy/device.py
+++ b/ivy/functional/ivy/device.py
@@ -22,7 +22,7 @@ from ivy.func_wrapper import (
     handle_out_argument,
     to_native_arrays_and_back,
     handle_nestable,
-    handle_array_like,
+    handle_array_like_without_promotion,
 )
 from ivy.exceptions import handle_exceptions
 
@@ -784,7 +784,7 @@ def unset_default_device() -> None:
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def to_device(
     x: Union[ivy.Array, ivy.NativeArray],
     device: Union[ivy.Device, ivy.NativeDevice],

--- a/ivy/functional/ivy/elementwise.py
+++ b/ivy/functional/ivy/elementwise.py
@@ -9,7 +9,7 @@ from ivy.func_wrapper import (
     to_native_arrays_and_back,
     handle_nestable,
     integer_arrays_to_float,
-    handle_array_like,
+    handle_array_like_without_promotion,
 )
 from ivy.exceptions import handle_exceptions
 
@@ -22,7 +22,7 @@ from ivy.exceptions import handle_exceptions
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def abs(
     x: Union[float, ivy.Array, ivy.NativeArray],
     /,
@@ -107,7 +107,7 @@ def abs(
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def acos(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -185,7 +185,7 @@ def acos(
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def acosh(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -265,7 +265,6 @@ def acosh(
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
-@handle_array_like
 def add(
     x1: Union[float, ivy.Array, ivy.NativeArray],
     x2: Union[float, ivy.Array, ivy.NativeArray],
@@ -385,7 +384,7 @@ def add(
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def asin(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -468,7 +467,7 @@ def asin(
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def asinh(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -555,7 +554,7 @@ def asinh(
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def atan(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -637,7 +636,6 @@ def atan(
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
-@handle_array_like
 def atan2(
     x1: Union[ivy.Array, ivy.NativeArray],
     x2: Union[ivy.Array, ivy.NativeArray],
@@ -810,7 +808,7 @@ def atan2(
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def atanh(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -879,7 +877,6 @@ def atanh(
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
-@handle_array_like
 def bitwise_and(
     x1: Union[int, bool, ivy.Array, ivy.NativeArray],
     x2: Union[int, bool, ivy.Array, ivy.NativeArray],
@@ -970,7 +967,7 @@ def bitwise_and(
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def bitwise_invert(
     x: Union[int, bool, ivy.Array, ivy.NativeArray, ivy.Container],
     /,
@@ -1043,7 +1040,6 @@ def bitwise_invert(
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
-@handle_array_like
 def bitwise_left_shift(
     x1: Union[int, ivy.Array, ivy.NativeArray],
     x2: Union[int, ivy.Array, ivy.NativeArray],
@@ -1091,7 +1087,6 @@ def bitwise_left_shift(
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
-@handle_array_like
 def bitwise_or(
     x1: Union[int, bool, ivy.Array, ivy.NativeArray],
     x2: Union[int, bool, ivy.Array, ivy.NativeArray],
@@ -1178,7 +1173,6 @@ def bitwise_or(
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
-@handle_array_like
 def bitwise_right_shift(
     x1: Union[int, ivy.Array, ivy.NativeArray],
     x2: Union[int, ivy.Array, ivy.NativeArray],
@@ -1291,7 +1285,6 @@ def bitwise_right_shift(
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
-@handle_array_like
 def bitwise_xor(
     x1: Union[int, bool, ivy.Array, ivy.NativeArray],
     x2: Union[int, bool, ivy.Array, ivy.NativeArray],
@@ -1394,7 +1387,7 @@ def bitwise_xor(
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def ceil(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -1481,7 +1474,7 @@ def ceil(
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def cos(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -1561,7 +1554,7 @@ def cos(
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def cosh(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -1645,7 +1638,6 @@ def cosh(
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
-@handle_array_like
 def divide(
     x1: Union[float, ivy.Array, ivy.NativeArray],
     x2: Union[float, ivy.Array, ivy.NativeArray],
@@ -1730,7 +1722,6 @@ def divide(
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
-@handle_array_like
 def equal(
     x1: Union[float, ivy.Array, ivy.NativeArray, ivy.Container],
     x2: Union[float, ivy.Array, ivy.NativeArray, ivy.Container],
@@ -1817,7 +1808,7 @@ def equal(
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def exp(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -1870,7 +1861,7 @@ def exp(
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def expm1(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -1952,7 +1943,7 @@ def expm1(
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def floor(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -2040,7 +2031,6 @@ def floor(
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
-@handle_array_like
 def floor_divide(
     x1: Union[float, ivy.Array, ivy.NativeArray],
     x2: Union[float, ivy.Array, ivy.NativeArray],
@@ -2127,7 +2117,6 @@ def floor_divide(
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
-@handle_array_like
 def greater(
     x1: Union[float, ivy.Array, ivy.NativeArray],
     x2: Union[float, ivy.Array, ivy.NativeArray],
@@ -2223,7 +2212,6 @@ def greater(
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
-@handle_array_like
 def greater_equal(
     x1: Union[float, ivy.Array, ivy.NativeArray],
     x2: Union[float, ivy.Array, ivy.NativeArray],
@@ -2322,7 +2310,6 @@ def greater_equal(
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
-@handle_array_like
 def less_equal(
     x1: Union[ivy.Array, ivy.NativeArray],
     x2: Union[ivy.Array, ivy.NativeArray],
@@ -2401,7 +2388,6 @@ def less_equal(
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
-@handle_array_like
 def multiply(
     x1: Union[float, ivy.Array, ivy.NativeArray],
     x2: Union[float, ivy.Array, ivy.NativeArray],
@@ -2496,7 +2482,7 @@ def multiply(
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def isfinite(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -2573,7 +2559,7 @@ def isfinite(
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def isinf(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -2678,7 +2664,7 @@ def isinf(
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def isnan(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -2770,7 +2756,6 @@ def isnan(
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
-@handle_array_like
 def less(
     x1: Union[float, ivy.Array, ivy.NativeArray],
     x2: Union[float, ivy.Array, ivy.NativeArray],
@@ -2857,7 +2842,7 @@ def less(
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def log(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -2930,7 +2915,7 @@ def log(
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def log10(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -3013,7 +2998,7 @@ def log10(
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def log1p(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -3103,7 +3088,7 @@ def log1p(
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def log2(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -3158,7 +3143,6 @@ def log2(
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
-@handle_array_like
 def logaddexp(
     x1: Union[ivy.Array, ivy.NativeArray],
     x2: Union[ivy.Array, ivy.NativeArray],
@@ -3261,7 +3245,6 @@ def logaddexp(
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
-@handle_array_like
 def logical_and(
     x1: Union[ivy.Array, ivy.NativeArray],
     x2: Union[ivy.Array, ivy.NativeArray],
@@ -3359,7 +3342,7 @@ def logical_and(
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def logical_not(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -3452,7 +3435,6 @@ def logical_not(
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
-@handle_array_like
 def logical_or(
     x1: Union[ivy.Array, ivy.NativeArray],
     x2: Union[ivy.Array, ivy.NativeArray],
@@ -3540,7 +3522,6 @@ def logical_or(
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
-@handle_array_like
 def logical_xor(
     x1: Union[ivy.Array, ivy.NativeArray],
     x2: Union[ivy.Array, ivy.NativeArray],
@@ -3636,7 +3617,7 @@ def logical_xor(
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def negative(
     x: Union[float, ivy.Array, ivy.NativeArray],
     /,
@@ -3709,7 +3690,6 @@ def negative(
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
-@handle_array_like
 def not_equal(
     x1: Union[float, ivy.Array, ivy.NativeArray, ivy.Container],
     x2: Union[float, ivy.Array, ivy.NativeArray, ivy.Container],
@@ -3866,7 +3846,7 @@ def not_equal(
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def positive(
     x: Union[float, ivy.Array, ivy.NativeArray],
     /,
@@ -3940,7 +3920,6 @@ def positive(
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
-@handle_array_like
 def pow(
     x1: Union[float, ivy.Array, ivy.NativeArray],
     x2: Union[float, ivy.Array, ivy.NativeArray],
@@ -4075,7 +4054,6 @@ pow.unsupported_gradients = {"torch": ["float16"]}
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
-@handle_array_like
 def remainder(
     x1: Union[float, ivy.Array, ivy.NativeArray],
     x2: Union[float, ivy.Array, ivy.NativeArray],
@@ -4201,7 +4179,7 @@ def remainder(
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def round(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -4296,7 +4274,7 @@ def round(
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def sign(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -4373,7 +4351,7 @@ def sign(
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def sin(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -4458,7 +4436,7 @@ def sin(
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def sinh(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -4536,7 +4514,7 @@ def sinh(
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def sqrt(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -4618,7 +4596,7 @@ def sqrt(
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def square(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -4687,7 +4665,6 @@ def square(
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
-@handle_array_like
 def subtract(
     x1: Union[float, ivy.Array, ivy.NativeArray],
     x2: Union[float, ivy.Array, ivy.NativeArray],
@@ -4749,7 +4726,7 @@ def subtract(
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def tan(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -4835,7 +4812,7 @@ def tan(
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def tanh(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -4920,7 +4897,7 @@ def tanh(
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def trunc(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -5008,7 +4985,7 @@ def trunc(
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def erf(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -5043,7 +5020,6 @@ def erf(
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
-@handle_array_like
 def maximum(
     x1: Union[ivy.Array, ivy.NativeArray, Number],
     x2: Union[ivy.Array, ivy.NativeArray, Number],
@@ -5131,7 +5107,6 @@ def maximum(
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
-@handle_array_like
 def minimum(
     x1: Union[ivy.Array, ivy.NativeArray],
     x2: Union[ivy.Array, ivy.NativeArray],
@@ -5220,7 +5195,7 @@ def minimum(
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def reciprocal(
     x: Union[float, ivy.Array, ivy.NativeArray],
     /,
@@ -5256,7 +5231,7 @@ def reciprocal(
 @to_native_arrays_and_back
 @handle_out_argument
 @handle_nestable
-@handle_array_like
+@handle_array_like_without_promotion
 def deg2rad(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -5333,7 +5308,7 @@ def deg2rad(
 @to_native_arrays_and_back
 @handle_out_argument
 @handle_nestable
-@handle_array_like
+@handle_array_like_without_promotion
 def rad2deg(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -5408,7 +5383,6 @@ def rad2deg(
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
-@handle_array_like
 def trunc_divide(
     x1: Union[float, ivy.Array, ivy.NativeArray],
     x2: Union[float, ivy.Array, ivy.NativeArray],
@@ -5456,7 +5430,7 @@ trunc_divide.mixed_function = True
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def isreal(
     x: Union[ivy.Array, ivy.NativeArray],
     /,

--- a/ivy/functional/ivy/experimental/activations.py
+++ b/ivy/functional/ivy/experimental/activations.py
@@ -8,7 +8,7 @@ from ivy.exceptions import handle_exceptions
 from ivy.func_wrapper import (
     handle_nestable,
     to_native_arrays_and_back,
-    handle_array_like,
+    handle_array_like_without_promotion,
     handle_out_argument,
 )
 
@@ -17,7 +17,7 @@ from ivy.func_wrapper import (
 @handle_nestable
 @to_native_arrays_and_back
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def logit(
     x: Union[float, int, ivy.Array],
     /,

--- a/ivy/functional/ivy/experimental/elementwise.py
+++ b/ivy/functional/ivy/experimental/elementwise.py
@@ -7,6 +7,7 @@ from ivy.func_wrapper import (
     to_native_arrays_and_back,
     handle_nestable,
     integer_arrays_to_float,
+    handle_array_like_without_promotion,
 )
 from ivy.exceptions import handle_exceptions
 
@@ -16,6 +17,7 @@ from ivy.exceptions import handle_exceptions
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
+@handle_array_like_without_promotion
 def sinc(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -255,6 +257,7 @@ def fmin(
 @to_native_arrays_and_back
 @handle_out_argument
 @handle_nestable
+@handle_array_like_without_promotion
 def trapz(
     y: ivy.Array,
     /,
@@ -355,6 +358,7 @@ def float_power(
 @to_native_arrays_and_back
 @handle_out_argument
 @handle_nestable
+@handle_array_like_without_promotion
 def exp2(
     x: Union[ivy.Array, float, list, tuple],
     /,
@@ -434,6 +438,7 @@ def copysign(
 @to_native_arrays_and_back
 @handle_nestable
 @handle_exceptions
+@handle_array_like_without_promotion
 def count_nonzero(
     a: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -489,6 +494,7 @@ def count_nonzero(
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
+@handle_array_like_without_promotion
 def nansum(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -583,6 +589,7 @@ def gcd(
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
+@handle_array_like_without_promotion
 def isclose(
     a: Union[ivy.Array, ivy.NativeArray],
     b: Union[ivy.Array, ivy.NativeArray],
@@ -645,6 +652,7 @@ def isclose(
 @to_native_arrays_and_back
 @handle_out_argument
 @handle_nestable
+@handle_array_like_without_promotion
 def angle(
     z: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -689,6 +697,7 @@ def angle(
 @to_native_arrays_and_back
 @handle_out_argument
 @handle_nestable
+@handle_array_like_without_promotion
 def imag(
     val: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -724,6 +733,7 @@ def imag(
 @to_native_arrays_and_back
 @handle_out_argument
 @handle_nestable
+@handle_array_like_without_promotion
 def nan_to_num(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -818,6 +828,7 @@ def logaddexp2(
 @to_native_arrays_and_back
 @handle_out_argument
 @handle_nestable
+@handle_array_like_without_promotion
 def signbit(
     x: Union[ivy.Array, ivy.NativeArray, float, int, list, tuple],
     /,
@@ -851,6 +862,7 @@ def signbit(
 @to_native_arrays_and_back
 @handle_out_argument
 @handle_nestable
+@handle_array_like_without_promotion
 def diff(
     x: Union[ivy.Array, ivy.NativeArray, int, list, tuple],
     /,
@@ -897,6 +909,7 @@ def diff(
 @handle_nestable
 @to_native_arrays_and_back
 @handle_exceptions
+@handle_array_like_without_promotion
 def allclose(
     a: Union[ivy.Array, ivy.NativeArray],
     b: Union[ivy.Array, ivy.NativeArray],
@@ -969,6 +982,7 @@ def allclose(
 @to_native_arrays_and_back
 @handle_out_argument
 @handle_nestable
+@handle_array_like_without_promotion
 def fix(
     x: Union[ivy.Array, ivy.NativeArray, float, int, list, tuple],
     /,
@@ -1004,6 +1018,7 @@ def fix(
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
+@handle_array_like_without_promotion
 def nextafter(
     x1: Union[ivy.Array, ivy.NativeArray],
     x2: Union[ivy.Array, ivy.NativeArray],
@@ -1043,6 +1058,7 @@ def nextafter(
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
+@handle_array_like_without_promotion
 def zeta(
     x: Union[ivy.Array, ivy.NativeArray],
     q: Union[ivy.Array, ivy.NativeArray],
@@ -1083,6 +1099,7 @@ def zeta(
 @to_native_arrays_and_back
 @handle_nestable
 @handle_exceptions
+@handle_array_like_without_promotion
 def gradient(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -1205,6 +1222,7 @@ def xlogy(
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
+@handle_array_like_without_promotion
 def real(
     x: Union[ivy.Array, ivy.NativeArray],
     /,

--- a/ivy/functional/ivy/experimental/layers.py
+++ b/ivy/functional/ivy/experimental/layers.py
@@ -1,7 +1,7 @@
 from typing import Optional, Union, Tuple, Literal
 import ivy
 from ivy.func_wrapper import (
-    handle_array_like,
+    handle_array_like_without_promotion,
     handle_out_argument,
     to_native_arrays_and_back,
     handle_nestable,
@@ -515,7 +515,7 @@ def dct(
 @to_native_arrays_and_back
 @handle_out_argument
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def fft(
     x: Union[ivy.Array, ivy.NativeArray],
     dim: int,
@@ -580,7 +580,7 @@ def fft(
 
 @handle_exceptions
 @to_native_arrays_and_back
-@handle_array_like
+@handle_array_like_without_promotion
 def dropout1d(
     x: Union[ivy.Array, ivy.NativeArray],
     prob: float,
@@ -625,7 +625,7 @@ def dropout1d(
 @handle_out_argument
 @handle_exceptions
 @handle_nestable
-@handle_array_like
+@handle_array_like_without_promotion
 def ifft(
     x: Union[ivy.Array, ivy.NativeArray],
     dim: int,

--- a/ivy/functional/ivy/experimental/linear_algebra.py
+++ b/ivy/functional/ivy/experimental/linear_algebra.py
@@ -8,6 +8,7 @@ from ivy.func_wrapper import (
     to_native_arrays_and_back,
     handle_out_argument,
     handle_nestable,
+    handle_array_like_without_promotion,
 )
 from ivy.exceptions import handle_exceptions
 
@@ -23,6 +24,7 @@ def _check_valid_dimension_size(std):
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
+@handle_array_like_without_promotion
 def diagflat(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -97,6 +99,7 @@ def diagflat(
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
+@handle_array_like_without_promotion
 def kron(
     a: Union[ivy.Array, ivy.NativeArray],
     b: Union[ivy.Array, ivy.NativeArray],
@@ -136,6 +139,7 @@ def kron(
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
+@handle_array_like_without_promotion
 def matrix_exp(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -175,6 +179,7 @@ def matrix_exp(
 @to_native_arrays_and_back
 @handle_nestable
 @handle_exceptions
+@handle_array_like_without_promotion
 def eig(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -235,6 +240,7 @@ def eig(
 @to_native_arrays_and_back
 @handle_nestable
 @handle_exceptions
+@handle_array_like_without_promotion
 def eigvals(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -276,6 +282,7 @@ def eigvals(
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
+@handle_array_like_without_promotion
 def adjoint(
     x: Union[ivy.Array, ivy.NativeArray],
     /,

--- a/ivy/functional/ivy/experimental/losses.py
+++ b/ivy/functional/ivy/experimental/losses.py
@@ -1,14 +1,14 @@
 # local
 import ivy
 from typing import Optional, Union
-from ivy.func_wrapper import handle_nestable, handle_array_like
+from ivy.func_wrapper import handle_nestable, handle_array_like_without_promotion
 from ivy.exceptions import handle_exceptions
 from ivy.functional.ivy.losses import _reduce_loss
 
 
 @handle_nestable
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def binary_cross_entropy_with_logits(
     true: Union[ivy.Array, ivy.NativeArray],
     pred: Union[ivy.Array, ivy.NativeArray],

--- a/ivy/functional/ivy/experimental/manipulation.py
+++ b/ivy/functional/ivy/experimental/manipulation.py
@@ -16,6 +16,7 @@ from ivy.func_wrapper import (
     handle_out_argument,
     to_native_arrays_and_back,
     handle_nestable,
+    handle_array_like_without_promotion,
 )
 from ivy.backend_handler import current_backend
 from ivy.exceptions import handle_exceptions
@@ -24,6 +25,7 @@ from ivy.exceptions import handle_exceptions
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
+@handle_array_like_without_promotion
 def flatten(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -172,6 +174,7 @@ flatten.mixed_function = True
 @to_native_arrays_and_back
 @handle_out_argument
 @handle_nestable
+@handle_array_like_without_promotion
 def moveaxis(
     a: Union[ivy.Array, ivy.NativeArray],
     source: Union[int, Sequence[int]],
@@ -296,6 +299,7 @@ def ndindex(
 @to_native_arrays_and_back
 @handle_out_argument
 @handle_nestable
+@handle_array_like_without_promotion
 def heaviside(
     x1: Union[ivy.Array, ivy.NativeArray],
     x2: Union[ivy.Array, ivy.NativeArray],
@@ -340,6 +344,7 @@ def heaviside(
 @to_native_arrays_and_back
 @handle_out_argument
 @handle_nestable
+@handle_array_like_without_promotion
 def flipud(
     m: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -450,6 +455,7 @@ def hstack(arrays: Sequence[ivy.Array], /) -> ivy.Array:
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
+@handle_array_like_without_promotion
 def rot90(
     m: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -528,6 +534,7 @@ def rot90(
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
+@handle_array_like_without_promotion
 def top_k(
     x: Union[ivy.Array, ivy.NativeArray],
     k: int,
@@ -602,6 +609,7 @@ def top_k(
 @to_native_arrays_and_back
 @handle_out_argument
 @handle_nestable
+@handle_array_like_without_promotion
 def fliplr(
     m: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -639,6 +647,7 @@ def fliplr(
 @to_native_arrays_and_back
 @handle_out_argument
 @handle_nestable
+@handle_array_like_without_promotion
 def i0(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -940,6 +949,7 @@ def _check_arguments(
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
+@handle_array_like_without_promotion
 def pad(
     input: Union[ivy.Array, ivy.NativeArray],
     pad_width: Union[Iterable[Tuple[int]], int],
@@ -1188,6 +1198,7 @@ def pad(
 @to_native_arrays_and_back
 @handle_out_argument
 @handle_nestable
+@handle_array_like_without_promotion
 def vsplit(
     ary: Union[ivy.Array, ivy.NativeArray],
     indices_or_sections: Union[int, Tuple[int]],
@@ -1236,6 +1247,7 @@ def vsplit(
 @to_native_arrays_and_back
 @handle_out_argument
 @handle_nestable
+@handle_array_like_without_promotion
 def dsplit(
     ary: Union[ivy.Array, ivy.NativeArray],
     indices_or_sections: Union[int, Tuple[int]],
@@ -1285,6 +1297,7 @@ def dsplit(
 @to_native_arrays_and_back
 @handle_out_argument
 @handle_nestable
+@handle_array_like_without_promotion
 def atleast_1d(
     *arys: Union[ivy.Array, ivy.NativeArray, bool, Number],
 ) -> List[ivy.Array]:
@@ -1359,6 +1372,7 @@ def dstack(
 @to_native_arrays_and_back
 @handle_out_argument
 @handle_nestable
+@handle_array_like_without_promotion
 def atleast_2d(
     *arys: Union[ivy.Array, ivy.NativeArray],
 ) -> List[ivy.Array]:
@@ -1443,6 +1457,7 @@ def atleast_3d(
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
+@handle_array_like_without_promotion
 def take_along_axis(
     arr: Union[ivy.Array, ivy.NativeArray],
     indices: Union[ivy.Array, ivy.NativeArray],
@@ -1483,6 +1498,7 @@ def take_along_axis(
 @to_native_arrays_and_back
 @handle_out_argument
 @handle_nestable
+@handle_array_like_without_promotion
 def hsplit(
     ary: Union[ivy.Array, ivy.NativeArray],
     indices_or_sections: Union[int, Tuple[int]],

--- a/ivy/functional/ivy/general.py
+++ b/ivy/functional/ivy/general.py
@@ -22,7 +22,7 @@ from ivy.func_wrapper import (
     to_native_arrays_and_back,
     handle_out_argument,
     handle_nestable,
-    handle_array_like,
+    handle_array_like_without_promotion,
 )
 from ivy.functional.ivy.device import dev
 
@@ -512,7 +512,7 @@ def get_show_func_wrapper_trace_mode() -> bool:
 @inputs_to_native_arrays
 @handle_nestable
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def array_equal(
     x0: Union[ivy.Array, ivy.NativeArray],
     x1: Union[ivy.Array, ivy.NativeArray],
@@ -649,7 +649,7 @@ def all_equal(
 @inputs_to_native_arrays
 @handle_nestable
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def to_numpy(
     x: Union[ivy.Array, ivy.NativeArray], /, *, copy: bool = True
 ) -> np.ndarray:
@@ -718,7 +718,7 @@ def isscalar(x: Any, /) -> bool:
 @inputs_to_native_arrays
 @handle_nestable
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def to_scalar(x: Union[ivy.Array, ivy.NativeArray], /) -> Number:
     """Converts an array with a single element into a scalar.
 
@@ -772,7 +772,7 @@ def to_scalar(x: Union[ivy.Array, ivy.NativeArray], /) -> Number:
 @inputs_to_native_arrays
 @handle_nestable
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def to_list(x: Union[ivy.Array, ivy.NativeArray], /) -> List:
     """Creates a (possibly nested) list from input array.
 
@@ -843,7 +843,7 @@ def to_list(x: Union[ivy.Array, ivy.NativeArray], /) -> List:
 @handle_nestable
 @outputs_to_ivy_arrays
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def clip_vector_norm(
     x: Union[ivy.Array, ivy.NativeArray],
     max_norm: float,
@@ -930,7 +930,7 @@ def clip_vector_norm(
 
 @handle_nestable
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def clip_matrix_norm(
     x: Union[ivy.Array, ivy.NativeArray],
     max_norm: float,
@@ -1010,7 +1010,7 @@ def clip_matrix_norm(
 @to_native_arrays_and_back
 @handle_nestable
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def fourier_encode(
     x: Union[ivy.Array, ivy.NativeArray],
     max_freq: Union[float, ivy.Array, ivy.NativeArray],
@@ -1113,7 +1113,7 @@ def fourier_encode(
 @inputs_to_ivy_arrays
 @handle_nestable
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def value_is_nan(
     x: Union[ivy.Array, ivy.NativeArray, Number],
     /,
@@ -1172,7 +1172,7 @@ def value_is_nan(
 @inputs_to_native_arrays
 @handle_nestable
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def has_nans(
     x: Union[ivy.Array, ivy.NativeArray], /, *, include_infs: bool = True
 ) -> bool:
@@ -1678,7 +1678,7 @@ def current_backend_str() -> Union[str, None]:
 @inputs_to_native_arrays
 @handle_nestable
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def einops_rearrange(
     x: Union[ivy.Array, ivy.NativeArray],
     pattern: str,
@@ -1746,7 +1746,7 @@ def einops_rearrange(
 @inputs_to_native_arrays
 @handle_nestable
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def einops_reduce(
     x: Union[ivy.Array, ivy.NativeArray],
     pattern: str,
@@ -1815,7 +1815,7 @@ einops_reduce.unsupported_dtypes = {"torch": ("float16",)}
 @inputs_to_native_arrays
 @handle_nestable
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def einops_repeat(
     x: Union[ivy.Array, ivy.NativeArray],
     pattern: str,
@@ -1968,7 +1968,7 @@ def set_min_base(val: float) -> None:
 @inputs_to_ivy_arrays
 @handle_nestable
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def stable_divide(
     numerator: Union[Number, ivy.Array, ivy.NativeArray],
     denominator: Union[Number, ivy.Array, ivy.NativeArray],
@@ -2067,7 +2067,7 @@ def stable_divide(
 @inputs_to_ivy_arrays
 @handle_nestable
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def stable_pow(
     base: Union[Number, ivy.Array, ivy.NativeArray],
     exponent: Union[Number, ivy.Array, ivy.NativeArray],
@@ -2386,7 +2386,7 @@ def assert_supports_inplace(x: Union[ivy.Array, ivy.NativeArray], /) -> bool:
 
 @to_native_arrays_and_back
 @handle_nestable
-@handle_array_like
+@handle_array_like_without_promotion
 def get_item(
     x: Union[ivy.Array, ivy.NativeArray],
     query: Union[ivy.Array, ivy.NativeArray, Tuple],
@@ -2588,7 +2588,7 @@ def inplace_increment(
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def scatter_flat(
     indices: Union[ivy.Array, ivy.NativeArray],
     updates: Union[ivy.Array, ivy.NativeArray],
@@ -2628,7 +2628,6 @@ def scatter_flat(
 @to_native_arrays_and_back
 @handle_nestable
 @handle_exceptions
-@handle_array_like
 def scatter_nd(
     indices: Union[ivy.Array, ivy.NativeArray],
     updates: Union[ivy.Array, ivy.NativeArray],
@@ -2709,7 +2708,7 @@ def scatter_nd(
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def gather(
     params: Union[ivy.Array, ivy.NativeArray],
     indices: Union[ivy.Array, ivy.NativeArray],
@@ -2815,7 +2814,7 @@ def gather(
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def gather_nd(
     params: Union[ivy.Array, ivy.NativeArray],
     indices: Union[ivy.Array, ivy.NativeArray],
@@ -2908,7 +2907,7 @@ def multiprocessing(context: str = None):
 @to_native_arrays_and_back
 @handle_nestable
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def shape(
     x: Union[ivy.Array, ivy.NativeArray], /, *, as_array: bool = False
 ) -> Union[ivy.Shape, ivy.NativeShape]:
@@ -3005,7 +3004,7 @@ def shape_array_mode() -> bool:
 
 @to_native_arrays_and_back
 @handle_nestable
-@handle_array_like
+@handle_array_like_without_promotion
 def get_num_dims(
     x: Union[ivy.Array, ivy.NativeArray], /, *, as_array: bool = False
 ) -> int:

--- a/ivy/functional/ivy/general.py
+++ b/ivy/functional/ivy/general.py
@@ -843,7 +843,6 @@ def to_list(x: Union[ivy.Array, ivy.NativeArray], /) -> List:
 @handle_nestable
 @outputs_to_ivy_arrays
 @handle_exceptions
-@handle_array_like_without_promotion
 def clip_vector_norm(
     x: Union[ivy.Array, ivy.NativeArray],
     max_norm: float,
@@ -930,7 +929,6 @@ def clip_vector_norm(
 
 @handle_nestable
 @handle_exceptions
-@handle_array_like_without_promotion
 def clip_matrix_norm(
     x: Union[ivy.Array, ivy.NativeArray],
     max_norm: float,
@@ -2067,7 +2065,6 @@ def stable_divide(
 @inputs_to_ivy_arrays
 @handle_nestable
 @handle_exceptions
-@handle_array_like_without_promotion
 def stable_pow(
     base: Union[Number, ivy.Array, ivy.NativeArray],
     exponent: Union[Number, ivy.Array, ivy.NativeArray],

--- a/ivy/functional/ivy/gradients.py
+++ b/ivy/functional/ivy/gradients.py
@@ -14,7 +14,7 @@ from ivy.func_wrapper import (
     to_native_arrays_and_back,
     handle_out_argument,
     handle_nestable,
-    handle_array_like,
+    handle_array_like_without_promotion,
 )
 from ivy.exceptions import handle_exceptions
 
@@ -450,7 +450,7 @@ def unset_with_grads():
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def stop_gradient(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -525,7 +525,7 @@ def stop_gradient(
 
 
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def execute_with_gradients(
     func, xs, /, *, retain_grads=False, xs_grad_idxs=None, ret_grad_idxs=None
 ):
@@ -676,7 +676,7 @@ grad.computes_gradients = True
 
 @inputs_to_ivy_arrays
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def adam_step(
     dcdw: Union[ivy.Array, ivy.NativeArray],
     mw: Union[ivy.Array, ivy.NativeArray],
@@ -829,7 +829,7 @@ adam_step.out_index = 0
 
 @inputs_to_ivy_arrays
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def optimizer_update(
     w: Union[ivy.Array, ivy.NativeArray],
     effective_grad: Union[ivy.Array, ivy.NativeArray],
@@ -951,7 +951,7 @@ def optimizer_update(
 
 @inputs_to_ivy_arrays
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def gradient_descent_update(
     w: Union[ivy.Array, ivy.NativeArray],
     dcdw: Union[ivy.Array, ivy.NativeArray],
@@ -1043,7 +1043,7 @@ def gradient_descent_update(
 
 @inputs_to_ivy_arrays
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def lars_update(
     w: Union[ivy.Array, ivy.NativeArray],
     dcdw: Union[ivy.Array, ivy.NativeArray],
@@ -1093,7 +1093,7 @@ def lars_update(
 
 @inputs_to_ivy_arrays
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def adam_update(
     w: Union[ivy.Array, ivy.NativeArray],
     dcdw: Union[ivy.Array, ivy.NativeArray],
@@ -1257,7 +1257,7 @@ adam_update.out_index = 0
 
 @inputs_to_ivy_arrays
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def lamb_update(
     w: Union[ivy.Array, ivy.NativeArray],
     dcdw: Union[ivy.Array, ivy.NativeArray],

--- a/ivy/functional/ivy/layers.py
+++ b/ivy/functional/ivy/layers.py
@@ -11,7 +11,7 @@ from ivy.func_wrapper import (
     to_native_arrays_and_back,
     handle_out_argument,
     handle_nestable,
-    handle_array_like,
+    handle_array_like_without_promotion,
 )
 from ivy.exceptions import handle_exceptions
 
@@ -25,7 +25,7 @@ from ivy.exceptions import handle_exceptions
 
 @handle_nestable
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def linear(
     x: Union[ivy.Array, ivy.NativeArray],
     weight: Union[ivy.Array, ivy.NativeArray],
@@ -169,7 +169,7 @@ def linear(
 
 
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def dropout(
     x: Union[ivy.Array, ivy.NativeArray],
     prob: float,
@@ -318,7 +318,7 @@ def dropout(
 
 
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def scaled_dot_product_attention(
     q: Union[ivy.Array, ivy.NativeArray],
     k: Union[ivy.Array, ivy.NativeArray],
@@ -522,7 +522,7 @@ def scaled_dot_product_attention(
 
 
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def multi_head_attention(
     x: Union[ivy.Array, ivy.NativeArray],
     scale: float,
@@ -757,7 +757,7 @@ def multi_head_attention(
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def conv1d(
     x: Union[ivy.Array, ivy.NativeArray],
     filters: Union[ivy.Array, ivy.NativeArray],
@@ -845,7 +845,7 @@ def conv1d(
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def conv1d_transpose(
     x: Union[ivy.Array, ivy.NativeArray],
     filters: Union[ivy.Array, ivy.NativeArray],
@@ -904,7 +904,7 @@ def conv1d_transpose(
 @to_native_arrays_and_back
 @handle_out_argument
 @handle_nestable
-@handle_array_like
+@handle_array_like_without_promotion
 def conv2d(
     x: Union[ivy.Array, ivy.NativeArray],
     filters: Union[ivy.Array, ivy.NativeArray],
@@ -1031,7 +1031,7 @@ def conv2d(
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def conv2d_transpose(
     x: Union[ivy.Array, ivy.NativeArray],
     filters: Union[ivy.Array, ivy.NativeArray],
@@ -1147,7 +1147,7 @@ def conv2d_transpose(
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def depthwise_conv2d(
     x: Union[ivy.Array, ivy.NativeArray],
     filters: Union[ivy.Array, ivy.NativeArray],
@@ -1283,7 +1283,7 @@ def depthwise_conv2d(
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def conv3d(
     x: Union[ivy.Array, ivy.NativeArray, ivy.Container],
     filters: Union[ivy.Array, ivy.NativeArray, ivy.Container],
@@ -1397,7 +1397,7 @@ def conv3d(
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def conv3d_transpose(
     x: Union[ivy.Array, ivy.NativeArray],
     filters: Union[ivy.Array, ivy.NativeArray],
@@ -1504,7 +1504,7 @@ def conv3d_transpose(
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def conv_general_dilated(
     x: Union[ivy.Array, ivy.NativeArray],
     filters: Union[ivy.Array, ivy.NativeArray],
@@ -1577,7 +1577,7 @@ def conv_general_dilated(
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def conv_general_transpose(
     x: Union[ivy.Array, ivy.NativeArray],
     filters: Union[ivy.Array, ivy.NativeArray],
@@ -1643,7 +1643,7 @@ def conv_general_transpose(
 
 @handle_out_argument
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def conv(
     x: Union[ivy.Array, ivy.NativeArray],
     filters: Union[ivy.Array, ivy.NativeArray],
@@ -1741,7 +1741,7 @@ def conv(
 @inputs_to_ivy_arrays
 @handle_nestable
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def lstm_update(
     x: Union[ivy.Array, ivy.NativeArray],
     init_h: Union[ivy.Array, ivy.NativeArray],

--- a/ivy/functional/ivy/linear_algebra.py
+++ b/ivy/functional/ivy/linear_algebra.py
@@ -8,7 +8,7 @@ from ivy.func_wrapper import (
     to_native_arrays_and_back,
     handle_out_argument,
     handle_nestable,
-    handle_array_like,
+    handle_array_like_without_promotion,
 )
 from ivy.exceptions import handle_exceptions
 
@@ -24,7 +24,7 @@ inf = float("inf")
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def cholesky(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -161,7 +161,6 @@ def cholesky(
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
-@handle_array_like
 def cross(
     x1: Union[ivy.Array, ivy.NativeArray],
     x2: Union[ivy.Array, ivy.NativeArray],
@@ -252,7 +251,7 @@ def cross(
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def det(
     x: Union[ivy.Array, ivy.NativeArray], /, *, out: Optional[ivy.Array] = None
 ) -> ivy.Array:
@@ -321,7 +320,7 @@ def det(
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def diagonal(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -497,7 +496,7 @@ def diagonal(
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def eig(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -557,7 +556,7 @@ def eig(
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def eigh(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -621,7 +620,7 @@ def eigh(
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def eigvalsh(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -723,7 +722,6 @@ def eigvalsh(
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
-@handle_array_like
 def inner(
     x1: Union[ivy.Array, ivy.NativeArray],
     x2: Union[ivy.Array, ivy.NativeArray],
@@ -761,7 +759,7 @@ def inner(
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def inv(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -851,7 +849,6 @@ def inv(
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
-@handle_array_like
 def matmul(
     x1: Union[ivy.Array, ivy.NativeArray],
     x2: Union[ivy.Array, ivy.NativeArray],
@@ -996,7 +993,7 @@ def matmul(
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def matrix_norm(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -1143,7 +1140,7 @@ def matrix_norm(
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def matrix_power(
     x: Union[ivy.Array, ivy.NativeArray], n: int, /, *, out: Optional[ivy.Array] = None
 ) -> ivy.Array:
@@ -1235,7 +1232,7 @@ def matrix_power(
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def matrix_rank(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -1338,7 +1335,7 @@ def matrix_rank(
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def matrix_transpose(
     x: Union[ivy.Array, ivy.NativeArray], /, *, out: Optional[ivy.Array] = None
 ) -> ivy.Array:
@@ -1419,7 +1416,6 @@ def matrix_transpose(
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
-@handle_array_like
 def outer(
     x1: Union[ivy.Array, ivy.NativeArray],
     x2: Union[ivy.Array, ivy.NativeArray],
@@ -1506,7 +1502,7 @@ def outer(
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def pinv(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -1575,7 +1571,7 @@ def pinv(
 @to_native_arrays_and_back
 @handle_nestable
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def qr(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -1633,7 +1629,7 @@ def qr(
 @to_native_arrays_and_back
 @handle_nestable
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def slogdet(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -1714,7 +1710,6 @@ def slogdet(
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
-@handle_array_like
 def solve(
     x1: Union[ivy.Array, ivy.NativeArray],
     x2: Union[ivy.Array, ivy.NativeArray],
@@ -1767,7 +1762,7 @@ def solve(
 @to_native_arrays_and_back
 @handle_nestable
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def svd(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -1890,7 +1885,7 @@ def svd(
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def svdvals(
     x: Union[ivy.Array, ivy.NativeArray], /, *, out: Optional[ivy.Array] = None
 ) -> ivy.Array:
@@ -2013,7 +2008,6 @@ def svdvals(
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
-@handle_array_like
 def tensordot(
     x1: Union[ivy.Array, ivy.NativeArray],
     x2: Union[ivy.Array, ivy.NativeArray],
@@ -2095,7 +2089,6 @@ def tensordot(
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
-@handle_array_like
 def tensorsolve(
     x1: Union[ivy.Array, ivy.NativeArray],
     x2: Union[ivy.Array, ivy.NativeArray],
@@ -2140,7 +2133,7 @@ def tensorsolve(
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def trace(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -2254,7 +2247,6 @@ def trace(
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
-@handle_array_like
 def vecdot(
     x1: Union[ivy.Array, ivy.NativeArray],
     x2: Union[ivy.Array, ivy.NativeArray],
@@ -2320,7 +2312,7 @@ def vecdot(
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def vector_norm(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -2418,7 +2410,7 @@ def vector_norm(
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def diag(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -2498,7 +2490,7 @@ def diag(
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def vander(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -2570,7 +2562,7 @@ def vander(
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def vector_to_skew_symmetric_matrix(
     vector: Union[ivy.Array, ivy.NativeArray], /, *, out: Optional[ivy.Array] = None
 ) -> ivy.Array:

--- a/ivy/functional/ivy/losses.py
+++ b/ivy/functional/ivy/losses.py
@@ -3,7 +3,7 @@
 # local
 import ivy
 from typing import Optional, Union
-from ivy.func_wrapper import handle_nestable, handle_array_like
+from ivy.func_wrapper import handle_nestable, handle_array_like_without_promotion
 from ivy.exceptions import handle_exceptions
 
 # Helpers #
@@ -25,7 +25,7 @@ def _reduce_loss(red, loss, axis, out):
 
 @handle_nestable
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def cross_entropy(
     true: Union[ivy.Array, ivy.NativeArray],
     pred: Union[ivy.Array, ivy.NativeArray],
@@ -79,7 +79,7 @@ def cross_entropy(
 
 @handle_nestable
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def binary_cross_entropy(
     true: Union[ivy.Array, ivy.NativeArray],
     pred: Union[ivy.Array, ivy.NativeArray],
@@ -185,7 +185,7 @@ def binary_cross_entropy(
 
 @handle_nestable
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def sparse_cross_entropy(
     true: Union[ivy.Array, ivy.NativeArray],
     pred: Union[ivy.Array, ivy.NativeArray],

--- a/ivy/functional/ivy/manipulation.py
+++ b/ivy/functional/ivy/manipulation.py
@@ -11,7 +11,7 @@ from ivy.func_wrapper import (
     to_native_arrays_and_back,
     handle_out_argument,
     handle_nestable,
-    handle_array_like,
+    handle_array_like_without_promotion,
 )
 from ivy.exceptions import handle_exceptions
 
@@ -93,7 +93,7 @@ def concat(
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def expand_dims(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -218,7 +218,7 @@ def expand_dims(
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def flip(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -302,7 +302,7 @@ def flip(
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def permute_dims(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -391,7 +391,7 @@ def permute_dims(
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def reshape(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -509,7 +509,7 @@ def reshape(
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def roll(
     x: Union[ivy.Array, ivy.NativeArray, ivy.Container],
     /,
@@ -618,7 +618,7 @@ def roll(
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def squeeze(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -785,7 +785,6 @@ def stack(
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
-@handle_array_like
 def clip(
     x: Union[ivy.Array, ivy.NativeArray],
     x_min: Union[Number, ivy.Array, ivy.NativeArray],
@@ -910,7 +909,7 @@ def clip(
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def constant_pad(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -996,7 +995,7 @@ def constant_pad(
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def repeat(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -1064,7 +1063,7 @@ def repeat(
 @to_native_arrays_and_back
 @handle_nestable
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def split(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -1138,7 +1137,7 @@ def split(
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def swapaxes(
     x: Union[ivy.Array, ivy.NativeArray],
     axis0: int,
@@ -1317,7 +1316,7 @@ def tile(
 @to_native_arrays_and_back
 @handle_nestable
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def unstack(
     x: Union[ivy.Array, ivy.NativeArray], /, *, axis: int = 0, keepdims: bool = False
 ) -> List[ivy.Array]:
@@ -1400,7 +1399,7 @@ def unstack(
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def zero_pad(
     x: Union[ivy.Array, ivy.NativeArray],
     /,

--- a/ivy/functional/ivy/norms.py
+++ b/ivy/functional/ivy/norms.py
@@ -7,7 +7,7 @@ import ivy
 from ivy.func_wrapper import (
     inputs_to_ivy_arrays,
     integer_arrays_to_float,
-    handle_array_like,
+    handle_array_like_without_promotion,
 )
 from ivy.exceptions import handle_exceptions
 
@@ -19,7 +19,7 @@ from ivy.exceptions import handle_exceptions
 @inputs_to_ivy_arrays
 @integer_arrays_to_float
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def layer_norm(
     x: Union[ivy.Array, ivy.NativeArray],
     normalized_idxs: List[int],

--- a/ivy/functional/ivy/searching.py
+++ b/ivy/functional/ivy/searching.py
@@ -10,7 +10,7 @@ from ivy.func_wrapper import (
     to_native_arrays_and_back,
     handle_out_argument,
     handle_nestable,
-    handle_array_like,
+    handle_array_like_without_promotion,
 )
 
 
@@ -22,7 +22,7 @@ from ivy.func_wrapper import (
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def argmax(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -125,7 +125,7 @@ def argmax(
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def argmin(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -228,7 +228,7 @@ def argmin(
 @to_native_arrays_and_back
 @handle_nestable
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def nonzero(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -365,7 +365,7 @@ def nonzero(
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def where(
     condition: Union[ivy.Array, ivy.NativeArray],
     x1: Union[ivy.Array, ivy.NativeArray],
@@ -454,7 +454,7 @@ def where(
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def argwhere(
     x: Union[ivy.Array, ivy.NativeArray],
     /,

--- a/ivy/functional/ivy/set.py
+++ b/ivy/functional/ivy/set.py
@@ -7,7 +7,7 @@ from ivy.func_wrapper import (
     to_native_arrays_and_back,
     handle_out_argument,
     handle_nestable,
-    handle_array_like,
+    handle_array_like_without_promotion,
 )
 from ivy.exceptions import handle_exceptions
 
@@ -19,7 +19,7 @@ from ivy.exceptions import handle_exceptions
 @to_native_arrays_and_back
 @handle_nestable
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def unique_all(
     x: Union[ivy.Array, ivy.NativeArray]
 ) -> Tuple[
@@ -137,7 +137,7 @@ def unique_all(
 @to_native_arrays_and_back
 @handle_nestable
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def unique_inverse(
     x: Union[ivy.Array, ivy.NativeArray]
 ) -> Tuple[Union[ivy.Array, ivy.NativeArray], Union[ivy.Array, ivy.NativeArray]]:
@@ -237,7 +237,7 @@ def unique_inverse(
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def unique_values(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -303,7 +303,7 @@ def unique_values(
 @to_native_arrays_and_back
 @handle_nestable
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def unique_counts(
     x: Union[ivy.Array, ivy.NativeArray]
 ) -> Tuple[Union[ivy.Array, ivy.NativeArray], Union[ivy.Array, ivy.NativeArray]]:

--- a/ivy/functional/ivy/sorting.py
+++ b/ivy/functional/ivy/sorting.py
@@ -7,7 +7,7 @@ from ivy.func_wrapper import (
     to_native_arrays_and_back,
     handle_out_argument,
     handle_nestable,
-    handle_array_like,
+    handle_array_like_without_promotion,
 )
 from ivy.exceptions import handle_exceptions
 
@@ -20,7 +20,7 @@ from ivy.exceptions import handle_exceptions
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def argsort(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -135,7 +135,7 @@ def argsort(
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def sort(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -242,7 +242,7 @@ def sort(
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def searchsorted(
     x: Union[ivy.Array, ivy.NativeArray],
     v: Union[ivy.Array, ivy.NativeArray],

--- a/ivy/functional/ivy/statistical.py
+++ b/ivy/functional/ivy/statistical.py
@@ -9,7 +9,7 @@ from ivy.func_wrapper import (
     handle_out_argument,
     handle_nestable,
     integer_arrays_to_float,
-    handle_array_like,
+    handle_array_like_without_promotion,
 )
 from ivy.exceptions import handle_exceptions
 
@@ -36,7 +36,7 @@ def _get_promoted_type_of_operands(operands):
 @to_native_arrays_and_back
 @handle_out_argument
 @handle_nestable
-@handle_array_like
+@handle_array_like_without_promotion
 def min(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -137,7 +137,7 @@ def min(
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def max(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -244,7 +244,7 @@ def max(
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def mean(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -351,7 +351,7 @@ def mean(
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def prod(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -472,7 +472,7 @@ def prod(
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def std(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -604,7 +604,7 @@ def std(
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def sum(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -736,7 +736,7 @@ def sum(
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def var(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -850,7 +850,7 @@ def var(
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def cumsum(
     x: Union[ivy.Array, ivy.NativeArray],
     axis: int = 0,
@@ -991,7 +991,7 @@ def cumsum(
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def cumprod(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -1138,7 +1138,7 @@ def cumprod(
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def einsum(
     equation: str,
     *operands: Union[ivy.Array, ivy.NativeArray],

--- a/ivy/functional/ivy/utility.py
+++ b/ivy/functional/ivy/utility.py
@@ -7,7 +7,7 @@ from ivy.func_wrapper import (
     to_native_arrays_and_back,
     handle_out_argument,
     handle_nestable,
-    handle_array_like,
+    handle_array_like_without_promotion,
 )
 from ivy.exceptions import handle_exceptions
 
@@ -20,7 +20,7 @@ from ivy.exceptions import handle_exceptions
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def all(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -130,7 +130,7 @@ def all(
 @handle_out_argument
 @handle_nestable
 @handle_exceptions
-@handle_array_like
+@handle_array_like_without_promotion
 def any(
     x: Union[ivy.Array, ivy.NativeArray],
     /,

--- a/ivy_tests/test_ivy/test_functional/test_experimental/test_core/test_elementwise.py
+++ b/ivy_tests/test_ivy/test_functional/test_experimental/test_core/test_elementwise.py
@@ -49,7 +49,7 @@ def test_sinc(
     dtype_and_x=helpers.dtype_and_values(
         available_dtypes=["int16", "int32", "int64"],
         num_arrays=2,
-        shared_dtype=True,
+        shared_dtype=False,
         min_num_dims=1,
         max_num_dims=3,
         min_value=-100,
@@ -84,7 +84,7 @@ def test_lcm(
     dtype_and_x=helpers.dtype_and_values(
         available_dtypes=helpers.get_dtypes("numeric"),
         num_arrays=2,
-        shared_dtype=True,
+        shared_dtype=False,
         large_abs_safety_factor=6,
         small_abs_safety_factor=6,
         safety_factor_scale="log",
@@ -126,7 +126,7 @@ def test_fmod(
         min_value=-10,
         max_value=10,
         num_arrays=2,
-        shared_dtype=True,
+        shared_dtype=False,
         min_num_dims=1,
         max_num_dims=3,
         min_dim_size=1,
@@ -164,7 +164,7 @@ def test_fmax(
         min_value=-10,
         max_value=10,
         num_arrays=2,
-        shared_dtype=True,
+        shared_dtype=False,
         min_num_dims=1,
         max_num_dims=3,
         min_dim_size=1,
@@ -348,7 +348,7 @@ def test_exp2(
         num_arrays=2,
         min_num_dims=0,
         allow_nan=False,
-        shared_dtype=True,
+        shared_dtype=False,
     ),
     test_gradients=st.just(False),
 )
@@ -487,7 +487,7 @@ def test_nansum(
     dtype_and_x=helpers.dtype_and_values(
         available_dtypes=helpers.get_dtypes("integer"),
         num_arrays=2,
-        shared_dtype=True,
+        shared_dtype=False,
         min_num_dims=1,
         max_num_dims=3,
         min_value=-100,
@@ -694,7 +694,7 @@ def test_nan_to_num(
 @handle_test(
     fn_tree="functional.ivy.experimental.logaddexp2",
     dtype_and_x=helpers.dtype_and_values(
-        available_dtypes=helpers.get_dtypes("float"),
+        available_dtypes=["float32", "float64"],
         num_arrays=2,
         shared_dtype=True,
         min_num_dims=1,
@@ -951,7 +951,7 @@ def test_gradient(
     dtype_and_x=helpers.dtype_and_values(
         available_dtypes=["float16", "float32", "float64"],
         num_arrays=2,
-        shared_dtype=True,
+        shared_dtype=False,
         min_value=-10,
         max_value=10,
         min_num_dims=1,

--- a/ivy_tests/test_ivy/test_misc/test_func_wrapper.py
+++ b/ivy_tests/test_ivy/test_misc/test_func_wrapper.py
@@ -1,6 +1,6 @@
 import ivy
 import pytest
-from ivy.func_wrapper import handle_array_like
+from ivy.func_wrapper import handle_array_like_without_promotion
 from typing import Union, Tuple, List, Sequence
 
 
@@ -31,7 +31,7 @@ def _fn4(x: Union[Sequence[ivy.Array], ivy.Array]):
     ],
 )
 def test_handle_array_like(fn, x, expected_type):
-    assert isinstance(handle_array_like(fn)(x), expected_type)
+    assert isinstance(handle_array_like_without_promotion(fn)(x), expected_type)
 
 
 def test_outputs_to_ivy_arrays():

--- a/ivy_tests/test_ivy/test_misc/test_func_wrapper.py
+++ b/ivy_tests/test_ivy/test_misc/test_func_wrapper.py
@@ -24,14 +24,17 @@ def _fn4(x: Union[Sequence[ivy.Array], ivy.Array]):
     ("fn", "x", "expected_type"),
     [
         (_fn1, (1, 2), tuple),
-        (_fn2, (1, 2), ivy.Array),
-        (_fn2, [1, 2], ivy.Array),
+        (_fn2, (1, 2), ivy.NativeArray),
+        (_fn2, [1, 2], ivy.NativeArray),
         (_fn3, [1, 2], list),
         (_fn4, [1, 2], list),
     ],
 )
-def test_handle_array_like(fn, x, expected_type):
-    assert isinstance(handle_array_like_without_promotion(fn)(x), expected_type)
+def test_handle_array_like_without_promotion(fn, x, expected_type):
+    if "NativeArray" in str(expected_type):
+        assert isinstance(handle_array_like_without_promotion(fn)(x), ivy.NativeArray)
+    else:
+        assert isinstance(handle_array_like_without_promotion(fn)(x), expected_type)
 
 
 def test_outputs_to_ivy_arrays():


### PR DESCRIPTION
…rapper, removed wrapper from functions with promotion as the promotion function handles array_likes separately to support weak_type promotion. Renamed wrapper to `handle_array_like_without_promotion` to improve clarity. Also added wrapper and promotion to experimental functions.