### PR TITLE
Add nextafter to Jax frontend

### DIFF
--- a/ivy/functional/frontends/jax/lax/operators.py
+++ b/ivy/functional/frontends/jax/lax/operators.py
@@ -615,3 +615,8 @@ def squeeze(array, dimensions):
 @to_ivy_arrays_and_back
 def real(x):
     return ivy.real(x)
+
+
+@to_ivy_arrays_and_back
+def nextafter(x1, x2):
+    return ivy.nextafter(x1, x2)

--- a/ivy_tests/test_ivy/test_frontends/test_jax/test_jax_lax_operators.py
+++ b/ivy_tests/test_ivy/test_frontends/test_jax/test_jax_lax_operators.py
@@ -2517,3 +2517,39 @@ def test_jax_lax_squeeze(
         array=value[0],
         dimensions=dim,
     )
+
+
+# nextafter
+@handle_frontend_test(
+    fn_tree="jax.lax.nextafter",
+    dtype_and_x=helpers.dtype_and_values(
+        available_dtypes=["float32", "float64"],
+        min_value=-100,
+        max_value=100,
+        min_num_dims=1,
+        max_num_dims=3,
+        min_dim_size=1,
+        max_dim_size=3,
+        num_arrays=2,
+        shared_dtype=True,
+    ),
+    test_with_out=st.just(False),
+)
+def test_jax_lax_nextafter(
+    *,
+    dtype_and_x,
+    on_device,
+    fn_tree,
+    frontend,
+    test_flags,
+):
+    input_dtype, x = dtype_and_x
+    helpers.test_frontend_function(
+        input_dtypes=input_dtype,
+        frontend=frontend,
+        test_flags=test_flags,
+        fn_tree=fn_tree,
+        on_device=on_device,
+        x1=x[0],
+        x2=x[0],
+    )


### PR DESCRIPTION
Close #14489
Implemented and tested the operator function `nextafter` from the `jax.lax` namespace in Jax frontend.