### PR TITLE
fix test_docstrings

### DIFF
--- a/ivy_tests/test_docstrings.py
+++ b/ivy_tests/test_docstrings.py
@@ -103,7 +103,14 @@ def check_docstring_examples_run(
     sub = ">>> print("
     for index, line in enumerate(trimmed_docstring):
         if sub in line:
-            end_index = trimmed_docstring.index("", index)
+            # find chunks of output
+            for i, s in enumerate(trimmed_docstring[index + 1 :]):
+                if s.startswith(">>>") or s.lower().startswith("with"):
+                    end_index = index + i + 1
+                    break
+            else:
+                # end of docstrings
+                end_index = len(trimmed_docstring)
             p_output = trimmed_docstring[index + 1 : end_index]
             p_output = ("").join(p_output).replace(" ", "")
             p_output = p_output.replace("...", "")

--- a/ivy_tests/test_docstrings.py
+++ b/ivy_tests/test_docstrings.py
@@ -85,7 +85,6 @@ def check_docstring_examples_run(
         ).__doc__
     else:
         docstring = ivy.backend_handler.ivy_original_dict[fn_name].__doc__
-
     if docstring is None:
         return True
 
@@ -93,7 +92,6 @@ def check_docstring_examples_run(
 
     trimmed_docstring = trim(docstring=docstring)
     trimmed_docstring = trimmed_docstring.split("\n")
-
     # end_index: -1, if print statement is not found in the docstring
     end_index = -1
 
@@ -105,10 +103,7 @@ def check_docstring_examples_run(
     sub = ">>> print("
     for index, line in enumerate(trimmed_docstring):
         if sub in line:
-            for i, s in enumerate(trimmed_docstring[index + 1 :]):
-                if s.startswith(">>>") or s.lower().startswith("with"):
-                    end_index = index + i + 1
-                    break
+            end_index = trimmed_docstring.index("", index)
             p_output = trimmed_docstring[index + 1 : end_index]
             p_output = ("").join(p_output).replace(" ", "")
             p_output = p_output.replace("...", "")
@@ -124,10 +119,12 @@ def check_docstring_examples_run(
     for line in trimmed_docstring:
         if line.startswith(">>>"):
             executable_lines.append(line.split(">>>")[1][1:])
-        if line.startswith("..."):
+            is_multiline_executable = True
+        if line.startswith("...") and is_multiline_executable:
             executable_lines[-1] += line.split("...")[1][1:]
         if ">>> print(" in line:
-            break
+            is_multiline_executable = False
+            continue
 
     # noinspection PyBroadException
     f = StringIO()
@@ -183,6 +180,8 @@ def check_docstring_examples_run(
     num_output = num_output.split(",")
     num_parsed_output = num_parsed_output.split(",")
     docstr_result = True
+    # print("N_OUTPUT", num_output)
+    # print("N_PUTPUT", num_parsed_output)
     for (doc_u, doc_v) in zip(num_output, num_parsed_output):
         try:
             docstr_result = np.allclose(

--- a/ivy_tests/test_docstrings.py
+++ b/ivy_tests/test_docstrings.py
@@ -103,13 +103,11 @@ def check_docstring_examples_run(
     sub = ">>> print("
     for index, line in enumerate(trimmed_docstring):
         if sub in line:
-            # find chunks of output
             for i, s in enumerate(trimmed_docstring[index + 1 :]):
                 if s.startswith(">>>") or s.lower().startswith("with"):
                     end_index = index + i + 1
                     break
             else:
-                # end of docstrings
                 end_index = len(trimmed_docstring)
             p_output = trimmed_docstring[index + 1 : end_index]
             p_output = ("").join(p_output).replace(" ", "")

--- a/ivy_tests/test_docstrings.py
+++ b/ivy_tests/test_docstrings.py
@@ -131,7 +131,6 @@ def check_docstring_examples_run(
             executable_lines[-1] += line.split("...")[1][1:]
         if ">>> print(" in line:
             is_multiline_executable = False
-            continue
 
     # noinspection PyBroadException
     f = StringIO()
@@ -187,8 +186,6 @@ def check_docstring_examples_run(
     num_output = num_output.split(",")
     num_parsed_output = num_parsed_output.split(",")
     docstr_result = True
-    # print("N_OUTPUT", num_output)
-    # print("N_PUTPUT", num_parsed_output)
     for (doc_u, doc_v) in zip(num_output, num_parsed_output):
         try:
             docstr_result = np.allclose(


### PR DESCRIPTION
Consider [this problematic docstring](https://github.com/unifyai/ivy/blob/0fe675920f387d7052e0114b49ccca470ff7181d/ivy/functional/ivy/experimental/layers.py#L119):
```python
>>> x = ivy.arange(12.).reshape((2, 1, 3, 2))
>>> print(ivy.max_pool2d(x, (2, 2), (1, 1), 'SAME'))
    ivy.array([[[[ 2,  3],
             [ 4,  5],
             [ 4,  5]]],


           [[[ 8,  9],
             [10, 11],
             [10, 11]]]])

>>> x = ivy.arange(48.).reshape((2, 4, 3, 2))
>>> print(ivy.max_pool2d(x, 3, 1, 'VALID'))
    ivy.array([[[[16, 17]],

            [[22, 23]]],


           [[[40, 41]],

            [[46, 47]]]])
```

607cf5cb87829bf5c9904b6c88d5edcedd32f0b3 fails to detect the second example's input.
8a077d9b59365b0ae571737991c933a37e51a428 fails to detect the second example's output.
=> Only care about the first example.

Consider [this different example](https://github.com/unifyai/ivy/blob/0fe675920f387d7052e0114b49ccca470ff7181d/ivy/array/layers.py#L487):
```python
>>> x = ivy.array([[[[1.], [2.0],[3.]],
...                 [[1.], [2.0],[3.]],
...                 [[1.], [2.0],[3.]]]]) #NHWC
>>> filters = ivy.array([[[[0.]], [[1.]], [[0.]]],
...                      [[[0.]], [[1.]], [[0.]]],
...                      [[[0.]], [[1.]], [[0.]]]]) #HWIO
>>> result = x.conv2d(filters, 1, 'SAME', data_format='NHWC',
...    dilations= 1)
>>> print(result)
ivy.array([[
          [[2.],[4.],[6.]],
          [[3.],[6.],[9.]],
          [[2.],[4.],[6.]]
          ]])
```

8a077d9b59365b0ae571737991c933a37e51a428 even fails to detect the first example's output and returns true immediately without running the input!