### PR TITLE
Close #14222 Added 'out' argument to the 'mershgrid' function in creation.py

### DIFF
--- a/ivy/functional/ivy/creation.py
+++ b/ivy/functional/ivy/creation.py
@@ -1302,6 +1302,7 @@ def meshgrid(
     *arrays: Union[ivy.Array, ivy.NativeArray],
     sparse: bool = False,
     indexing: str = "xy",
+    out: Optional(ivy.Array) = None
 ) -> List[ivy.Array]:
     """Returns coordinate matrices from coordinate vectors.
 
@@ -1404,7 +1405,7 @@ def meshgrid(
             [4, 4]])
 
     """
-    return current_backend().meshgrid(*arrays, sparse=sparse, indexing=indexing)
+    return current_backend().meshgrid(*arrays, sparse=sparse, indexing=indexing, out=out)
 
 
 @infer_device


### PR DESCRIPTION
The `out` argument was provided as a keyword-only argument the mershgrid function in the Ivy API under creation.py, with a default value of `None`.