### PR TITLE
Add operator function real to Jax frontend

### DIFF
--- a/ivy/functional/frontends/jax/lax/operators.py
+++ b/ivy/functional/frontends/jax/lax/operators.py
@@ -534,3 +534,8 @@ def top_k(operand, k):
     values, indices = ivy.top_k(operand, k, axis=-1)
     indices = ivy.astype(indices, ivy.int32, copy=False)
     return [values, indices]
+
+
+@to_ivy_arrays_and_back
+def real(x):
+    return ivy.real(x)

--- a/ivy_tests/test_ivy/test_frontends/test_jax/test_jax_lax_operators.py
+++ b/ivy_tests/test_ivy/test_frontends/test_jax/test_jax_lax_operators.py
@@ -2307,3 +2307,30 @@ def test_jax_lax_top_k(
         k=k,
         # test_values=False,
     )
+
+
+# real
+@handle_frontend_test(
+    fn_tree="jax.lax.real",
+    dtype_and_x=helpers.dtype_and_values(
+        available_dtypes=helpers.get_dtypes("complex")
+    ),
+)
+def test_jax_lax_real(
+    *,
+    dtype_and_x,
+    on_device,
+    fn_tree,
+    frontend,
+    test_flags,
+):
+    input_dtype, x = dtype_and_x
+    helpers.test_frontend_function(
+        input_dtypes=input_dtype,
+        frontend=frontend,
+        test_flags=test_flags,
+        fn_tree=fn_tree,
+        on_device=on_device,
+        test_values=True,
+        x=x[0],
+    )


### PR DESCRIPTION
Close #12391
Implemented the function `real` in `jax.lax` operators with tests passing locally.