### PR TITLE
Exploring and fixing support of device submodule functions on the GPU (First half)

### DIFF
--- a/ivy/functional/backends/jax/device.py
+++ b/ivy/functional/backends/jax/device.py
@@ -94,7 +94,7 @@ def as_native_dev(device, /):
     return jax.devices(device)[idx]
 
 
-def clear_mem_on_dev(device: str, /):
+def clear_cached_mem_on_dev(device: str, /):
     return None
 
 

--- a/ivy/functional/backends/numpy/device.py
+++ b/ivy/functional/backends/numpy/device.py
@@ -25,7 +25,7 @@ def as_native_dev(device: str, /):
     return "cpu"
 
 
-def clear_mem_on_dev(device: str, /):
+def clear_cached_mem_on_dev(device: str, /):
     return None
 
 

--- a/ivy/functional/backends/tensorflow/device.py
+++ b/ivy/functional/backends/tensorflow/device.py
@@ -72,7 +72,7 @@ def as_native_dev(device: str, /):
     return ret
 
 
-def clear_mem_on_dev(device: str, /):
+def clear_cached_mem_on_dev(device: str, /):
     return None
 
 

--- a/ivy/functional/backends/torch/device.py
+++ b/ivy/functional/backends/torch/device.py
@@ -66,8 +66,9 @@ def as_native_dev(
     return torch.device(ivy.Device(device).replace("gpu", "cuda"))
 
 
-def clear_mem_on_dev(device: torch.device, /):
-    if "gpu" in device:
+def clear_cached_mem_on_dev(device: Union[ivy.Device, torch.device], /) -> None:
+    torch_dev = as_native_dev(device)
+    if torch_dev.type == "cuda":
         torch.cuda.empty_cache()
 
 

--- a/ivy/functional/ivy/device.py
+++ b/ivy/functional/ivy/device.py
@@ -266,6 +266,7 @@ def print_all_ivy_arrays_on_dev(
 
 @handle_nestable
 @handle_exceptions
+@to_native_arrays_and_back
 def dev(
     x: Union[ivy.Array, ivy.NativeArray], /, *, as_native: bool = False
 ) -> Union[ivy.Device, ivy.NativeDevice]:
@@ -375,23 +376,23 @@ def as_native_dev(device: Union[ivy.Device, ivy.NativeDevice], /) -> ivy.NativeD
 
 
 @handle_exceptions
-def clear_mem_on_dev(device: Union[ivy.Device, ivy.NativeDevice], /) -> None:
+def clear_cached_mem_on_dev(device: Union[ivy.Device, ivy.NativeDevice], /) -> None:
     """Clear memory cache on target device.
 
     Parameters
     ----------
     device
-        The device string to convert to native device handle.
+        The device string to convert to native device handle or native device handle.
 
     Examples
     --------
     >>> import torch
     >>> ivy.set_backend("torch")
     >>> device = torch.device("cuda")
-    >>> ivy.clear_mem_on_dev(device)
+    >>> ivy.clear_cached_mem_on_dev(device)
 
     """
-    ivy.current_backend(None).clear_mem_on_dev(device)
+    ivy.current_backend().clear_cached_mem_on_dev(device)
 
 
 @handle_exceptions
@@ -471,13 +472,14 @@ def used_mem_on_dev(
     0.525205504
 
     """
-    ivy.clear_mem_on_dev(device)
+    ivy.clear_cached_mem_on_dev(device)
     if "gpu" in device:
-        ivy.utils.assertions.check_false(
-            process_specific,
-            "process-specific GPU queries are currently not supported",
-        )
         handle = _get_nvml_gpu_handle(device)
+        if process_specific:
+            pid = os.getpid()
+            for process in pynvml.nvmlDeviceGetComputeRunningProcesses(handle):
+                if process.pid == pid:
+                    return process.usedGpuMemory / 1e9
         info = pynvml.nvmlDeviceGetMemoryInfo(handle)
         return info.used / 1e9
     elif device == "cpu":
@@ -531,14 +533,15 @@ def percent_used_mem_on_dev(
     0.7095597456708771
 
     """
-    ivy.clear_mem_on_dev(device)
+    ivy.clear_cached_mem_on_dev(device)
     if "gpu" in device:
-        ivy.utils.assertions.check_false(
-            process_specific,
-            "process-specific GPU queries are currently not supported",
-        )
         handle = _get_nvml_gpu_handle(device)
         info = pynvml.nvmlDeviceGetMemoryInfo(handle)
+        if process_specific:
+            pid = os.getpid()
+            for process in pynvml.nvmlDeviceGetComputeRunningProcesses(handle):
+                if process.pid == pid:
+                    return (process.usedGpuMemory / info.total) * 100
         return (info.used / info.total) * 100
     elif device == "cpu":
         vm = psutil.virtual_memory()

--- a/ivy_tests/test_ivy/test_functional/test_core/test_device.py
+++ b/ivy_tests/test_ivy/test_functional/test_core/test_device.py
@@ -26,6 +26,7 @@ import ivy
 from ivy.functional.ivy.gradients import _variable
 import ivy_tests.test_ivy.helpers as helpers
 from ivy_tests.test_ivy.helpers import handle_test
+from ivy.functional.ivy.device import _get_nvml_gpu_handle
 
 
 # Helpers #
@@ -38,7 +39,7 @@ def _ram_array_and_clear_test(metric_fn, size=10000000):
     # Measure usage before creating array
     before = metric_fn()
     # Create an array of floats, by default with 10 million elements (40 MB)
-    arr = ivy.ones((size,), dtype="float32", device="cpu")
+    arr = ivy.random_normal(shape=(size,), dtype="float32", device="cpu")
     during = metric_fn()
     # Check that the memory usage has increased
     assert before < during
@@ -498,8 +499,9 @@ def test_total_mem_on_dev():
         if "cpu" in device:
             assert ivy.total_mem_on_dev(device) == psutil.virtual_memory().total / 1e9
         elif "gpu" in device:
-            gpu_mem = pynvml.nvmlDeviceGetMemoryInfo(device)
-            assert ivy.total_mem_on_dev(device) == gpu_mem / 1e9
+            handle = _get_nvml_gpu_handle(device)
+            gpu_mem = pynvml.nvmlDeviceGetMemoryInfo(handle)
+            assert ivy.total_mem_on_dev(device) == gpu_mem.total / 1e9
 
 
 @handle_test(fn_tree="used_mem_on_dev")
@@ -599,7 +601,7 @@ def test_function_unsupported_devices(
 # ---------------#
 
 
-# clear_mem_on_dev
+# clear_cached_mem_on_dev
 # used_mem_on_dev # working fine for cpu
 # percent_used_mem_on_dev # working fine for cpu
 # dev_util # working fine for cpu


### PR DESCRIPTION
[Trello task](https://trello.com/c/2fl6Mo3Y/1435-exploring-and-fixing-support-of-device-submodule-functions-on-the-gpu)

@VedPatwardhan 

- Fixed the first half of functions in `device.py`, the other half will be pushed by @soma2000-lang later.
- Renamed `clear_mem_on_dev` to `clear_cached_mem_on_dev` for clarity.
- Add support for process-specific GPU queries.