### PR TITLE
[torch frontend] Add torch frontend function `median`

### DIFF
--- a/ivy/functional/frontends/torch/reduction_ops.py
+++ b/ivy/functional/frontends/torch/reduction_ops.py
@@ -63,6 +63,11 @@ def nanmean(input, dim=None, keepdim=False, *, dtype=None, out=None):
 
 
 @to_ivy_arrays_and_back
+def median(input, dim=-1, keepdim=False, *, out=None):
+    return ivy.median(input, axis=dim, keepdims=keepdim, out=out)
+
+
+@to_ivy_arrays_and_back
 def std(input, dim, unbiased, keepdim=False, *, out=None):
     return ivy.std(input, axis=dim, correction=int(unbiased), keepdims=keepdim, out=out)
 

--- a/ivy_tests/test_ivy/test_frontends/test_torch/test_reduction_ops.py
+++ b/ivy_tests/test_ivy/test_frontends/test_torch/test_reduction_ops.py
@@ -336,6 +336,37 @@ def test_torch_nanmean(
 
 
 @handle_frontend_test(
+    fn_tree="torch.median",
+    dtype_and_x=statistical_dtype_values(
+        function="median",
+        min_value=-1e04,
+        max_value=1e04,
+    ),
+    keepdims=st.booleans(),
+)
+def test_torch_median(
+    *,
+    dtype_and_x,
+    keepdims,
+    on_device,
+    fn_tree,
+    frontend,
+    test_flags
+):
+    input_dtype, x, axis = dtype_and_x
+    helpers.test_frontend_function(
+        input_dtypes=input_dtype,
+        frontend=frontend,
+        test_flags=test_flags,
+        fn_tree=fn_tree,
+        on_device=on_device,
+        input=x[0],
+        dim=axis,
+        keepdim=keepdims
+    )
+
+
+@handle_frontend_test(
     fn_tree="torch.std",
     dtype_and_x=statistical_dtype_values(function="std"),
     keepdims=st.booleans(),


### PR DESCRIPTION
closes #13211 

Added median function to the torch frontend with accompanying test
https://pytorch.org/docs/stable/generated/torch.median.html

Note: Default value for the `dim` argument is `-1`