### PR TITLE
Fix `ivy.functional.ivy` import

### DIFF
--- a/ivy/__init__.py
+++ b/ivy/__init__.py
@@ -4,6 +4,7 @@ import warnings
 from ivy._version import __version__ as __version__
 import builtins
 import numpy as np
+import sys
 
 
 warnings.filterwarnings("ignore", module="^(?!.*ivy).*$")

--- a/ivy/functional/ivy/__init__.py
+++ b/ivy/functional/ivy/__init__.py
@@ -43,3 +43,11 @@ from . import utility
 from .utility import *
 from . import control_flow_ops
 from .control_flow_ops import *
+import types
+
+__all__ = [
+    name
+    for name, thing in globals().items()
+    if not (name.startswith("_") or isinstance(thing, types.ModuleType))
+]
+del types

--- a/ivy/functional/ivy/experimental/__init__.py
+++ b/ivy/functional/ivy/experimental/__init__.py
@@ -21,3 +21,11 @@ from .sorting import *
 from .statistical import *
 from .sparse_array import *
 from .utility import *
+import types
+
+__all__ = [
+    name
+    for name, thing in globals().items()
+    if not (name.startswith("_") or isinstance(thing, types.ModuleType))
+]
+del types


### PR DESCRIPTION
[Trello task](https://trello.com/c/i8fyJEyf/1384-fix-ivyfunctionalivyimport)
Using `__all__` prevents builtin libraries and root ivy when importing subpackages. This PR also found out that `sys` was not imported from `ivy/__init__.py`, but was imported accidentally when using `from .functional import *`.

If we don't want to prevent builtin libraries from polluting ivy namespace, we can tweak the condition to `if not (name.startswith("_") or name == "ivy")`