### PR TITLE
fix get_ret_and_flatten_np_array to detect np.ndarrays

### DIFF
--- a/ivy_tests/test_ivy/helpers/function_testing.py
+++ b/ivy_tests/test_ivy/helpers/function_testing.py
@@ -1982,7 +1982,7 @@ def get_ret_and_flattened_np_array(fn, *args, test_compile: bool = False, **kwar
     def map_fn(x):
         if _is_frontend_array(x):
             return x.ivy_array
-        elif ivy.is_native_array(x):
+        elif ivy.is_native_array(x) or isinstance(x, np.ndarray):
             return ivy.to_ivy(x)
         return x
 


### PR DESCRIPTION
This fixes the tests for some of the tests that were failing when the ground truth framework returns a Numpy `ndarray` and we are not on that backend.

For example the tests were failing for `ivy.to_numpy`  numpy backend tests 