### PR TITLE
Added: Raw Ops: Rsqrt

### DIFF
--- a/ivy/functional/frontends/tensorflow/raw_ops.py
+++ b/ivy/functional/frontends/tensorflow/raw_ops.py
@@ -245,7 +245,7 @@ def MatMul(*, a, b, transpose_a=False, transpose_b=False, name="MatMul"):
 
 @to_ivy_arrays_and_back
 def Rsqrt(*, x, name="Rsqrt"):
-    return 1 / ivy.sqrt(x)
+    return ivy.sqrt(ivy.reciprocal(x))
 
 
 @to_ivy_arrays_and_back

--- a/ivy/functional/frontends/tensorflow/raw_ops.py
+++ b/ivy/functional/frontends/tensorflow/raw_ops.py
@@ -244,7 +244,7 @@ def MatMul(*, a, b, transpose_a=False, transpose_b=False, name="MatMul"):
 
 
 @to_ivy_arrays_and_back
-def Rsqrt(x, name=None):
+def Rsqrt(*, x, name="Rsqrt"):
     return 1 / ivy.sqrt(x)
 
 

--- a/ivy/functional/frontends/tensorflow/raw_ops.py
+++ b/ivy/functional/frontends/tensorflow/raw_ops.py
@@ -244,6 +244,11 @@ def MatMul(*, a, b, transpose_a=False, transpose_b=False, name="MatMul"):
 
 
 @to_ivy_arrays_and_back
+def Rsqrt(x, name=None):
+    return 1 / ivy.sqrt(x)
+
+
+@to_ivy_arrays_and_back
 def MatrixInverse(*, input, adjoint=False, name="MatrixInverse"):
     return ivy.inv(input, adjoint=adjoint)
 

--- a/ivy_tests/test_ivy/test_frontends/test_tensorflow/test_raw_ops.py
+++ b/ivy_tests/test_ivy/test_frontends/test_tensorflow/test_raw_ops.py
@@ -221,6 +221,33 @@ def test_tensorflow_Cos(  # NOQA
     )
 
 
+# Rsqrt
+@handle_frontend_test(
+    fn_tree="tensorflow.raw_ops.Rsqrt",
+    dtype_and_x=helpers.dtype_and_values(
+        available_dtypes=helpers.get_dtypes("float"),
+    ),
+    test_with_out=st.just(False),
+)
+def test_tensorflow_Rsqrt(  
+    *,
+    dtype_and_x,
+    frontend,
+    test_flags,
+    fn_tree,
+    on_device,
+):
+    input_dtype, x = dtype_and_x
+    helpers.test_frontend_function(
+        input_dtypes=input_dtype,
+        frontend=frontend,
+        test_flags=test_flags,
+        fn_tree=fn_tree,
+        on_device=on_device,
+        x=x[0],
+    )
+
+
 # Cosh
 @handle_frontend_test(
     fn_tree="tensorflow.raw_ops.Cosh",


### PR DESCRIPTION
Completed sub task in #1565

Added ```Rsqrt``` in ```raw_ops.py``` with following tasks:

- [x] Written test for ```Rsqrt``` in ```test_raw_ops.py```
- [x] Written function for ```Rsqrt```

Added function properties:

Parameter : x -> ```Any```, name -> ```Rsqrt```
Return Type: ```ivy.Array```
Function tree:  ```tensorflow.raw_ops.Rsqrt```