### PR TITLE
Updated torch backend implementation of randint to handle high and low as tensors 

### DIFF
--- a/ivy/functional/backends/jax/random.py
+++ b/ivy/functional/backends/jax/random.py
@@ -155,7 +155,7 @@ def randint(
         dtype = ivy.default_int_dtype()
     dtype = ivy.as_native_dtype(dtype)
     _randint_check_dtype_and_bound(low, high, dtype)
-    shape = _check_bounds_and_get_shape(low, high, shape)
+    low, high, shape = _check_bounds_and_get_shape(low, high, shape)
 
     if seed:
         rng_input = jax.random.PRNGKey(seed)

--- a/ivy/functional/backends/numpy/random.py
+++ b/ivy/functional/backends/numpy/random.py
@@ -104,7 +104,7 @@ def randint(
         dtype = ivy.default_int_dtype()
     dtype = ivy.as_native_dtype(dtype)
     _randint_check_dtype_and_bound(low, high, dtype)
-    shape = _check_bounds_and_get_shape(low, high, shape)
+    low, high, shape = _check_bounds_and_get_shape(low, high, shape)
     if seed:
         np.random.seed(seed)
     return np.random.randint(low, high, shape, dtype=dtype)

--- a/ivy/functional/backends/tensorflow/random.py
+++ b/ivy/functional/backends/tensorflow/random.py
@@ -138,7 +138,7 @@ def randint(
         dtype = ivy.default_int_dtype()
     dtype = ivy.as_native_dtype(dtype)
     _randint_check_dtype_and_bound(low, high, dtype)
-    shape = _check_bounds_and_get_shape(low, high, shape)
+    low, high, shape = _check_bounds_and_get_shape(low, high, shape)
     low = tf.cast(low, "float32")
     high = tf.cast(high, "float32")
     with tf.device(device):

--- a/ivy/functional/backends/torch/random.py
+++ b/ivy/functional/backends/torch/random.py
@@ -106,7 +106,7 @@ def randint(
         dtype = ivy.default_int_dtype()
     dtype = ivy.as_native_dtype(dtype)
     _randint_check_dtype_and_bound(low, high, dtype)
-    shape = _check_bounds_and_get_shape(low, high, shape)
+    low, high, shape = _check_bounds_and_get_shape(low, high, shape)
     if seed:
         torch.manual_seed(seed)
     if torch.is_tensor(low):

--- a/ivy/functional/backends/torch/random.py
+++ b/ivy/functional/backends/torch/random.py
@@ -104,14 +104,17 @@ def randint(
 ) -> torch.Tensor:
     if not dtype:
         dtype = ivy.default_int_dtype()
-    if not shape:
-        shape = (1,)
     dtype = ivy.as_native_dtype(dtype)
     _randint_check_dtype_and_bound(low, high, dtype)
     shape = _check_bounds_and_get_shape(low, high, shape)
     if seed:
         torch.manual_seed(seed)
-    return torch.randint(low=low, high=high, size=shape, device=device, dtype=dtype)
+    if torch.is_tensor(low):
+        low = torch.flatten(low)
+        high = torch.flatten(high)
+    result = torch.tensor([torch.randint(l, h, (1,)) for l, h in zip(low, high)])
+    return torch.reshape(result, shape)
+
 
 
 def seed(*, seed_value: int = 0) -> None:

--- a/ivy/functional/ivy/random.py
+++ b/ivy/functional/ivy/random.py
@@ -26,7 +26,7 @@ def _check_bounds_and_get_shape(low, high, shape):
         ivy.assertions.check_all_or_any_fn(
             low,
             high,
-            fn=lambda x: isinstance(x, (int, float)),
+            fn=lambda x: (ivy.is_float_dtype(x) or ivy.is_int_dtype(x)),
             type="all",
             message="low and high bounds must be numerics when shape is specified",
         )


### PR DESCRIPTION
close #10434.

`torch.randint` does not natively support `high` and `low` as tensors. I updated the backend implementation to add support for the same.