### PR TITLE
Fixing some failing ivy tests in layers

### DIFF
--- a/ivy/functional/backends/jax/layers.py
+++ b/ivy/functional/backends/jax/layers.py
@@ -117,35 +117,6 @@ def conv2d(
     )
 
 
-def depthwise_conv2d(
-    x: JaxArray,
-    filters: JaxArray,
-    strides: Union[int, Tuple[int, int]],
-    padding: str,
-    /,
-    *,
-    data_format: str = "NHWC",
-    dilations: Optional[Union[int, Tuple[int, int]]] = 1,
-    out: Optional[JaxArray] = None,
-) -> JaxArray:
-    strides = [strides] * 2 if isinstance(strides, int) else strides
-    strides = [strides[1], strides[2]] if len(strides) == 4 else strides
-    dilations = [dilations] * 2 if isinstance(dilations, int) else dilations
-    filters = jnp.squeeze(filters, 3) if filters.ndim == 4 else filters
-    cn = filters.shape[-1]
-    filters = jnp.expand_dims(filters, -2)
-    return jlax.conv_general_dilated(
-        x,
-        filters,
-        strides,
-        padding,
-        None,
-        dilations,
-        (data_format, "HWIO", data_format),
-        feature_group_count=cn,
-    )
-
-
 def conv2d_transpose(
     x: JaxArray,
     filters: JaxArray,
@@ -191,6 +162,35 @@ def conv2d_transpose(
         dilations,
         (data_format, "HWIO", data_format),
         True,
+    )
+
+
+def depthwise_conv2d(
+    x: JaxArray,
+    filters: JaxArray,
+    strides: Union[int, Tuple[int, int]],
+    padding: str,
+    /,
+    *,
+    data_format: str = "NHWC",
+    dilations: Optional[Union[int, Tuple[int, int]]] = 1,
+    out: Optional[JaxArray] = None,
+) -> JaxArray:
+    strides = [strides] * 2 if isinstance(strides, int) else strides
+    strides = [strides[1], strides[2]] if len(strides) == 4 else strides
+    dilations = [dilations] * 2 if isinstance(dilations, int) else dilations
+    filters = jnp.squeeze(filters, 3) if filters.ndim == 4 else filters
+    cn = filters.shape[-1]
+    filters = jnp.expand_dims(filters, -2)
+    return jlax.conv_general_dilated(
+        x,
+        filters,
+        strides,
+        padding,
+        None,
+        dilations,
+        (data_format, "HWIO", data_format),
+        feature_group_count=cn,
     )
 
 

--- a/ivy/functional/backends/tensorflow/layers.py
+++ b/ivy/functional/backends/tensorflow/layers.py
@@ -46,6 +46,10 @@ def conv1d_transpose(
     dilations: int = 1,
     out: Optional[Union[tf.Tensor, tf.Variable]] = None,
 ):
+    if not ivy.gpu_is_available() and dilations > 1:
+        raise ivy.exceptions.IvyException(
+            "Tensorflow does not support dilations greater than 1 when device is cpu"
+        )
     filters = tf.transpose(filters, (0, 2, 1))
     if data_format == "NCW":
         x = tf.transpose(x, (0, 2, 1))
@@ -103,6 +107,10 @@ def conv2d_transpose(
     dilations: Optional[Union[int, Tuple[int, int]]] = 1,
     out: Optional[Union[tf.Tensor, tf.Variable]] = None,
 ):
+    if not ivy.gpu_is_available() and dilations > 1:
+        raise ivy.exceptions.IvyException(
+            "Tensorflow does not support dilations greater than 1 when device is cpu"
+        )
     if isinstance(strides, int):
         strides = [strides] * 2
     dilations = [dilations] * 2 if isinstance(dilations, int) else dilations

--- a/ivy_tests/test_ivy/test_functional/test_nn/test_layers.py
+++ b/ivy_tests/test_ivy/test_functional/test_nn/test_layers.py
@@ -432,8 +432,9 @@ def test_conv1d(
     ground_truth_backend,
 ):
     dtype, x, filters, dilations, data_format, stride, pad, fc = x_f_d_df
+    # ToDo: Enable gradient tests for dilations > 1 when tensorflow supports it.
     if backend_fw.current_backend_str() == "tensorflow":
-        assume(not (on_device == "cpu" and dilations > 1))
+        assume(not (on_device == "cpu" and dilations > 1 and test_flags.test_gradients))
     helpers.test_function(
         ground_truth_backend=ground_truth_backend,
         input_dtypes=dtype,
@@ -506,8 +507,15 @@ def test_conv2d(
     ground_truth_backend,
 ):
     dtype, x, filters, dilations, data_format, stride, pad, fc = x_f_d_df
+    # ToDo: Enable gradient tests for dilations > 1 when tensorflow supports it.
     if backend_fw.current_backend_str() == "tensorflow":
-        assume(not (on_device == "cpu" and any(i > 1 for i in dilations)))
+        assume(
+            not (
+                on_device == "cpu"
+                and any(i > 1 for i in dilations)
+                and test_flags.test_gradients
+            )
+        )
     helpers.test_function(
         ground_truth_backend=ground_truth_backend,
         input_dtypes=dtype,


### PR DESCRIPTION
1. Updated `assume` block for `test_conv1d` and `test_conv2d` to only skip gradient tests, not the value tests when `dilations>1`.
2. Added the error messages back to the `tensorflow` backend implementations for `conv1d_transpose` and `conv2d_transpose` when `dilations>1`.
3. Reordered the `conv2d_transpose` `jax` backend implementation in the file