### PR TITLE
added type-hints to function _get_devices

### DIFF
--- a/ivy/functional/ivy/device.py
+++ b/ivy/functional/ivy/device.py
@@ -1094,7 +1094,7 @@ def _is_valid_devices_attributes(fn: Callable) -> bool:
     return True
 
 
-def _get_devices(fn, complement=True):
+def _get_devices(fn: Callable, complement: bool = True) -> Tuple:
     valid_devices = ivy.valid_devices
     invalid_devices = ivy.invalid_devices
     all_devices = ivy.all_devices


### PR DESCRIPTION
This pull request adds type hints to the `_get_devices` function to improve the readability and maintainability of the code.

Changes made:
- Added type hints to the function arguments and return value

Closes #14182 
