### PR TITLE
add fix for array test

### DIFF
--- a/ivy_tests/test_ivy/test_misc/test_array.py
+++ b/ivy_tests/test_ivy/test_misc/test_array.py
@@ -63,7 +63,7 @@ def test_array_function():
 
     x = MyArray(-3)
     y = ivy.array([1, -1])
-    xy = _(x, ivy_array=y)  # works
+    xy = _(x, ivy_array=y)
     x1 = xy[0]
     y1 = xy[1]
     assert x1.data == 3

--- a/ivy_tests/test_ivy/test_misc/test_array.py
+++ b/ivy_tests/test_ivy/test_misc/test_array.py
@@ -63,7 +63,7 @@ def test_array_function():
 
     x = MyArray(-3)
     y = ivy.array([1, -1])
-    xy = ivy.abs(x, ivy_array=y)  # works
+    xy = _(x, ivy_array=y)  # works
     x1 = xy[0]
     y1 = xy[1]
     assert x1.data == 3


### PR DESCRIPTION
Closes #10450

Seems to be a typo, ```_``` was decorated to use ```ivy.abs```, but ```ivy.abs``` was called instead of ```_```