### PR TITLE
Close #10179

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -16,7 +16,8 @@
 	// "forwardPorts": [],
 
 	// Uncomment the next line to run commands after the container is created - for example installing curl.
-	"postCreateCommand": "bash .devcontainer/post_create_commands.sh"
+	"postCreateCommand": "bash .devcontainer/post_create_commands.sh",
+	"postStartCommand": "git config --global --add safe.directory ${containerWorkspaceFolder}"
 
 	// Uncomment when using a ptrace-based debugger like C++, Go, and Rust
 	// "runArgs": [ "--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined" ],

--- a/ivy/functional/frontends/numpy/creation_routines/from_existing_data.py
+++ b/ivy/functional/frontends/numpy/creation_routines/from_existing_data.py
@@ -2,6 +2,7 @@ import ivy
 from ivy.functional.frontends.numpy.func_wrapper import (
     to_ivy_arrays_and_back,
     handle_numpy_dtype,
+    handle_numpy_out
 )
 
 
@@ -26,3 +27,69 @@ def asarray(
 @to_ivy_arrays_and_back
 def copy(a, order="K", subok=False):
     return ivy.copy_array(a)
+
+
+def check_shapes_numpy_broadcastable(shape1, shape2):
+    """ Checks whether two shapes satisfy Numpy's broadcasting rules. """
+    for s1, s2 in zip(shape1[::-1], shape2[::-1]):
+        if s1 == 1 or s2 == 1 or s1 == s2:
+            pass
+        else:
+            return False
+    return True
+        
+    
+def numpy_style_broadcast(a1, a2):
+    """ Broadcast two arrays as Numpy would do it. """
+    assert check_shapes_numpy_broadcastable(a1.shape, a2.shape), \
+        f"Could not broadcast shapes {a1.shape} and {a2.shape}"
+    if a1.ndim > a2.ndim:
+        a2_ext_shape = (a1.ndim - a2.ndim)*(1,) + a2.shape
+        a1_ext_shape = a1.shape
+    elif a2.ndim > a1.ndim:
+        a1_ext_shape = (a2.ndim - a1.ndim)*(1,) + a1.shape
+        a2_ext_shape = a2.shape
+    else:
+        a1_ext_shape = a1.shape
+        a2_ext_shape = a2.shape
+    final_shape = ivy.maximum(a1_ext_shape, a2_ext_shape)
+    a1_tile_reps = (int(fd - ad) + 1 for fd, ad in zip(final_shape, a1_ext_shape))
+    a2_tile_reps = (int(fd - ad) + 1 for fd, ad in zip(final_shape, a2_ext_shape))
+
+    return a1.tile(a1_tile_reps), a2.tile(a2_tile_reps)
+
+
+@handle_numpy_out
+@to_ivy_arrays_and_back
+def choose(a, choices, out=None, mode='raise'):
+    _choices = list(choices)
+    n = len(_choices)
+    # broadcast as necessary
+    shapes_checked = False
+    while not shapes_checked:
+        shapes_checked = True
+        for i, choice in enumerate(_choices):
+            if a.shape != choice.shape:
+                a, _choices[i] = numpy_style_broadcast(a, choice)
+                shapes_checked = False
+    # create composite array
+    c = ivy.empty_like(a)
+    if mode == 'raise':
+        assert ivy.max(a) < n and ivy.min(a) >= 0, "Invalid entry in index array"
+    elif mode == 'clip':
+        a = a.clip(0, n-1)
+    elif mode == 'wrap':
+        a = ivy.abs(ivy.fmod(a, n))
+    else:
+        raise ValueError("Invalid mode")
+    for I in ivy.ndindex(a.shape):
+        c[I]= _choices[int(a[I])][I]
+
+    if out is not None:
+        print(out)
+        if out.shape == c.shape:
+            out = c
+        else:
+            raise ValueError("Invalid shape for output array")
+    else:
+        return c

--- a/ivy/functional/frontends/numpy/creation_routines/from_existing_data.py
+++ b/ivy/functional/frontends/numpy/creation_routines/from_existing_data.py
@@ -86,9 +86,8 @@ def choose(a, choices, out=None, mode='raise'):
         c[I]= _choices[int(a[I])][I]
 
     if out is not None:
-        print(out)
         if out.shape == c.shape:
-            out = c
+            ivy.copy_array(c, out=out)
         else:
             raise ValueError("Invalid shape for output array")
     else:

--- a/ivy/functional/frontends/numpy/ndarray/ndarray.py
+++ b/ivy/functional/frontends/numpy/ndarray/ndarray.py
@@ -171,6 +171,19 @@ class ndarray:
             out=out,
         )
 
+    def choose(
+        self,
+        choices,
+        out=None,
+        mode='raise'
+    ):
+        return np_frontend.choose(
+            self,
+            choices,
+            out=out,
+            mode=mode
+        )
+
     def clip(
         self,
         min,


### PR DESCRIPTION
Hello guys. I'm submitting an almost complete solution, but I feel we should discuss some things before going forward.  

* My subtask, chosen form https://github.com/unifyai/ivy/issues/3607 has still not been assigned by the Ivy team, but it's been 4 days since I reserved it (https://github.com/unifyai/ivy/issues/10179), so I'm hoping it's OK to send the PR.
* I made a relatively "heavy" compositional implementation. This was because numpy.choose relies on Numpy's broadcasting rules, which seem different from the ones currently used in Ivy (e.g. `ivy.broadcast_to`). I thus added two auxiliary functions to perform array broadcasting as in Numpy. I think it's best if you guys take a look before I continue further.
* Numpy's choose does not support type promotion; it turns everything into integers. I removed this limitation. Type promotion is not performed when the argument `out` is not None
* When mode='wrap' my tests fail on torch and tensorflow. The error happens in `ivy.fmod`, apparently because the backends do not support the `int64` data type.
* I have not yet added the tests to the codebase. I have not managed to figure out how to use `@handle_frontend_tests` so: 1) the shape of the index and choices arrays make sense, and 2) the tests are performed for the 3 modes ('raise', 'wrap', and 'clip'). A little guidance would be appreciated.
