### PR TITLE
Nested support for arbitrary objects' attributes

### DIFF
--- a/ivy/functional/ivy/nest.py
+++ b/ivy/functional/ivy/nest.py
@@ -786,7 +786,11 @@ def nested_argwhere(
         _indices = [idx for idxs in _indices if idxs for idx in idxs]
         if check_nests and fn(nest):
             _indices.append(_index)
-    elif check_attributes and hasattr(nest, "__dict__"):
+    elif (
+        check_attributes
+        and hasattr(nest, "__dict__")
+        and not isinstance(nest, (ivy.Array, ivy.NativeArray))
+    ):
         for k, v in nest.__dict__.items():
             if nested_any(
                 v, fn, check_nests, check_attributes, False, extra_nest_types
@@ -1231,7 +1235,11 @@ def nested_any(
                 return True
         if check_nests and fn(nest):
             return True
-    elif check_attributes and hasattr(nest, "__dict__"):
+    elif (
+        check_attributes
+        and hasattr(nest, "__dict__")
+        and not isinstance(nest, (ivy.Array, ivy.NativeArray))
+    ):
         for k, v in nest.__dict__.items():
             if nested_any(
                 v, fn, check_nests, check_attributes, False, extra_nest_types

--- a/ivy/functional/ivy/nest.py
+++ b/ivy/functional/ivy/nest.py
@@ -1231,14 +1231,14 @@ def nested_any(
                 return True
         if check_nests and fn(nest):
             return True
-    elif fn(nest):
-        return True
     elif check_attributes and hasattr(nest, "__dict__"):
         for k, v in nest.__dict__.items():
             if nested_any(
                 v, fn, check_nests, check_attributes, False, extra_nest_types
             ):
                 return True
+    elif fn(nest):
+        return True
     return False
 
 

--- a/ivy/functional/ivy/nest.py
+++ b/ivy/functional/ivy/nest.py
@@ -789,13 +789,18 @@ def nested_argwhere(
     elif (
         check_attributes
         and hasattr(nest, "__dict__")
-        and not isinstance(nest, (ivy.Array, ivy.NativeArray))
+        and not hasattr(nest, "__array__")
     ):
-        for k, v in nest.__dict__.items():
-            if nested_any(
-                v, fn, check_nests, check_attributes, False, extra_nest_types
-            ):
-                return [_index]
+        if nested_any(
+            list(nest.__dict__.values()),
+            fn,
+            check_nests,
+            check_attributes,
+            False,
+            extra_nest_types,
+        ):
+            return [_index]
+        return False
     else:
         cond_met = fn(nest)
         if cond_met:
@@ -1238,7 +1243,7 @@ def nested_any(
     elif (
         check_attributes
         and hasattr(nest, "__dict__")
-        and not isinstance(nest, (ivy.Array, ivy.NativeArray))
+        and not hasattr(nest, "__array__")
     ):
         for k, v in nest.__dict__.items():
             if nested_any(


### PR DESCRIPTION
```python
output = kornia.feature.disk.disk.DISK()(torch.rand([1,3,224,224])) 
# output == [DiskFeatures]
# https://kornia.readthedocs.io/en/latest/_modules/kornia/feature/disk/structs.html#DISKFeatures
ivy.nested_any(output, lambda x: isinstance(x, torch.Tensor))  # False
ivy.nested_any(output, lambda x: isinstance(x, torch.Tensor), check_attributes=True)  # True

ivy.nested_argwhere(output, lambda x: isinstance(x, torch.Tensor))  # []
ivy.nested_argwhere(output, lambda x: isinstance(x, torch.Tensor), check_attributes=True)  # [[0]]
```

Do we need `nested_map` and `nested_multi_map` too? Modifying an object's attribute might be scary for an unaware user.