### PR TITLE
frontends.torch.adjoint

### DIFF
--- a/ivy/functional/frontends/torch/indexing_slicing_joining_mutating_ops.py
+++ b/ivy/functional/frontends/torch/indexing_slicing_joining_mutating_ops.py
@@ -4,6 +4,11 @@ from ivy.functional.frontends.torch.func_wrapper import to_ivy_arrays_and_back
 
 
 @to_ivy_arrays_and_back
+def adjoint(input):
+    return ivy.adjoint(input)
+
+
+@to_ivy_arrays_and_back
 def cat(tensors, dim=0, *, out=None):
     return ivy.concat(tensors, axis=dim, out=out)
 

--- a/ivy_tests/test_ivy/helpers/function_testing.py
+++ b/ivy_tests/test_ivy/helpers/function_testing.py
@@ -674,20 +674,6 @@ def test_frontend_function(
                 frontend_ret = np.asarray(
                     frontend_ret
                 )  # we do this because frontend_ret comes from a module in another file
-                if ivy.isscalar(frontend_ret):
-                    frontend_ret_np_flat = [np.asarray(frontend_ret)]
-                else:
-                    # tuplify the frontend return
-                    if not isinstance(frontend_ret, tuple):
-                        frontend_ret = (frontend_ret,)
-                    frontend_ret_idxs = ivy.nested_argwhere(
-                        frontend_ret, ivy.is_native_array
-                    )
-                    frontend_ret_flat = ivy.multi_index_nest(
-                        frontend_ret, frontend_ret_idxs
-                    )
-                    frontend_ret_np_flat = [ivy.to_numpy(x) for x in frontend_ret_flat]
-
             except Exception as e:
                 ivy.unset_backend()
                 raise e
@@ -736,21 +722,6 @@ def test_frontend_function(
                 frontend_ret = frontend_fw.__dict__[fn_name](
                     *args_frontend, **kwargs_frontend
                 )
-
-                if ivy.isscalar(frontend_ret):
-                    frontend_ret_np_flat = [np.asarray(frontend_ret)]
-                else:
-                    # tuplify the frontend return
-                    if not isinstance(frontend_ret, tuple):
-                        frontend_ret = (frontend_ret,)
-                    frontend_ret_idxs = ivy.nested_argwhere(
-                        frontend_ret, ivy.is_native_array
-                    )
-                    print(frontend_ret_idxs, frontend_ret)
-                    frontend_ret_flat = ivy.multi_index_nest(
-                        frontend_ret, frontend_ret_idxs
-                    )
-                    frontend_ret_np_flat = [ivy.to_numpy(x) for x in frontend_ret_flat]
             except Exception as e:
                 ivy.unset_backend()
                 raise e
@@ -798,31 +769,26 @@ def test_frontend_function(
             frontend_ret = frontend_fw.__dict__[fn_name](
                 *args_frontend, **kwargs_frontend
             )
-
-            if ivy.isscalar(frontend_ret):
-                frontend_ret_np_flat = [np.asarray(frontend_ret)]
-            else:
-                # tuplify the frontend return
-                if not isinstance(frontend_ret, tuple):
-                    frontend_ret = (frontend_ret,)
-                frontend_ret_idxs = ivy.nested_argwhere(
-                    frontend_ret, ivy.is_native_array
-                )
-                frontend_ret_flat = ivy.multi_index_nest(
-                    frontend_ret, frontend_ret_idxs
-                )
-                frontend_ret_np_flat = [ivy.to_numpy(x) for x in frontend_ret_flat]
         except Exception as e:
             ivy.unset_backend()
             raise e
     # unset frontend framework from backend
     ivy.unset_backend()
 
-    ret_np_flat = flatten_and_to_np(ret=ret)
-
     # assuming value test will be handled manually in the test function
     if not test_values:
         return ret, frontend_ret
+
+    ret_np_flat = flatten_and_to_np(ret=ret)
+    if ivy.isscalar(frontend_ret):
+        frontend_ret_np_flat = [np.asarray(frontend_ret)]
+    else:
+        # tuplify the frontend return
+        if not isinstance(frontend_ret, tuple):
+            frontend_ret = (frontend_ret,)
+        frontend_ret_idxs = ivy.nested_argwhere(frontend_ret, ivy.is_native_array)
+        frontend_ret_flat = ivy.multi_index_nest(frontend_ret, frontend_ret_idxs)
+        frontend_ret_np_flat = [ivy.to_numpy(x) for x in frontend_ret_flat]
 
     if isinstance(rtol, dict):
         rtol = _get_framework_rtol(rtol, ivy.backend)

--- a/ivy_tests/test_ivy/helpers/function_testing.py
+++ b/ivy_tests/test_ivy/helpers/function_testing.py
@@ -772,14 +772,11 @@ def test_frontend_function(
         except Exception as e:
             ivy.unset_backend()
             raise e
-    # unset frontend framework from backend
-    ivy.unset_backend()
-
     # assuming value test will be handled manually in the test function
     if not test_values:
+        ivy.unset_backend()
         return ret, frontend_ret
 
-    ret_np_flat = flatten_and_to_np(ret=ret)
     if ivy.isscalar(frontend_ret):
         frontend_ret_np_flat = [np.asarray(frontend_ret)]
     else:
@@ -789,6 +786,9 @@ def test_frontend_function(
         frontend_ret_idxs = ivy.nested_argwhere(frontend_ret, ivy.is_native_array)
         frontend_ret_flat = ivy.multi_index_nest(frontend_ret, frontend_ret_idxs)
         frontend_ret_np_flat = [ivy.to_numpy(x) for x in frontend_ret_flat]
+    # unset frontend framework from backend
+    ivy.unset_backend()
+    ret_np_flat = flatten_and_to_np(ret=ret)
 
     if isinstance(rtol, dict):
         rtol = _get_framework_rtol(rtol, ivy.backend)

--- a/ivy_tests/test_ivy/test_frontends/test_torch/test_indexing_slicing_joining_mutating_ops.py
+++ b/ivy_tests/test_ivy/test_frontends/test_torch/test_indexing_slicing_joining_mutating_ops.py
@@ -1,7 +1,6 @@
 # global
 from hypothesis import strategies as st, assume
 import math
-from torch import resolve_conj
 
 # local
 import ivy
@@ -94,7 +93,7 @@ def test_torch_adjoint(
         test_values=False,
         input=value[0],
     )
-    frontend_ret = resolve_conj(frontend_ret)
+    frontend_ret = frontend_ret.resolve_conj()
     ret_np_flat = flatten_and_to_np(ret=ret)
 
     ivy.set_backend("torch")

--- a/ivy_tests/test_ivy/test_frontends/test_torch/test_indexing_slicing_joining_mutating_ops.py
+++ b/ivy_tests/test_ivy/test_frontends/test_torch/test_indexing_slicing_joining_mutating_ops.py
@@ -3,7 +3,6 @@ from hypothesis import strategies as st, assume
 import math
 
 # local
-import ivy
 import ivy_tests.test_ivy.helpers as helpers
 from ivy_tests.test_ivy.helpers import handle_frontend_test
 from ivy_tests.test_ivy.test_functional.test_core.test_manipulation import _get_splits
@@ -84,30 +83,13 @@ def test_torch_adjoint(
     test_flags,
 ):
     input_dtype, value = dtype_and_values
-    ret, frontend_ret = helpers.test_frontend_function(
+    helpers.test_frontend_function(
         input_dtypes=input_dtype,
         frontend=frontend,
         test_flags=test_flags,
         fn_tree=fn_tree,
         on_device=on_device,
-        test_values=False,
         input=value[0],
-    )
-    frontend_ret = frontend_ret.resolve_conj()
-    ret_np_flat = flatten_and_to_np(ret=ret)
-
-    ivy.set_backend("torch")
-    if not isinstance(frontend_ret, tuple):
-        frontend_ret = (frontend_ret,)
-    frontend_ret_idxs = ivy.nested_argwhere(frontend_ret, ivy.is_native_array)
-    frontend_ret_flat = ivy.multi_index_nest(frontend_ret, frontend_ret_idxs)
-    frontend_ret_np_flat = [ivy.to_numpy(x) for x in frontend_ret_flat]
-    ivy.unset_backend()
-
-    helpers.value_test(
-        ret_np_flat=ret_np_flat,
-        ret_np_from_gt_flat=frontend_ret_np_flat,
-        ground_truth_backend=frontend,
     )
 
 


### PR DESCRIPTION
Close #10097 

I couldn't flatten `frontend_ret` in `test_frontend_function` due to the following error:
> Can't call numpy() on Tensor that has conjugate bit set. Use tensor.resolve_conj().numpy() instead.

So I had to return raw `frontend_ret` first.