### PR TITLE
Frontend numpy.matrix.sum api and test.

### DIFF
--- a/ivy/functional/frontends/numpy/matrix/methods.py
+++ b/ivy/functional/frontends/numpy/matrix/methods.py
@@ -8,6 +8,7 @@ from ivy.functional.frontends.numpy import (
     argmax,
     any,
     ndarray,
+    sum,
 )
 
 
@@ -117,3 +118,8 @@ class matrix:
         if ivy.exists(axis):
             return any(self.A, axis=axis, keepdims=True, out=out)
         return any(self.A, axis=axis, out=out)
+
+    def sum(self, axis=None, dtype=None, out=None):
+        """Returns the sum of the matrix elements, along the given axis."""
+
+        return sum(self.A, axis=axis, dtype=dtype, out=out)

--- a/ivy_tests/test_ivy/test_frontends/test_numpy/test_matrix/test_methods.py
+++ b/ivy_tests/test_ivy/test_frontends/test_numpy/test_matrix/test_methods.py
@@ -179,11 +179,55 @@ def test_numpy_matrix_argmax(
 
 # any
 @handle_frontend_method(
+        class_tree=CLASS_TREE,
+        init_tree="numpy.matrix",
+        method_name="any",
+        dtype_x_axis=helpers.dtype_values_axis(
+                available_dtypes=helpers.get_dtypes("numeric"),
+                min_num_dims=2,
+                max_num_dims=2,
+                min_dim_size=2,
+                valid_axis=True,
+                force_int_axis=True,
+                allow_neg_axes=False,
+        ),
+        to_str=st.booleans(),
+)
+def test_numpy_matrix_any(
+        dtype_x_axis,
+        to_str,
+        init_flags,
+        method_flags,
+        frontend_method_data,
+        frontend,
+):
+    input_dtype, x, axis = dtype_x_axis
+    x = _get_x_matrix(x, to_str)
+    if isinstance(axis, tuple):
+        axis = axis[0]
+    helpers.test_frontend_method(
+            init_input_dtypes=input_dtype,
+            init_flags=init_flags,
+            method_flags=method_flags,
+            init_all_as_kwargs_np={
+                    "data": x,
+                    "dtype": input_dtype[0],
+            },
+            method_input_dtypes=[],
+            method_all_as_kwargs_np={
+                    "axis": axis,
+            },
+            frontend=frontend,
+            frontend_method_data=frontend_method_data,
+    )
+
+# sum
+@handle_frontend_method(
     class_tree=CLASS_TREE,
     init_tree="numpy.matrix",
-    method_name="any",
+    method_name="sum",
     dtype_x_axis=helpers.dtype_values_axis(
-        available_dtypes=helpers.get_dtypes("numeric"),
+        available_dtypes=helpers.get_dtypes("numeric", full=True),
         min_num_dims=2,
         max_num_dims=2,
         min_dim_size=2,
@@ -191,20 +235,24 @@ def test_numpy_matrix_argmax(
         force_int_axis=True,
         allow_neg_axes=False,
     ),
+    dtype=helpers.get_dtypes("numeric", full=False, none=True),
     to_str=st.booleans(),
 )
-def test_numpy_matrix_any(
+def test_numpy_matrix_sum(
     dtype_x_axis,
     to_str,
     init_flags,
     method_flags,
     frontend_method_data,
     frontend,
+    dtype,
 ):
     input_dtype, x, axis = dtype_x_axis
     x = _get_x_matrix(x, to_str)
+
     if isinstance(axis, tuple):
         axis = axis[0]
+
     helpers.test_frontend_method(
         init_input_dtypes=input_dtype,
         init_flags=init_flags,
@@ -216,7 +264,9 @@ def test_numpy_matrix_any(
         method_input_dtypes=[],
         method_all_as_kwargs_np={
             "axis": axis,
+            "dtype": dtype[0],
         },
         frontend=frontend,
+        on_device='numpy',
         frontend_method_data=frontend_method_data,
     )


### PR DESCRIPTION
- [] #6620
Close https://github.com/unifyai/ivy/issues/6620

I have implemented matrix method `sum`, but tests are not passing correctly.

Both methods (frontend and backend) return big integers, while dtype passed was `uint8`. I am confused about what should I do here.
```
E       AssertionError: the ground truth framework numpy returned a uint32 datatype while the backend numpy returned a int32 datatype
E       Falsifying example: test_numpy_matrix_sum(
E           dtype_x_axis=(['uint8'], [array([[0, 0],
E                    [0, 0]], dtype=uint8)], 0),
E           to_str=False,
E           init_flags=FrontendMethodTestFlags(
E               num_positional_args=0,
E               as_variable=[False],
E               native_arrays=[False],
E           ),
E           method_flags=FrontendMethodTestFlags(
E               num_positional_args=0,
E               as_variable=[False],
E               native_arrays=[False],
E           ),
E           frontend_method_data=FrontendMethodData(ivy_init_module=<module 'ivy.functional.frontends.numpy' from 'P:\\LocalPrograms\\repos\\ivy\\ivy\\functional\\frontends\\numpy\\__init__.py'>, framework_init_module=<module 'numpy' from 'C:\\Users\\Greg\\anaconda3\\envs\\ivy\\lib\\site-packages\\numpy\\__init__.py'>, init_name='matrix', method_name='sum'),
E           frontend='numpy',
E       )
E       
E       You can reproduce this example by temporarily adding @reproduce_failure('6.68.2', b'AXicY2bAAgAAVAAE') as a decorator on your test case
```