### PR TITLE
Add missing Onnx functions in the Experimental API

### DIFF
--- a/ivy/array/experimental/layers.py
+++ b/ivy/array/experimental/layers.py
@@ -557,3 +557,76 @@ class ArrayWithLayersExperimental(abc.ABC):
 
     def embedding(self, indices, /, *, max_norm=None, out=None):
         return ivy.embedding(self._data, indices, max_norm=max_norm, out=out)
+
+    def dft(
+        self,
+        /,
+        *,
+        axis: int = 1,
+        inverse: bool = False,
+        onesided: bool = False,
+        dft_length: Optional[Union[int, Tuple[int]]] = None,
+        norm: Optional[str] = "backward",
+        out: Optional[ivy.Array] = None,
+    ) -> ivy.Array:
+        """
+        Computes the discrete Fourier transform of input.
+
+        Parameters
+        ----------
+        self
+            Input volume *[...,d_in,...]*,
+            where d_in indicates the dimension that needs FFT.
+        axis
+            The axis on which to perform the DFT. By default this
+            value is  set to 1, which corresponds to the first dimension
+            after the batch index.
+        inverse
+            Whether to perform the inverse discrete fourier transform.
+            By default this value is set to False.
+        onesided
+            If onesided is True, only values for w in [0, 1, 2, …, floor(n_fft/2) + 1]
+            are returned because the real-to-complex Fourier transform satisfies the
+            conjugate symmetry, i.e., X[m, w] = X[m,w]=X[m,n_fft-w]*. Note if the
+            input or window tensors are complex, then onesided output is not possible.
+            Enabling onesided with real inputs performs a Real-valued fast Fourier
+            transform (RFFT). When invoked with real or complex valued input, the
+            default value is False. Values can be True or False.
+        dft_length
+            The length of the signal.If greater than the axis dimension,
+            the signal will be zero-padded up to dft_length. If less than
+            the axis dimension, only the first dft_length values will be
+            used as the signal. It’s an optional value.
+        norm
+            Optional argument, "backward", "ortho" or "forward". Defaults to be
+            "backward".
+            "backward" indicates no normalization.
+            "ortho" indicates normalization by 1/sqrt(n).
+            "forward" indicates normalization by 1/n.
+        out
+            Optional output array, for writing the result to. It must
+            have a shape that the inputs broadcast to.
+
+        Returns
+        -------
+        ret
+            The Fourier Transform of the input vector.If onesided is False,
+            the following shape is expected: [batch_idx][signal_dim1][signal_dim2]
+            …[signal_dimN][2]. If axis=0 and onesided is True, the following shape
+            is expected: [batch_idx][floor(signal_dim1/2)+1][signal_dim2]
+            …[signal_dimN][2]. If axis=1 and onesided is True, the following
+            shape is expected: [batch_idx][signal_dim1] [floor(signal_dim2/2)+1]
+            …[signal_dimN][2]. If axis=N-1 and onesided is True, the following
+            shape is expected: [batch_idx][signal_dim1][signal_dim2]…
+            [floor(signal_dimN/2)+1][2]. The signal_dim at the specified axis
+            is equal to the dft_length.
+        """
+        return ivy.dft(
+            self._data,
+            axis=axis,
+            inverse=inverse,
+            onesided=onesided,
+            dft_length=dft_length,
+            norm=norm,
+            out=out,
+        )

--- a/ivy/array/experimental/manipulation.py
+++ b/ivy/array/experimental/manipulation.py
@@ -789,3 +789,25 @@ class ArrayWithManipulationExperimental(abc.ABC):
                     [14., 15.]]))
         """
         return ivy.hsplit(self._data, indices_or_sections, out=out)
+
+    def expand(
+        self: ivy.Array,
+        shape: Union[ivy.Shape, ivy.NativeShape],
+        /,
+        *,
+        device: Optional[Union[ivy.Device, ivy.NativeDevice]] = None,
+        out: Optional[ivy.Array] = None,
+    ) -> ivy.Array:
+        """
+
+        Parameters
+        ----------
+        shape
+        device
+        out
+
+        Returns
+        -------
+
+        """
+        return ivy.expand(self._data, shape, device=device, out=out)

--- a/ivy/array/experimental/random.py
+++ b/ivy/array/experimental/random.py
@@ -214,3 +214,58 @@ class ArrayWithRandomExperimental(abc.ABC):
             seed=seed,
             out=out,
         )
+
+    def bernoulli(
+        self: ivy.Array,
+        *,
+        logits: Optional[Union[float, ivy.Array, ivy.NativeArray]] = None,
+        shape: Optional[Union[ivy.Shape, ivy.NativeShape]] = None,
+        device: Optional[Union[ivy.Device, ivy.NativeDevice]] = None,
+        dtype: Optional[Union[ivy.Dtype, ivy.NativeDtype]] = None,
+        seed: Optional[int] = None,
+        out: Optional[ivy.Array] = None,
+    ):
+        """
+
+        Parameters
+        ----------
+        self
+             An N-D Array representing the probability of a 1 event.
+             Each entry in the Array parameterizes an independent Bernoulli
+             distribution. Only one of logits or probs should be passed in
+        logits
+            An N-D Array representing the log-odds of a 1 event.
+            Each entry in the Array parameterizes an independent Bernoulli
+            distribution where the probability of an event is sigmoid
+            (logits). Only one of logits or probs should be passed in.
+
+        shape
+            If the given shape is, e.g '(m, n, k)', then 'm * n * k' samples are drawn.
+            (Default value = 'None', where 'ivy.shape(logits)' samples are drawn)
+        device
+            device on which to create the array 'cuda:0', 'cuda:1', 'cpu' etc.
+            (Default value = None).
+
+        dtype
+            output array data type. If ``dtype`` is ``None``, the output array data
+            type will be the default floating-point data type. Default ``None``
+        seed
+            A python integer. Used to create a random seed distribution
+        out
+            optional output array, for writing the result to. It must
+            have a shape that the inputs broadcast to.
+
+        Returns
+        -------
+        ret
+            Drawn samples from the Bernoulli distribution
+        """
+        return ivy.bernoulli(
+            self,
+            logits=logits,
+            shape=shape,
+            device=device,
+            dtype=dtype,
+            seed=seed,
+            out=out,
+        )

--- a/ivy/container/experimental/layers.py
+++ b/ivy/container/experimental/layers.py
@@ -1258,3 +1258,103 @@ class ContainerWithLayersExperimental(ContainerBase):
             map_sequences=map_sequences,
             out=out,
         )
+
+    @staticmethod
+    def static_dft(
+        x: Union[ivy.Array, ivy.NativeArray, ivy.Container],
+        /,
+        *,
+        axis: int = 1,
+        inverse: bool = False,
+        onesided: bool = False,
+        dft_length: Optional[Union[int, Tuple[int]]] = None,
+        norm: Optional[str] = "backward",
+        key_chains: Optional[Union[List[str], Dict[str, str]]] = None,
+        to_apply: bool = True,
+        prune_unapplied: bool = False,
+        map_sequences: bool = False,
+        out: Optional[ivy.Array] = None,
+    ) -> ivy.Container:
+        """
+
+        Parameters
+        ----------
+        x
+        axis
+        inverse
+        onesided
+        dft_length
+        norm
+        key_chains
+        to_apply
+        prune_unapplied
+        map_sequences
+        out
+
+        Returns
+        -------
+
+        """
+
+        return ContainerBase.cont_multi_map_in_function(
+            "dft",
+            x,
+            axis=axis,
+            inverse=inverse,
+            onesided=onesided,
+            dft_length=dft_length,
+            norm=norm,
+            key_chains=key_chains,
+            to_apply=to_apply,
+            prune_unapplied=prune_unapplied,
+            map_sequences=map_sequences,
+            out=out,
+        )
+
+    def dft(
+        self: Union[ivy.Array, ivy.NativeArray, ivy.Container],
+        /,
+        *,
+        axis: int = 1,
+        inverse: bool = False,
+        onesided: bool = False,
+        dft_length: Optional[Union[int, Tuple[int]]] = None,
+        norm: Optional[str] = "backward",
+        key_chains: Optional[Union[List[str], Dict[str, str]]] = None,
+        to_apply: bool = True,
+        prune_unapplied: bool = False,
+        map_sequences: bool = False,
+        out: Optional[ivy.Array] = None,
+    ) -> ivy.Container:
+        """
+
+        Parameters
+        ----------
+        axis
+        inverse
+        onesided
+        dft_length
+        norm
+        key_chains
+        to_apply
+        prune_unapplied
+        map_sequences
+        out
+
+        Returns
+        -------
+
+        """
+        return self.static_dft(
+            self,
+            axis=axis,
+            inverse=inverse,
+            onesided=onesided,
+            dft_length=dft_length,
+            norm=norm,
+            key_chains=key_chains,
+            to_apply=to_apply,
+            prune_unapplied=prune_unapplied,
+            map_sequences=map_sequences,
+            out=out,
+        )

--- a/ivy/container/experimental/manipulation.py
+++ b/ivy/container/experimental/manipulation.py
@@ -2289,3 +2289,67 @@ class ContainerWithManipulationExperimental(ContainerBase):
 
         """
         return self.static_broadcast_shapes(self, out=out)
+
+    @staticmethod
+    def static_expand(
+        x: Union[ivy.Array, ivy.NativeArray, ivy.Container],
+        shape: Union[ivy.Shape, ivy.NativeShape],
+        /,
+        *,
+        device: Optional[Union[ivy.Device, ivy.NativeDevice]] = None,
+        key_chains: Optional[Union[List[str], Dict[str, str]]] = None,
+        to_apply: bool = True,
+        prune_unapplied: bool = False,
+        map_sequences: bool = False,
+        out: Optional[ivy.Container] = None,
+    ) -> ivy.Container:
+        """
+
+        Parameters
+        ----------
+        x
+        shape
+        device
+        out
+        key_chains
+        to_apply
+        prune_unapplied
+        map_sequences
+
+        Returns
+        -------
+
+        """
+        return ContainerBase.cont_multi_map_in_function(
+            "expand",
+            x,
+            shape,
+            device=device,
+            key_chains=key_chains,
+            to_apply=to_apply,
+            prune_unapplied=prune_unapplied,
+            map_sequences=map_sequences,
+            out=out,
+        )
+
+    def expand(
+        self: Union[ivy.Array, ivy.NativeArray, ivy.Container],
+        shape: Union[ivy.Shape, ivy.NativeShape],
+        /,
+        *,
+        device: Optional[Union[ivy.Device, ivy.NativeDevice]] = None,
+        out: Optional[ivy.Container] = None,
+    ) -> ivy.Container:
+        """
+
+        Parameters
+        ----------
+        shape
+        device
+        out
+
+        Returns
+        -------
+
+        """
+        return self.static_expand(self, shape, device=device, out=out)

--- a/ivy/container/experimental/random.py
+++ b/ivy/container/experimental/random.py
@@ -407,3 +407,135 @@ class ContainerWithRandomExperimental(ContainerBase):
             seed=seed,
             out=out,
         )
+
+    @staticmethod
+    def static_bernoulli(
+        probs: ivy.Container,
+        *,
+        key_chains: Optional[Union[List[str], Dict[str, str]]] = None,
+        to_apply: bool = True,
+        prune_unapplied: bool = False,
+        map_sequences: bool = False,
+        logits: Optional[Union[float, ivy.Array, ivy.NativeArray]] = None,
+        shape: Optional[Union[ivy.Shape, ivy.NativeShape]] = None,
+        device: Optional[Union[ivy.Device, ivy.NativeDevice]] = None,
+        dtype: Optional[Union[ivy.Dtype, ivy.NativeDtype]] = None,
+        seed: Optional[int] = None,
+        out: Optional[ivy.Array] = None,
+    ) -> ivy.Container:
+        """
+
+        Parameters
+        ----------
+        probs
+             An N-D Array representing the probability of a 1 event.
+             Each entry in the Array parameterizes an independent Bernoulli
+             distribution. Only one of logits or probs should be passed in
+        key_chains
+            The key-chains to apply or not apply the method to. Default is ``None``.
+        to_apply
+            If True, the method will be applied to key_chains, otherwise key_chains
+            will be skipped. Default is ``True``.
+        prune_unapplied
+            Whether to prune key_chains for which the function was not applied.
+            Default is ``False``.
+        map_sequences
+            Whether to also map method to sequences (lists, tuples).
+            Default is ``False``.
+        logits
+            An N-D Array representing the log-odds of a 1 event.
+            Each entry in the Array parameterizes an independent Bernoulli
+            distribution where the probability of an event is sigmoid
+            (logits). Only one of logits or probs should be passed in.
+        shape
+            If the given shape is, e.g '(m, n, k)', then 'm * n * k' samples are drawn.
+            (Default value = 'None', where 'ivy.shape(logits)' samples are drawn)
+        device
+            The device to place the output array on. Default is ``None``.
+        dtype
+            The data type of the output array. Default is ``None``.
+        seed
+            A python integer. Used to create a random seed distribution
+        out
+            optional output container, for writing the result to. It must have a shape
+            that the inputs broadcast to.
+
+        Returns
+        -------
+        ret
+            Drawn samples from the Bernoulli distribution
+
+        """
+        return ContainerBase.cont_multi_map_in_function(
+            "bernoulli",
+            probs,
+            key_chains=key_chains,
+            to_apply=to_apply,
+            prune_unapplied=prune_unapplied,
+            map_sequences=map_sequences,
+            logits=logits,
+            shape=shape,
+            device=device,
+            dtype=dtype,
+            out=out,
+        )
+
+    def bernoulli(
+        self: ivy.Container,
+        /,
+        *,
+        logits: Optional[Union[float, ivy.Array, ivy.NativeArray]] = None,
+        shape: Optional[Union[ivy.Shape, ivy.NativeShape, ivy.Container]] = None,
+        device: Optional[Union[ivy.Device, ivy.NativeDevice]] = None,
+        dtype: Optional[Union[ivy.Dtype, ivy.NativeDtype, ivy.Container]] = None,
+        seed: Optional[int] = None,
+        out: Optional[ivy.Container] = None,
+    ) -> ivy.Container:
+        """
+
+        Parameters
+        ----------
+        self
+             An N-D Array representing the probability of a 1 event.
+             Each entry in the Array parameterizes an independent
+             Bernoulli distribution. Only one of logits or probs should
+             be passed in.
+        logits
+            An N-D Array representing the log-odds of a 1 event.
+            Each entry in the Array parameterizes an independent Bernoulli
+            distribution where the probability of an event is
+            sigmoid(logits). Only one of logits or probs should be passed in.
+
+        shape
+            If the given shape is, e.g '(m, n, k)', then 'm * n * k' samples are drawn.
+            (Default value = 'None', where 'ivy.shape(logits)' samples are drawn)
+        device
+            device on which to create the array 'cuda:0', 'cuda:1', 'cpu' etc.
+            (Default value = None).
+
+        dtype
+            output array data type. If ``dtype`` is ``None``, the output array data
+            type will be the default floating-point data type. Default ``None``
+        seed
+            A python integer. Used to create a random seed distribution
+
+        out
+            optional output array, for writing the result to.
+            It must have a shape that the inputs broadcast to.
+
+        Returns
+        -------
+        ret
+            Drawn samples from the Bernoulli distribution
+
+        """
+
+        return self.static_bernoulli(
+            self,
+            logits=logits,
+            shape=shape,
+            device=device,
+            dtype=dtype,
+            seed=seed,
+            out=out,
+        )

--- a/ivy/functional/backends/jax/experimental/random.py
+++ b/ivy/functional/backends/jax/experimental/random.py
@@ -97,3 +97,25 @@ def poisson(
         jax.random.poisson(rng_input, lam, shape=shape),
         device,
     )
+
+
+def bernoulli(
+    probs: Union[float, JaxArray],
+    *,
+    logits: Union[float, JaxArray] = None,
+    shape: Optional[Union[ivy.NativeArray, Sequence[int]]] = None,
+    device: jaxlib.xla_extension.Device,
+    dtype: jnp.dtype = None,
+    seed: Optional[int] = None,
+    out: Optional[JaxArray] = None,
+) -> JaxArray:
+    if seed:
+        rng_input = jax.random.PRNGKey(seed)
+    else:
+        RNG_, rng_input = jax.random.split(_getRNG())
+        _setRNG(RNG_)
+    if logits is not None:
+        probs = jax.nn.softmax(logits, axis=-1)
+    if not _check_shapes_broadcastable(shape, probs.shape):
+        shape = probs.shape
+    return to_device(jax.random.bernoulli(rng_input, probs, shape=shape), device)

--- a/ivy/functional/backends/numpy/experimental/random.py
+++ b/ivy/functional/backends/numpy/experimental/random.py
@@ -81,3 +81,22 @@ def poisson(
     if seed:
         np.random.seed(seed)
     return np.asarray(np.random.poisson(lam, shape), dtype=dtype)
+
+
+def bernoulli(
+    probs: [float, np.ndarray],
+    *,
+    logits: [float, np.ndarray] = None,
+    shape: Optional[Union[ivy.NativeArray, Sequence[int]]] = None,
+    device: str = None,
+    dtype: np.dtype = None,
+    seed: Optional[int] = None,
+    out: Optional[np.ndarray] = None,
+) -> np.ndarray:
+    if seed is not None:
+        np.random.seed(seed)
+    if logits is not None:
+        probs = np.asarray(ivy.softmax(logits), dtype=dtype)
+    if not _check_shapes_broadcastable(shape, probs.shape):
+        shape = probs.shape
+    return np.asarray(np.random.binomial(1, p=probs, size=shape), dtype=dtype)

--- a/ivy/functional/backends/tensorflow/experimental/random.py
+++ b/ivy/functional/backends/tensorflow/experimental/random.py
@@ -115,3 +115,29 @@ def poisson(
         _check_shapes_broadcastable(shape, lam.shape)
         lam = tf.broadcast_to(lam, tuple(shape))
         return tf.random.poisson((), lam, dtype=dtype, seed=seed)
+
+
+def bernoulli(
+    probs: Union[float, tf.Tensor, tf.Variable],
+    *,
+    logits: Union[float, tf.Tensor, tf.Variable] = None,
+    shape: Optional[Union[ivy.NativeShape, Sequence[int]]] = None,
+    device: str,
+    dtype: DType,
+    seed: Optional[int] = None,
+    out: Optional[Union[tf.Tensor, tf.Variable]] = None,
+) -> Union[tf.Tensor, tf.Variable]:
+    with tf.device(device):
+        if seed is not None:
+            tf.random.set_seed(seed)
+        if logits is not None:
+            logits = tf.cast(logits, dtype)
+            if not _check_shapes_broadcastable(shape, logits.shape):
+                shape = logits.shape
+        elif probs is not None:
+            probs = tf.cast(probs, dtype)
+            if not _check_shapes_broadcastable(shape, probs.shape):
+                shape = probs.shape
+        return tfp.distributions.Bernoulli(
+            logits=logits, probs=probs, dtype=dtype, allow_nan_stats=True
+        ).sample(shape, seed)

--- a/ivy/functional/backends/torch/experimental/random.py
+++ b/ivy/functional/backends/torch/experimental/random.py
@@ -84,3 +84,28 @@ def poisson(
     _check_shapes_broadcastable(shape, lam.shape)
     lam = torch.broadcast_to(lam, tuple(shape))
     return torch.poisson(lam).type(dtype).to(device)
+
+
+def bernoulli(
+    probs: Union[float, torch.Tensor],
+    *,
+    logits: Union[float, torch.Tensor] = None,
+    shape: Optional[Union[ivy.NativeArray, Sequence[int]]] = None,
+    device: torch.device,
+    dtype: torch.dtype,
+    seed: Optional[int] = None,
+    out: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    if seed:
+        torch.manual_seed(seed)
+    if logits is not None:
+        if not _check_shapes_broadcastable(shape, logits.shape):
+            shape = logits.shape
+    elif probs is not None:
+        if not _check_shapes_broadcastable(shape, probs.shape):
+            shape = probs.shape
+    return (
+        torch.distributions.bernoulli.Bernoulli(probs=probs, logits=logits)
+        .sample(shape)
+        .to(device, dtype)
+    )

--- a/ivy/functional/ivy/experimental/layers.py
+++ b/ivy/functional/ivy/experimental/layers.py
@@ -770,3 +770,83 @@ def embedding(
         else:
             ret[i] = weights[x, :]
     return ret
+
+
+@to_native_arrays_and_back
+@handle_out_argument
+@handle_exceptions
+@handle_nestable
+def dft(
+    x: Union[ivy.Array, ivy.NativeArray],
+    /,
+    *,
+    axis: int = 1,
+    inverse: bool = False,
+    onesided: bool = False,
+    dft_length: Optional[Union[int, Tuple[int]]] = None,
+    norm: Optional[str] = "backward",
+    out: Optional[ivy.Array] = None,
+) -> ivy.Array:
+    """
+        Computes the discrete Fourier transform of input.
+
+    Parameters
+    ----------
+    x
+        Input volume *[...,d_in,...]*,
+        where d_in indicates the dimension that needs FFT.
+    axis
+        The axis on which to perform the DFT. By default this
+        value is  set to 1, which corresponds to the first dimension
+        after the batch index.
+    inverse
+        Whether to perform the inverse discrete fourier transform.
+        By default this value is set to False.
+    onesided
+        If onesided is True, only values for w in [0, 1, 2, …, floor(n_fft/2) + 1]
+        are returned because the real-to-complex Fourier transform satisfies the
+        conjugate symmetry, i.e., X[m, w] = X[m,w]=X[m,n_fft-w]*. Note if the
+        input or window tensors are complex, then onesided output is not possible.
+        Enabling onesided with real inputs performs a Real-valued fast Fourier
+        transform (RFFT). When invoked with real or complex valued input, the
+        default value is False. Values can be True or False.
+    dft_length
+        The length of the signal.If greater than the axis dimension,
+        the signal will be zero-padded up to dft_length. If less than
+        the axis dimension, only the first dft_length values will be
+        used as the signal. It’s an optional value.
+    norm
+          Optional argument, "backward", "ortho" or "forward". Defaults to be
+          "backward".
+          "backward" indicates no normalization.
+          "ortho" indicates normalization by 1/sqrt(n).
+          "forward" indicates normalization by 1/n.
+    out
+        Optional output array, for writing the result to. It must
+        have a shape that the inputs broadcast to.
+
+    Returns
+    -------
+    ret
+        The Fourier Transform of the input vector.If onesided is False,
+        the following shape is expected: [batch_idx][signal_dim1][signal_dim2]
+        …[signal_dimN][2]. If axis=0 and onesided is True, the following shape
+        is expected: [batch_idx][floor(signal_dim1/2)+1][signal_dim2]…[signal_dimN][2].
+        If axis=1 and onesided is True, the following shape is expected:
+        [batch_idx][signal_dim1][floor(signal_dim2/2)+1]…[signal_dimN][2].
+        If axis=N-1 and onesided is True, the following shape is expected:
+        [batch_idx][signal_dim1][signal_dim2]…[floor(signal_dimN/2)+1][2].
+        The signal_dim at the specified axis is equal to the dft_length.
+
+    """
+    if inverse:
+        res = ivy.ifft(x, axis, norm=norm, n=dft_length, out=out)
+    else:
+        res = ivy.fft(x, axis, norm=norm, n=dft_length, out=out)
+
+    if onesided:
+        slices = [slice(0, a) for a in res.shape]
+        slices[axis] = slice(0, res.shape[axis] // 2 + 1)
+        res = res[tuple(slices)]
+
+    return res

--- a/ivy/functional/ivy/experimental/layers.py
+++ b/ivy/functional/ivy/experimental/layers.py
@@ -840,13 +840,12 @@ def dft(
 
     """
     if inverse:
-        res = ivy.ifft(x, axis, norm=norm, n=dft_length, out=out)
+        res = ifft(x, axis, norm=norm, n=dft_length, out=out)
     else:
-        res = ivy.fft(x, axis, norm=norm, n=dft_length, out=out)
+        res = fft(x, axis, norm=norm, n=dft_length, out=out)
 
     if onesided:
         slices = [slice(0, a) for a in res.shape]
         slices[axis] = slice(0, res.shape[axis] // 2 + 1)
         res = res[tuple(slices)]
-
     return res

--- a/ivy/functional/ivy/experimental/manipulation.py
+++ b/ivy/functional/ivy/experimental/manipulation.py
@@ -1573,3 +1573,38 @@ def broadcast_shapes(shapes: Union[List[int], List[Tuple]]) -> Tuple[int]:
     (3, 3)
     """
     return ivy.current_backend().broadcast_shapes(shapes)
+
+
+@to_native_arrays_and_back
+@handle_out_argument
+@handle_nestable
+@handle_exceptions
+@handle_out_argument
+@handle_array_like_without_promotion
+def expand(
+    x: Union[ivy.Array, ivy.NativeArray],
+    shape: Union[ivy.Shape, ivy.NativeShape],
+    /,
+    *,
+    device: Optional[Union[ivy.Device, ivy.NativeDevice]] = None,
+    out: Optional[ivy.Array] = None,
+) -> ivy.Array:
+    """
+    Broadcast the input Array following the given shape
+    and the broadcast rule.
+    Parameters
+    ----------
+    x
+        Array input.
+    shape
+        A 1-D Array indicates the shape you want to expand to,
+        following the broadcast rule
+    out
+        optional output array, for writing the result to.
+    Returns
+    -------
+    ret
+        Output Array
+    """
+    ones = ivy.ones(shape, dtype=x.dtype, device=device, out=out)
+    return x * ones

--- a/ivy/functional/ivy/experimental/random.py
+++ b/ivy/functional/ivy/experimental/random.py
@@ -238,3 +238,62 @@ def poisson(
         seed=seed,
         out=out,
     )
+
+
+@to_native_arrays_and_back
+@handle_out_argument
+@infer_device
+@infer_dtype
+@handle_nestable
+@handle_exceptions
+def bernoulli(
+    probs: Union[float, ivy.Array, ivy.NativeArray],
+    *,
+    logits: Optional[Union[float, ivy.Array, ivy.NativeArray]] = None,
+    shape: Optional[Union[ivy.Shape, ivy.NativeShape]] = None,
+    device: Optional[Union[ivy.Device, ivy.NativeDevice]] = None,
+    dtype: Optional[Union[ivy.Dtype, ivy.NativeDtype]] = None,
+    seed: Optional[int] = None,
+    out: Optional[ivy.Array] = None,
+) -> ivy.Array:
+    """
+    Draws samples from Bernoulli distrubution paramterized by
+    probs or logits(but not both)
+
+    Parameters
+    ----------
+    logits
+        An N-D Array representing the log-odds of a 1 event.
+        Each entry in the Array parameterizes an independent Bernoulli
+        distribution where the probability of an event is sigmoid
+        (logits). Only one of logits or probs should be passed in.
+
+    probs
+        An N-D Array representing the probability of a 1 event.
+        Each entry in the Array parameterizes an independent Bernoulli
+        distribution. Only one of logits or probs should be passed in
+    shape
+        If the given shape is, e.g '(m, n, k)', then 'm * n * k' samples are drawn.
+        (Default value = 'None', where 'ivy.shape(logits)' samples are drawn)
+    device
+        device on which to create the array 'cuda:0', 'cuda:1', 'cpu' etc.
+        (Default value = None).
+
+    dtype
+        output array data type. If ``dtype`` is ``None``, the output array data
+        type will be the default floating-point data type. Default ``None``
+    seed
+        A python integer. Used to create a random seed distribution
+
+    out
+        optional output array, for writing the result to. It must have a shape that the
+        inputs broadcast to.
+
+    Returns
+    -------
+        ret
+        Drawn samples from the Bernoulli distribution
+    """
+    return ivy.current_backend(probs).bernoulli(
+        logits, probs, shape=shape, device=device, dtype=dtype, seed=seed, out=out
+    )

--- a/ivy_tests/test_ivy/test_functional/test_experimental/test_core/test_manipulation.py
+++ b/ivy_tests/test_ivy/test_functional/test_experimental/test_core/test_manipulation.py
@@ -928,3 +928,56 @@ def test_broadcast_shapes(
         on_device=on_device,
         shapes=shapes,
     )
+
+
+@handle_test(
+    fn_tree="expand",
+    dtype_and_x=helpers.dtype_and_values(
+        available_dtypes=helpers.get_dtypes("numeric", full=False),
+        shape=st.shared(
+            helpers.get_shape(
+                allow_none=False,
+                min_num_dims=1,
+                max_num_dims=5,
+                min_dim_size=1,
+                max_dim_size=5,
+            ),
+            key="value_shape",
+        ),
+    ),
+    shape=st.shared(
+        helpers.get_shape(
+            allow_none=False,
+            min_num_dims=1,
+            max_num_dims=5,
+            min_dim_size=1,
+            max_dim_size=5,
+        ),
+        key="value_shape",
+    ),
+    container_flags=st.just([False]),
+    test_instance_method=st.just(False),
+    test_gradients=st.just(False),
+)
+def test_expand(
+    *,
+    dtype_and_x,
+    shape,
+    test_flags,
+    backend_fw,
+    fn_name,
+    on_device,
+    ground_truth_backend,
+):
+    dtype, x = dtype_and_x
+    helpers.test_function(
+        ground_truth_backend=ground_truth_backend,
+        input_dtypes=dtype,
+        test_flags=test_flags,
+        fw=backend_fw,
+        fn_name=fn_name,
+        on_device=on_device,
+        x=x,
+        shape=shape,
+        device=on_device,
+    )

--- a/ivy_tests/test_ivy/test_functional/test_experimental/test_core/test_random.py
+++ b/ivy_tests/test_ivy/test_functional/test_experimental/test_core/test_random.py
@@ -233,3 +233,44 @@ def test_poisson(
     for (u, v) in zip(ret, ret_gt):
         assert u.dtype == v.dtype
         assert u.shape == v.shape
+
+
+@handle_test(
+    fn_tree="functional.ivy.experimental.bernoulli",
+    dtype_and_probs=helpers.dtype_and_values(
+        available_dtypes=helpers.get_dtypes("float", full=False),
+        min_value=0,
+        max_value=1,
+        min_num_dims=0,
+    ),
+    seed=helpers.ints(min_value=0, max_value=100),
+    test_gradients=st.just(False),
+)
+def test_bernoulli(
+    *,
+    dtype_and_probs,
+    seed,
+    test_flags,
+    backend_fw,
+    fn_name,
+    on_device,
+    ground_truth_backend,
+):
+    dtype, probs = dtype_and_probs
+    # torch doesn't support half precision on CPU
+    assume(
+        not ("torch" in str(backend_fw) and "float16" in dtype and on_device == "cpu")
+    )
+    helpers.test_function(
+        ground_truth_backend=ground_truth_backend,
+        input_dtypes=dtype,
+        test_flags=test_flags,
+        on_device=on_device,
+        fw=backend_fw,
+        fn_name=fn_name,
+        test_values=False,
+        probs=probs[0],
+        logits=None,
+        shape=None,
+        seed=seed,
+    )

--- a/ivy_tests/test_ivy/test_functional/test_experimental/test_nn/test_layers.py
+++ b/ivy_tests/test_ivy/test_functional/test_experimental/test_nn/test_layers.py
@@ -424,7 +424,7 @@ def test_embedding(
 
 
 @handle_test(
-    fn_tree="functional.ivy.experimental.dft",
+    fn_tree="dft",
     d_xfft_axis_n_length=x_and_fft(helpers.get_dtypes("complex")),
     d_xifft_axis_n_length=x_and_ifft(),
     inverse=st.booleans(),
@@ -441,7 +441,6 @@ def test_dft(
     fn_name,
     ground_truth_backend,
 ):
-    print(fn_name)
     if inverse:
         dtype, x, axis, norm, dft_length = d_xifft_axis_n_length
     else:
@@ -453,13 +452,12 @@ def test_dft(
         test_flags=test_flags,
         fw=backend_fw,
         fn_name=fn_name,
-        rtol_=1e-2,
-        atol_=1e-2,
-        test_gradients=False,
         x=x,
         axis=axis,
         inverse=inverse,
         onesided=onesided,
         dft_length=dft_length,
         norm=norm,
+        rtol_=1e-2,
+        atol_=1e-2,
     )

--- a/ivy_tests/test_ivy/test_functional/test_experimental/test_nn/test_layers.py
+++ b/ivy_tests/test_ivy/test_functional/test_experimental/test_nn/test_layers.py
@@ -421,3 +421,45 @@ def test_embedding(
         indices=indices,
         max_norm=max_norm,
     )
+
+
+@handle_test(
+    fn_tree="functional.ivy.experimental.dft",
+    d_xfft_axis_n_length=x_and_fft(helpers.get_dtypes("complex")),
+    d_xifft_axis_n_length=x_and_ifft(),
+    inverse=st.booleans(),
+    onesided=st.booleans(),
+)
+def test_dft(
+    *,
+    d_xfft_axis_n_length,
+    d_xifft_axis_n_length,
+    inverse,
+    onesided,
+    test_flags,
+    backend_fw,
+    fn_name,
+    ground_truth_backend,
+):
+    print(fn_name)
+    if inverse:
+        dtype, x, axis, norm, dft_length = d_xifft_axis_n_length
+    else:
+        dtype, x, axis, norm, dft_length = d_xfft_axis_n_length
+
+    helpers.test_function(
+        ground_truth_backend=ground_truth_backend,
+        input_dtypes=dtype,
+        test_flags=test_flags,
+        fw=backend_fw,
+        fn_name=fn_name,
+        rtol_=1e-2,
+        atol_=1e-2,
+        test_gradients=False,
+        x=x,
+        axis=axis,
+        inverse=inverse,
+        onesided=onesided,
+        dft_length=dft_length,
+        norm=norm,
+    )


### PR DESCRIPTION
Added Bernoulli #9840 (all tests passing)
Points to note -:
1. Torch does not support half precision(float16) ops on CPU
2. Added superset behaviour for the `logits` parameter in Numpy and JaX.  
