### PR TITLE
Added _init_overload param to frontend torch.Tensor and numpy.ndarray

### DIFF
--- a/ivy/functional/frontends/numpy/func_wrapper.py
+++ b/ivy/functional/frontends/numpy/func_wrapper.py
@@ -263,9 +263,7 @@ def _numpy_frontend_to_ivy(x: Any) -> Any:
 
 def _ivy_to_numpy(x: Any) -> Any:
     if isinstance(x, ivy.Array) or ivy.is_native_array(x):
-        a = ndarray(
-            x, _init_overload=True
-        )  # TODO Find better initialisation workaround
+        a = ndarray(x, _init_overload=True)
         return a
     else:
         return x

--- a/ivy/functional/frontends/numpy/func_wrapper.py
+++ b/ivy/functional/frontends/numpy/func_wrapper.py
@@ -263,8 +263,9 @@ def _numpy_frontend_to_ivy(x: Any) -> Any:
 
 def _ivy_to_numpy(x: Any) -> Any:
     if isinstance(x, ivy.Array) or ivy.is_native_array(x):
-        a = ndarray(0)  # TODO Find better initialisation workaround
-        a.ivy_array = x
+        a = ndarray(
+            x, _init_overload=True
+        )  # TODO Find better initialisation workaround
         return a
     else:
         return x

--- a/ivy/functional/frontends/numpy/ndarray/ndarray.py
+++ b/ivy/functional/frontends/numpy/ndarray/ndarray.py
@@ -6,10 +6,17 @@ import ivy.functional.frontends.numpy as np_frontend
 
 
 class ndarray:
-    def __init__(self, shape, dtype="float32", order=None):
+    def __init__(self, shape, dtype="float32", order=None, _init_overload=False):
         if isinstance(dtype, np_frontend.dtype):
             dtype = dtype.ivy_dtype
-        self._ivy_array = ivy.empty(shape, dtype=dtype)
+
+        # in thise case shape is actually the desired array
+        if _init_overload:
+            self._ivy_array = (
+                ivy.array(shape) if not isinstance(shape, ivy.Array) else shape
+            )
+        else:
+            self._ivy_array = ivy.empty(shape, dtype=dtype)
 
         ivy.assertions.check_elem_in_list(
             order,

--- a/ivy/functional/frontends/torch/func_wrapper.py
+++ b/ivy/functional/frontends/torch/func_wrapper.py
@@ -19,9 +19,7 @@ def _from_ivy_array_to_torch_frontend_tensor(x, nested=False, include_derived=No
             x, _from_ivy_array_to_torch_frontend_tensor, include_derived, shallow=False
         )
     elif isinstance(x, ivy.Array) or ivy.is_native_array(x):
-        a = torch_frontend.Tensor(
-            x, _init_overload=True
-        )  # TODO: Find better initialisation workaround
+        a = torch_frontend.Tensor(x, _init_overload=True)
         return a
     return x
 

--- a/ivy/functional/frontends/torch/func_wrapper.py
+++ b/ivy/functional/frontends/torch/func_wrapper.py
@@ -19,8 +19,10 @@ def _from_ivy_array_to_torch_frontend_tensor(x, nested=False, include_derived=No
             x, _from_ivy_array_to_torch_frontend_tensor, include_derived, shallow=False
         )
     elif isinstance(x, ivy.Array) or ivy.is_native_array(x):
-        a = torch_frontend.Tensor(0)  # TODO: Find better initialisation workaround
-        a.ivy_array = x
+        a = torch_frontend.Tensor(
+            x, _init_overload=True
+        )  # TODO: Find better initialisation workaround
+        # a.ivy_array = x
         return a
     return x
 

--- a/ivy/functional/frontends/torch/func_wrapper.py
+++ b/ivy/functional/frontends/torch/func_wrapper.py
@@ -22,7 +22,6 @@ def _from_ivy_array_to_torch_frontend_tensor(x, nested=False, include_derived=No
         a = torch_frontend.Tensor(
             x, _init_overload=True
         )  # TODO: Find better initialisation workaround
-        # a.ivy_array = x
         return a
     return x
 

--- a/ivy/functional/frontends/torch/tensor.py
+++ b/ivy/functional/frontends/torch/tensor.py
@@ -8,10 +8,15 @@ from ivy.func_wrapper import with_unsupported_dtypes
 
 
 class Tensor:
-    def __init__(self, array, device=None):
-        self._ivy_array = ivy.asarray(
-            array, dtype=torch_frontend.float32, device=device
-        )
+    def __init__(self, array, device=None, _init_overload=False):
+
+        if _init_overload:
+            self._ivy_array = ivy.asarray(array, device=device)
+
+        else:
+            self._ivy_array = ivy.asarray(
+                array, dtype=torch_frontend.float32, device=device
+            )
 
     def __repr__(self):
         return str(self._ivy_array.__repr__()).replace(

--- a/ivy/functional/frontends/torch/tensor.py
+++ b/ivy/functional/frontends/torch/tensor.py
@@ -11,7 +11,9 @@ class Tensor:
     def __init__(self, array, device=None, _init_overload=False):
 
         if _init_overload:
-            self._ivy_array = ivy.asarray(array, device=device)
+            self._ivy_array = (
+                ivy.array(array) if not isinstance(array, ivy.Array) else array
+            )
 
         else:
             self._ivy_array = ivy.asarray(


### PR DESCRIPTION
this allows us to create tensors/arrays with ivy_torch.tensor/ivy_numpy.array or ivy_torch.Tensor/ivy_numpy.ndarray efficiently, if we use tensor/array, _init_overload will be set to True and the tensor returned will be of the same data type as the underlying ivy array, otherwise, the default behavior of Tensor (returning float32 tensors) or ndarray (accepting shapes instead of arrays) will be set.