### PR TITLE
backends.torch.to_numpy: add resolve_neg

### DIFF
--- a/ivy/functional/backends/torch/general.py
+++ b/ivy/functional/backends/torch/general.py
@@ -82,8 +82,7 @@ def to_numpy(
         else:
             return x
     elif torch.is_tensor(x):
-        if x.is_conj():
-            x = x.resolve_conj()
+        x = x.resolve_neg().resolve_conj()
         if copy:
             if x.dtype is torch.bfloat16:
                 default_dtype = ivy.default_float_dtype(as_native=True)


### PR DESCRIPTION
We added `resolve_conj`, so let's add `resolve_neg` too.

And remove the conditional check because `torch.resolve_` already does.