### PR TITLE
Added superset behavior of round function to support `decimals`

### DIFF
--- a/ivy/data_classes/array/elementwise.py
+++ b/ivy/data_classes/array/elementwise.py
@@ -2102,6 +2102,8 @@ class _ArrayWithElementwise(abc.ABC):
         ----------
         self
             input array. Should have a numeric data type.
+        decimals
+            number of decimal places to round to. Default is ``0``.
         out
             optional output array, for writing the result to. It must have a shape that
             the inputs broadcast to.

--- a/ivy/data_classes/array/elementwise.py
+++ b/ivy/data_classes/array/elementwise.py
@@ -2090,7 +2090,9 @@ class _ArrayWithElementwise(abc.ABC):
         """
         return ivy.remainder(self._data, x2, modulus=modulus, out=out)
 
-    def round(self: ivy.Array, *, out: Optional[ivy.Array] = None) -> ivy.Array:
+    def round(
+        self: ivy.Array, *, decimals: int = 0, out: Optional[ivy.Array] = None
+    ) -> ivy.Array:
         """
         ivy.Array instance method variant of ivy.round. This method simply wraps the
         function, and so the docstring for ivy.round also applies to this method
@@ -2136,7 +2138,7 @@ class _ArrayWithElementwise(abc.ABC):
         ivy.array([[-1., -67., 0., 16., 1.],
         [3., -45., 25., -678., 33.]])
         """
-        return ivy.round(self._data, out=out)
+        return ivy.round(self._data, decimals=decimals, out=out)
 
     def sign(self: ivy.Array, *, out: Optional[ivy.Array] = None) -> ivy.Array:
         """

--- a/ivy/data_classes/container/elementwise.py
+++ b/ivy/data_classes/container/elementwise.py
@@ -6411,6 +6411,8 @@ class _ContainerWithElementwise(ContainerBase):
         ----------
         x
             input container. Should have a numeric data type.
+        decimals
+            number of decimal places to round to. Default is ``0``.
         key_chains
             The key-chains to apply or not apply the method to. Default is ``None``.
         to_apply
@@ -6475,6 +6477,8 @@ class _ContainerWithElementwise(ContainerBase):
         ----------
         self
             input container. Should have a numeric data type.
+        decimals
+            number of decimal places to round to. Default is ``0``.
         key_chains
             The key-chains to apply or not apply the method to. Default is ``None``.
         to_apply

--- a/ivy/data_classes/container/elementwise.py
+++ b/ivy/data_classes/container/elementwise.py
@@ -6395,6 +6395,7 @@ class _ContainerWithElementwise(ContainerBase):
         x: Union[ivy.Container, ivy.Array, ivy.NativeArray],
         /,
         *,
+        decimals: int = 0,
         key_chains: Optional[Union[List[str], Dict[str, str]]] = None,
         to_apply: bool = True,
         prune_unapplied: bool = False,
@@ -6447,6 +6448,7 @@ class _ContainerWithElementwise(ContainerBase):
         return ContainerBase.cont_multi_map_in_function(
             "round",
             x,
+            decimals=decimals,
             key_chains=key_chains,
             to_apply=to_apply,
             prune_unapplied=prune_unapplied,
@@ -6457,6 +6459,7 @@ class _ContainerWithElementwise(ContainerBase):
     def round(
         self: ivy.Container,
         *,
+        decimals: int = 0,
         key_chains: Optional[Union[List[str], Dict[str, str]]] = None,
         to_apply: bool = True,
         prune_unapplied: bool = False,
@@ -6508,6 +6511,7 @@ class _ContainerWithElementwise(ContainerBase):
         """
         return self._static_round(
             self,
+            decimals=decimals,
             key_chains=key_chains,
             to_apply=to_apply,
             prune_unapplied=prune_unapplied,

--- a/ivy/functional/backends/jax/elementwise.py
+++ b/ivy/functional/backends/jax/elementwise.py
@@ -385,7 +385,10 @@ def round(
     if "int" in str(x.dtype):
         return x
     else:
-        return jnp.round(x, decimals=decimals)
+        ret_dtype = x.dtype
+        factor = jnp.power(10, decimals).astype(ret_dtype)
+        factor_denom = jnp.where(jnp.isinf(factor), 1.0, factor)
+        return jnp.round(x * factor) / factor_denom
 
 
 def sign(x: JaxArray, /, *, out: Optional[JaxArray] = None) -> JaxArray:

--- a/ivy/functional/backends/jax/elementwise.py
+++ b/ivy/functional/backends/jax/elementwise.py
@@ -379,11 +379,13 @@ def remainder(
     return jnp.remainder(x1, x2)
 
 
-def round(x: JaxArray, /, *, out: Optional[JaxArray] = None) -> JaxArray:
+def round(
+    x: JaxArray, /, *, decimals: int = 0, out: Optional[JaxArray] = None
+) -> JaxArray:
     if "int" in str(x.dtype):
         return x
     else:
-        return jnp.round(x)
+        return jnp.round(x, decimals=decimals)
 
 
 def sign(x: JaxArray, /, *, out: Optional[JaxArray] = None) -> JaxArray:

--- a/ivy/functional/backends/jax/elementwise.py
+++ b/ivy/functional/backends/jax/elementwise.py
@@ -385,6 +385,8 @@ def round(
     if "int" in str(x.dtype):
         return x
     else:
+        if decimals == 0:
+            return jnp.round(x)
         ret_dtype = x.dtype
         factor = jnp.power(10, decimals).astype(ret_dtype)
         factor_denom = jnp.where(jnp.isinf(factor), 1.0, factor)

--- a/ivy/functional/backends/numpy/elementwise.py
+++ b/ivy/functional/backends/numpy/elementwise.py
@@ -566,11 +566,13 @@ remainder.support_native_out = True
 
 
 @_scalar_output_to_0d_array
-def round(x: np.ndarray, /, *, out: Optional[np.ndarray] = None) -> np.ndarray:
+def round(
+    x: np.ndarray, /, *, decimals: int = 0, out: Optional[np.ndarray] = None
+) -> np.ndarray:
     if "int" in str(x.dtype):
         ret = np.copy(x)
     else:
-        return np.round(x, out=out)
+        ret = np.round(x, decimals=decimals, out=out)
     if ivy.exists(out):
         return ivy.inplace_update(out, ret)
     return ret

--- a/ivy/functional/backends/tensorflow/elementwise.py
+++ b/ivy/functional/backends/tensorflow/elementwise.py
@@ -572,6 +572,8 @@ def round(
     if "int" in str(x.dtype):
         return x
     else:
+        if decimals == 0:
+            return tf.cast(tf.round(x), x.dtype)
         ret_dtype = x.dtype
         factor = tf.constant(10**decimals, dtype=ret_dtype)
         factor_deno = tf.where(

--- a/ivy/functional/backends/tensorflow/elementwise.py
+++ b/ivy/functional/backends/tensorflow/elementwise.py
@@ -566,12 +566,13 @@ def round(
     x: Union[tf.Tensor, tf.Variable],
     /,
     *,
+    decimals: int = 0,
     out: Optional[Union[tf.Tensor, tf.Variable]] = None,
 ) -> Union[tf.Tensor, tf.Variable]:
     if "int" in str(x.dtype):
         return x
     else:
-        return tf.round(x)
+        return tf.round(x * (10**decimals)) / 10**decimals
 
 
 def sign(

--- a/ivy/functional/backends/tensorflow/elementwise.py
+++ b/ivy/functional/backends/tensorflow/elementwise.py
@@ -572,7 +572,12 @@ def round(
     if "int" in str(x.dtype):
         return x
     else:
-        return tf.round(x * (10**decimals)) / 10**decimals
+        ret_dtype = x.dtype
+        factor = tf.constant(10**decimals, dtype=ret_dtype)
+        factor_deno = tf.where(
+            tf.math.is_finite(factor), factor, tf.constant(1, dtype=ret_dtype)
+        )
+        return tf.cast(tf.round(x * factor) / factor_deno, ret_dtype)
 
 
 def sign(

--- a/ivy/functional/backends/torch/elementwise.py
+++ b/ivy/functional/backends/torch/elementwise.py
@@ -493,12 +493,14 @@ pow.support_native_out = True
 
 
 @with_unsupported_dtypes({"1.11.0 and below": ("float16", "complex")}, backend_version)
-def round(x: torch.Tensor, /, *, out: Optional[torch.Tensor] = None) -> torch.Tensor:
+def round(
+    x: torch.Tensor, /, *, decimals: int = 0, out: Optional[torch.Tensor] = None
+) -> torch.Tensor:
     if "int" in str(x.dtype):
         if ivy.exists(out):
             return ivy.inplace_update(out, x)
         return x
-    return torch.round(x, out=out)
+    return torch.round(x, decimals=decimals, out=out)
 
 
 round.support_native_out = True

--- a/ivy/functional/frontends/jax/numpy/mathematical_functions.py
+++ b/ivy/functional/frontends/jax/numpy/mathematical_functions.py
@@ -515,9 +515,7 @@ def around(a, decimals=0, out=None):
     if ivy.shape(a) == ():
         a = ivy.expand_dims(a, axis=0)
     ret_dtype = a.dtype
-    factor = ivy.pow(10, decimals)
-    a = ivy.multiply(a, factor)
-    return ivy.divide(ivy.round(a), factor).astype(ret_dtype)
+    return ivy.round(a, decimals=decimals, out=out).astype(ret_dtype, copy=False)
 
 
 @to_ivy_arrays_and_back

--- a/ivy/functional/frontends/numpy/mathematical_functions/rounding.py
+++ b/ivy/functional/frontends/numpy/mathematical_functions/rounding.py
@@ -116,6 +116,4 @@ def rint(
 def around(a, decimals=0, out=None):
     if ivy.shape(a) == ():
         a = ivy.expand_dims(a, axis=0)
-    factor = ivy.pow(10, decimals)
-    a = ivy.multiply(a, factor)
-    return ivy.divide(ivy.round(a), factor)
+    return ivy.round(a, decimals=decimals, out=out)

--- a/ivy/functional/ivy/elementwise.py
+++ b/ivy/functional/ivy/elementwise.py
@@ -4259,6 +4259,8 @@ def round(
     ----------
     x
         input array containing elements to round.
+    decimals
+        number of decimal places to round to. Default is ``0``.
     out
         optional output array, for writing the result to. It must have a shape that the
         inputs broadcast to.

--- a/ivy/functional/ivy/elementwise.py
+++ b/ivy/functional/ivy/elementwise.py
@@ -4235,6 +4235,7 @@ def round(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
     *,
+    decimals: Optional[int] = 0,
     out: Optional[ivy.Array] = None,
 ) -> ivy.Array:
     """Rounds each element ``x_i`` of the input array ``x`` to the nearest
@@ -4318,7 +4319,7 @@ def round(
         b:ivy.array([-301.,-527.,4.])
     }
     """
-    return ivy.current_backend(x).round(x, out=out)
+    return ivy.current_backend(x).round(x, decimals=decimals, out=out)
 
 
 @handle_array_function

--- a/ivy_tests/test_ivy/test_frontends/test_jax/test_jax_numpy_math.py
+++ b/ivy_tests/test_ivy/test_frontends/test_jax/test_jax_numpy_math.py
@@ -2500,12 +2500,9 @@ def test_jax_numpy_subtract(
 @handle_frontend_test(
     fn_tree="jax.numpy.around",
     dtype_and_x=helpers.dtype_and_values(
-        available_dtypes=helpers.get_dtypes("float"),
-        min_value=-100,
-        max_value=100,
-        min_num_dims=1,
+        available_dtypes=helpers.get_dtypes("numeric"),
     ),
-    decimals=helpers.ints(min_value=0, max_value=3),
+    decimals=st.integers(min_value=0, max_value=5),
 )
 def test_jax_numpy_around(
     *,

--- a/ivy_tests/test_ivy/test_frontends/test_numpy/test_mathematical_functions/test_rounding.py
+++ b/ivy_tests/test_ivy/test_frontends/test_numpy/test_mathematical_functions/test_rounding.py
@@ -1,3 +1,6 @@
+# global
+from hypothesis import strategies as st
+
 # local
 import ivy_tests.test_ivy.helpers as helpers
 import ivy_tests.test_ivy.test_frontends.test_numpy.helpers as np_frontend_helpers
@@ -215,9 +218,9 @@ def test_numpy_rint(
 @handle_frontend_test(
     fn_tree="numpy.around",
     dtype_and_x=helpers.dtype_and_values(
-        available_dtypes=helpers.get_dtypes("float"),
+        available_dtypes=helpers.get_dtypes("numeric"),
     ),
-    decimals=helpers.ints(min_value=0, max_value=5),
+    decimals=st.integers(min_value=0, max_value=5),
 )
 def test_numpy_around(
     *,

--- a/ivy_tests/test_ivy/test_functional/test_core/test_elementwise.py
+++ b/ivy_tests/test_ivy/test_functional/test_core/test_elementwise.py
@@ -1539,10 +1539,12 @@ def test_remainder(
     dtype_and_x=helpers.dtype_and_values(
         available_dtypes=helpers.get_dtypes("numeric")
     ),
+    decimals=st.integers(min_value=0, max_value=5),
 )
 def test_round(
     *,
     dtype_and_x,
+    decimals,
     test_flags,
     backend_fw,
     fn_name,
@@ -1558,6 +1560,7 @@ def test_round(
         fn_name=fn_name,
         on_device=on_device,
         x=x[0],
+        decimals=decimals,
     )
 
 


### PR DESCRIPTION
This extended function supports decimals parameter
Usage example

```python
import ivy
print(ivy.round(16.055, decimals=2)) # ivy.array(16.06)
```