### PR TITLE
Adding jax lax is_finite operator and tests

### DIFF
--- a/ivy/functional/frontends/jax/lax/operators.py
+++ b/ivy/functional/frontends/jax/lax/operators.py
@@ -730,3 +730,8 @@ def nextafter(x1, x2):
 @to_ivy_arrays_and_back
 def conj(x):
     return ivy.conj(x)
+
+
+@to_ivy_arrays_and_back
+def is_finite(x):
+    return ivy.isfinite(x)

--- a/ivy_tests/test_ivy/test_frontends/test_jax/test_jax_lax_operators.py
+++ b/ivy_tests/test_ivy/test_frontends/test_jax/test_jax_lax_operators.py
@@ -2725,3 +2725,28 @@ def test_jax_lax_conj(
         on_device=on_device,
         x=x[0],
     )
+
+
+# is_finite
+@handle_frontend_test(
+    fn_tree="jax.lax.is_finite",
+    dtype_and_x=helpers.dtype_and_values(available_dtypes=helpers.get_dtypes("float")),
+    test_with_out=st.just(False),
+)
+def test_jax_lax_is_finite(
+    *,
+    dtype_and_x,
+    on_device,
+    fn_tree,
+    frontend,
+    test_flags,
+):
+    input_dtype, x = dtype_and_x
+    helpers.test_frontend_function(
+        input_dtypes=input_dtype,
+        frontend=frontend,
+        test_flags=test_flags,
+        fn_tree=fn_tree,
+        on_device=on_device,
+        x=x[0],
+    )


### PR DESCRIPTION
For the `is_finite` operator (addressed in the issue https://github.com/unifyai/ivy/issues/13916):

- Implements Ivy Frontend API.
- Includes Ivy Frontend Tests.

There was a typo in https://github.com/unifyai/ivy/issues/1578 as the list of operators doesn't have `is_dinite`.

Ref: [Operator functions](https://jax.readthedocs.io/en/latest/jax.lax.html#operators)

Previous PR: https://github.com/unifyai/ivy/pull/13917