### PR TITLE
functional: paddle.random: implement randint and random_uniform

### DIFF
--- a/ivy/functional/ivy/random.py
+++ b/ivy/functional/ivy/random.py
@@ -38,8 +38,8 @@ def _check_bounds_and_get_shape(low, high, shape):
         ivy.get_backend("jax").NativeArray,
         ivy.get_backend("numpy").NativeArray,
         ivy.get_backend("tensorflow").NativeArray,
+        ivy.get_backend("paddle").NativeArray,
     )
-
     if len(backend_stack) == 0:
         valid_types += (ivy.current_backend().NativeArray,)
     else:


### PR DESCRIPTION
Hi,
Implemented `randint` and `random_uniform` methods. 
I added `unsupported types` decorator since some `dtypes` had no supported comparison kernels in the package. I'm also reshaping the return value to better correspond with the input types (a scalar input without specifying shape, results in a scalar output).
Please do let me know of any suggestions and omissions. Thanks.