### PR TITLE
implement tf.where in tensorflow frontend

### DIFF
--- a/ivy/functional/frontends/tensorflow/general_functions.py
+++ b/ivy/functional/frontends/tensorflow/general_functions.py
@@ -302,3 +302,16 @@ def one_hot(
     out=None,
 ):
     return ivy.one_hot(indices, depth)
+
+
+@to_ivy_arrays_and_back
+def where(
+    condition: ivy.array,
+    x=None,
+    y=None,
+    name=None
+):
+    if x is None and y is None:
+        return ivy.argwhere(condition)
+    else:
+        return ivy.where(condition, x, y)

--- a/ivy_tests/test_ivy/test_frontends/test_tensorflow/test_general_functions.py
+++ b/ivy_tests/test_ivy/test_frontends/test_tensorflow/test_general_functions.py
@@ -1233,3 +1233,75 @@ def test_tensorflow_one_hot(
         indices=x[0],
         depth=depth,
     )
+
+
+# where
+@handle_frontend_test(
+    fn_tree="tensorflow.where",
+    dtype_and_input=helpers.dtype_and_values(
+        available_dtypes=helpers.get_dtypes("integer"),
+        num_arrays=1,
+        min_value=0,
+        max_value=10,
+        min_num_dims=1
+    )
+)
+def test_tensorflow_where_no_xy(
+    *,
+    dtype_and_input,
+    frontend,
+    fn_tree,
+    test_flags,
+    on_device,
+):
+    input_dtype, [condition] = dtype_and_input
+    helpers.test_frontend_function(
+        input_dtypes=input_dtype,
+        frontend=frontend,
+        test_flags=test_flags,
+        fn_tree=fn_tree,
+        on_device=on_device,
+        condition=condition
+    )
+
+
+# where
+@handle_frontend_test(
+    fn_tree="tensorflow.where",
+    dtype_and_input=helpers.dtype_and_values(
+        available_dtypes=helpers.get_dtypes("bool"),
+        num_arrays=3,
+        min_value=0,
+        max_value=10,
+        min_num_dims=1
+    ),
+    dim_remove_from_x=st.integers(),
+    dim_remove_from_y=st.integers()
+)
+def test_tensorflow_where_with_xy(
+    *,
+    dtype_and_input,
+    dim_remove_from_x,
+    dim_remove_from_y,
+    frontend,
+    fn_tree,
+    test_flags,
+    on_device,
+):
+    input_dtype, [condition, x, y] = dtype_and_input
+    if input_dtype != ['bool', 'bool', 'bool']:
+        return
+    for _ in range(min(len(x.shape) - 1, dim_remove_from_x)):
+        x = x[0]
+    for _ in range(min(len(y.shape) - 1, dim_remove_from_y)):
+        y = y[0]
+    helpers.test_frontend_function(
+        input_dtypes=input_dtype,
+        frontend=frontend,
+        test_flags=test_flags,
+        fn_tree=fn_tree,
+        on_device=on_device,
+        condition=condition,
+        x=x,
+        y=y
+    )


### PR DESCRIPTION
This PR implements `tf.where` in the tensorflow frontend.

Workaround note:
`helpers.get_dtypes("bool")` seems to include complex types, instead of just boolean types. Once this is fixed, line 1292-1293 can be removed.

Usage note:
The function `tf.where` has two modes. When x,y is not supplied, condition can be some numeric type (subject to support in the framework). When x,y is supplied, `condition` can only be a boolean tensor.

Looking forward to hearing any feedback.