### PR TITLE
Added frontend numpy.random.gamma.

### DIFF
--- a/ivy/functional/frontends/numpy/random/functions.py
+++ b/ivy/functional/frontends/numpy/random/functions.py
@@ -79,6 +79,14 @@ def beta(a, b, size=None):
 
 @to_ivy_arrays_and_back
 @from_zero_dim_arrays_to_scalar
+def gamma(shape, scale=1.0, size=None):
+    # Numpy uses shape for the shape parameter k, which is alpha in Ivy.
+    # Numpy uses scale for the scale parameter theta, which is 1/beta in Ivy.
+    return ivy.gamma(shape, 1.0 / scale, dtype="float64")  # , shape=size)
+
+
+@to_ivy_arrays_and_back
+@from_zero_dim_arrays_to_scalar
 def shuffle(x, /):
     if isinstance(x, int):
         x = ivy.arange(x)

--- a/ivy_tests/test_ivy/test_frontends/test_numpy/test_random/test_functions.py
+++ b/ivy_tests/test_ivy/test_frontends/test_numpy/test_random/test_functions.py
@@ -300,6 +300,43 @@ def test_numpy_beta(
     )
 
 
+# gamma
+@handle_frontend_test(
+    fn_tree="numpy.random.gamma",
+    input_dtypes=helpers.get_dtypes("float", index=2),
+    k=st.floats(
+        allow_nan=False, allow_infinity=False, width=32, min_value=0, exclude_min=True
+    ),
+    theta=st.floats(
+        allow_nan=False, allow_infinity=False, width=32, min_value=0, exclude_min=True
+    ),
+    size=st.tuples(
+        st.integers(min_value=2, max_value=5), st.integers(min_value=2, max_value=5)
+    ),
+)
+def test_numpy_gamma(
+    input_dtypes,
+    size,
+    frontend,
+    test_flags,
+    fn_tree,
+    on_device,
+    k,
+    theta,
+):
+    helpers.test_frontend_function(
+        input_dtypes=input_dtypes,
+        frontend=frontend,
+        test_flags=test_flags,
+        fn_tree=fn_tree,
+        on_device=on_device,
+        test_values=False,
+        shape=k,
+        scale=theta,
+        size=size,
+    )
+
+
 # shuffle
 @handle_frontend_test(
     fn_tree="numpy.random.shuffle",


### PR DESCRIPTION
Closes #13841
See [Numpy's documentaiton](https://numpy.org/doc/stable/reference/random/generated/numpy.random.gamma.html) and [the Gamma distribution](https://en.wikipedia.org/wiki/Gamma_distribution).
Numpy uses shape parameter k (which is equal to alpha), and scale parameter theta (which is 1/beta).
I think there might be issues with `ivy.gamma`; in `ivy/functional/ivy/experimental/random.py` I assume `shape` is the same as in `ivy.beta`, `ivy.dirichlet`, `ivy.poisson` and the other distributions, yet the docstring and the type are significantly different. Gamma distributions have a "shape parameter" which is "alpha", I think there might've been a confusion there.
Numpy's `gamma` and `standard_gamma` both have an optional `size=None` parameter which should coincide with Ivy's `shape`, currently neither `gamma` nor `standard_gamma` in the frontend implement it.