### PR TITLE
Rename wrappers new_fn to reflect the decorators applied

### DIFF
--- a/ivy/func_wrapper.py
+++ b/ivy/func_wrapper.py
@@ -143,7 +143,7 @@ def handle_array_function(func):
     """
 
     @functools.wraps(func)
-    def new_func(*args, **kwargs):
+    def _handle_array_function(*args, **kwargs):
         overloaded_types = []
         overloaded_args = []
 
@@ -193,13 +193,13 @@ def handle_array_function(func):
             return value
         return func(*args, **kwargs)
 
-    new_func.handle_array_function = True
-    return new_func
+    _handle_array_function.handle_array_function = True
+    return _handle_array_function
 
 
 def handle_array_like_without_promotion(fn: Callable) -> Callable:
     @functools.wraps(fn)
-    def new_fn(*args, **kwargs):
+    def _handle_array_like_without_promotion(*args, **kwargs):
         args = list(args)
         num_args = len(args)
         try:
@@ -237,13 +237,13 @@ def handle_array_like_without_promotion(fn: Callable) -> Callable:
 
         return fn(*args, **kwargs)
 
-    new_fn.handle_array_like_without_promotion = True
-    return new_fn
+    _handle_array_like_without_promotion.handle_array_like_without_promotion = True
+    return _handle_array_like_without_promotion
 
 
 def inputs_to_native_arrays(fn: Callable) -> Callable:
     @functools.wraps(fn)
-    def new_fn(*args, **kwargs):
+    def _inputs_to_native_arrays(*args, **kwargs):
         """
         Converts all `ivy.Array` instances in both the positional and keyword arguments
         into `ivy.NativeArray` instances, and then calls the function with the updated
@@ -277,13 +277,13 @@ def inputs_to_native_arrays(fn: Callable) -> Callable:
             new_kwargs["out"] = out
         return fn(*new_args, **new_kwargs)
 
-    new_fn.inputs_to_native_arrays = True
-    return new_fn
+    _inputs_to_native_arrays.inputs_to_native_arrays = True
+    return _inputs_to_native_arrays
 
 
 def inputs_to_ivy_arrays(fn: Callable) -> Callable:
     @functools.wraps(fn)
-    def new_fn(*args, **kwargs):
+    def _inputs_to_ivy_arrays(*args, **kwargs):
         """
         Converts all `ivy.NativeArray` instances in both the positional and keyword
         arguments into `ivy.Array` instances, and then calls the function with the
@@ -313,13 +313,13 @@ def inputs_to_ivy_arrays(fn: Callable) -> Callable:
             ivy_kwargs["out"] = out
         return fn(*ivy_args, **ivy_kwargs)
 
-    new_fn.inputs_to_ivy_arrays = True
-    return new_fn
+    _inputs_to_ivy_arrays.inputs_to_ivy_arrays = True
+    return _inputs_to_ivy_arrays
 
 
 def outputs_to_ivy_arrays(fn: Callable) -> Callable:
     @functools.wraps(fn)
-    def new_fn(*args, **kwargs):
+    def _outputs_to_ivy_arrays(*args, **kwargs):
         """
         Calls the function, and then converts all `ivy.NativeArray` instances in
         the function return into `ivy.Array` instances.
@@ -345,8 +345,8 @@ def outputs_to_ivy_arrays(fn: Callable) -> Callable:
             else ret
         )
 
-    new_fn.outputs_to_ivy_arrays = True
-    return new_fn
+    _outputs_to_ivy_arrays.outputs_to_ivy_arrays = True
+    return _outputs_to_ivy_arrays
 
 
 def output_to_native_arrays(fn: Callable) -> Callable:
@@ -368,12 +368,12 @@ def output_to_native_arrays(fn: Callable) -> Callable:
     """
 
     @functools.wraps(fn)
-    def new_fn(*args, **kwargs):
+    def _output_to_native_arrays(*args, **kwargs):
         ret = fn(*args, **kwargs)
         return ivy.to_native(ret, nested=True, include_derived={tuple: True})
 
-    new_fn.outputs_to_native_arrays = True
-    return new_fn
+    _output_to_native_arrays.outputs_to_native_arrays = True
+    return _output_to_native_arrays
 
 
 def to_ivy_arrays_and_back(fn: Callable) -> Callable:
@@ -405,7 +405,7 @@ def handle_view(fn: Callable) -> Callable:
     """
 
     @functools.wraps(fn)
-    def new_fn(*args, **kwargs):
+    def _handle_view(*args, **kwargs):
         ret = fn(*args, **kwargs)
         if ("copy" in kwargs and kwargs["copy"]) or not ivy.is_ivy_array(args[0]):
             return ret
@@ -417,8 +417,8 @@ def handle_view(fn: Callable) -> Callable:
             ret = _build_view(original, ret, fn.__name__, args, kwargs, None)
         return ret
 
-    new_fn.handle_view = True
-    return new_fn
+    _handle_view.handle_view = True
+    return _handle_view
 
 
 def handle_view_indexing(fn: Callable) -> Callable:
@@ -435,7 +435,7 @@ def handle_view_indexing(fn: Callable) -> Callable:
     """
 
     @functools.wraps(fn)
-    def new_fn(*args, **kwargs):
+    def _handle_view_indexing(*args, **kwargs):
         ret = fn(*args, **kwargs)
         if ("copy" in kwargs and kwargs["copy"]) or not ivy.is_ivy_array(args[0]):
             return ret
@@ -449,8 +449,8 @@ def handle_view_indexing(fn: Callable) -> Callable:
         ret = _build_view(original, ret, "get_item", args, kwargs)
         return ret
 
-    new_fn.handle_view_indexing = True
-    return new_fn
+    _handle_view_indexing.handle_view_indexing = True
+    return _handle_view_indexing
 
 
 # Data Type Handling #
@@ -459,7 +459,7 @@ def handle_view_indexing(fn: Callable) -> Callable:
 
 def infer_dtype(fn: Callable) -> Callable:
     @functools.wraps(fn)
-    def new_fn(*args, dtype=None, **kwargs):
+    def _infer_dtype(*args, dtype=None, **kwargs):
         """
         Determines the correct `dtype`, and then calls the function with the `dtype`
         passed explicitly.
@@ -487,13 +487,13 @@ def infer_dtype(fn: Callable) -> Callable:
         # call the function with dtype provided explicitly
         return fn(*args, dtype=dtype, **kwargs)
 
-    new_fn.infer_dtype = True
-    return new_fn
+    _infer_dtype.infer_dtype = True
+    return _infer_dtype
 
 
 def integer_arrays_to_float(fn: Callable) -> Callable:
     @functools.wraps(fn)
-    def new_fn(*args, **kwargs):
+    def _integer_arrays_to_float(*args, **kwargs):
         """
         Promotes all the integer array inputs passed to the function both
         as positional or keyword arguments to the default float dtype.
@@ -524,8 +524,8 @@ def integer_arrays_to_float(fn: Callable) -> Callable:
         kwargs = ivy.nested_map(kwargs, _to_float_array, to_mutable=True)
         return fn(*args, **kwargs)
 
-    new_fn.integer_arrays_to_float = True
-    return new_fn
+    _integer_arrays_to_float.integer_arrays_to_float = True
+    return _integer_arrays_to_float
 
 
 # Device Handling #
@@ -534,7 +534,7 @@ def integer_arrays_to_float(fn: Callable) -> Callable:
 
 def infer_device(fn: Callable) -> Callable:
     @functools.wraps(fn)
-    def new_fn(*args, device=None, **kwargs):
+    def _infer_device(*args, device=None, **kwargs):
         """
         Determines the correct `device`, and then calls the function with the `device`
         passed explicitly.
@@ -561,8 +561,8 @@ def infer_device(fn: Callable) -> Callable:
         # call the function with device provided explicitly
         return fn(*args, device=device, **kwargs)
 
-    new_fn.infer_device = True
-    return new_fn
+    _infer_device.infer_device = True
+    return _infer_device
 
 
 # Inplace Update Handling #
@@ -574,7 +574,7 @@ def handle_out_argument(fn: Callable) -> Callable:
     handle_out_in_ivy = hasattr(fn, "mixed_function")
 
     @functools.wraps(fn)
-    def new_fn(*args, out=None, **kwargs):
+    def _handle_out_argument(*args, out=None, **kwargs):
         """
         Calls `fn` with the `out` argument handled correctly for performing an inplace
         update.
@@ -626,8 +626,8 @@ def handle_out_argument(fn: Callable) -> Callable:
         return ivy.inplace_update(out, ivy.astype(ret, ivy.dtype(out)))
         # return output matches the dtype of the out array to match numpy and torch
 
-    new_fn.handle_out_argument = True
-    return new_fn
+    _handle_out_argument.handle_out_argument = True
+    return _handle_out_argument
 
 
 def _update_torch_views(x, visited_view=None):
@@ -667,7 +667,7 @@ def handle_nestable(fn: Callable) -> Callable:
     fn_name = fn.__name__
 
     @functools.wraps(fn)
-    def new_fn(*args, **kwargs):
+    def _handle_nestable(*args, **kwargs):
         """
         Calls `fn` with the *nestable* property of the function correctly handled.
         This means mapping the function to the container leaves if any containers are
@@ -704,8 +704,8 @@ def handle_nestable(fn: Callable) -> Callable:
         # the passed arguments, returning an ivy or a native array.
         return fn(*args, **kwargs)
 
-    new_fn.handle_nestable = True
-    return new_fn
+    _handle_nestable.handle_nestable = True
+    return _handle_nestable
 
 
 # Functions #
@@ -948,7 +948,7 @@ def _nest_has_nans(x):
 
 def handle_nans(fn: Callable) -> Callable:
     @functools.wraps(fn)
-    def new_fn(*args, **kwargs):
+    def _handle_nans(*args, **kwargs):
         """
         Checks for the existence of nans in all arrays in the `args`
         and `kwargs`. The presence of nans is then handled depending
@@ -990,22 +990,22 @@ def handle_nans(fn: Callable) -> Callable:
 
         return fn(*args, **kwargs)
 
-    new_fn.handle_nans = True
-    return new_fn
+    _handle_nans.handle_nans = True
+    return _handle_nans
 
 
 def handle_mixed_function(condition) -> Callable:
     def inner_function(fn):
         @functools.wraps(fn)
-        def new_fn(*args, **kwargs):
-            compos = getattr(new_fn, "compos")
+        def _handle_mixed_function(*args, **kwargs):
+            compos = getattr(_handle_mixed_function, "compos")
             if condition(*args, **kwargs):
                 return fn(*args, **kwargs)
 
             return compos(*args, **kwargs)
 
-        new_fn.handle_mixed_functions = True
-        return new_fn
+        _handle_mixed_function.handle_mixed_functions = True
+        return _handle_mixed_function
 
     return inner_function
 

--- a/ivy/functional/frontends/jax/func_wrapper.py
+++ b/ivy/functional/frontends/jax/func_wrapper.py
@@ -58,7 +58,7 @@ def _to_ivy_array(x):
 
 def inputs_to_ivy_arrays(fn: Callable) -> Callable:
     @functools.wraps(fn)
-    def new_fn(*args, **kwargs):
+    def _inputs_to_ivy_arrays_jax(*args, **kwargs):
         # check if kwargs contains an out argument, and if so, remove it
         has_out = False
         out = None
@@ -78,12 +78,12 @@ def inputs_to_ivy_arrays(fn: Callable) -> Callable:
             new_kwargs["out"] = out
         return fn(*new_args, **new_kwargs)
 
-    return new_fn
+    return _inputs_to_ivy_arrays_jax
 
 
 def outputs_to_frontend_arrays(fn: Callable) -> Callable:
     @functools.wraps(fn)
-    def new_fn(*args, **kwargs):
+    def _outputs_to_frontend_arrays_jax(*args, **kwargs):
         weak_type = not any(
             (isinstance(arg, jax_frontend.DeviceArray) and arg.weak_type is False)
             or ivy.is_array(arg)
@@ -116,7 +116,7 @@ def outputs_to_frontend_arrays(fn: Callable) -> Callable:
             ret, nested=True, include_derived={tuple: True}
         )
 
-    return new_fn
+    return _outputs_to_frontend_arrays_jax
 
 
 def to_ivy_arrays_and_back(fn: Callable) -> Callable:
@@ -125,7 +125,7 @@ def to_ivy_arrays_and_back(fn: Callable) -> Callable:
 
 def handle_jax_dtype(fn: Callable) -> Callable:
     @functools.wraps(fn)
-    def new_fn(*args, dtype=None, **kwargs):
+    def _handle_jax_dtype(*args, dtype=None, **kwargs):
         if len(args) > (dtype_pos + 1):
             dtype = args[dtype_pos]
             kwargs = {
@@ -158,15 +158,15 @@ def handle_jax_dtype(fn: Callable) -> Callable:
         return fn(*args, dtype=dtype, **kwargs)
 
     dtype_pos = list(inspect.signature(fn).parameters).index("dtype")
-    return new_fn
+    return _handle_jax_dtype
 
 
 def outputs_to_native_arrays(fn: Callable):
     @functools.wraps(fn)
-    def new_fn(*args, **kwargs):
+    def _outputs_to_native_arrays(*args, **kwargs):
         ret = fn(*args, **kwargs)
         if isinstance(ret, jax_frontend.DeviceArray):
             ret = ret.ivy_array.data
         return ret
 
-    return new_fn
+    return _outputs_to_native_arrays

--- a/ivy/functional/frontends/mxnet/func_wrapper.py
+++ b/ivy/functional/frontends/mxnet/func_wrapper.py
@@ -30,7 +30,7 @@ def _to_ivy_array(x):
 
 def inputs_to_ivy_arrays(fn: Callable) -> Callable:
     @functools.wraps(fn)
-    def new_fn(*args, **kwargs):
+    def _inputs_to_ivy_arrays_mxnet(*args, **kwargs):
         """
         Converts all `ndarray.NDArray` instances in both the positional and keyword
         arguments into `ivy.Array` instances, and then calls the function with the
@@ -45,13 +45,13 @@ def inputs_to_ivy_arrays(fn: Callable) -> Callable:
         )
         return fn(*new_args, **new_kwargs)
 
-    new_fn.inputs_to_ivy_arrays = True
-    return new_fn
+    _inputs_to_ivy_arrays_mxnet.inputs_to_ivy_arrays = True
+    return _inputs_to_ivy_arrays_mxnet
 
 
 def outputs_to_frontend_arrays(fn: Callable) -> Callable:
     @functools.wraps(fn)
-    def new_fn(*args, **kwargs):
+    def _outputs_to_frontend_arrays_mxnet(*args, **kwargs):
         """
         Calls the function, and then converts all `ivy.Array` instances in
         the function return into `ndarray.NDArray` instances.
@@ -62,8 +62,8 @@ def outputs_to_frontend_arrays(fn: Callable) -> Callable:
         # convert all arrays in the return to `frontend.Tensorflow.tensor` instances
         return ivy.nested_map(ret, _ivy_array_to_mxnet, include_derived={tuple: True})
 
-    new_fn.outputs_to_frontend_arrays = True
-    return new_fn
+    _outputs_to_frontend_arrays_mxnet.outputs_to_frontend_arrays = True
+    return _outputs_to_frontend_arrays_mxnet
 
 
 def to_ivy_arrays_and_back(fn: Callable) -> Callable:
@@ -76,7 +76,7 @@ def to_ivy_arrays_and_back(fn: Callable) -> Callable:
 
 def handle_mxnet_out(fn: Callable) -> Callable:
     @functools.wraps(fn)
-    def new_fn(*args, out=None, **kwargs):
+    def _handle_mxnet_out(*args, out=None, **kwargs):
         if len(args) > (out_pos + 1):
             out = args[out_pos]
             kwargs = {
@@ -103,5 +103,5 @@ def handle_mxnet_out(fn: Callable) -> Callable:
         return fn(*args, **kwargs)
 
     out_pos = list(inspect.signature(fn).parameters).index("out")
-    new_fn.handle_numpy_out = True
-    return new_fn
+    _handle_mxnet_out.handle_numpy_out = True
+    return _handle_mxnet_out

--- a/ivy/functional/frontends/numpy/func_wrapper.py
+++ b/ivy/functional/frontends/numpy/func_wrapper.py
@@ -130,7 +130,7 @@ def _assert_no_scalar(args, dtype, none=False):
 
 def handle_numpy_dtype(fn: Callable) -> Callable:
     @functools.wraps(fn)
-    def new_fn(*args, dtype=None, **kwargs):
+    def _handle_numpy_dtype(*args, dtype=None, **kwargs):
         if len(args) > (dtype_pos + 1):
             dtype = args[dtype_pos]
             kwargs = {
@@ -151,13 +151,13 @@ def handle_numpy_dtype(fn: Callable) -> Callable:
         return fn(*args, dtype=np_frontend.to_ivy_dtype(dtype), **kwargs)
 
     dtype_pos = list(inspect.signature(fn).parameters).index("dtype")
-    new_fn.handle_numpy_dtype = True
-    return new_fn
+    _handle_numpy_dtype.handle_numpy_dtype = True
+    return _handle_numpy_dtype
 
 
 def handle_numpy_casting(fn: Callable) -> Callable:
     @functools.wraps(fn)
-    def new_fn(*args, casting="same_kind", dtype=None, **kwargs):
+    def _handle_numpy_casting(*args, casting="same_kind", dtype=None, **kwargs):
         """
         Check numpy casting type.
 
@@ -213,13 +213,13 @@ def handle_numpy_casting(fn: Callable) -> Callable:
 
         return fn(*args, **kwargs)
 
-    new_fn.handle_numpy_casting = True
-    return new_fn
+    _handle_numpy_casting.handle_numpy_casting = True
+    return _handle_numpy_casting
 
 
 def handle_numpy_casting_special(fn: Callable) -> Callable:
     @functools.wraps(fn)
-    def new_fn(*args, casting="same_kind", dtype=None, **kwargs):
+    def _handle_numpy_casting_special(*args, casting="same_kind", dtype=None, **kwargs):
         """
         Check numpy casting type for special cases where output must be type bool.
 
@@ -249,8 +249,8 @@ def handle_numpy_casting_special(fn: Callable) -> Callable:
 
         return fn(*args, **kwargs)
 
-    new_fn.handle_numpy_casting_special = True
-    return new_fn
+    _handle_numpy_casting_special.handle_numpy_casting_special = True
+    return _handle_numpy_casting_special
 
 
 def _numpy_frontend_to_ivy(x: Any) -> Any:
@@ -322,7 +322,7 @@ def _set_order(args, order):
 
 def inputs_to_ivy_arrays(fn: Callable) -> Callable:
     @functools.wraps(fn)
-    def new_fn(*args, **kwargs):
+    def _inputs_to_ivy_arrays_np(*args, **kwargs):
         """
         Converts all `ndarray` instances in both the positional and keyword
         arguments into `ivy.Array` instances, and then calls the function with the
@@ -346,13 +346,13 @@ def inputs_to_ivy_arrays(fn: Callable) -> Callable:
         )
         return fn(*ivy_args, **ivy_kwargs)
 
-    new_fn.inputs_to_ivy_arrays = True
-    return new_fn
+    _inputs_to_ivy_arrays_np.inputs_to_ivy_arrays = True
+    return _inputs_to_ivy_arrays_np
 
 
 def outputs_to_numpy_arrays(fn: Callable) -> Callable:
     @functools.wraps(fn)
-    def new_fn(*args, order="K", **kwargs):
+    def _outputs_to_numpy_arrays(*args, order="K", **kwargs):
         """
         Calls the function, and then converts all `ivy.Array` instances returned
         by the function into `ndarray` instances.
@@ -403,8 +403,8 @@ def outputs_to_numpy_arrays(fn: Callable) -> Callable:
         order_pos = list(inspect.signature(fn).parameters).index("order")
     else:
         contains_order = False
-    new_fn.outputs_to_numpy_arrays = True
-    return new_fn
+    _outputs_to_numpy_arrays.outputs_to_numpy_arrays = True
+    return _outputs_to_numpy_arrays
 
 
 def to_ivy_arrays_and_back(fn: Callable) -> Callable:
@@ -417,7 +417,7 @@ def to_ivy_arrays_and_back(fn: Callable) -> Callable:
 
 def from_zero_dim_arrays_to_scalar(fn: Callable) -> Callable:
     @functools.wraps(fn)
-    def new_fn(*args, **kwargs):
+    def _from_zero_dim_arrays_to_scalar(*args, **kwargs):
         """
         Calls the function, and then converts all 0 dimensional array instances in
         the function to float numbers if out argument is not provided.
@@ -466,13 +466,13 @@ def from_zero_dim_arrays_to_scalar(fn: Callable) -> Callable:
                         )
         return ret
 
-    new_fn.from_zero_dim_arrays_to_scalar = True
-    return new_fn
+    _from_zero_dim_arrays_to_scalar.from_zero_dim_arrays_to_scalar = True
+    return _from_zero_dim_arrays_to_scalar
 
 
 def handle_numpy_out(fn: Callable) -> Callable:
     @functools.wraps(fn)
-    def new_fn(*args, out=None, **kwargs):
+    def _handle_numpy_out(*args, out=None, **kwargs):
         if len(args) > (out_pos + 1):
             out = args[out_pos]
             kwargs = {
@@ -499,5 +499,5 @@ def handle_numpy_out(fn: Callable) -> Callable:
         return fn(*args, **kwargs)
 
     out_pos = list(inspect.signature(fn).parameters).index("out")
-    new_fn.handle_numpy_out = True
-    return new_fn
+    _handle_numpy_out.handle_numpy_out = True
+    return _handle_numpy_out

--- a/ivy/functional/frontends/tensorflow/func_wrapper.py
+++ b/ivy/functional/frontends/tensorflow/func_wrapper.py
@@ -17,7 +17,7 @@ def to_ivy_dtype(dtype):
 
 def handle_tf_dtype(fn: Callable) -> Callable:
     @functools.wraps(fn)
-    def new_fn(*args, dtype=None, **kwargs):
+    def _handle_tf_dtype(*args, dtype=None, **kwargs):
         if len(args) > (dtype_pos + 1):
             dtype = args[dtype_pos]
             kwargs = {
@@ -39,8 +39,8 @@ def handle_tf_dtype(fn: Callable) -> Callable:
         return fn(*args, dtype=dtype, **kwargs)
 
     dtype_pos = list(inspect.signature(fn).parameters).index("dtype")
-    new_fn.handle_tf_dtype = True
-    return new_fn
+    _handle_tf_dtype.handle_tf_dtype = True
+    return _handle_tf_dtype
 
 
 def _tf_frontend_array_to_ivy(x):
@@ -67,7 +67,7 @@ def _to_ivy_array(x):
 
 def inputs_to_ivy_arrays(fn: Callable) -> Callable:
     @functools.wraps(fn)
-    def new_fn(*args, **kwargs):
+    def _inputs_to_ivy_arrays_tf(*args, **kwargs):
         """
         Converts all `TensorFlow.Tensor` instances in both the positional and keyword
         arguments into `ivy.Array` instances, and then calls the function with the
@@ -103,13 +103,13 @@ def inputs_to_ivy_arrays(fn: Callable) -> Callable:
             ivy_kwargs["out"] = out
         return fn(*ivy_args, **ivy_kwargs)
 
-    new_fn.inputs_to_ivy_arrays = True
-    return new_fn
+    _inputs_to_ivy_arrays_tf.inputs_to_ivy_arrays = True
+    return _inputs_to_ivy_arrays_tf
 
 
 def outputs_to_frontend_arrays(fn: Callable) -> Callable:
     @functools.wraps(fn)
-    def new_fn(*args, **kwargs):
+    def _outputs_to_frontend_arrays_tf(*args, **kwargs):
         """
         Calls the function, and then converts all `tensorflow.Tensor` instances in
         the function return into `ivy.Array` instances.
@@ -134,8 +134,8 @@ def outputs_to_frontend_arrays(fn: Callable) -> Callable:
             ret, _ivy_array_to_tensorflow, include_derived={tuple: True}
         )
 
-    new_fn.outputs_to_frontend_arrays = True
-    return new_fn
+    _outputs_to_frontend_arrays_tf.outputs_to_frontend_arrays = True
+    return _outputs_to_frontend_arrays_tf
 
 
 def to_ivy_arrays_and_back(fn: Callable) -> Callable:

--- a/ivy/functional/frontends/torch/func_wrapper.py
+++ b/ivy/functional/frontends/torch/func_wrapper.py
@@ -33,7 +33,7 @@ def _to_ivy_array(x):
 
 def inputs_to_ivy_arrays(fn: Callable) -> Callable:
     @functools.wraps(fn)
-    def new_fn(*args, **kwargs):
+    def _inputs_to_ivy_arrays_torch(*args, **kwargs):
         """
         Converts all `Tensor` instances in both the positional and keyword
         arguments into `ivy.Array` instances, and then calls the function with the
@@ -55,12 +55,12 @@ def inputs_to_ivy_arrays(fn: Callable) -> Callable:
         )
         return fn(*new_args, **new_kwargs)
 
-    return new_fn
+    return _inputs_to_ivy_arrays_torch
 
 
 def outputs_to_frontend_arrays(fn: Callable) -> Callable:
     @functools.wraps(fn)
-    def new_fn(*args, **kwargs):
+    def outputs_to_frontend_arrays_torch(*args, **kwargs):
         """
         Calls the function, and then converts all `ivy.Array` instances returned
         by the function into `Tensor` instances.
@@ -86,7 +86,7 @@ def outputs_to_frontend_arrays(fn: Callable) -> Callable:
             ret, nested=True, include_derived={tuple: True}
         )
 
-    return new_fn
+    return outputs_to_frontend_arrays_torch
 
 
 def to_ivy_arrays_and_back(fn: Callable) -> Callable:
@@ -99,10 +99,10 @@ def to_ivy_arrays_and_back(fn: Callable) -> Callable:
 
 def outputs_to_native_arrays(fn: Callable):
     @functools.wraps(fn)
-    def new_fn(*args, **kwargs):
+    def outputs_to_native_arrays_torch(*args, **kwargs):
         ret = fn(*args, **kwargs)
         if isinstance(ret, torch_frontend.Tensor):
             ret = ret.ivy_array.data
         return ret
 
-    return new_fn
+    return outputs_to_native_arrays_torch

--- a/ivy/functional/ivy/creation.py
+++ b/ivy/functional/ivy/creation.py
@@ -38,7 +38,7 @@ def asarray_handle_nestable(fn: Callable) -> Callable:
     fn_name = fn.__name__
 
     @functools.wraps(fn)
-    def new_fn(*args, **kwargs):
+    def _asarray_handle_nestable(*args, **kwargs):
         """
         Calls `fn` with the *nestable* property of the function correctly handled.
         This means mapping the function to the container leaves if any containers are
@@ -66,8 +66,8 @@ def asarray_handle_nestable(fn: Callable) -> Callable:
         # the passed arguments, returning an ivy or a native array.
         return fn(*args, **kwargs)
 
-    new_fn.handle_nestable = True
-    return new_fn
+    _asarray_handle_nestable.handle_nestable = True
+    return _asarray_handle_nestable
 
 
 def _ivy_to_native(x):
@@ -87,7 +87,7 @@ def _ivy_to_native(x):
 
 def asarray_to_native_arrays_and_back(fn: Callable) -> Callable:
     @functools.wraps(fn)
-    def new_fn(*args, dtype=None, **kwargs):
+    def _asarray_to_native_arrays_and_back(*args, dtype=None, **kwargs):
         """
         Wraps `fn` so that input arrays are all converted to `ivy.NativeArray` instances
         and return arrays are all converted to `ivy.Array` instances. This wrapper is
@@ -102,12 +102,12 @@ def asarray_to_native_arrays_and_back(fn: Callable) -> Callable:
             dtype = ivy.default_dtype(dtype=dtype, as_native=True)
         return to_ivy(fn(*new_args, dtype=dtype, **kwargs))
 
-    return new_fn
+    return _asarray_to_native_arrays_and_back
 
 
 def asarray_infer_device(fn: Callable) -> Callable:
     @functools.wraps(fn)
-    def new_fn(*args, device=None, **kwargs):
+    def _asarray_infer_device(*args, device=None, **kwargs):
         """
         Determines the correct `device`, and then calls the function with the `device`
         passed explicitly. This wrapper is specifically for the backend implementations
@@ -140,8 +140,8 @@ def asarray_infer_device(fn: Callable) -> Callable:
         # call the function with device provided explicitly
         return fn(*args, device=device, **kwargs)
 
-    new_fn.infer_device = True
-    return new_fn
+    _asarray_infer_device.infer_device = True
+    return _asarray_infer_device
 
 
 # Type hints #

--- a/ivy/functional/ivy/data_type.py
+++ b/ivy/functional/ivy/data_type.py
@@ -45,7 +45,7 @@ def _is_valid_dtypes_attributes(fn: Callable) -> bool:
 
 
 def _handle_nestable_dtype_info(fn):
-    def new_fn(type):
+    def _handle_nestable_dtype_info_wrapper(type):
         if isinstance(type, ivy.Container):
             type = type.cont_map(lambda x, kc: fn(x))
             type.__dict__["max"] = type.cont_map(lambda x, kc: x.max)
@@ -53,7 +53,7 @@ def _handle_nestable_dtype_info(fn):
             return type
         return fn(type)
 
-    return new_fn
+    return _handle_nestable_dtype_info_wrapper
 
 
 # Unindent every line in the source such that

--- a/ivy/stateful/module.py
+++ b/ivy/stateful/module.py
@@ -134,7 +134,7 @@ class Module(ModuleConverters, ModuleHelpers):
         as inputs to the call function fn of the module.
         """
 
-        def new_fn(*a, with_grads=None, **kw):
+        def _fn_with_var_arg_wrapper(*a, with_grads=None, **kw):
             with_grads = ivy.with_grads(with_grads=with_grads)
             if "v" in kw.keys():
                 del kw["v"]
@@ -143,8 +143,8 @@ class Module(ModuleConverters, ModuleHelpers):
                 v = v.stop_gradient()
             return fn(*a, **kw, v=v)
 
-        new_fn.wrapped = True
-        return new_fn
+        _fn_with_var_arg_wrapper.wrapped = True
+        return _fn_with_var_arg_wrapper
 
     def _find_variables(self, /, *, obj=None, _visited=None):
         """

--- a/ivy/utils/backend/handler.py
+++ b/ivy/utils/backend/handler.py
@@ -55,12 +55,12 @@ for backend in os.listdir(
 
 def prevent_access_locally(fn):
     @functools.wraps(fn)
-    def new_fn(*args, **kwargs):
+    def _prevent_access_locally(*args, **kwargs):
         if ivy.is_local():
             raise RuntimeError(f"Calling {fn.__name__} is not allowed on this object.")
         return fn(*args, **kwargs)
 
-    return new_fn
+    return _prevent_access_locally
 
 
 @functools.lru_cache

--- a/ivy/utils/exceptions.py
+++ b/ivy/utils/exceptions.py
@@ -102,7 +102,7 @@ class IvyError(IndexError, ValueError, AttributeError, IvyException):
 
 def handle_exceptions(fn: Callable) -> Callable:
     @functools.wraps(fn)
-    def new_fn(*args, **kwargs):
+    def _handle_exceptions(*args, **kwargs):
         """
         Catch all exceptions and raise them in IvyException
 
@@ -130,5 +130,5 @@ def handle_exceptions(fn: Callable) -> Callable:
             _print_traceback_history()
             raise ivy.utils.exceptions.IvyBackendException(fn.__name__, str(e))
 
-    new_fn.handle_exceptions = True
-    return new_fn
+    _handle_exceptions.handle_exceptions = True
+    return _handle_exceptions


### PR DESCRIPTION
Will be helpful in error messages to see decorator names rather than long list of `new_fn`. Task https://trello.com/c/QiuekMP8/1715-rename-the-newfn-in-decorators.