### PR TITLE
Bug fix no Numpy frontend prod on TensorFlow

### DIFF
--- a/ivy/functional/frontends/numpy/mathematical_functions/sums_products_differences.py
+++ b/ivy/functional/frontends/numpy/mathematical_functions/sums_products_differences.py
@@ -51,16 +51,19 @@ def prod(
     dtype=None,
     out=None,
     keepdims=False,
-    initial=ivy.nan,
+    initial=None,
     where=True,
 ):
     if ivy.is_array(where):
         x = ivy.where(where, x, ivy.default(out, ivy.ones_like(x)), out=out)
     if initial is not None:
-        s = ivy.shape(x, as_array=True)
-        s[axis] = 1
-        header = ivy.full(ivy.Shape(tuple(s)), initial)
-        x = ivy.concat([header, x], axis=axis)
+        if axis is not None:
+            s = ivy.to_list(ivy.shape(x, as_array=True))
+            s[axis] = 1
+            header = ivy.full(ivy.Shape(tuple(s)), initial)
+            x = ivy.concat([header, x], axis=axis)
+        else:
+            x[0] *= initial
     return ivy.prod(x, axis=axis, dtype=dtype, keepdims=keepdims, out=out)
 
 


### PR DESCRIPTION
Using the TensorFlow backend, `initial` not `None`, and `axis=-1` leads to an exception Example:
```
import ivy.functional.frontends.numpy as ivy_np
ivy.set_backend('tensorflow')
a =  ivy_np.array([[0, 0], [0, 0]], dtype='uint16')
prod = ivy_np.prod(a, axis=-1, dtype='uint16', keepdims=False)
```
This is because the indexing of TensorFlow tensors causes the `s[-1] = 1` instruction to collapse the shape. Additionally I made changes to avoid two other problems. First, setting `initial=ivy.nan` causes the product to be `nan` whenever `initial` is not passed to `prod`. Second, the code will fail when `initial` is specified, but `axis` is not.