### PR TITLE
feat: implement paddle unique_inverse function

### DIFF
--- a/ivy/functional/backends/paddle/set.py
+++ b/ivy/functional/backends/paddle/set.py
@@ -1,6 +1,5 @@
 # global
 import paddle
-import paddle.fluid as fluid
 from typing import Tuple, Optional
 from collections import namedtuple
 from ivy.func_wrapper import with_unsupported_dtypes
@@ -37,7 +36,8 @@ def unique_counts(x: paddle.Tensor, /) -> Tuple[paddle.Tensor, paddle.Tensor]:
 
 
 @with_unsupported_dtypes(
-    {"2.4.2 and below": ("int8", "int16", "uint8", "uint16", "bfloat16", "float16", "float32", "float64", "bool")},
+    {"2.4.2 and below": ("int8", "int16", "uint8", "uint16", "bfloat16",
+                         "float16", "complex64", "complex128", "bool")},
     backend_version,
 )
 def unique_inverse(x: paddle.Tensor, /) -> Tuple[paddle.Tensor, paddle.Tensor]:
@@ -48,8 +48,8 @@ def unique_inverse(x: paddle.Tensor, /) -> Tuple[paddle.Tensor, paddle.Tensor]:
     if nan_count > 0:
         inverse_val[nan_idx] = len(unique)
         unique_nan = paddle.full(shape=[1, nan_count], fill_value=float('nan')).cast(x.dtype)
-        unique = fluid.layers.concat(input=[unique.astype(x.dtype), paddle.reshape(unique_nan, [nan_count])], axis=0)
-
+        unique = paddle.concat(input=[unique.astype(x.dtype), paddle.reshape(unique_nan, [nan_count])], axis=-1)
+    inverse_val = paddle.reshape(inverse_val, shape=x.shape)
     Results = namedtuple("Results", ["values", "inverse_indices"])
     return Results(unique, inverse_val)
 

--- a/ivy/functional/backends/paddle/set.py
+++ b/ivy/functional/backends/paddle/set.py
@@ -1,8 +1,10 @@
 # global
 import paddle
+import paddle.fluid as fluid
 from typing import Tuple, Optional
 from collections import namedtuple
 from ivy.func_wrapper import with_unsupported_dtypes
+
 # local
 
 from . import backend_version
@@ -34,8 +36,22 @@ def unique_counts(x: paddle.Tensor, /) -> Tuple[paddle.Tensor, paddle.Tensor]:
     return Results(unique, counts)
 
 
+@with_unsupported_dtypes(
+    {"2.4.2 and below": ("int8", "int16", "uint8", "uint16", "bfloat16", "float16", "float32", "float64", "bool")},
+    backend_version,
+)
 def unique_inverse(x: paddle.Tensor, /) -> Tuple[paddle.Tensor, paddle.Tensor]:
-    raise IvyNotImplementedException()
+    unique, inverse_val = paddle.unique(x, return_inverse=True)
+    nan_idx = paddle.where(paddle.isnan(x) > 0)
+    nan_count = paddle.count_nonzero(nan_idx).numpy()[0]
+
+    if nan_count > 0:
+        inverse_val[nan_idx] = len(unique)
+        unique_nan = paddle.full(shape=[1, nan_count], fill_value=float('nan')).cast(x.dtype)
+        unique = fluid.layers.concat(input=[unique.astype(x.dtype), paddle.reshape(unique_nan, [nan_count])], axis=0)
+
+    Results = namedtuple("Results", ["values", "inverse_indices"])
+    return Results(unique, inverse_val)
 
 
 def unique_values(


### PR DESCRIPTION
Implement function on #11593  task 3 unique_inverse

Hello @MahmoudAshraf97, I implemented unique_inverse function for paddle. Would you mind checking it whether I done it correctly again?
I tried the paddle functional paddle.concat() but it created error when I was trying to concat Tensor with nan, so I used paddle.fluid.layers again... If it is still okay to use just paddle functional please let me know!

I tested sample input from ivy docs https://lets-unify.ai/ivy/functional/ivy/set.html.
https://colab.research.google.com/drive/11sn3kxh5DbaZ19Phj_h78X5IPTkS264M?usp=sharing

Thank you!