### PR TITLE
Added frontent jax random rademacher.

### DIFF
--- a/ivy/functional/frontends/jax/random.py
+++ b/ivy/functional/frontends/jax/random.py
@@ -45,3 +45,11 @@ def _get_seed(key):
 def beta(key, a, b, shape=None, dtype=None):
     seed = _get_seed(key)
     return ivy.beta(a, b, shape=shape, dtype=dtype, seed=seed)
+
+
+# Rademacher distribution, 1 or -1 with equal probability.
+@handle_jax_dtype
+@to_ivy_arrays_and_back
+def rademacher(key, shape=(), dtype=None):
+    seed = _get_seed(key)
+    return ivy.astype(ivy.randint(0, 2, shape=shape, seed=seed) * 2 - 1, dtype)

--- a/ivy_tests/test_ivy/test_frontends/test_jax/test_jax_random.py
+++ b/ivy_tests/test_ivy/test_frontends/test_jax/test_jax_random.py
@@ -183,3 +183,59 @@ def test_jax_beta(
     for (u, v) in zip(ret_np, ret_from_np):
         assert u.dtype == v.dtype
         assert u.shape == v.shape
+
+
+# Rademacher
+@handle_frontend_test(
+    fn_tree="jax.random.rademacher",
+    dtype_key=helpers.dtype_and_values(
+        available_dtypes=["uint32"],
+        min_value=0,
+        max_value=2000,
+        min_num_dims=1,
+        max_num_dims=1,
+        min_dim_size=2,
+        max_dim_size=2,
+    ),
+    shape=helpers.get_shape(
+        min_num_dims=2, max_num_dims=2, min_dim_size=1, max_dim_size=5
+    ),
+    dtype=helpers.get_dtypes("float", full=False),
+    test_with_out=st.just(False),
+)
+def test_jax_rademacher(
+    *,
+    dtype_key,
+    shape,
+    dtype,
+    on_device,
+    fn_tree,
+    frontend,
+    test_flags,
+):
+    input_dtype, key = dtype_key
+
+    def call():
+        return helpers.test_frontend_function(
+            input_dtypes=input_dtype,
+            frontend=frontend,
+            test_flags=test_flags,
+            fn_tree=fn_tree,
+            on_device=on_device,
+            test_values=False,
+            key=key[0],
+            shape=shape,
+            dtype=dtype[0],
+        )
+
+    ret = call()
+
+    if not ivy.exists(ret):
+        return
+
+    ret_np, ret_from_np = ret
+    ret_np = helpers.flatten_and_to_np(ret=ret_np)
+    ret_from_np = helpers.flatten_and_to_np(ret=ret_from_np)
+    for (u, v) in zip(ret_np, ret_from_np):
+        assert u.dtype == v.dtype
+        assert u.shape == v.shape


### PR DESCRIPTION
Closes #14017

The [Rademacher](https://en.wikipedia.org/wiki/Rademacher_distribution) distribution returns either 1 or -1, with equal probability. [Jax's implementation](https://jax.readthedocs.io/en/latest/_autosummary/jax.random.rademacher.html) uses the bernuilli distribution (with `p=0.5`) to implement it. I've implemented it instead with `ivy.randint`.

Since it is possible to easily implement this method from the Ivy API, it might be worth considering adding `ivy.rademacher` into Ivy's API. While it is not implemented in all frameworks, it is available in some others such as [Tensorflow](https://www.tensorflow.org/probability/api_docs/python/tfp/random/rademacher).

There seems to be an issue with the tests at the moment, which others in the discord server have also encountered.