### PR TITLE
fixed ivy.histogram() not returning bin_edges

### DIFF
--- a/ivy/functional/ivy/experimental/statistical.py
+++ b/ivy/functional/ivy/experimental/statistical.py
@@ -14,6 +14,8 @@ from ivy.utils.exceptions import handle_exceptions
 #       Bins as str is not defined (check Numpy implementation).
 #       Permit multiple axis.
 #       Modify documentation to match the above modifications.
+
+
 @to_native_arrays_and_back
 @handle_out_argument
 @handle_nestable
@@ -31,7 +33,7 @@ def histogram(
     weights: Optional[Union[ivy.Array, ivy.NativeArray]] = None,
     density: Optional[bool] = False,
     out: Optional[ivy.Array] = None,
-) -> ivy.Array:
+) -> Tuple[ivy.Array, ivy.Array]:
     """
     Compute the histogram of the array ``a``.
 
@@ -130,7 +132,7 @@ def histogram(
     (ivy.array([1, 1, 1, 0, 0]), ivy.array([0., 1., 2., 3., 4., 5.]))
     (ivy.array([0, 0, 0, 1, 2]), ivy.array([0., 1., 2., 3., 4., 5.]))
     """
-    return ivy.current_backend(a).histogram(
+    hist = ivy.current_backend(a).histogram(
         a,
         bins=bins,
         axis=axis,
@@ -142,6 +144,11 @@ def histogram(
         density=density,
         out=out,
     )
+    if isinstance(bins, int):
+        bin_edges = ivy.linspace(range[0], range[1], bins + 1)
+    else:
+        bin_edges = bins
+    return hist, bin_edges
 
 
 @to_native_arrays_and_back


### PR DESCRIPTION
The current version of `ivy.histogram()` only return the values of the histogram and not the `bin_edges`. Although, the  doc-string and example mentions that it returns both, the `histogram_values` as well as the `bin_edges` values but it doesn't.
```py
@to_native_arrays_and_back
@handle_out_argument
@handle_nestable
@handle_exceptions
def histogram(
    a: Union[ivy.Array, ivy.NativeArray],
    /,
    *,
    bins: Optional[Union[int, ivy.Array, ivy.NativeArray, str]] = None,
    axis: Optional[Union[ivy.Array, ivy.NativeArray]] = None,
    extend_lower_interval: Optional[bool] = False,
    extend_upper_interval: Optional[bool] = False,
    dtype: Optional[Union[ivy.Dtype, ivy.NativeDtype]] = None,
    range: Optional[Tuple[float]] = None,
    weights: Optional[Union[ivy.Array, ivy.NativeArray]] = None,
    density: Optional[bool] = False,
    out: Optional[ivy.Array] = None,
) -> ivy.Array:
```
The current  function signature(as shown in the above code-block)  signals that  we are  returning a single array but the current doc-string is saying that we're returning a tuple:
```text
    -------
    ret
        a tuple containing the values of the histogram and the bin edges.

    Both the description and the type hints above assumes an array input for simplicity,
    but this function is *nestable*, and therefore also accepts :class:`ivy.Container`
    instances in place of any of the arguments.

    Examples
    --------
    With :class:`ivy.Array` input:

    >>> x = ivy.array([0, 1, 2])
    >>> y = ivy.array([0., 0.5, 1., 1.5, 2.])
    >>> z = ivy.histogram(x, bins=y)
    >>> print(z)
    (ivy.array([1, 0, 1, 1]), ivy.array([0. , 0.5, 1. , 1.5, 2. ])) 
```

Thus,  at-present the calling `ivy.histogram` with the following will only return the `histogram_values` as shown below:
```py
import ivy
x = ivy.array([0, 1, 2])
y = ivy.array([0., 0.5, 1., 1.5, 2.])
hist = ivy.histogram(x, bins=y)
print(f'hist={hist}'
# returns : hist=ivy.array([1, 0, 1, 1])
```

This **PR** is fixing this issue and we're returning both the `histogram_values` as well as the `bin_edges`:
```py
import ivy
x = ivy.array([0, 1, 2])
y = ivy.array([0., 0.5, 1., 1.5, 2.])
hist = ivy.histogram(x, bins=y)
print(f'hist={hist}')

"""prints
hist=(ivy.array([1, 0, 1, 1]), ivy.array([0. , 0.5, 1. , 1.5, 2. ]))
"""
```

But if we only want to return the `histogram_values`  then the current `ivy.histogram()` is working as expected and the changes proposed in this PR can ignored and  instead we should just change the `doc-string` examples to highlight that `ivy.histogram()` only return `histogram_values`.