### PR TITLE
fix test_dsplit

### DIFF
--- a/ivy_tests/test_ivy/test_functional/test_experimental/test_core/test_manipulation.py
+++ b/ivy_tests/test_ivy/test_functional/test_experimental/test_core/test_manipulation.py
@@ -602,6 +602,44 @@ def test_pad(
     )
 
 
+@st.composite
+def _get_split_locations(draw, min_num_dims, axis):
+    """
+    Generate valid splits, either by generating an integer that evenly divides the axis
+    or a list of split locations.
+    """
+    shape = draw(
+        st.shared(helpers.get_shape(min_num_dims=min_num_dims), key="value_shape")
+    )
+    if len(shape) == 1:
+        axis = draw(st.just(0))
+    else:
+        axis = draw(st.just(axis))
+
+    @st.composite
+    def get_int_split(draw):
+        if shape[axis] == 0:
+            return 0
+        factors = []
+        for i in range(1, shape[axis] + 1):
+            if shape[axis] % i == 0:
+                factors.append(i)
+        return draw(st.sampled_from(factors))
+
+    @st.composite
+    def get_list_split(draw):
+        return draw(
+            st.lists(
+                st.integers(min_value=0, max_value=shape[axis]),
+                min_size=0,
+                max_size=shape[axis],
+                unique=True,
+            ).map(sorted)
+        )
+
+    return draw(get_list_split() | get_int_split())
+
+
 # vsplit
 @handle_test(
     fn_tree="functional.ivy.experimental.vsplit",
@@ -644,12 +682,10 @@ def test_vsplit(
 @handle_test(
     fn_tree="functional.ivy.experimental.dsplit",
     dtype_and_x=helpers.dtype_and_values(
-        available_dtypes=helpers.get_dtypes("float"),
-        shape=st.shared(helpers.get_shape(min_num_dims=3), key="dsplit_shape"),
+        available_dtypes=helpers.get_dtypes("valid"),
+        shape=st.shared(helpers.get_shape(min_num_dims=3), key="value_shape"),
     ),
-    indices_or_sections=helpers.get_shape(
-        min_num_dims=1, max_num_dims=3, min_dim_size=1, max_dim_size=3
-    ),
+    indices_or_sections=_get_split_locations(min_num_dims=3, axis=2),
     test_gradients=st.just(False),
     test_with_out=st.just(False),
 )
@@ -663,7 +699,6 @@ def test_dsplit(
     ground_truth_backend,
 ):
     input_dtype, x = dtype_and_x
-    indices_or_sections = sorted(indices_or_sections)
     helpers.test_function(
         ground_truth_backend=ground_truth_backend,
         input_dtypes=input_dtype,


### PR DESCRIPTION
Previous failing example:
`@reproduce_failure('6.55.0', b'AXicY2BkYIAgEIBSDIyMcCYAAKgACA==')`