### PR TITLE
Add torch randn_like function to Pytorch frontend

### DIFF
--- a/ivy/functional/frontends/torch/random_sampling.py
+++ b/ivy/functional/frontends/torch/random_sampling.py
@@ -131,6 +131,27 @@ def randn(
     )
 
 
+@to_ivy_arrays_and_back
+def randn_like(
+    input,
+    *,
+    dtype=None,
+    layout=None,
+    device=None,
+    requires_grad=False,
+    memory_format=None
+):
+    shape = input.shape
+    if not dtype:
+        dtype = input.dtype
+
+    return ivy.random_normal(
+        shape=shape,
+        dtype=dtype,
+        device=device,
+    )
+
+
 @with_supported_dtypes(
     {
         "1.11.0 and below": (

--- a/ivy_tests/test_ivy/test_frontends/test_torch/test_random_sampling.py
+++ b/ivy_tests/test_ivy/test_frontends/test_torch/test_random_sampling.py
@@ -305,6 +305,7 @@ def test_torch_randn(*, dtype, size, frontend, fn_tree, test_flags):
 )
 def test_torch_randn_like(dtype_and_x, dtype, *, frontend, fn_tree, test_flags):
     input_dtype, input = dtype_and_x
+
     def call():
         return helpers.test_frontend_function(
             input_dtypes=input_dtype,

--- a/ivy_tests/test_ivy/test_frontends/test_torch/test_random_sampling.py
+++ b/ivy_tests/test_ivy/test_frontends/test_torch/test_random_sampling.py
@@ -293,6 +293,43 @@ def test_torch_randn(*, dtype, size, frontend, fn_tree, test_flags):
 
 
 @handle_frontend_test(
+    fn_tree="torch.randn_like",
+    dtype=helpers.get_dtypes("float", full=False),
+    dtype_and_x=helpers.dtype_and_values(
+        available_dtypes=helpers.get_dtypes("float"),
+        min_num_dims=1,
+        max_num_dims=10,
+        min_dim_size=1,
+        max_dim_size=10,
+    ),
+)
+def test_torch_randn_like(dtype_and_x, dtype, *, frontend, fn_tree, test_flags):
+    input_dtype, input = dtype_and_x
+    def call():
+        return helpers.test_frontend_function(
+            input_dtypes=input_dtype,
+            frontend=frontend,
+            test_values=False,
+            fn_tree=fn_tree,
+            test_flags=test_flags,
+            input=input[0],
+            dtype=dtype[0],
+        )
+
+    ret = call()
+
+    if not ivy.exists(ret):
+        return
+
+    ret_np, ret_from_np = ret
+    ret_np = helpers.flatten_and_to_np(ret=ret_np)
+    ret_from_np = helpers.flatten_and_to_np(ret=ret_from_np)
+    for (u, v) in zip(ret_np, ret_from_np):
+        assert u.dtype == v.dtype
+        assert u.shape == v.shape
+
+
+@handle_frontend_test(
     fn_tree="torch.bernoulli",
     dtype_and_probs=helpers.dtype_and_values(
         available_dtypes=helpers.get_dtypes("float", full=False),


### PR DESCRIPTION
Added torch `randn_like` function to Pytorch frontend.

**CHANGELOG:**

1. Added a single function named `randn_like` in `ivy/functional/frontends/torch/random_sampling.py`.
2. Added relevant test function named `test_torch_randn_like` in `ivy_tests/test_ivy/test_frontends/test_torch/test_random_sampling.py`.