### PR TITLE
Fix `ivy.functional.ivy` import

### DIFF
--- a/ivy/__init__.py
+++ b/ivy/__init__.py
@@ -713,6 +713,8 @@ from .utils import assertions, exceptions, verbosity
 from .utils.backend import handler
 from . import functional
 from .functional import *
+from . import alias
+from .alias import *
 from . import stateful
 from .stateful import *
 from ivy.utils.inspection import fn_array_spec, add_array_specs

--- a/ivy/alias/__init__.py
+++ b/ivy/alias/__init__.py
@@ -1,0 +1,2 @@
+# flake8: noqa
+from .ivy import *

--- a/ivy/alias/ivy/__init__.py
+++ b/ivy/alias/ivy/__init__.py
@@ -1,0 +1,3 @@
+# flake8: noqa
+from . import activation
+from .activation import *

--- a/ivy/alias/ivy/activation.py
+++ b/ivy/alias/ivy/activation.py
@@ -1,0 +1,5 @@
+import ivy
+
+
+def test():
+    print(ivy.__version__)


### PR DESCRIPTION
This PR is demonstration of the alias problem, it's not intended to  be merged.

The results of adding the PR code is similar to the `ivy.functional.ivy` import problem:
```python
>>> ivy
<module 'ivy' from '/home/root/project/ivy/__init__.py'>
>>> ivy.alias
<module 'ivy.alias' from '/home/root/project/ivy/alias/__init__.py'>
>>> ivy.alias.ivy
<module 'ivy' from '/home/root/project/ivy/__init__.py'>
```