### PR TITLE
Fix typo and delete old reference in setting up docs

### DIFF
--- a/docs/partial_source/contributing/setting_up.rst
+++ b/docs/partial_source/contributing/setting_up.rst
@@ -416,7 +416,7 @@ For questions, please reach out on `discord`_ in the `docker channel`_!
 
 **"Empty Suite" error fix:**
 
-Click on the "green arrow button" from where you run the funcion in PyCharm. Open "Modify Run Configuration...", under "Target:" on the right side click on "..." it'll open a new window, manually add the path to the specific function, For instance, for stateful -> "test_stateful.test_submodule_name.test_function_name" and for functional -> "test_submodule_name.test_function_name", the function will pop up below, select that, click on "Apply" then "OK". Now, do not run the test from the "green arrow button" in the left panel, run it from above where there is a "green arrow button" on the left side of the "debugger button" making sure you've selected the latest modified configuration of that specific test you want to run.
+Click on the "green arrow button" from where you run the function in PyCharm. Open "Modify Run Configuration...", under "Target:" on the right side click on "..." it'll open a new window, manually add the path to the specific function, For instance, for stateful -> "test_stateful.test_submodule_name.test_function_name" and for functional -> "test_submodule_name.test_function_name", the function will pop up below, select that, click on "Apply" then "OK". Now, do not run the test from the "green arrow button" in the left panel, run it from above where there is a "green arrow button" on the left side of the "debugger button" making sure you've selected the latest modified configuration of that specific test you want to run.
 
 Setting up for Free
 -------------------

--- a/docs/partial_source/contributing/setting_up.rst
+++ b/docs/partial_source/contributing/setting_up.rst
@@ -412,8 +412,7 @@ Now, if Hypothesis detects an error in the code it will return more detailed inf
 .. image:: https://raw.githubusercontent.com/unifyai/unifyai.github.io/master/img/externally_linked/contributing/setting_up/more_detailed_hypothesis_logs/detailed_hypothesis_example.png?raw=true
    :width: 420
 
-For questions, please reach out on the `setting up discussion`_
-or on `discord`_ in the `docker channel`_!
+For questions, please reach out on `discord`_ in the `docker channel`_!
 
 **"Empty Suite" error fix:**
 


### PR DESCRIPTION
I split the two small changes into two commits (they are very small, but I saw that small commits were preferred) if a fast forward merge is preferred, otherwise a squash would work.

Note: the `setting up discussion` (which was added in [this](https://github.com/unifyai/ivy/commit/a4946054e4520ade91cd175313e92a00294714d5) commit) in the past linked to https://github.com/unifyai/ivy/discussions/1308, which now leads to 404 error website right now, but now `setting up discussion`  leads to nothing. Hence I am just removing it. Please let me know if there is new discussion.