### PR TITLE
Created TensorFlow expm frontend function

### DIFF
--- a/ivy/functional/frontends/tensorflow/linalg.py
+++ b/ivy/functional/frontends/tensorflow/linalg.py
@@ -293,3 +293,9 @@ def diag(
     if (num_cols and num_rows) and (size == (num_cols * num_rows)):
         output = ivy.reshape(output, (num_rows, num_cols))
     return ivy.astype(output, ivy.dtype(diagonal))
+
+
+@to_ivy_arrays_and_back
+@with_unsupported_dtypes({"2.9.1 and below": ("float16", "bfloat16", "float32", "complex64")}, "tensorflow")
+def expm(input, name=None):
+    return ivy.matrix_exp(input)

--- a/ivy_tests/test_ivy/test_frontends/test_tensorflow/test_linalg.py
+++ b/ivy_tests/test_ivy/test_frontends/test_tensorflow/test_linalg.py
@@ -869,3 +869,36 @@ def test_tensorflow_diag(
         v=x[0],
         k=k,
     )
+
+
+#expm
+@handle_frontend_test(
+    fn_tree="tensorflow.linalg.expm",
+    dtype_and_x=
+    helpers.dtype_and_values(
+        available_dtypes=helpers.get_dtypes("float_and_complex"),
+        min_value=1e-3,
+        max_value=50,
+        shape=helpers.ints(min_value=2, max_value=8).map(lambda x: tuple([x, x])),
+    ),
+    test_with_out=st.just(False),
+)
+def test_tensorflow_expm(
+    *,
+    dtype_and_x,
+    frontend,
+    test_flags,
+    fn_tree,
+    on_device,
+):
+    input_dtype, x = dtype_and_x
+    helpers.test_frontend_function(
+        input_dtypes=input_dtype,
+        frontend=frontend,
+        test_flags=test_flags,
+        fn_tree=fn_tree,
+        on_device=on_device,
+        input=x[0],
+        atol=1e-3,
+        rtol=1e-3,
+    )


### PR DESCRIPTION
Currently facing 2 issues:
1. Some dtypes that the original function supports don't work with some backend functions; I've found that only float64 and complex128 seem to work across all backends (except for Paddle)
2. Paddle's backend implementation is performing a completely different operation to the Ivy function it's linked to, and I can't find a native implementation for a matrix exponential. Should a compositional backend function also be implemented as part of this PR?