### PR TITLE
Fix backends._.diff

### DIFF
--- a/ivy/array/experimental/elementwise.py
+++ b/ivy/array/experimental/elementwise.py
@@ -849,9 +849,13 @@ class ArrayWithElementWiseExperimental(abc.ABC):
         )
 
     def diff(
-        self: Union[ivy.Array, int, float, list, tuple],
+        self: ivy.Array,
         /,
         *,
+        n: int = 1,
+        axis: int = -1,
+        prepend: Optional[Union[ivy.Array, ivy.NativeArray, int, list, tuple]] = None,
+        append: Optional[Union[ivy.Array, ivy.NativeArray, int, list, tuple]] = None,
         out: Optional[ivy.Array] = None,
     ) -> ivy.Array:
         """ivy.Array instance method variant of ivy.diff. This method simply
@@ -862,6 +866,16 @@ class ArrayWithElementWiseExperimental(abc.ABC):
         ----------
         self
             array-like input.
+        n
+            The number of times values are differenced. If zero, the input is returned
+            as-is.
+        axis
+            The axis along which the difference is taken, default is the last axis.
+        prepend,append
+            Values to prepend/append to x along given axis prior to performing the
+            difference. Scalar values are expanded to arrays with length 1 in the
+            direction of axis and the shape of the input array in along all other
+            axes. Otherwise the dimension and shape must match x except along axis.
         out
             optional output array, for writing the result to.
 
@@ -872,15 +886,13 @@ class ArrayWithElementWiseExperimental(abc.ABC):
 
         Examples
         --------
-        >>> x = ivy.Container(a=ivy.array([1, 2, 4, 7, 0]),\
-                               b=ivy.array([1, 2, 4, 7, 0]))
-        >>> ivy.Container.static_diff(x)
-        {
-            a: ivy.array([ 1,  2,  3, -7])
-            b: ivy.array([ 1,  2,  3, -7])
-        }
+        >>> x = ivy.array([1, 2, 4, 7, 0])
+        >>> x.diff()
+        ivy.array([ 1,  2,  3, -7])
         """
-        return ivy.diff(self._data, out=out)
+        return ivy.diff(
+            self._data, n=n, axis=axis, prepend=prepend, append=append, out=out
+        )
 
     def fix(
         self: ivy.Array,

--- a/ivy/container/experimental/elementwise.py
+++ b/ivy/container/experimental/elementwise.py
@@ -2232,9 +2232,13 @@ class ContainerWithElementWiseExperimental(ContainerBase):
 
     @staticmethod
     def static_diff(
-        x: Union[ivy.Array, ivy.NativeArray, ivy.Container, int, list, tuple],
+        x: Union[ivy.Container, ivy.Array, ivy.NativeArray],
         /,
         *,
+        n: int = 1,
+        axis: int = -1,
+        prepend: Optional[Union[ivy.Array, ivy.NativeArray, int, list, tuple]] = None,
+        append: Optional[Union[ivy.Array, ivy.NativeArray, int, list, tuple]] = None,
         key_chains: Optional[Union[List[str], Dict[str, str]]] = None,
         to_apply: bool = True,
         prune_unapplied: bool = False,
@@ -2250,6 +2254,27 @@ class ContainerWithElementWiseExperimental(ContainerBase):
         ----------
         x
             input container with array-like items.
+        n
+            The number of times values are differenced. If zero, the input is returned
+            as-is.
+        axis
+            The axis along which the difference is taken, default is the last axis.
+        prepend,append
+            Values to prepend/append to x along given axis prior to performing the
+            difference. Scalar values are expanded to arrays with length 1 in the
+            direction of axis and the shape of the input array in along all other
+            axes. Otherwise the dimension and shape must match x except along axis.
+        key_chains
+            The key-chains to apply or not apply the method to. Default is ``None``.
+        to_apply
+            If True, the method will be applied to key_chains, otherwise key_chains
+            will be skipped. Default is ``True``.
+        prune_unapplied
+            Whether to prune key_chains for which the function was not applied.
+            Default is ``False``.
+        map_sequences
+            Whether to also map method to sequences (lists, tuples).
+            Default is ``False``.
         out
             optional output container, for writing the result to.
 
@@ -2261,17 +2286,21 @@ class ContainerWithElementWiseExperimental(ContainerBase):
 
         Examples
         --------
-        >>> x = ivy.Container(a=ivy.array([1, 2, 4, 7, 0]),\
-                               b=ivy.array([1, 2, 4, 7, 0]))
+        >>> x = ivy.Container(a=ivy.array([1, 2, 4, 7, 0]),
+                              b=ivy.array([1, 2, 4, 7, 0]))
         >>> ivy.Container.static_diff(x)
         {
-            a: ivy.array([ 1,  2,  3, -7])
+            a: ivy.array([ 1,  2,  3, -7]),
             b: ivy.array([ 1,  2,  3, -7])
         }
         """
         return ContainerBase.cont_multi_map_in_function(
             "diff",
             x,
+            n=n,
+            axis=axis,
+            prepend=prepend,
+            append=append,
             key_chains=key_chains,
             to_apply=to_apply,
             prune_unapplied=prune_unapplied,
@@ -2283,6 +2312,10 @@ class ContainerWithElementWiseExperimental(ContainerBase):
         self: ivy.Container,
         /,
         *,
+        n: int = 1,
+        axis: int = -1,
+        prepend: Optional[Union[ivy.Array, ivy.NativeArray, int, list, tuple]] = None,
+        append: Optional[Union[ivy.Array, ivy.NativeArray, int, list, tuple]] = None,
         out: Optional[ivy.Container] = None,
     ) -> ivy.Container:
         """ivy.Container instance method variant of ivy.diff. This method simply
@@ -2293,6 +2326,16 @@ class ContainerWithElementWiseExperimental(ContainerBase):
         ----------
         self
             input container with array-like items.
+        n
+            The number of times values are differenced. If zero, the input is returned
+            as-is.
+        axis
+            The axis along which the difference is taken, default is the last axis.
+        prepend,append
+            Values to prepend/append to x along given axis prior to performing the
+            difference. Scalar values are expanded to arrays with length 1 in the
+            direction of axis and the shape of the input array in along all other
+            axes. Otherwise the dimension and shape must match x except along axis.
         out
             optional output container, for writing the result to.
 
@@ -2304,15 +2347,17 @@ class ContainerWithElementWiseExperimental(ContainerBase):
 
         Examples
         --------
-        >>> x = ivy.Container(a=ivy.array([1, 2, 4, 7, 0]),\
-                               b=ivy.array([1, 2, 4, 7, 0]))
-        >>> ivy.Container.static_diff(x)
+        >>> x = ivy.Container(a=ivy.array([1, 2, 4, 7, 0]),
+                              b=ivy.array([1, 2, 4, 7, 0]))
+        >>> x.diff()
         {
-            a: ivy.array([ 1,  2,  3, -7])
-            b: ivy.array([ 1,  2,  3, -7])
+            a: ivy.array([1, 2, 3, -7]),
+            b: ivy.array([1, 2, 3, -7])
         }
         """
-        return self.static_diff(self, out=out)
+        return self.static_diff(
+            self, n=n, axis=axis, prepend=prepend, append=append, out=out
+        )
 
     @staticmethod
     def static_fix(

--- a/ivy/functional/backends/jax/experimental/elementwise.py
+++ b/ivy/functional/backends/jax/experimental/elementwise.py
@@ -210,15 +210,20 @@ def allclose(
 
 
 def diff(
-    x: Union[JaxArray, int, float, list, tuple],
+    x: JaxArray,
     /,
     *,
-    n: Optional[int] = 1,
-    axis: Optional[int] = -1,
+    n: int = 1,
+    axis: int = -1,
     prepend: Optional[Union[JaxArray, int, float, list, tuple]] = None,
     append: Optional[Union[JaxArray, int, float, list, tuple]] = None,
     out: Optional[JaxArray] = None,
 ) -> JaxArray:
+    x = jnp.asarray(x)
+    if isinstance(prepend, (list, tuple)):
+        prepend = jnp.asarray(prepend)
+    if isinstance(append, (list, tuple)):
+        append = jnp.asarray(append)
     return jnp.diff(x, n=n, axis=axis, prepend=prepend, append=append)
 
 

--- a/ivy/functional/backends/numpy/experimental/elementwise.py
+++ b/ivy/functional/backends/numpy/experimental/elementwise.py
@@ -316,11 +316,11 @@ def hypot(
 
 
 def diff(
-    x: Union[np.ndarray, int, float, list, tuple],
+    x: Union[np.ndarray, list, tuple],
     /,
     *,
-    n: Optional[int] = 1,
-    axis: Optional[int] = -1,
+    n: int = 1,
+    axis: int = -1,
     prepend: Optional[Union[np.ndarray, int, float, list, tuple]] = None,
     append: Optional[Union[np.ndarray, int, float, list, tuple]] = None,
     out: Optional[np.ndarray] = None,

--- a/ivy/functional/backends/tensorflow/experimental/elementwise.py
+++ b/ivy/functional/backends/tensorflow/experimental/elementwise.py
@@ -297,15 +297,17 @@ def nextafter(
     {"2.9.1 and below": ("uint8", "uint16", "uint32", "uint64")}, backend_version
 )
 def diff(
-    x: Union[tf.Tensor, tf.Variable, int, float, list, tuple],
+    x: Union[tf.Tensor, tf.Variable, list, tuple],
     /,
     *,
-    n: Optional[int] = 1,
-    axis: Optional[int] = -1,
+    n: int = 1,
+    axis: int = -1,
     prepend: Optional[Union[tf.Tensor, tf.Variable, int, float, list, tuple]] = None,
     append: Optional[Union[tf.Tensor, tf.Variable, int, float, list, tuple]] = None,
     out: Optional[Union[tf.Tensor, tf.Variable]] = None,
 ) -> Union[tf.Tensor, tf.Variable]:
+    if n == 0:
+        return x
     if prepend is not None:
         x = tf.experimental.numpy.append(prepend, x, axis=axis)
     if append is not None:

--- a/ivy/functional/backends/torch/experimental/elementwise.py
+++ b/ivy/functional/backends/torch/experimental/elementwise.py
@@ -290,11 +290,11 @@ logaddexp2.support_native_out = True
 
 
 def diff(
-    x: Union[torch.Tensor, int, float, list, tuple],
+    x: Union[torch.Tensor, list, tuple],
     /,
     *,
-    n: Optional[int] = 1,
-    axis: Optional[int] = -1,
+    n: int = 1,
+    axis: int = -1,
     prepend: Optional[Union[torch.Tensor, int, float, list, tuple]] = None,
     append: Optional[Union[torch.Tensor, int, float, list, tuple]] = None,
     out: Optional[torch.Tensor] = None,

--- a/ivy/functional/ivy/experimental/elementwise.py
+++ b/ivy/functional/ivy/experimental/elementwise.py
@@ -899,11 +899,11 @@ def hypot(
 @handle_nestable
 @handle_array_like_without_promotion
 def diff(
-    x: Union[ivy.Array, ivy.NativeArray, int, list, tuple],
+    x: Union[ivy.Array, ivy.NativeArray, list, tuple],
     /,
     *,
-    n: Optional[int] = 1,
-    axis: Optional[int] = -1,
+    n: int = 1,
+    axis: int = -1,
     prepend: Optional[Union[ivy.Array, ivy.NativeArray, int, list, tuple]] = None,
     append: Optional[Union[ivy.Array, ivy.NativeArray, int, list, tuple]] = None,
     out: Optional[ivy.Array] = None,
@@ -923,14 +923,18 @@ def diff(
         Values to prepend/append to x along given axis prior to performing the
         difference. Scalar values are expanded to arrays with length 1 in the direction
         of axis and the shape of the input array in along all other axes. Otherwise the
-        dimension and shape must match a except along axis.
+        dimension and shape must match x except along axis.
     out
         optional output array, for writing the result to.
 
     Returns
     -------
     ret
-        Rreturns the n-th discrete difference along the given axis.
+        Returns the n-th discrete difference along the given axis.
+
+    Both the description and the type hints above assumes an array input for simplicity,
+    but this function is *nestable*, and therefore also accepts :class:`ivy.Container`
+    instances in place of any of the arguments.
 
     Examples
     --------

--- a/ivy_tests/test_ivy/test_functional/test_experimental/test_core/test_elementwise.py
+++ b/ivy_tests/test_ivy/test_functional/test_experimental/test_core/test_elementwise.py
@@ -840,28 +840,40 @@ def test_nextafter(
 # diff
 @handle_test(
     fn_tree="functional.ivy.experimental.diff",
-    dtype_and_x=helpers.dtype_and_values(
-        available_dtypes=helpers.get_dtypes("integer"),
-        num_arrays=2,
-        shared_dtype=True,
+    dtype_n_x_n_axis=helpers.dtype_values_axis(
+        available_dtypes=st.shared(helpers.get_dtypes("valid"), key="dtype"),
         min_num_dims=1,
-        max_num_dims=3,
-        min_value=-100,
-        max_value=100,
-        allow_nan=False,
+        valid_axis=True,
+        force_int_axis=True,
+    ),
+    n=st.integers(min_value=0, max_value=5),
+    dtype_prepend=helpers.dtype_and_values(
+        available_dtypes=st.shared(helpers.get_dtypes("valid"), key="dtype"),
+        min_num_dims=1,
+        max_num_dims=1,
+    ),
+    dtype_append=helpers.dtype_and_values(
+        available_dtypes=st.shared(helpers.get_dtypes("valid"), key="dtype"),
+        min_num_dims=1,
+        max_num_dims=1,
     ),
     test_gradients=st.just(False),
 )
 def test_diff(
     *,
-    dtype_and_x,
+    dtype_n_x_n_axis,
+    n,
+    dtype_prepend,
+    dtype_append,
     test_flags,
     backend_fw,
     fn_name,
     on_device,
     ground_truth_backend,
 ):
-    input_dtype, x = dtype_and_x
+    input_dtype, x, axis = dtype_n_x_n_axis
+    _, prepend = dtype_prepend
+    _, append = dtype_append
     helpers.test_function(
         ground_truth_backend=ground_truth_backend,
         input_dtypes=input_dtype,
@@ -870,6 +882,10 @@ def test_diff(
         fn_name=fn_name,
         on_device=on_device,
         x=x[0],
+        n=n,
+        axis=axis,
+        prepend=prepend[0],
+        append=append[0],
     )
 
 


### PR DESCRIPTION
1. Fix backend `diff` type hints.
2. Fix backend `diff` docstrings and examples.
3. Fix `array` and `container` method arguments.
4. Fix `backends.jax.diff` implementation (didn't work before).
5. Fix `backends.tensorflow.diff` implementation (had a minor bug).
6. Fix `test_diff` (didn't test all of the arguments)