### PR TITLE
Fix linalg.test_torch_cross torch Frontend

### DIFF
--- a/ivy/functional/frontends/torch/linalg.py
+++ b/ivy/functional/frontends/torch/linalg.py
@@ -95,7 +95,7 @@ def matrix_norm(input, ord="fro", dim=(-2, -1), keepdim=False, *, dtype=None, ou
 @to_ivy_arrays_and_back
 @with_unsupported_dtypes({"1.11.0 and below": ("float16",)}, "torch")
 def cross(input, other, *, dim=None, out=None):
-    return torch_frontend.cross(input, other, dim=dim, out=out)
+    return torch_frontend.miscellaneous_ops.cross(input, other, dim=dim, out=out)
 
 
 @to_ivy_arrays_and_back


### PR DESCRIPTION
__Init__ Override the cross function in miscellaneous_ops.py by the cross function in linalg.py which causes recursion.