### PR TITLE
fix shape not being cast to proper dtype

### DIFF
--- a/ivy/functional/backends/tensorflow/experimental/random.py
+++ b/ivy/functional/backends/tensorflow/experimental/random.py
@@ -92,6 +92,7 @@ def gamma(
     shape = _check_bounds_and_get_shape(alpha, beta, shape)
     alpha = tf.cast(alpha, dtype)
     beta = tf.cast(beta, dtype)
+    shape = tf.cast(shape, dtype)
     with tf.device(device):
         return tfp.distributions.Gamma(alpha, beta).sample(shape, seed=seed)
 


### PR DESCRIPTION
Closes #14607

`shape` was being passed as `ivy.Shape` to a tensorflow function, instead of being first cast to the proper `dtype`