### PR TITLE
Fix init file warnings

### DIFF
--- a/ivy/__init__.py
+++ b/ivy/__init__.py
@@ -1,11 +1,24 @@
 # global
 import copy
 import warnings
-from ivy._version import __version__ as __version__
 import builtins
 import numpy as np
 import sys
 
+
+import ivy.utils.backend.handler
+from ivy._version import __version__ as __version__
+
+_not_imported_backends = list(ivy.utils.backend.handler._backend_dict.keys())
+try:
+    # Skip numpy from frameworks installed
+    _not_imported_backends.remove("numpy")
+except KeyError:
+    pass
+for backend_framework in _not_imported_backends.copy():
+    # If a framework was already imported before our init execution
+    if backend_framework in sys.modules:
+        _not_imported_backends.remove(backend_framework)
 
 warnings.filterwarnings("ignore", module="^(?!.*ivy).*$")
 
@@ -718,10 +731,17 @@ from ivy.utils.inspection import fn_array_spec, add_array_specs
 
 add_array_specs()
 
+_imported_frameworks_before_compiler = list(sys.modules.keys())
 try:
     from .compiler.compiler import transpile, compile, unify
 except:  # noqa: E722
     compile, transpile, unify = None, None, None
+finally:
+    # Skip framework imports done by Ivy compiler for now
+    for backend_framework in _not_imported_backends.copy():
+        if backend_framework in sys.modules:
+            if backend_framework not in _imported_frameworks_before_compiler:
+                _not_imported_backends.remove(backend_framework)
 
 
 # add instance methods to Ivy Array and Container
@@ -1162,10 +1182,9 @@ def dynamic_backend_as(value):
     return DynamicBackendContext(value)
 
 
-modules = ivy.utils.backend.handler._backend_dict.keys()
-for module in modules:
-    if module != "numpy" and module in sys.modules:
+for backend_framework in _not_imported_backends:
+    if backend_framework in sys.modules:
         warnings.warn(
-            f"{module} module has been imported while ivy doesn't import it without "
-            "setting a backend, ignore if that's intended"
+            f"{backend_framework} module has been imported while ivy doesn't "
+            "import it without setting a backend, ignore if that's intended"
         )


### PR DESCRIPTION
# Summary:

- Fixed Import warning logic to handle if frameworks were imported before Ivy
- Updated Import warning logic to skip imports done by Ivy compiler