### PR TITLE
Fixed the ivy tests for the qr function

### DIFF
--- a/ivy/array/linear_algebra.py
+++ b/ivy/array/linear_algebra.py
@@ -610,8 +610,52 @@ class ArrayWithLinearAlgebra(abc.ABC):
         /,
         *,
         mode: str = "reduced",
+        out: Optional[Tuple[ivy.Array, ivy.Array]] = None,
     ) -> Tuple[ivy.Array, ivy.Array]:
-        return ivy.qr(self._data, mode=mode)
+        """
+        ivy.Array instance method variant of ivy.qr. This method simply wraps the
+        function, and so the docstring for ivy.qr also applies to this method with
+        minimal changes.
+
+        Returns the qr decomposition x = QR of a full column rank matrix (or a stack of
+        matrices), where Q is an orthonormal matrix (or a stack of matrices) and R is an
+        upper-triangular matrix (or a stack of matrices).
+
+        Parameters
+        ----------
+        self
+            input array having shape (..., M, N) and whose innermost two dimensions form
+            MxN matrices of rank N. Should have a floating-point data type.
+        mode
+            decomposition mode. Should be one of the following modes:
+            - 'reduced': compute only the leading K columns of q, such that q and r have
+            dimensions (..., M, K) and (..., K, N), respectively, and where
+            K = min(M, N).
+            - 'complete': compute q and r with dimensions (..., M, M) and (..., M, N),
+            respectively.
+            Default: 'reduced'.
+        out
+            optional output tuple of arrays, for writing the result to. The arrays must
+            have shapes that the inputs broadcast to.
+
+        Returns
+        -------
+        ret
+            a namedtuple (Q, R) whose
+            - first element must have the field name Q and must be an array whose shape
+            depends on the value of mode and contain matrices with orthonormal columns.
+            If mode is 'complete', the array must have shape (..., M, M). If mode is
+            'reduced', the array must have shape (..., M, K), where K = min(M, N). The
+            first x.ndim-2 dimensions must have the same size as those of the input
+            array x.
+            - second element must have the field name R and must be an array whose shape
+            depends on the value of mode and contain upper-triangular matrices. If mode
+            is 'complete', the array must have shape (..., M, N). If mode is 'reduced',
+            the array must have shape (..., K, N), where K = min(M, N). The first
+            x.ndim-2 dimensions must have the same size as those of the input x.
+
+        """
+        return ivy.qr(self._data, mode=mode, out=out)
 
     def slogdet(
         self: ivy.Array,

--- a/ivy/container/linear_algebra.py
+++ b/ivy/container/linear_algebra.py
@@ -1793,8 +1793,62 @@ class ContainerWithLinearAlgebra(ContainerBase):
         to_apply: bool = True,
         prune_unapplied: bool = False,
         map_sequences: bool = False,
-        out: Optional[ivy.Container] = None,
+        out: Optional[Tuple[ivy.Container, ivy.Container]] = None,
     ) -> ivy.Container:
+        """
+        ivy.Container static method variant of ivy.qr. This method simply wraps the
+        function, and so the docstring for ivy.qr also applies to this method with
+        minimal changes.
+
+        Returns the qr decomposition x = QR of a full column rank matrix (or a stack of
+        matrices), where Q is an orthonormal matrix (or a stack of matrices) and R is an
+        upper-triangular matrix (or a stack of matrices).
+
+        Parameters
+        ----------
+        x
+            input container having shape (..., M, N) and whose innermost two dimensions
+            form MxN matrices of rank N. Should have a floating-point data type.
+        mode
+            decomposition mode. Should be one of the following modes:
+            - 'reduced': compute only the leading K columns of q, such that q and r have
+            dimensions (..., M, K) and (..., K, N), respectively, and where
+            K = min(M, N).
+            - 'complete': compute q and r with dimensions (..., M, M) and (..., M, N),
+            respectively.
+            Default: 'reduced'.
+        key_chains
+            The key-chains to apply or not apply the method to. Default is ``None``.
+        to_apply
+            If True, the method will be applied to key_chains, otherwise key_chains
+            will be skipped. Default is ``True``.
+        prune_unapplied
+            Whether to prune key_chains for which the function was not applied.
+            Default is ``False``.
+        map_sequences
+            Whether to also map method to sequences (lists, tuples).
+            Default is ``False``.
+        out
+            optional output tuple of containers, for writing the result to. The arrays
+            must have shapes that the inputs broadcast to.
+
+        Returns
+        -------
+        ret
+            a namedtuple (Q, R) whose
+            - first element must have the field name Q and must be an container whose
+            shape depends on the value of mode and contain matrices with orthonormal
+            columns. If mode is 'complete', the container must have shape (..., M, M).
+            If mode is 'reduced', the container must have shape (..., M, K), where
+            K = min(M, N). The first x.ndim-2 dimensions must have the same size as
+            those of the input container x.
+            - second element must have the field name R and must be an container whose
+            shape depends on the value of mode and contain upper-triangular matrices. If
+            mode is 'complete', the container must have shape (..., M, N). If mode is
+            'reduced', the container must have shape (..., K, N), where K = min(M, N).
+            The first x.ndim-2 dimensions must have the same size as those of the input
+            x.
+        """
         return ContainerBase.cont_multi_map_in_function(
             "qr",
             x,
@@ -1815,8 +1869,62 @@ class ContainerWithLinearAlgebra(ContainerBase):
         to_apply: bool = True,
         prune_unapplied: bool = False,
         map_sequences: bool = False,
-        out: Optional[ivy.Container] = None,
-    ) -> ivy.Container:
+        out: Optional[Tuple[ivy.Container, ivy.Container]] = None,
+    ) -> Tuple[ivy.Container, ivy.Container]:
+        """
+        ivy.Container instance method variant of ivy.qr. This method simply wraps the
+        function, and so the docstring for ivy.qr also applies to this method with
+        minimal changes.
+
+        Returns the qr decomposition x = QR of a full column rank matrix (or a stack of
+        matrices), where Q is an orthonormal matrix (or a stack of matrices) and R is an
+        upper-triangular matrix (or a stack of matrices).
+
+        Parameters
+        ----------
+        self
+            input container having shape (..., M, N) and whose innermost two dimensions
+            form MxN matrices of rank N. Should have a floating-point data type.
+        mode
+            decomposition mode. Should be one of the following modes:
+            - 'reduced': compute only the leading K columns of q, such that q and r have
+            dimensions (..., M, K) and (..., K, N), respectively, and where
+            K = min(M, N).
+            - 'complete': compute q and r with dimensions (..., M, M) and (..., M, N),
+            respectively.
+            Default: 'reduced'.
+        key_chains
+            The key-chains to apply or not apply the method to. Default is ``None``.
+        to_apply
+            If True, the method will be applied to key_chains, otherwise key_chains
+            will be skipped. Default is ``True``.
+        prune_unapplied
+            Whether to prune key_chains for which the function was not applied.
+            Default is ``False``.
+        map_sequences
+            Whether to also map method to sequences (lists, tuples).
+            Default is ``False``.
+        out
+            optional output tuple of containers, for writing the result to. The arrays
+            must have shapes that the inputs broadcast to.
+
+        Returns
+        -------
+        ret
+            a namedtuple (Q, R) whose
+            - first element must have the field name Q and must be an container whose
+            shape depends on the value of mode and contain matrices with orthonormal
+            columns. If mode is 'complete', the container must have shape (..., M, M).
+            If mode is 'reduced', the container must have shape (..., M, K), where
+            K = min(M, N). The first x.ndim-2 dimensions must have the same size as
+            those of the input container x.
+            - second element must have the field name R and must be an container whose
+            shape depends on the value of mode and contain upper-triangular matrices. If
+            mode is 'complete', the container must have shape (..., M, N). If mode is
+            'reduced', the container must have shape (..., K, N), where K = min(M, N).
+            The first x.ndim-2 dimensions must have the same size as those of the input
+            x.
+        """
         return self.static_qr(
             self,
             mode=mode,

--- a/ivy/functional/backends/jax/linear_algebra.py
+++ b/ivy/functional/backends/jax/linear_algebra.py
@@ -270,7 +270,11 @@ def pinv(
 
 @with_unsupported_dtypes({"0.3.14 and below": ("float16", "bfloat16")}, backend_version)
 def qr(
-    x: JaxArray, /, *, mode: str = "reduced", out: Optional[JaxArray] = None
+    x: JaxArray,
+    /,
+    *,
+    mode: str = "reduced",
+    out: Optional[Tuple[JaxArray, JaxArray]] = None,
 ) -> Tuple[JaxArray, JaxArray]:
     res = namedtuple("qr", ["Q", "R"])
     q, r = jnp.linalg.qr(x, mode=mode)

--- a/ivy/functional/backends/numpy/linear_algebra.py
+++ b/ivy/functional/backends/numpy/linear_algebra.py
@@ -276,7 +276,11 @@ def pinv(
 
 @with_unsupported_dtypes({"1.23.0 and below": ("float16",)}, backend_version)
 def qr(
-    x: np.ndarray, /, *, mode: str = "reduced", out: Optional[np.ndarray] = None
+    x: np.ndarray,
+    /,
+    *,
+    mode: str = "reduced",
+    out: Optional[Tuple[np.ndarray, np.ndarray]] = None,
 ) -> NamedTuple:
     res = namedtuple("qr", ["Q", "R"])
     q, r = np.linalg.qr(x, mode=mode)

--- a/ivy/functional/backends/tensorflow/linear_algebra.py
+++ b/ivy/functional/backends/tensorflow/linear_algebra.py
@@ -488,7 +488,9 @@ def qr(
     /,
     *,
     mode: str = "reduced",
-    out: Optional[tf.Tensor] = None,
+    out: Optional[
+        Tuple[Union[tf.Tensor, tf.Variable], Union[tf.Tensor, tf.Variable]]
+    ] = None,
 ) -> NamedTuple:
     res = namedtuple("qr", ["Q", "R"])
     if mode == "reduced":

--- a/ivy/functional/backends/torch/linear_algebra.py
+++ b/ivy/functional/backends/torch/linear_algebra.py
@@ -269,7 +269,11 @@ pinv.support_native_out = True
 
 @with_unsupported_dtypes({"1.11.0 and below": ("float16", "bfloat16")}, backend_version)
 def qr(
-    x: torch.Tensor, /, *, mode: str = "reduced", out: Optional[torch.Tensor] = None
+    x: torch.Tensor,
+    /,
+    *,
+    mode: str = "reduced",
+    out: Optional[Tuple[torch.Tensor, torch.Tensor]] = None,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     res = namedtuple("qr", ["Q", "R"])
     if mode == "reduced":

--- a/ivy/functional/ivy/linear_algebra.py
+++ b/ivy/functional/ivy/linear_algebra.py
@@ -1569,6 +1569,7 @@ def pinv(
 
 
 @to_native_arrays_and_back
+@handle_out_argument
 @handle_nestable
 @handle_exceptions
 @handle_array_like_without_promotion
@@ -1577,7 +1578,8 @@ def qr(
     /,
     *,
     mode: str = "reduced",
-) -> Tuple[Union[ivy.Array, ivy.NativeArray], Union[ivy.Array, ivy.NativeArray]]:
+    out: Optional[Tuple[ivy.Array, ivy.Array]] = None,
+) -> Tuple[ivy.Array, ivy.Array]:
     """
     Returns the qr decomposition x = QR of a full column rank matrix (or a stack of
     matrices), where Q is an orthonormal matrix (or a stack of matrices) and R is an
@@ -1595,6 +1597,9 @@ def qr(
         - 'complete': compute q and r with dimensions (..., M, M) and (..., M, N),
           respectively.
         Default: 'reduced'.
+    out
+        optional output tuple of arrays, for writing the result to. The arrays must have
+        shapes that the inputs broadcast to.
 
     Returns
     -------
@@ -1623,7 +1628,7 @@ def qr(
     instances in place of any of the arguments.
 
     """
-    return current_backend(x).qr(x, mode=mode)
+    return current_backend(x).qr(x, mode=mode, out=out)
 
 
 @to_native_arrays_and_back

--- a/ivy_tests/test_ivy/test_functional/test_core/test_linalg.py
+++ b/ivy_tests/test_ivy/test_functional/test_core/test_linalg.py
@@ -1015,17 +1015,17 @@ def test_qr(
 
     ret_np_flat, ret_from_np_flat = results
     for i in range(len(ret_np_flat) // 2):
-        q_np_flat = ret_np_flat[i * 2]
-        r_np_flat = ret_np_flat[i * 2 + 1]
+        q_np_flat = ret_np_flat[i]
+        r_np_flat = ret_np_flat[len(ret_np_flat) // 2 + i]
     reconstructed_np_flat = np.matmul(q_np_flat, r_np_flat)
     for i in range(len(ret_from_np_flat) // 2):
-        q_from_np_flat = ret_from_np_flat[i * 2]
-        r_from_np_flat = ret_from_np_flat[i * 2 + 1]
+        q_from_np_flat = ret_from_np_flat[i]
+        r_from_np_flat = ret_from_np_flat[len(ret_np_flat) // 2 + i]
     reconstructed_from_np_flat = np.matmul(q_from_np_flat, r_from_np_flat)
 
     # value test
     helpers.assert_all_close(
-        reconstructed_np_flat, reconstructed_from_np_flat, rtol=1e-2, atol=1e-2
+        reconstructed_np_flat, reconstructed_from_np_flat, rtol=1e-1, atol=1e-1
     )
 
 


### PR DESCRIPTION
1. Fixed argument inconsistencies.
2. Fixed `out` argument typehints to work with tuples.
3. Added array and container docstrings to indicate the tuple `out` argument.
4. Updated the tolerance in the test.
5. Updated indexing during reconstruction for a nest of containers rather than a container of nests