### PR TITLE
Fix local import for `ivy.with_backend`

### DIFF
--- a/ivy/utils/_importlib.py
+++ b/ivy/utils/_importlib.py
@@ -25,7 +25,6 @@ class LocalIvyImporter:
     def __exit__(self, *exc):
         path_hooks.remove(self.finder)
         sys.meta_path.remove(self.finder)
-        _clear_cache()
 
 
 def _clear_cache():

--- a/ivy/utils/backend/handler.py
+++ b/ivy/utils/backend/handler.py
@@ -601,6 +601,7 @@ def with_backend(backend: str, cached: bool = False):
             _importlib.import_cache
         )
         _compiled_backends_ids[ivy_pack._compiled_id] = ivy_pack
+        _importlib._clear_cache()
     try:
         compiled_backends[backend].append(ivy_pack)
     except KeyError:


### PR DESCRIPTION
- Fix a bug where the import cache is cleared when using Ivy dynamic import