### PR TITLE
Fix the Import behaviour of nvidia-ml-py ( pynvml )

### DIFF
--- a/ivy/functional/ivy/device.py
+++ b/ivy/functional/ivy/device.py
@@ -6,11 +6,16 @@ import gc
 import abc
 import math
 import psutil
-import pynvml
+
 import types
 from typing import Type, Optional, Tuple
 
 # noinspection PyUnresolvedReferences
+try:
+    import pynvml
+except ImportError:
+    # nvidia-ml-py (pynvml) is not installed in CPU Dockerfile.
+    pass
 try:
     pynvml.nvmlInit()
 except pynvml.NVMLError:
@@ -81,10 +86,12 @@ class DefaultDevice:
         ivy.set_default_device(self._dev)
         return self
 
-    def __exit__(self,
-                 exc_type: Optional[Type[BaseException]],
-                 exc_val: Optional[Type[BaseException]],
-                 exc_tb: Optional[types.TracebackType]) -> Union[ivy.Device, str]:
+    def __exit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_val: Optional[Type[BaseException]],
+        exc_tb: Optional[types.TracebackType],
+    ) -> Union[ivy.Device, str]:
         """
         Exit the runtime context related to the specified device.
 

--- a/ivy/functional/ivy/device.py
+++ b/ivy/functional/ivy/device.py
@@ -13,13 +13,19 @@ from typing import Type, Optional, Tuple
 # noinspection PyUnresolvedReferences
 try:
     import pynvml
+
+    pynvml_installed = True
 except ImportError:
     # nvidia-ml-py (pynvml) is not installed in CPU Dockerfile.
+    pynvml_installed = False
     pass
-try:
-    pynvml.nvmlInit()
-except pynvml.NVMLError:
-    pass
+
+if pynvml_installed:
+    try:
+        pynvml.nvmlInit()
+    except pynvml.NVMLError:
+        pass
+
 from typing import Union, Callable, Iterable, Any
 
 # local

--- a/ivy/functional/ivy/device.py
+++ b/ivy/functional/ivy/device.py
@@ -14,18 +14,13 @@ from typing import Type, Optional, Tuple
 try:
     import pynvml
 
-    pynvml_installed = True
-except ImportError:
-    # nvidia-ml-py (pynvml) is not installed in CPU Dockerfile.
-    pynvml_installed = False
-    pass
-
-if pynvml_installed:
     try:
         pynvml.nvmlInit()
     except pynvml.NVMLError:
         pass
-
+except ImportError:
+    # nvidia-ml-py (pynvml) is not installed in CPU Dockerfile.
+    pass
 from typing import Union, Callable, Iterable, Any
 
 # local

--- a/ivy/functional/ivy/device.py
+++ b/ivy/functional/ivy/device.py
@@ -6,7 +6,7 @@ import gc
 import abc
 import math
 import psutil
-
+import warnings
 import types
 from typing import Type, Optional, Tuple
 
@@ -19,8 +19,11 @@ try:
     except pynvml.NVMLError:
         pass
 except ImportError:
+    warnings.warn(
+        "Unable to import pynvml, please install if you are using GPU with Ivy."
+    )
     # nvidia-ml-py (pynvml) is not installed in CPU Dockerfile.
-    pass
+
 from typing import Union, Callable, Iterable, Any
 
 # local

--- a/ivy_tests/test_ivy/test_functional/test_core/test_device.py
+++ b/ivy_tests/test_ivy/test_functional/test_core/test_device.py
@@ -7,6 +7,7 @@ import os
 import re
 import shutil
 import sys
+import warnings
 
 import numpy as np
 import psutil
@@ -15,8 +16,10 @@ from hypothesis import strategies as st, assume
 try:
     import pynvml
 except ImportError:
+    warnings.warn(
+        "Unable to import pynvml, please install if you are using GPU with Ivy."
+    )
     # nvidia-ml-py (pynvml) is not installed in CPU Dockerfile.
-    pass
 
 # local
 import ivy

--- a/ivy_tests/test_ivy/test_functional/test_core/test_device.py
+++ b/ivy_tests/test_ivy/test_functional/test_core/test_device.py
@@ -9,9 +9,14 @@ import shutil
 import sys
 
 import numpy as np
-import pynvml
 import psutil
 from hypothesis import strategies as st, assume
+
+try:
+    import pynvml
+except ImportError:
+    # nvidia-ml-py (pynvml) is not installed in CPU Dockerfile.
+    pass
 
 # local
 import ivy


### PR DESCRIPTION
This PR fixes the Import behaviour of `pynvml` to only be imported in case of GPU enabled environments.