### PR TITLE
Change base image from debian to ubuntu and upgrade python version

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,8 +1,8 @@
-FROM debian:buster
+FROM ubuntu:22.04
 WORKDIR /ivy
 ARG CLI
 # python version for conda
-ARG pycon=3.8.10
+ARG pycon=3.10
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -27,7 +27,6 @@ ENV PATH=/opt/miniconda/envs/multienv/bin:$PATH
 RUN apt-get update && \
     apt-get install -y python3-pip python3-tk && \
     apt-get install -y libsm6 libxext6 libxrender-dev libgl1-mesa-glx && \
-    apt-get install -y python-opengl && \
     apt-get install -y git && \
     apt-get install -y rsync && \
     apt-get install -y libusb-1.0-0 && \
@@ -35,7 +34,8 @@ RUN apt-get update && \
     apt-get install -y jq && \
     pip3 install --upgrade pip && \
     pip3 install pip-autoremove &&\
-    pip3 install setuptools==58.5.3
+    pip3 install setuptools==58.5.3 && \
+    pip3 install PyOpenGL PyOpenGL_accelerate
 
 
 


### PR DESCRIPTION
The PR updates the dockerfile with the following changes:

1. Change the docker image from Debian buster to Ubuntu 22.04
2. Upgrade Python from 3.8 to 3.10
3. Make use of `PyOpenGL` pip package instead of the apt package