### PR TITLE
feat(ci): enable `pip` cache in CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,9 +7,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: "3.8"
+          cache: "pip"
+          cache-dependency-path: |
+            **/optional*.txt
+            **/requirements*.txt
       - name: Install dependencies
         run: |
           python -m pip install flake8

--- a/.github/workflows/test-docstrings.yml
+++ b/.github/workflows/test-docstrings.yml
@@ -14,9 +14,13 @@ jobs:
           path: ivy
           persist-credentials: false
           submodules: "recursive"
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: "3.8"
+          cache: "pip"
+          cache-dependency-path: |
+            **/optional*.txt
+            **/requirements*.txt
 
       - name: Run Docstring Tests
         run: |

--- a/.github/workflows/test-numpy-docstrings.yml
+++ b/.github/workflows/test-numpy-docstrings.yml
@@ -10,9 +10,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: "3.8"
+          cache: "pip"
+          cache-dependency-path: |
+            **/optional*.txt
+            **/requirements*.txt
       - name: Install dependencies
         run: |
           pip install pydocstyle


### PR DESCRIPTION
Changes made by this PR can be summarized as follows:

- Use an updated version of `actions/setup-python` so as to allow the caching of `pip`.