### PR TITLE
Allowing custom backward passes during gradient computation

### DIFF
--- a/ivy/functional/backends/jax/experimental/gradients.py
+++ b/ivy/functional/backends/jax/experimental/gradients.py
@@ -10,9 +10,9 @@ def bind_custom_gradient_function(func, custom_grad_fn):
     def custom_forward(x):
         ret = func(x)
         return ivy.to_native((ret, (x, ret)), nested=True, include_derived=True)
-    
+
     def custom_backward(*args):
-        return custom_grad_fn(*args),
+        return (custom_grad_fn(*args),)
 
     func = jax.custom_vjp(func)
     func.defvjp(custom_forward, custom_backward)

--- a/ivy/functional/backends/jax/experimental/gradients.py
+++ b/ivy/functional/backends/jax/experimental/gradients.py
@@ -1,0 +1,19 @@
+# global
+import jax
+
+# local
+import ivy
+from ivy.func_wrapper import inputs_to_native_arrays
+
+
+def bind_custom_gradient_function(func, custom_grad_fn):
+    def custom_forward(x):
+        ret = func(x)
+        return ivy.to_native((ret, (x, ret)), nested=True, include_derived=True)
+    
+    def custom_backward(*args):
+        return custom_grad_fn(*args),
+
+    func = jax.custom_vjp(func)
+    func.defvjp(custom_forward, custom_backward)
+    return inputs_to_native_arrays(func)

--- a/ivy/functional/backends/numpy/experimental/gradients.py
+++ b/ivy/functional/backends/numpy/experimental/gradients.py
@@ -1,0 +1,10 @@
+# global
+import logging
+
+
+def bind_custom_gradient_function(func, custom_grad_fn):
+    logging.warning(
+        "NumPy does not support autograd, 'bind_custom_gradient_function' "
+        "has no effect on the array, as gradients are not supported in the first place."
+    )
+    return func

--- a/ivy/functional/backends/tensorflow/experimental/gradients.py
+++ b/ivy/functional/backends/tensorflow/experimental/gradients.py
@@ -1,0 +1,21 @@
+# global
+import tensorflow as tf
+
+# local
+import ivy
+from ivy.func_wrapper import inputs_to_native_arrays
+from ivy.functional.ivy.gradients import _get_required_float_variables
+
+
+def bind_custom_gradient_function(func, custom_grad_fn):
+    @tf.custom_gradient
+    def custom_module(x):
+        x, _, _, _ = _get_required_float_variables(x, xs_grad_idxs=None)
+        ret = func(x)
+
+        def grad(upstream):
+            return custom_grad_fn((x, ret), upstream)
+
+        return ivy.to_native((ret, grad), nested=True, include_derived=True)
+
+    return inputs_to_native_arrays(custom_module)

--- a/ivy/functional/backends/torch/experimental/gradients.py
+++ b/ivy/functional/backends/torch/experimental/gradients.py
@@ -1,0 +1,27 @@
+# global
+import torch
+
+# local
+import ivy
+from ivy.func_wrapper import inputs_to_native_arrays
+
+
+def bind_custom_gradient_function(func, custom_grad_fn):
+    class _CustomModule(torch.autograd.Function):
+        @staticmethod
+        def forward(ctx, x):
+            ret = ivy.to_native(func(x), nested=True, include_derived=True)
+            ctx.save_for_backward(x, ret)
+            return ret
+
+        @staticmethod
+        def backward(ctx, upstream):
+            grads = custom_grad_fn(
+                *ivy.to_ivy(
+                    (ctx.saved_tensors, upstream), nested=True, include_derived=True
+                )
+            )
+            return ivy.to_native(grads, nested=True, include_derived=True)
+
+    custom_module = _CustomModule.apply
+    return inputs_to_native_arrays(custom_module)

--- a/ivy/functional/ivy/experimental/gradients.py
+++ b/ivy/functional/ivy/experimental/gradients.py
@@ -1,0 +1,22 @@
+# local
+from ivy.backend_handler import current_backend
+
+
+def bind_custom_gradient_function(func, custom_grad_func):
+    """Bind a custom gradient function to a function.
+
+    Parameters
+    ----------
+    func
+        Function for which we compute the gradients of the output with respect to.
+    custom_grad_func
+        Custom gradient function. Should accept a tuple containing the (output, inputs)
+        and the upstream gradients w.r.t previous operations.
+
+    Returns
+    -------
+    ret
+        the function
+
+    """
+    return current_backend(None).bind_custom_gradient_function(func, custom_grad_func)

--- a/ivy_tests/test_ivy/test_functional/test_experimental/test_core/test_gradients.py
+++ b/ivy_tests/test_ivy/test_functional/test_experimental/test_core/test_gradients.py
@@ -12,13 +12,14 @@ import ivy_tests.test_ivy.helpers as helpers
     "x_", [[[4.6, 2.1, 5], [2.8, 1.3, 6.2]], [[4.6, 2.1], [5, 2.8], [1.3, 6.2]]]
 )
 @pytest.mark.parametrize("dtype", ["float32", "float64"])
+@pytest.mark.parametrize("inter_func_", [lambda x: ivy.square(x), lambda x: ivy.cos(x)])
 @pytest.mark.parametrize(
-    "inter_func_", [lambda x: ivy.square(x), lambda x: ivy.cos(x)]
+    "custom_grad_fn",
+    [lambda *args: args[1] * args[0][0], lambda *args: args[1] * args[0][1]],
 )
-@pytest.mark.parametrize(
-    "custom_grad_fn", [lambda *args: args[1] * args[0][0], lambda *args: args[1] * args[0][1]]
-)
-def test_bind_custom_gradient_function(x_, dtype, inter_func_, custom_grad_fn, backend_fw):
+def test_bind_custom_gradient_function(
+    x_, dtype, inter_func_, custom_grad_fn, backend_fw
+):
     fw = backend_fw.current_backend_str()
     if fw == "numpy":
         return

--- a/ivy_tests/test_ivy/test_functional/test_experimental/test_core/test_gradients.py
+++ b/ivy_tests/test_ivy/test_functional/test_experimental/test_core/test_gradients.py
@@ -1,0 +1,43 @@
+# global
+import pytest
+import numpy as np
+
+# local
+import ivy
+import ivy_tests.test_ivy.helpers as helpers
+
+
+# bind_custom_gradient_function
+@pytest.mark.parametrize(
+    "x_", [[[4.6, 2.1, 5], [2.8, 1.3, 6.2]], [[4.6, 2.1], [5, 2.8], [1.3, 6.2]]]
+)
+@pytest.mark.parametrize("dtype", ["float32", "float64"])
+@pytest.mark.parametrize(
+    "inter_func_", [lambda x: ivy.square(x), lambda x: ivy.cos(x)]
+)
+@pytest.mark.parametrize(
+    "custom_grad_fn", [lambda *args: args[1] * args[0][0], lambda *args: args[1] * args[0][1]]
+)
+def test_bind_custom_gradient_function(x_, dtype, inter_func_, custom_grad_fn, backend_fw):
+    fw = backend_fw.current_backend_str()
+    if fw == "numpy":
+        return
+    x = ivy.array(x_, dtype=dtype)
+    inter_func = ivy.bind_custom_gradient_function(inter_func_, custom_grad_fn)
+    func = lambda x: ivy.mean(ivy.exp(inter_func(x)))
+    ret, grad = ivy.execute_with_gradients(func, x)
+    ret_np = helpers.flatten_and_to_np(ret=ret)
+    grad_np = helpers.flatten_and_to_np(ret=grad)
+    ivy.set_backend("tensorflow")
+    x = ivy.array(x_, dtype=dtype)
+    inter_func = ivy.bind_custom_gradient_function(inter_func_, custom_grad_fn)
+    func = lambda x: ivy.mean(ivy.exp(inter_func(x)))
+    ret_gt, grad_gt = ivy.execute_with_gradients(func, x)
+    ret_np_from_gt = helpers.flatten_and_to_np(ret=ret_gt)
+    grad_np_from_gt = helpers.flatten_and_to_np(ret=grad_gt)
+    ivy.unset_backend()
+    for ret, ret_from_gt in zip(ret_np, ret_np_from_gt):
+        assert np.allclose(ret, ret_from_gt)
+    for grad, grad_from_gt in zip(grad_np, grad_np_from_gt):
+        assert grad.shape == grad_from_gt.shape
+        assert np.allclose(grad, grad_from_gt)


### PR DESCRIPTION
`torch` enables the creation of [custom backward passes](https://pytorch.org/docs/stable/notes/extending.html#how-to-use "‌") when subclassing `Function`, `jax` provides [an interface for differentiation rules](https://jax.readthedocs.io/en/latest/notebooks/Custom_derivative_rules_for_Python_code.html "‌"), and `tensorflow` includes the function [tf.custom_gradient](https://www.tensorflow.org/api_docs/python/tf/custom_gradient "‌").

This PR enables a similar feature in `ivy` via the `bind_custom_gradient_function`, enabling more fine-grained control for the gradient computation of each function.
