### PR TITLE
Refactored tests for jax.random such that they work with all backends

### DIFF
--- a/ivy/functional/frontends/jax/random.py
+++ b/ivy/functional/frontends/jax/random.py
@@ -9,26 +9,26 @@ from ivy.functional.frontends.jax.func_wrapper import (
 
 @to_ivy_arrays_and_back
 def PRNGKey(seed):
-    return ivy.array([0, seed % 4294967295 - (seed // 4294967295)], dtype=ivy.int64)
+    return ivy.array([0, seed % 4294967295], dtype=ivy.int64)
+
+
+def _get_seed(key):
+    key1, key2 = int(key[0]), int(key[1])
+    return ivy.to_scalar(int("".join(map(str, [key1, key2]))))
 
 
 @handle_jax_dtype
 @to_ivy_arrays_and_back
 def uniform(key, shape=(), dtype=None, minval=0.0, maxval=1.0):
     return ivy.random_uniform(
-        low=minval, high=maxval, shape=shape, dtype=dtype, seed=ivy.to_scalar(key[1])
+        low=minval, high=maxval, shape=shape, dtype=dtype, seed=_get_seed(key)
     )
 
 
 @handle_jax_dtype
 @to_ivy_arrays_and_back
 def normal(key, shape=(), dtype=None):
-    return ivy.random_normal(shape=shape, dtype=dtype, seed=ivy.to_scalar(key[1]))
-
-
-def _get_seed(key):
-    key1, key2 = int(key[0]), int(key[1])
-    return ivy.to_scalar(int("".join(map(str, [key1, key2]))))
+    return ivy.random_normal(shape=shape, dtype=dtype, seed=_get_seed(key))
 
 
 @handle_jax_dtype

--- a/ivy_tests/test_ivy/test_frontends/test_jax/test_jax_random.py
+++ b/ivy_tests/test_ivy/test_frontends/test_jax/test_jax_random.py
@@ -1,185 +1,95 @@
 # global
-from hypothesis import strategies as st
-import ivy
+from hypothesis import strategies as st, given
+import jax
 
 # local
 import ivy_tests.test_ivy.helpers as helpers
-from ivy_tests.test_ivy.helpers import handle_frontend_test
+import ivy.functional.frontends.jax as jax_frontend
+
+"""
+Tests for jax.random cannot be made normally since a `uint32` PRNG key must
+be passed for jax, meaning torch and paddle would always fail.
+The format used below should be followed for jax.random tests
+"""
 
 
 @st.composite
 def _get_minval_maxval(draw):
     interval = draw(st.integers(min_value=1, max_value=50))
     minval = draw(st.floats(min_value=-100, max_value=100))
-    maxval = draw(st.floats(min_value=-100 + interval, max_value=100 + interval))
+    maxval = minval + interval
     return minval, maxval
 
 
-@handle_frontend_test(
-    fn_tree="jax.random.uniform",
-    dtype_key=helpers.dtype_and_values(
-        available_dtypes=["uint32"],
-        min_value=0,
-        max_value=2000,
-        min_num_dims=1,
-        max_num_dims=1,
-        min_dim_size=2,
-        max_dim_size=2,
-    ),
+@given(
+    key=st.integers(min_value=int(-1e15), max_value=int(1e15)),
     shape=helpers.get_shape(),
-    dtype=helpers.get_dtypes("float", full=False),
-    dtype_minval_maxval=_get_minval_maxval(),
+    dtype=helpers.get_dtypes("float", full=False, prune_function=False),
+    minval_maxval=_get_minval_maxval(),
 )
 def test_jax_uniform(
-    *,
-    dtype_key,
+    key,
     shape,
     dtype,
-    dtype_minval_maxval,
-    on_device,
-    fn_tree,
-    frontend,
-    test_flags,
+    minval_maxval,
 ):
-    input_dtype, key = dtype_key
-    minval, maxval = dtype_minval_maxval
+    minval, maxval = minval_maxval
 
-    def call():
-        return helpers.test_frontend_function(
-            input_dtypes=input_dtype,
-            frontend=frontend,
-            test_flags=test_flags,
-            fn_tree=fn_tree,
-            on_device=on_device,
-            test_values=False,
-            key=key[0],
-            shape=shape,
-            dtype=dtype[0],
-            minval=minval,
-            maxval=maxval,
-        )
+    jax_frontend.config.update("jax_enable_x64", True)
+    frontend_prng_key = jax_frontend.random.PRNGKey(key)
+    frontend_ret = jax_frontend.random.uniform(
+        frontend_prng_key, shape, dtype[0], minval, maxval
+    )
 
-    ret = call()
+    framework_prng_key = jax.random.PRNGKey(key)
+    framework_ret = jax.random.uniform(
+        framework_prng_key, shape, dtype[0], minval, maxval
+    )
 
-    if not ivy.exists(ret):
-        return
-
-    ret_np, ret_from_np = ret
-    ret_np = helpers.flatten_and_to_np(ret=ret_np)
-    ret_from_np = helpers.flatten_and_to_np(ret=ret_from_np)
-    for (u, v) in zip(ret_np, ret_from_np):
-        assert u.dtype == v.dtype
-        assert u.shape == v.shape
+    assert frontend_ret.ivy_array.dtype == framework_ret.dtype.name
+    assert framework_ret.shape == framework_ret.shape
 
 
-@handle_frontend_test(
-    fn_tree="jax.random.normal",
-    dtype_key=helpers.dtype_and_values(
-        available_dtypes=["uint32"],
-        min_value=0,
-        max_value=2000,
-        min_num_dims=1,
-        max_num_dims=1,
-        min_dim_size=2,
-        max_dim_size=2,
-    ),
+@given(
+    key=st.integers(min_value=int(-1e15), max_value=int(1e15)),
     shape=helpers.get_shape(),
-    dtype=helpers.get_dtypes("float", full=False),
+    dtype=helpers.get_dtypes("float", full=False, prune_function=False),
 )
 def test_jax_normal(
-    *,
-    dtype_key,
+    key,
     shape,
     dtype,
-    on_device,
-    fn_tree,
-    frontend,
-    test_flags,
 ):
-    input_dtype, key = dtype_key
+    jax_frontend.config.update("jax_enable_x64", True)
+    frontend_prng_key = jax_frontend.random.PRNGKey(key)
+    frontend_ret = jax_frontend.random.normal(frontend_prng_key, shape, dtype[0])
 
-    def call():
-        return helpers.test_frontend_function(
-            input_dtypes=input_dtype,
-            frontend=frontend,
-            test_flags=test_flags,
-            fn_tree=fn_tree,
-            on_device=on_device,
-            test_values=False,
-            key=key[0],
-            shape=shape,
-            dtype=dtype[0],
-        )
+    framework_prng_key = jax.random.PRNGKey(key)
+    framework_ret = jax.random.normal(framework_prng_key, shape, dtype[0])
 
-    ret = call()
-
-    if not ivy.exists(ret):
-        return
-
-    ret_np, ret_from_np = ret
-    ret_np = helpers.flatten_and_to_np(ret=ret_np)
-    ret_from_np = helpers.flatten_and_to_np(ret=ret_from_np)
-    for (u, v) in zip(ret_np, ret_from_np):
-        assert u.dtype == v.dtype
-        assert u.shape == v.shape
+    assert frontend_ret.ivy_array.dtype == framework_ret.dtype.name
+    assert framework_ret.shape == framework_ret.shape
 
 
-@handle_frontend_test(
-    fn_tree="jax.random.beta",
-    dtype_key=helpers.dtype_and_values(
-        available_dtypes=["uint32"],
-        min_value=0,
-        max_value=2000,
-        min_num_dims=1,
-        max_num_dims=1,
-        min_dim_size=2,
-        max_dim_size=2,
-    ),
+@given(
+    key=st.integers(min_value=int(-1e15), max_value=int(1e15)),
     alpha=st.floats(min_value=0, max_value=5, exclude_min=True),
     beta=st.floats(min_value=0, max_value=5, exclude_min=True),
     shape=helpers.get_shape(
         min_num_dims=2, max_num_dims=2, min_dim_size=1, max_dim_size=5
     ),
-    dtype=helpers.get_dtypes("float", full=False),
-    test_with_out=st.just(False),
+    dtype=helpers.get_dtypes("float", full=False, prune_function=False),
 )
-def test_jax_beta(
-    *,
-    dtype_key,
-    alpha,
-    beta,
-    shape,
-    dtype,
-    on_device,
-    fn_tree,
-    frontend,
-    test_flags,
-):
-    input_dtype, key = dtype_key
+def test_jax_beta(key, alpha, beta, shape, dtype):
 
-    def call():
-        return helpers.test_frontend_function(
-            input_dtypes=input_dtype,
-            frontend=frontend,
-            test_flags=test_flags,
-            fn_tree=fn_tree,
-            on_device=on_device,
-            test_values=False,
-            key=key[0],
-            a=alpha,
-            b=beta,
-            shape=shape,
-            dtype=dtype[0],
-        )
+    jax_frontend.config.update("jax_enable_x64", True)
+    frontend_prng_key = jax_frontend.random.PRNGKey(key)
+    frontend_ret = jax_frontend.random.beta(
+        frontend_prng_key, alpha, beta, shape, dtype[0]
+    )
 
-    ret = call()
+    framework_prng_key = jax.random.PRNGKey(key)
+    framework_ret = jax.random.beta(framework_prng_key, alpha, beta, shape, dtype[0])
 
-    if not ivy.exists(ret):
-        return
-
-    ret_np, ret_from_np = ret
-    ret_np = helpers.flatten_and_to_np(ret=ret_np)
-    ret_from_np = helpers.flatten_and_to_np(ret=ret_from_np)
-    for (u, v) in zip(ret_np, ret_from_np):
-        assert u.dtype == v.dtype
-        assert u.shape == v.shape
+    assert frontend_ret.ivy_array.dtype == framework_ret.dtype.name
+    assert framework_ret.shape == framework_ret.shape


### PR DESCRIPTION
Modified the tests to call the PRNG function directly because otherwise we would need to generate a `uint32` PRNGKey. Now the tests can pass for all backends (even if some fail now for backend related issues)