### PR TITLE
An implementation of dropout3d from scratch for all frameworks.

### DIFF
--- a/ivy/array/layers.py
+++ b/ivy/array/layers.py
@@ -197,6 +197,48 @@ class ArrayWithLayers(abc.ABC):
             out=out,
         )
 
+    def dropout3d(
+        self: ivy.Array,
+        prob: float,
+        /,
+        *,
+        training: bool = True,
+        data_format: str = "NDHWC",
+        out: Optional[ivy.Array] = None,
+    ) -> ivy.Array:
+        """
+        ivy.Array instance method variant of ivy.dropout3d. This method simply
+        wraps the function, and so the docstring for ivy.droput3d also applies
+        to this method with minimal changes.
+
+        Parameters
+        ----------
+        self
+            The input array x to perform dropout on.
+        prob
+            The probability of zeroing out each array element, float between 0 and 1.
+        training
+            Turn on dropout if training, turn off otherwise. Default is ``True``.
+        data_format
+            "NDHWC" or "NCDHW". Default is ``"NDHWC"``.
+        out
+            optional output array, for writing the result to. It must have
+            a shape that the inputs broadcast to.
+
+        Returns
+        -------
+        ret
+            Result array of the output after dropout is performed.
+
+        """
+        return ivy.dropout3d(
+            self._data,
+            prob,
+            training=training,
+            data_format=data_format,
+            out=out,
+        )
+
     def scaled_dot_product_attention(
         self: ivy.Array,
         k: Union[ivy.Array, ivy.NativeArray],

--- a/ivy/container/layers.py
+++ b/ivy/container/layers.py
@@ -509,6 +509,129 @@ class ContainerWithLayers(ContainerBase):
         )
 
     @staticmethod
+    def static_dropout3d(
+        x: ivy.Container,
+        prob: float,
+        /,
+        *,
+        training: bool = True,
+        data_format: str = "NDHWC",
+        key_chains: Optional[Union[List[str], Dict[str, str]]] = None,
+        to_apply: bool = True,
+        prune_unapplied: bool = False,
+        map_sequences: bool = False,
+        out: Optional[ivy.Container] = None,
+    ) -> ivy.Container:
+        """
+        ivy.Container static method variant of ivy.dropout3d. This method simply
+        wraps the function, and so the docstring for ivy.dropout3d also applies
+        to this method with minimal changes.
+
+        Parameters
+        ----------
+        x
+            The input container to perform dropout on.
+        prob
+            The probability of zeroing out each array element, float between 0 and 1.
+        training
+            Turn on dropout if training, turn off otherwise. Default is ``True``.
+        data_format
+            "NDHWC" or "NCDHW". Default is ``"NDHWC"``.
+        key_chains
+            The key-chains to apply or not apply the method to. Default is ``None``.
+        to_apply
+            If True, the method will be applied to key_chains, otherwise key_chains
+            will be skipped. Default is ``True``.
+        prune_unapplied
+            Whether to prune key_chains for which the function was not applied.
+            Default is ``False``.
+        map_sequences
+            Whether to also map method to sequences (lists, tuples).
+            Default is ``False``.
+        out
+            optional output array, for writing the result to. It must have a shape
+            that the inputs broadcast to.
+
+        Returns
+        -------
+        ret
+            Result container of the output after dropout is performed.
+
+        """
+        return ContainerBase.cont_multi_map_in_function(
+            "dropout3d",
+            x,
+            prob,
+            training=training,
+            data_format=data_format,
+            key_chains=key_chains,
+            to_apply=to_apply,
+            prune_unapplied=prune_unapplied,
+            map_sequences=map_sequences,
+            out=out,
+        )
+
+    def dropout3d(
+        self: ivy.Container,
+        prob: float,
+        /,
+        *,
+        training: bool = True,
+        data_format: str = "NDHWC",
+        key_chains: Optional[Union[List[str], Dict[str, str]]] = None,
+        to_apply: bool = True,
+        prune_unapplied: bool = False,
+        map_sequences: bool = False,
+        out: Optional[ivy.Container] = None,
+    ) -> ivy.Container:
+        """
+        ivy.Container instance method variant of ivy.dropout3d. This method simply
+        wraps the function, and so the docstring for ivy.dropout3d also applies
+        to this method with minimal changes.
+
+        Parameters
+        ----------
+        self
+            The input container to perform dropout on.
+        prob
+            The probability of zeroing out each array element, float between 0 and 1.
+        training
+            Turn on dropout if training, turn off otherwise. Default is ``True``.
+        data_format
+            "NDHWC" or "NCDHW". Default is ``"NDHWC"``.
+        key_chains
+            The key-chains to apply or not apply the method to. Default is ``None``.
+        to_apply
+            If True, the method will be applied to key_chains, otherwise key_chains
+            will be skipped. Default is ``True``.
+        prune_unapplied
+            Whether to prune key_chains for which the function was not applied.
+            Default is ``False``.
+        map_sequences
+            Whether to also map method to sequences (lists, tuples).
+            Default is ``False``.
+        out
+            optional output array, for writing the result to. It must have a shape
+            that the inputs broadcast to.
+
+        Returns
+        -------
+        ret
+            Result container of the output after dropout is performed.
+        """
+        return self.static_dropout3d(
+            self,
+            prob,
+            training=training,
+            data_format=data_format,
+            key_chains=key_chains,
+            to_apply=to_apply,
+            prune_unapplied=prune_unapplied,
+            map_sequences=map_sequences,
+            out=out,
+        )
+
+    @staticmethod
     def static_scaled_dot_product_attention(
         q: Union[ivy.Array, ivy.NativeArray, ivy.Container],
         k: Union[ivy.Array, ivy.NativeArray, ivy.Container],

--- a/ivy/functional/backends/jax/experimental/layers.py
+++ b/ivy/functional/backends/jax/experimental/layers.py
@@ -404,6 +404,34 @@ def dropout1d(
         return x
 
 
+def dropout3d(
+    x: JaxArray,
+    prob: float,
+    /,
+    *,
+    training: bool = True,
+    data_format: str = "NDHWC",
+    out: Optional[JaxArray] = None,
+) -> JaxArray:
+    if training:
+        is_batched = len(x.shape) == 5
+        if data_format == "NCDHW":
+            perm = (0, 2, 3, 4, 1) if is_batched else (1, 2, 3, 0)
+            x = jnp.transpose(x, perm)
+        noise_shape = list(x.shape)
+        sl = slice(1,-1) if is_batched else slice(-1)
+        noise_shape[sl] = [1] * 3
+        _, rng_input = jax.random.split(RNG.key)
+        mask = jax.random.bernoulli(rng_input, 1 - prob, noise_shape)
+        res = jnp.where(mask, x / (1 - prob), 0)
+        if data_format == "NCDHW":
+            perm = (0, 4, 1, 2, 3) if is_batched else (3, 0, 1, 2)
+            res = jnp.transpose(res, perm)
+        return res
+    else:
+        return x
+
+
 def ifft(
     x: JaxArray,
     dim: int,

--- a/ivy/functional/backends/jax/experimental/layers.py
+++ b/ivy/functional/backends/jax/experimental/layers.py
@@ -15,13 +15,13 @@ from ivy.functional.ivy.layers import _handle_padding
 def _from_int_to_tuple(arg, dim):
     if isinstance(arg, int):
         return (arg,) * dim
-    if _check_if_iterable(arg) and len(arg) == 1:
+    if isinstance(arg, tuple) and len(arg) == 1:
         return (arg[0],) * dim
     return arg
 
 
 def general_pool(
-    inputs, init, reduce_fn, window_shape, strides, padding, dim, dilation=1, ceil_mode=True
+    inputs, init, reduce_fn, window_shape, strides, padding, dim, dilation, ceil_mode
 ):
     window_shape = _from_int_to_tuple(window_shape, dim)
     strides = _from_int_to_tuple(strides, dim)
@@ -199,7 +199,7 @@ def avg_pool1d(
     if len(div_shape) - 2 == len(kernel):
         div_shape = (1,) + div_shape[1:]
     res = res / general_pool(
-        jnp.ones(div_shape, dtype=res.dtype), 0.0, jlax.add, kernel, strides, padding,1
+        jnp.ones(div_shape, dtype=res.dtype), 0.0, jlax.add, kernel, strides, padding
     )
     if data_format == "NCW":
         res = jnp.transpose(x, (0, 2, 1))
@@ -235,7 +235,7 @@ def avg_pool2d(
     if len(div_shape) - 2 == len(kernel):
         div_shape = (1,) + div_shape[1:]
     res = res / general_pool(
-        jnp.ones(div_shape, dtype=res.dtype), 0.0, jlax.add, kernel, strides, padding,2
+        jnp.ones(div_shape, dtype=res.dtype), 0.0, jlax.add, kernel, strides, padding
     )
     if data_format == "NCHW":
         return jnp.transpose(res, (0, 3, 1, 2))
@@ -269,7 +269,7 @@ def avg_pool3d(
     res = general_pool(x, 0.0, jlax.add, kernel, strides, padding, 3)
 
     res = res / general_pool(
-        jnp.ones_like(x, dtype=res.dtype), 0.0, jlax.add, kernel, strides, padding,3
+        jnp.ones_like(x, dtype=res.dtype), 0.0, jlax.add, kernel, strides, padding
     )
 
     if data_format == "NCDHW":

--- a/ivy/functional/backends/numpy/experimental/layers.py
+++ b/ivy/functional/backends/numpy/experimental/layers.py
@@ -564,6 +564,33 @@ def dropout1d(
         return x
 
 
+def dropout3d(
+    x: np.ndarray,
+    prob: float,
+    /,
+    *,
+    training: bool = True,
+    data_format: str = "NDHWC",
+    out: Optional[np.ndarray] = None,
+) -> np.ndarray:
+    if training:
+        is_batched = len(x.shape) == 5
+        if data_format == "NCDHW":
+            perm = (0, 2, 3, 4, 1) if is_batched else (1, 2, 3, 0)
+            x = np.transpose(x, perm)
+        noise_shape = list(x.shape)
+        sl = slice(1,-1) if is_batched else slice(-1)
+        noise_shape[sl] = [1] * 3
+        mask = np.random.binomial(1, 1 - prob, noise_shape)
+        res = np.where(mask, x / (1 - prob), 0)
+        if data_format == "NCDHW":
+            perm = (0, 4, 1, 2, 3) if is_batched else (3, 0, 1, 2)
+            res = np.transpose(res, perm)
+        return res
+    else:
+        return x
+
+
 def ifft(
     x: np.ndarray,
     dim: int,

--- a/ivy/functional/backends/numpy/experimental/layers.py
+++ b/ivy/functional/backends/numpy/experimental/layers.py
@@ -579,7 +579,7 @@ def dropout3d(
             perm = (0, 2, 3, 4, 1) if is_batched else (1, 2, 3, 0)
             x = np.transpose(x, perm)
         noise_shape = list(x.shape)
-        sl = slice(1,-1) if is_batched else slice(-1)
+        sl = slice(1, -1) if is_batched else slice(-1)
         noise_shape[sl] = [1] * 3
         mask = np.random.binomial(1, 1 - prob, noise_shape)
         res = np.where(mask, x / (1 - prob), 0)

--- a/ivy/functional/backends/tensorflow/experimental/layers.py
+++ b/ivy/functional/backends/tensorflow/experimental/layers.py
@@ -305,6 +305,32 @@ def dropout1d(
         return x
 
 
+def dropout3d(
+    x: Union[tf.Tensor, tf.Variable],
+    prob: float,
+    /,
+    *,
+    training: bool = True,
+    data_format: str = "NDHWC",
+    out: Optional[Union[tf.Tensor, tf.Variable]] = None,
+) -> Union[tf.Tensor, tf.Variable]:
+    if training:
+        is_batched = len(x.shape) == 5
+        if data_format == "NCDHW":
+            perm = (0, 2, 3, 4, 1) if is_batched else (1, 2, 3, 0)
+            x = tf.transpose(x, perm)
+        noise_shape = list(x.shape)
+        sl = slice(1,-1) if is_batched else slice(-1)
+        noise_shape[sl] = [1] * 3
+        res = tf.nn.dropout(x, prob, noise_shape=noise_shape)
+        if data_format == "NCDHW":
+            perm = (0, 4, 1, 2, 3) if is_batched else (3, 0, 1, 2)
+            res = tf.transpose(res, perm)
+        return res
+    else:
+        return x
+
+
 def ifft(
     x: Union[tf.Tensor, tf.Variable],
     dim: int,

--- a/ivy/functional/backends/tensorflow/experimental/layers.py
+++ b/ivy/functional/backends/tensorflow/experimental/layers.py
@@ -320,7 +320,7 @@ def dropout3d(
             perm = (0, 2, 3, 4, 1) if is_batched else (1, 2, 3, 0)
             x = tf.transpose(x, perm)
         noise_shape = list(x.shape)
-        sl = slice(1,-1) if is_batched else slice(-1)
+        sl = slice(1, -1) if is_batched else slice(-1)
         noise_shape[sl] = [1] * 3
         res = tf.nn.dropout(x, prob, noise_shape=noise_shape)
         if data_format == "NCDHW":

--- a/ivy/functional/ivy/experimental/layers.py
+++ b/ivy/functional/ivy/experimental/layers.py
@@ -666,6 +666,55 @@ def dropout1d(
     )
 
 
+@handle_nestable
+@handle_exceptions
+@to_native_arrays_and_back
+@handle_array_like_without_promotion
+def dropout3d(
+    x: Union[ivy.Array, ivy.NativeArray],
+    prob: float,
+    /,
+    *,
+    training: bool = True,
+    data_format: str = "NDHWC",
+    out: Optional[ivy.Array] = None,
+) -> ivy.Array:
+    """Randomly zero out entire channels with probability prob using samples from
+     a Bernoulli distribution and the remaining channels are scaled by (1/1-prob).
+     In this case, dropout3d performs a channel-wise dropout but assumes
+     a channel is a 1D feature map.
+
+    Parameters
+    ----------
+    x
+        a 4D or 5D input array. Should have a floating-point data type.
+    prob
+        probability of a channel to be zero-ed.
+    training
+        controls whether dropout3d is performed during training or ignored
+        during testing.
+    data_format
+        "NDHWC" or "NCDHW". Defaults to "NDHWC".
+    out
+        optional output array, for writing the result to.
+        It must have a shape that the inputs broadcast to.
+
+    Returns
+    -------
+    ret
+        an array with some channels zero-ed and the rest of channels are
+         scaled by (1/1-prob).
+
+    Both the description and the type hints above assumes an array input for simplicity,
+    but this function is *nestable*, and therefore also accepts :class:`ivy.Container`
+    instances in place of any of the arguments.
+
+    """
+    return ivy.current_backend(x).dropout3d(
+        x, prob, training=training, data_format=data_format, out=out
+    )
+
+
 @to_native_arrays_and_back
 @handle_out_argument
 @handle_exceptions

--- a/ivy_tests/test_docstrings.py
+++ b/ivy_tests/test_docstrings.py
@@ -262,6 +262,7 @@ def test_docstrings(backend):
         "deserialize",
         "dropout",
         "dropout1d",
+        "dropout3d",
     ]
     # the temp skip list consists of functions which have an issue with their
     # implementation
@@ -283,6 +284,7 @@ def test_docstrings(backend):
         "slogdet",
         "dropout",
         "dropout1d",
+        "dropout3",
     ]
     # currently_being_worked_on = ["layer_norm"]
 

--- a/ivy_tests/test_ivy/test_functional/test_experimental/test_nn/test_layers.py
+++ b/ivy_tests/test_ivy/test_functional/test_experimental/test_nn/test_layers.py
@@ -441,6 +441,57 @@ def test_dropout1d(
         assert u.shape == v.shape == w.shape
 
 
+@handle_test(
+    fn_tree="functional.ivy.experimental.dropout3d",
+    dtype_and_x=helpers.dtype_and_values(
+        available_dtypes=helpers.get_dtypes("float"),
+        min_value=0,
+        max_value=50,
+        allow_inf=False,
+        min_num_dims=4,
+        max_num_dims=5,
+        min_dim_size=1,
+        max_dim_size=5,
+    ),
+    prob=helpers.floats(min_value=0, max_value=0.9),
+    training=st.booleans(),
+    data_format=st.sampled_from(["NCDHW", "NDHWC"]),
+    test_gradients=st.just(False),
+    test_with_out=st.just(False),
+)
+def test_dropout3d(
+    *,
+    dtype_and_x,
+    prob,
+    training,
+    data_format,
+    test_flags,
+    backend_fw,
+    on_device,
+    fn_name,
+    ground_truth_backend,
+):
+    dtype, x = dtype_and_x
+    ret, gt_ret = helpers.test_function(
+        ground_truth_backend=ground_truth_backend,
+        input_dtypes=dtype,
+        test_flags=test_flags,
+        fw=backend_fw,
+        fn_name=fn_name,
+        test_values=False,
+        x=x[0],
+        prob=prob,
+        training=training,
+        data_format=data_format,
+        return_flat_np_arrays=True,
+    )
+    ret = helpers.flatten_and_to_np(ret=ret)
+    gt_ret = helpers.flatten_and_to_np(ret=gt_ret)
+    for u, v, w in zip(ret, gt_ret, x):
+        # cardinality test
+        assert u.shape == v.shape == w.shape
+
+
 @st.composite
 def x_and_ifft(draw):
     min_fft_points = 2


### PR DESCRIPTION
add: dropout3d has been implemented from scratch for all backends except for tensorflow:

  -torch\experimental\layers.py:
       Generated a Bernoulli samples from uniform with the appropriate noise_shape which is then passed as a mask to np.where for efficiency.

  -tensorflow\experimental\layers.py:
      Used the noise_shape argument in tf.nn.dropout to perform a channel-wise dropout.

  -numpy\experimental\layers.py:
       Generated a Bernoulli samples with the appropriate noise_shape which is then passed as a mask to np.where for efficiency.

  -jax\experimental\layers.py:
       Similar to numpy.

and:functional\ivy\layers.py
    calls ivy.current_backend

add:ivy\array\layers.py, ivy\container\layers.py
    instance method support

add:ivy\array\layers.py, ivy\container\layers.py
    instance method support

add: test_ivy\test_docstrings.py
    added to skiplist since output is dependent on external factors.