### PR TITLE
Added encdoing='utf-8' to source code file opener.

### DIFF
--- a/ivy/utils/backend/ast_helpers.py
+++ b/ivy/utils/backend/ast_helpers.py
@@ -265,7 +265,7 @@ class IvyLoader(Loader):
         if self.filename in _compiled_modules_cache:
             compiled_obj = _compiled_modules_cache[self.filename]
         else:
-            with open(self.filename) as f:
+            with open(self.filename, mode="r", encoding="utf-8") as f:
                 data = f.read()
 
             ast_tree = parse(data)


### PR DESCRIPTION
Added encdoing='utf-8' to source code file opener. It was failing to open when file contains no-ascii characters