### PR TITLE
Update layers.py

### DIFF
--- a/ivy/functional/backends/tensorflow/experimental/layers.py
+++ b/ivy/functional/backends/tensorflow/experimental/layers.py
@@ -644,8 +644,7 @@ def interpolate(
     size: Union[Sequence[int], int],
     /,
     *,
-    mode: Union[
-        Literal[
+    mode: Literal[
             "linear",
             "bilinear",
             "trilinear",
@@ -659,8 +658,7 @@ def interpolate(
             "lanczos3",
             "lanczos5",
             "gaussian",
-        ]
-    ] = "linear",
+        ] = "linear",
     scale_factor: Optional[Union[Sequence[int], int]] = None,
     recompute_scale_factor: Optional[bool] = None,
     align_corners: Optional[bool] = None,


### PR DESCRIPTION
In interpolate function of tensorflow/experimental/layers.py file there is union with only one argument. In interpolate function's mode argument I think there is no need of union.