### PR TITLE
nonzero

### DIFF
--- a/ivy/functional/backends/jax/searching.py
+++ b/ivy/functional/backends/jax/searching.py
@@ -96,5 +96,10 @@ def where(
 # ----- #
 
 
-def argwhere(x: JaxArray, /, *, out: Optional[JaxArray] = None) -> JaxArray:
+def argwhere(
+        x: JaxArray,
+        /,
+        *,
+        out: Optional[JaxArray] = None
+) -> JaxArray:
     return jnp.argwhere(x)

--- a/ivy/functional/backends/numpy/searching.py
+++ b/ivy/functional/backends/numpy/searching.py
@@ -101,5 +101,10 @@ def where(
 # ----- #
 
 
-def argwhere(x: np.ndarray, /, *, out: Optional[np.ndarray] = None) -> np.ndarray:
+def argwhere(
+        x: np.ndarray,
+        /,
+        *,
+        out: Optional[np.ndarray] = None
+) -> np.ndarray:
     return np.argwhere(x)

--- a/ivy/functional/backends/torch/searching.py
+++ b/ivy/functional/backends/torch/searching.py
@@ -111,5 +111,10 @@ def where(
 # ----- #
 
 
-def argwhere(x: torch.Tensor, /, *, out: Optional[torch.Tensor] = None) -> torch.Tensor:
+def argwhere(
+        x: torch.Tensor,
+        /,
+        *,
+        out: Optional[torch.Tensor] = None
+) -> torch.Tensor:
     return torch.argwhere(x)


### PR DESCRIPTION
`nonzero` seems to be formatted fine.

`argwhere` minor formatting modification.