### PR TITLE
fix frontends.torch.{h,v,d}split

### DIFF
--- a/ivy/functional/frontends/torch/indexing_slicing_joining_mutating_ops.py
+++ b/ivy/functional/frontends/torch/indexing_slicing_joining_mutating_ops.py
@@ -215,18 +215,40 @@ def split(tensor, split_size_or_sections, dim=0):
     )
 
 
+def _get_indices_or_sections(indices_or_sections, indices, sections):
+    if not indices_or_sections:
+        if isinstance(indices_or_sections, (list, tuple)):
+            pass
+        elif indices and not sections:
+            indices_or_sections = indices
+        elif sections and not indices:
+            indices_or_sections = sections
+        else:
+            raise TypeError("got invalid argument for indices_or_sections")
+    return indices_or_sections
+
+
 @to_ivy_arrays_and_back
-def dsplit(input, indices_or_sections):
+def dsplit(input, indices_or_sections=None, /, *, indices=None, sections=None):
+    indices_or_sections = _get_indices_or_sections(
+        indices_or_sections, indices, sections
+    )
     return tuple(ivy.dsplit(input, indices_or_sections))
 
 
 @to_ivy_arrays_and_back
-def hsplit(input, indices_or_sections):
+def hsplit(input, indices_or_sections=None, /, *, indices=None, sections=None):
+    indices_or_sections = _get_indices_or_sections(
+        indices_or_sections, indices, sections
+    )
     return tuple(ivy.hsplit(input, indices_or_sections))
 
 
 @to_ivy_arrays_and_back
-def vsplit(input, indices_or_sections):
+def vsplit(input, indices_or_sections=None, /, *, indices=None, sections=None):
+    indices_or_sections = _get_indices_or_sections(
+        indices_or_sections, indices, sections
+    )
     return tuple(ivy.vsplit(input, indices_or_sections))
 
 

--- a/ivy/functional/frontends/torch/indexing_slicing_joining_mutating_ops.py
+++ b/ivy/functional/frontends/torch/indexing_slicing_joining_mutating_ops.py
@@ -216,15 +216,15 @@ def split(tensor, split_size_or_sections, dim=0):
 
 
 def _get_indices_or_sections(indices_or_sections, indices, sections):
-    if not indices_or_sections:
-        if isinstance(indices_or_sections, (list, tuple)):
-            pass
-        elif indices and not sections:
+    if not isinstance(indices_or_sections, (list, tuple, int)):
+        if indices and not sections:
             indices_or_sections = indices
         elif sections and not indices:
             indices_or_sections = sections
         else:
-            raise TypeError("got invalid argument for indices_or_sections")
+            raise ivy.utils.exception.IvyError(
+                "got invalid argument for indices_or_sections"
+            )
     return indices_or_sections
 
 

--- a/ivy/functional/frontends/torch/indexing_slicing_joining_mutating_ops.py
+++ b/ivy/functional/frontends/torch/indexing_slicing_joining_mutating_ops.py
@@ -217,9 +217,9 @@ def split(tensor, split_size_or_sections, dim=0):
 
 def _get_indices_or_sections(indices_or_sections, indices, sections):
     if not ivy.exists(indices_or_sections):
-        if indices and not sections:
+        if ivy.exists(indices) and not ivy.exists(sections):
             indices_or_sections = indices
-        elif sections and not indices:
+        elif ivy.exists(sections) and not ivy.exists(indices):
             indices_or_sections = sections
         else:
             raise ivy.utils.exception.IvyError(

--- a/ivy/functional/frontends/torch/indexing_slicing_joining_mutating_ops.py
+++ b/ivy/functional/frontends/torch/indexing_slicing_joining_mutating_ops.py
@@ -216,7 +216,7 @@ def split(tensor, split_size_or_sections, dim=0):
 
 
 def _get_indices_or_sections(indices_or_sections, indices, sections):
-    if not isinstance(indices_or_sections, (list, tuple, int)):
+    if not ivy.exists(indices_or_sections):
         if indices and not sections:
             indices_or_sections = indices
         elif sections and not indices:


### PR DESCRIPTION
Apparently, unlike what [the docs](https://pytorch.org/docs/1.11/generated/torch.hsplit.html) state:
> torch.hsplit(input, indices_or_sections) → List of Tensors

these calls are all valid:
```python
a = torch.tensor([1, 2])
torch.hsplit(a, 1)
torch.hsplit(a, indices=[1])
torch.hsplit(a, sections=1)
```