### PR TITLE
Corrected 2nd Typo

### DIFF
--- a/docs/partial_source/deep_dive/ivy_frontends_tests.rst
+++ b/docs/partial_source/deep_dive/ivy_frontends_tests.rst
@@ -158,7 +158,7 @@ ivy.tan()
 * NumPy has an optional argument :code:`where` which is generated using :func:`np_frontend_helpers.where`.
 * Using :func:`np_frontend_helpers.handle_where_and_array_bools` we do some processing on the generated :code:`where` value.
 * Instead of :func:`helpers.test_frontend_function` we use :func:`np_frontend_helpers.test_frontend_function` which behaves the same but has some extra code to handle the :code:`where` argument.
-* :code:`casting`, :code:`order`, :code:`subok` and are other other optional arguments for :func:`numpy.tan`.
+* :code:`casting`, :code:`order`, :code:`subok` and other are optional arguments for :func:`numpy.tan`.
 
 **TensorFlow**
 


### PR DESCRIPTION
Corrected 2nd Typo on 
DeepDive-> ivy_frontends_tests page

![chrome_fdeIXgUuAo](https://user-images.githubusercontent.com/22115102/222954258-c7ad3039-64f5-4264-965d-064fe7f6dbff.png)
https://lets-unify.ai/ivy/deep_dive/ivy_frontends_tests.html