### PR TITLE
Fix TypeError by converting axis to a tuple (Small fix)

### DIFF
--- a/ivy/functional/backends/jax/linear_algebra.py
+++ b/ivy/functional/backends/jax/linear_algebra.py
@@ -196,7 +196,7 @@ def matrix_norm(
     out: Optional[JaxArray] = None,
 ) -> JaxArray:
     if not isinstance(axis, tuple):
-        axis = tuple(axis)
+        axis = (axis, )
     return jnp.linalg.norm(x, ord=ord, axis=axis, keepdims=keepdims)
 
 


### PR DESCRIPTION
Converted the variable axis from an integer to a tuple to resolve the TypeError. The original code was throwing a 'int' object is not iterable error. By encapsulating axis with parentheses and adding a comma, it was transformed into a tuple, allowing it to be used as an argument in functions that require an iterable object.

Closes #14977 