### PR TITLE
torch frontend implementation of torch.nn.functional.interpolate

### DIFF
--- a/ivy/functional/frontends/torch/nn/functional/vision_functions.py
+++ b/ivy/functional/frontends/torch/nn/functional/vision_functions.py
@@ -1,4 +1,5 @@
 import ivy
+from ivy import with_unsupported_dtypes
 from ivy.functional.frontends.torch.func_wrapper import to_ivy_arrays_and_back
 from ivy.exceptions import IvyNotImplementedException
 
@@ -249,6 +250,7 @@ def upsample_bilinear(input, size=None, scale_factor=None):
     return result
 
 
+@with_unsupported_dtypes({"1.11.0 and below": ("bfloat16", "float16",)}, "torch")
 @to_ivy_arrays_and_back
 def interpolate(
     input,
@@ -262,7 +264,7 @@ def interpolate(
     if mode in ["nearest", "area", "nearest-exact"]:
         ivy.assertions.check_exists(
             align_corners,
-            inverse=False,
+            inverse=True,
             message="align_corners option can only be set with the interpolating modes:"
             " linear | bilinear | bicubic | trilinear",
         )
@@ -284,7 +286,7 @@ def interpolate(
             ivy.assertions.check_equal(
                 len(size),
                 dim,
-                inverse=True,
+                inverse=False,
                 message=
                 f"Input and output must have the same number of spatial dimensions,"
                 f" but got input with spatial dimensions of {list(input.shape[2:])}"
@@ -303,7 +305,7 @@ def interpolate(
             ivy.assertions.check_equal(
                 len(scale_factor),
                 dim,
-                inverse=True,
+                inverse=False,
                 message=
                 f"Input and scale_factor must have the same number of spatial dimensions,"
                 f" but got input with spatial dimensions of {list(input.shape[2:])}"

--- a/ivy/functional/frontends/torch/nn/functional/vision_functions.py
+++ b/ivy/functional/frontends/torch/nn/functional/vision_functions.py
@@ -392,3 +392,27 @@ def interpolate(
     return ivy.interpolate(
         input, size, mode=mode, align_corners=align_corners, antialias=antialias
     )
+
+
+@to_ivy_arrays_and_back
+def upsample(
+    input,
+    size=None,
+    scale_factor=None,
+    mode="nearest",
+    align_corners=None,
+):
+
+    return interpolate(
+        input,
+        size=size,
+        scale_factor=scale_factor,
+        mode=mode,
+        align_corners=align_corners,
+    )
+
+
+@to_ivy_arrays_and_back
+def upsample_nearest(input, size=None, scale_factor=None):
+
+    return interpolate(input, size=size, scale_factor=scale_factor, mode="nearest")

--- a/ivy/functional/frontends/torch/nn/functional/vision_functions.py
+++ b/ivy/functional/frontends/torch/nn/functional/vision_functions.py
@@ -250,7 +250,15 @@ def upsample_bilinear(input, size=None, scale_factor=None):
     return result
 
 
-@with_unsupported_dtypes({"1.11.0 and below": ("bfloat16", "float16",)}, "torch")
+@with_unsupported_dtypes(
+    {
+        "1.11.0 and below": (
+            "bfloat16",
+            "float16",
+        )
+    },
+    "torch",
+)
 @to_ivy_arrays_and_back
 def interpolate(
     input,
@@ -287,8 +295,8 @@ def interpolate(
                 len(size),
                 dim,
                 inverse=False,
-                message=
-                f"Input and output must have the same number of spatial dimensions,"
+                message=f"Input and output must have the "
+                f"same number of spatial dimensions,"
                 f" but got input with spatial dimensions of {list(input.shape[2:])}"
                 f" and output size of {size}. "
                 f"Please provide input tensor in (N, C, d1, d2, ...,dK) format"
@@ -306,8 +314,8 @@ def interpolate(
                 len(scale_factor),
                 dim,
                 inverse=False,
-                message=
-                f"Input and scale_factor must have the same number of spatial dimensions,"
+                message=f"Input and scale_factor must have the "
+                f"same number of spatial dimensions,"
                 f" but got input with spatial dimensions of {list(input.shape[2:])}"
                 f" and scale_factor of shape {scale_factor}. "
                 f"Please provide input tensor in (N, C, d1, d2, ...,dK) format"

--- a/ivy/functional/frontends/torch/nn/functional/vision_functions.py
+++ b/ivy/functional/frontends/torch/nn/functional/vision_functions.py
@@ -1,5 +1,6 @@
 import ivy
 from ivy.functional.frontends.torch.func_wrapper import to_ivy_arrays_and_back
+from ivy.exceptions import IvyNotImplementedException
 
 
 @to_ivy_arrays_and_back
@@ -246,3 +247,148 @@ def upsample_bilinear(input, size=None, scale_factor=None):
     )
 
     return result
+
+
+@to_ivy_arrays_and_back
+def interpolate(
+    input,
+    size=None,
+    scale_factor=None,
+    mode="nearest",
+    align_corners=None,
+    recompute_scale_factor=None,
+    antialias=False,
+):
+    if mode in ["nearest", "area", "nearest-exact"]:
+        ivy.assertions.check_exists(
+            align_corners,
+            inverse=False,
+            message="align_corners option can only be set with the interpolating modes:"
+            " linear | bilinear | bicubic | trilinear",
+        )
+    else:
+        if not ivy.exists(align_corners):
+            align_corners = False
+
+    dim = ivy.get_num_dims(input) - 2  # Number of spatial dimensions.
+
+    if ivy.exists(size) and ivy.exists(scale_factor):
+        raise ivy.exceptions.IvyException(
+            "only one of size or scale_factor should be defined"
+        )
+
+    elif ivy.exists(size) and not ivy.exists(scale_factor):
+        scale_factors = None
+
+        if isinstance(size, (list, tuple)):
+            ivy.assertions.check_equal(
+                len(size),
+                dim,
+                inverse=True,
+                message=
+                f"Input and output must have the same number of spatial dimensions,"
+                f" but got input with spatial dimensions of {list(input.shape[2:])}"
+                f" and output size of {size}. "
+                f"Please provide input tensor in (N, C, d1, d2, ...,dK) format"
+                f" and output size in (o1, o2, ...,oK) format.",
+            )
+            output_size = size
+        else:
+            output_size = [size for _ in range(dim)]
+
+    elif ivy.exists(scale_factor) and not ivy.exists(size):
+        output_size = None
+
+        if isinstance(scale_factor, (list, tuple)):
+            ivy.assertions.check_equal(
+                len(scale_factor),
+                dim,
+                inverse=True,
+                message=
+                f"Input and scale_factor must have the same number of spatial dimensions,"
+                f" but got input with spatial dimensions of {list(input.shape[2:])}"
+                f" and scale_factor of shape {scale_factor}. "
+                f"Please provide input tensor in (N, C, d1, d2, ...,dK) format"
+                f" and scale_factor in (s1, s2, ...,sK) format.",
+            )
+            scale_factors = scale_factor
+        else:
+            scale_factors = [scale_factor for _ in range(dim)]
+
+    else:
+        ivy.assertions.check_any(
+            [ivy.exists(size), ivy.exists(scale_factor)],
+            message="either size or scale_factor should be defined",
+        )
+
+    if (
+        ivy.exists(size)
+        and ivy.exists(recompute_scale_factor)
+        and bool(recompute_scale_factor)
+    ):
+        raise ivy.exceptions.IvyException(
+            "recompute_scale_factor is not meaningful with an explicit size."
+        )
+
+    if mode == "area" and not ivy.exists(output_size):
+        recompute_scale_factor = True
+
+    if ivy.all(
+        [
+            ivy.exists(recompute_scale_factor),
+            bool(recompute_scale_factor),
+            ivy.exists(scale_factors),
+        ]
+    ):
+        output_size = [
+            ivy.astype(
+                ivy.floor(
+                    ivy.astype(input.size(i + 2)) * scale_factors[i], ivy.FloatDtype
+                ),
+                ivy.IntDtype,
+            )
+            for i in range(dim)
+        ]
+        scale_factors = None
+
+    if (
+        bool(antialias)
+        and not (mode in ["bilinear", "bicubic"])
+        and ivy.get_num_dims(input) == 4
+    ):
+        raise ivy.exceptions.IvyException(
+            "recompute_scale_factor is not meaningful with an explicit size."
+        )
+
+    if ivy.get_num_dims(input) == 3 and mode == "bilinear":
+        raise IvyNotImplementedException(
+            "Got 3D input, but bilinear mode needs 4D input"
+        )
+    if ivy.get_num_dims(input) == 3 and mode == "trilinear":
+        raise IvyNotImplementedException(
+            "Got 3D input, but trilinear mode needs 5D input"
+        )
+    if ivy.get_num_dims(input) == 4 and mode == "linear":
+        raise IvyNotImplementedException("Got 4D input, but linear mode needs 3D input")
+    if ivy.get_num_dims(input) == 4 and mode == "trilinear":
+        raise IvyNotImplementedException(
+            "Got 4D input, but trilinear mode needs 5D input"
+        )
+    if ivy.get_num_dims(input) == 5 and mode == "linear":
+        raise IvyNotImplementedException("Got 5D input, but linear mode needs 3D input")
+    if ivy.get_num_dims(input) == 5 and mode == "bilinear":
+        raise IvyNotImplementedException(
+            "Got 5D input, but bilinear mode needs 4D input"
+        )
+
+    ivy.assertions.check_elem_in_list(
+        ivy.get_num_dims(input),
+        range(3, 6),
+        message=f"Input Error: Only 3D, 4D and 5D input Tensors supported "
+        f"(got {ivy.get_num_dims(input)}D) for the modes: nearest | linear | bilinear "
+        f"| bicubic | trilinear | area | nearest-exact (got {mode})",
+    )
+
+    return ivy.interpolate(
+        input, size, mode=mode, align_corners=align_corners, antialias=antialias
+    )

--- a/ivy_tests/test_ivy/test_frontends/test_torch/test_vision_functions.py
+++ b/ivy_tests/test_ivy/test_frontends/test_torch/test_vision_functions.py
@@ -3,6 +3,7 @@ from hypothesis import assume, strategies as st
 # local
 import ivy
 import ivy_tests.test_ivy.helpers as helpers
+from ivy_tests.test_ivy.helpers import handle_frontend_test
 from ivy_tests.test_ivy.test_functional.test_experimental.test_nn.test_layers import (
     _interp_args,
 )

--- a/ivy_tests/test_ivy/test_frontends/test_torch/test_vision_functions.py
+++ b/ivy_tests/test_ivy/test_frontends/test_torch/test_vision_functions.py
@@ -275,3 +275,53 @@ def test_torch_interpolate(
         align_corners=align_corners,
         antialias=antialias,
     )
+
+
+@handle_frontend_test(
+    fn_tree="torch.nn.functional.upsample",
+    dtype_and_input_and_other=_interpolate_helper(),
+)
+def test_torch_upsample(
+    *,
+    dtype_and_input_and_other,
+    on_device,
+    fn_tree,
+    frontend,
+    test_flags,
+):
+    dtype, input, size, mode, align_corners, _ = dtype_and_input_and_other
+    helpers.test_frontend_function(
+        input_dtypes=dtype,
+        frontend=frontend,
+        test_flags=test_flags,
+        fn_tree=fn_tree,
+        on_device=on_device,
+        input=input,
+        size=size,
+        mode=mode,
+        align_corners=align_corners,
+    )
+
+
+@handle_frontend_test(
+    fn_tree="torch.nn.functional.upsample_nearest",
+    dtype_and_input_and_other=_interpolate_helper(),
+)
+def test_torch_upsample_nearest(
+    *,
+    dtype_and_input_and_other,
+    on_device,
+    fn_tree,
+    frontend,
+    test_flags,
+):
+    dtype, input, size, _, _, _ = dtype_and_input_and_other
+    helpers.test_frontend_function(
+        input_dtypes=dtype,
+        frontend=frontend,
+        test_flags=test_flags,
+        fn_tree=fn_tree,
+        on_device=on_device,
+        input=input,
+        size=size,
+    )

--- a/ivy_tests/test_ivy/test_frontends/test_torch/test_vision_functions.py
+++ b/ivy_tests/test_ivy/test_frontends/test_torch/test_vision_functions.py
@@ -215,6 +215,7 @@ def test_torch_upsample_bilinear(
         scale_factor=scale_factor,
     )
 
+
 @st.composite
 def _interpolate_helper(draw):
     dtype, input, shape = draw(

--- a/ivy_tests/test_ivy/test_frontends/test_torch/test_vision_functions.py
+++ b/ivy_tests/test_ivy/test_frontends/test_torch/test_vision_functions.py
@@ -215,7 +215,7 @@ def test_torch_upsample_bilinear(
         scale_factor=scale_factor,
     )
 
-
+@st.composite
 def _interpolate_helper(draw):
     dtype, input, shape = draw(
         helpers.dtype_and_values(


### PR DESCRIPTION
closes #10523 and closes #10533 
it has `scale_factor` and `recompute_scale_factor` in its arguments but they are not yet implemented in `ivy.interpolate` so they are ignored in the body

the tests have a problem so i'd appreciate some help with passing the arguments to the test function
`ivy.exceptions.IvyBackendException: numpy: interpolate: 'LazyStrategy' object is not iterable`

run the tests using
`pytest ivy_tests/test_ivy/test_frontends/test_torch/test_vision_functions.py::test_torch_interpolate`
