### PR TITLE
fix complex behaviour in ivy.divide

### DIFF
--- a/ivy/functional/backends/jax/elementwise.py
+++ b/ivy/functional/backends/jax/elementwise.py
@@ -154,7 +154,7 @@ def divide(
 ) -> JaxArray:
     x1, x2 = ivy.promote_types_of_inputs(x1, x2)
     ret = jax.numpy.divide(x1, x2)
-    if ivy.is_float_dtype(x1.dtype):
+    if ivy.is_float_dtype(x1.dtype) or ivy.is_complex_dtype(x1.dtype):
         ret = jnp.asarray(ret, dtype=x1.dtype)
     else:
         ret = jnp.asarray(ret, dtype=ivy.default_float_dtype(as_native=True))

--- a/ivy/functional/backends/numpy/elementwise.py
+++ b/ivy/functional/backends/numpy/elementwise.py
@@ -232,7 +232,7 @@ def divide(
 ) -> np.ndarray:
     x1, x2 = ivy.promote_types_of_inputs(x1, x2)
     ret = np.divide(x1, x2, out=out)
-    if ivy.is_float_dtype(x1):
+    if ivy.is_float_dtype(x1.dtype) or ivy.is_complex_dtype(x1.dtype):
         ret = np.asarray(ret, dtype=x1.dtype)
     else:
         ret = np.asarray(ret, dtype=ivy.default_float_dtype(as_native=True))

--- a/ivy/functional/backends/tensorflow/elementwise.py
+++ b/ivy/functional/backends/tensorflow/elementwise.py
@@ -227,7 +227,7 @@ def divide(
 ) -> Union[tf.Tensor, tf.Variable]:
     x1, x2 = ivy.promote_types_of_inputs(x1, x2)
     ret = tf.experimental.numpy.divide(x1, x2)
-    if ivy.is_float_dtype(x1.dtype):
+    if ivy.is_float_dtype(x1.dtype) or ivy.is_complex_dtype(x1.dtype):
         ret = tf.cast(ret, dtype=x1.dtype)
     else:
         ret = tf.cast(ret, dtype=ivy.default_float_dtype(as_native=True))

--- a/ivy/functional/backends/torch/elementwise.py
+++ b/ivy/functional/backends/torch/elementwise.py
@@ -291,7 +291,7 @@ def divide(
 ) -> torch.Tensor:
     x1, x2 = ivy.promote_types_of_inputs(x1, x2)
     ret = torch.div(x1, x2)
-    if ivy.is_float_dtype(x1.dtype):
+    if ivy.is_float_dtype(x1.dtype) or ivy.is_complex_dtype(x1.dtype):
         ret = ivy.astype(ret, x1.dtype, copy=False)
     else:
         ret = ivy.astype(ret, ivy.default_float_dtype(as_native=True), copy=False)


### PR DESCRIPTION
ivy.divide truncated the complex part in complex numbers as a side effect of casting to float