### PR TITLE
Add quantile function

### DIFF
--- a/ivy/functional/frontends/numpy/statistics/order_statistics.py
+++ b/ivy/functional/frontends/numpy/statistics/order_statistics.py
@@ -1,0 +1,37 @@
+import numpy as np
+import ivy
+from ivy.functional.frontends.numpy.func_wrapper import (
+    to_ivy_arrays_and_back,
+    from_zero_dim_arrays_to_scalar,
+)
+
+
+@to_ivy_arrays_and_back
+@from_zero_dim_arrays_to_scalar
+def quantile(
+    a,
+    q,
+    axis=None,
+    out=None,
+    overwrite_input=False,
+    method='linear',
+    keepdims=False,
+    *,
+    interpolation=None
+):
+    if axis is None:
+        axis = tuple(range(len(a.shape)))
+    axis = (axis,) if isinstance(axis, int) else tuple(axis)
+
+    if a.size == 0:
+        return np.asarray(float("nan"))
+
+    a = ivy.astype(a, ivy.float64)
+
+    return ivy.quantile(a,
+                        q,
+                        axis=axis,
+                        keepdims=keepdims,
+                        interpolation= method,
+                        out=out)
+

--- a/ivy/functional/frontends/numpy/statistics/order_statistics.py
+++ b/ivy/functional/frontends/numpy/statistics/order_statistics.py
@@ -34,4 +34,3 @@ def quantile(
                         keepdims=keepdims,
                         interpolation= method,
                         out=out)
-

--- a/ivy_tests/test_ivy/test_frontends/test_numpy/test_statistics/test_order_statistics.py
+++ b/ivy_tests/test_ivy/test_frontends/test_numpy/test_statistics/test_order_statistics.py
@@ -1,0 +1,35 @@
+# global
+
+# local
+import ivy_tests.test_ivy.helpers as helpers
+import ivy_tests.test_ivy.test_frontends.test_numpy.helpers as np_frontend_helpers
+from ivy_tests.test_ivy.helpers import handle_frontend_test
+
+# quantile
+@handle_frontend_test(
+    fn_tree="numpy.quantile",
+    dtype_and_x=helpers.dtype_and_values(
+        available_dtypes=helpers.get_dtypes("float", full=True),
+        min_num_dims=1,
+        max_num_dims=3,
+        num_arrays=1,
+        shared_dtype=True,
+    ),
+)
+def test_numpy_quantile(
+    dtype_and_x,
+    frontend,
+    test_flags,
+    fn_tree,
+    on_device,
+):
+    input_dtypes, xs = dtype_and_x
+    np_frontend_helpers.test_frontend_function(
+        input_dtypes=input_dtypes,
+        frontend=frontend,
+        test_flags=test_flags,
+        fn_tree=fn_tree,
+        on_device=on_device,
+        a=xs[0],
+        v=xs[1],
+    )


### PR DESCRIPTION
testing order statistics still outputs the following error

`@handle_frontend_test(
     ^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\arana\Documents\venvs\ivy_dev\Lib\site-packages\ivy_tests\test_ivy\helpers\testing_helpers.py", line 383, in test_wrapper
    callable_fn, fn_name, fn_mod = _import_fn(fn_tree)
                                   ^^^^^^^^^^^^^^^^^^^
  File "C:\Users\arana\Documents\venvs\ivy_dev\Lib\site-packages\ivy_tests\test_ivy\helpers\testing_helpers.py", line 152, in _import_fn
    callable_fn = mod.__dict__[fn_name]
                  ~~~~~~~~~~~~^^^^^^^^^

    @handle_frontend_test(
     ^^^^^^^^^^^^^^^^^^^^^  File "C:\Users\arana\Documents\venvs\ivy_dev\Lib\site-packages\ivy_tests\test_ivy\helpers\testing_helpers.py", line 383, in test_wrapper
    callable_fn, fn_name, fn_mod = _import_fn(fn_tree)
                                   ^^^^^^^^^^^^^^^^^^^
  File "C:\Users\arana\Documents\venvs\ivy_dev\Lib\site-packages\ivy_tests\test_ivy\helpers\testing_helpers.py", line 152, in _import_fn
    callable_fn = mod.__dict__[fn_name]
                  ~~~~~~~~~~~~^^^^^^^^^` 