### PR TITLE
Unsupported dtype decorator

### DIFF
--- a/ivy/func_wrapper.py
+++ b/ivy/func_wrapper.py
@@ -1058,8 +1058,9 @@ def _dtype_from_version(dic, version):
         if "to" in key and k1 <= version_tuple <= tuple(map(int, kl[2].split("."))):
             return dic[key]
 
-    # if no version is found, return the last version
-    return dic[list(dic.keys())[-1]]
+    # if no version is found, we return empty tuple
+    return ()
+
 
 
 def _versioned_attribute_factory(attribute_function, base):

--- a/ivy/functional/backends/jax/__init__.py
+++ b/ivy/functional/backends/jax/__init__.py
@@ -78,7 +78,9 @@ native_bool = jnp.dtype("bool")
 
 # valid data types
 # ToDo: Add complex dtypes to valid_dtypes and fix all resulting failures.
-valid_dtypes_dict = {
+
+# update these to add new dtypes
+valid_dtypes = {
     "0.3.14 and below": (
         ivy.int8,
         ivy.int16,
@@ -97,7 +99,7 @@ valid_dtypes_dict = {
         ivy.bool,
     )
 }
-valid_numeric_dtypes_dict = {
+valid_numeric_dtypes = {
     "0.3.14 and below": (
         ivy.int8,
         ivy.int16,
@@ -116,7 +118,7 @@ valid_numeric_dtypes_dict = {
     )
 }
 
-valid_int_dtypes_dict = {
+valid_int_dtypes = {
     "0.3.14 and below": (
         ivy.int8,
         ivy.int16,
@@ -129,45 +131,43 @@ valid_int_dtypes_dict = {
     )
 }
 
-valid_uint_dtypes_dict = {
+valid_uint_dtypes = {
     "0.3.14 and below": (ivy.uint8, ivy.uint16, ivy.uint32, ivy.uint64)
 }
-
-
-valid_float_dtypes_dict = {
+valid_float_dtypes = {
     "0.3.14 and below": (ivy.bfloat16, ivy.float16, ivy.float32, ivy.float64)
 }
-valid_complex_dtypes_dict = {"0.3.14 and below": (ivy.complex64, ivy.complex128)}
-valid_dtypes = _dtype_from_version(valid_dtypes_dict, backend_version)
+valid_complex_dtypes = {"0.3.14 and below": (ivy.complex64, ivy.complex128)}
 
 
-valid_numeric_dtypes = _dtype_from_version(valid_numeric_dtypes_dict, backend_version)
+# leave these untouched
+valid_dtypes = _dtype_from_version(valid_dtypes, backend_version)
+valid_numeric_dtypes = _dtype_from_version(valid_numeric_dtypes, backend_version)
+valid_float_dtypes = _dtype_from_version(valid_float_dtypes, backend_version)
+valid_uint_dtypes = _dtype_from_version(valid_uint_dtypes, backend_version)
+valid_complex_dtypes = _dtype_from_version(valid_complex_dtypes, backend_version)
 
-valid_float_dtypes = _dtype_from_version(valid_float_dtypes_dict, backend_version)
-
-
-valid_uint_dtypes = _dtype_from_version(valid_uint_dtypes_dict, backend_version)
-
-
-valid_complex_dtypes = _dtype_from_version(valid_complex_dtypes_dict, backend_version)
 
 # invalid data types
-invalid_dtypes_dict = {"0.3.14 and below": ()}
-invalid_numeric_dtypes_dict = {"0.3.14 and below": ()}
-invalid_int_dtypes_dict = {"0.3.14 and below": ()}
-invalid_float_dtypes_dict = {"0.3.14 and below": ()}
-invalid_uint_dtypes_dict = {"0.3.14 and below": ()}
-invalid_complex_dtypes_dict = {"0.3.14 and below": ()}
 
-invalid_dtypes = _dtype_from_version(invalid_dtypes_dict, backend_version)
+# update these to add new dtypes
+invalid_dtypes = {"0.3.14 and below": ()}
+invalid_numeric_dtypes = {"0.3.14 and below": ()}
+invalid_int_dtypes = {"0.3.14 and below": ()}
+invalid_float_dtypes = {"0.3.14 and below": ()}
+invalid_uint_dtypes = {"0.3.14 and below": ()}
+invalid_complex_dtypes = {"0.3.14 and below": ()}
+
+# leave these untouched
+invalid_dtypes = _dtype_from_version(invalid_dtypes, backend_version)
 invalid_numeric_dtypes = _dtype_from_version(
-    invalid_numeric_dtypes_dict, backend_version
+    invalid_numeric_dtypes, backend_version
 )
-invalid_int_dtypes = _dtype_from_version(invalid_int_dtypes_dict, backend_version)
-invalid_float_dtypes = _dtype_from_version(invalid_float_dtypes_dict, backend_version)
-invalid_uint_dtypes = _dtype_from_version(invalid_uint_dtypes_dict, backend_version)
+invalid_int_dtypes = _dtype_from_version(invalid_int_dtypes, backend_version)
+invalid_float_dtypes = _dtype_from_version(invalid_float_dtypes, backend_version)
+invalid_uint_dtypes = _dtype_from_version(invalid_uint_dtypes, backend_version)
 invalid_complex_dtypes = _dtype_from_version(
-    invalid_complex_dtypes_dict, backend_version
+    invalid_complex_dtypes, backend_version
 )
 
 native_inplace_support = False

--- a/ivy/functional/backends/jax/__init__.py
+++ b/ivy/functional/backends/jax/__init__.py
@@ -160,15 +160,11 @@ invalid_complex_dtypes = {"0.3.14 and below": ()}
 
 # leave these untouched
 invalid_dtypes = _dtype_from_version(invalid_dtypes, backend_version)
-invalid_numeric_dtypes = _dtype_from_version(
-    invalid_numeric_dtypes, backend_version
-)
+invalid_numeric_dtypes = _dtype_from_version(invalid_numeric_dtypes, backend_version)
 invalid_int_dtypes = _dtype_from_version(invalid_int_dtypes, backend_version)
 invalid_float_dtypes = _dtype_from_version(invalid_float_dtypes, backend_version)
 invalid_uint_dtypes = _dtype_from_version(invalid_uint_dtypes, backend_version)
-invalid_complex_dtypes = _dtype_from_version(
-    invalid_complex_dtypes, backend_version
-)
+invalid_complex_dtypes = _dtype_from_version(invalid_complex_dtypes, backend_version)
 
 native_inplace_support = False
 

--- a/ivy/functional/backends/jax/experimental/layers.py
+++ b/ivy/functional/backends/jax/experimental/layers.py
@@ -597,7 +597,9 @@ def interpolate(
     mode = (
         "nearest"
         if mode == "nearest-exact"
-        else "bicubic" if mode == "bicubic_tensorflow" else mode
+        else "bicubic"
+        if mode == "bicubic_tensorflow"
+        else mode
     )
 
     size = [x.shape[0], *size, x.shape[1]]

--- a/ivy/functional/backends/mxnet/__init__.py
+++ b/ivy/functional/backends/mxnet/__init__.py
@@ -35,7 +35,8 @@ native_double = native_float64
 native_bool = np.dtype("bool")
 
 
-valid_dtypes_dict = {
+# update these to add new dtypes
+valid_dtypes = {
     "1.9.1 and below": (
         ivy.int8,
         ivy.int32,
@@ -48,8 +49,7 @@ valid_dtypes_dict = {
         ivy.bool,
     )
 }
-valid_dtypes = _dtype_from_version(valid_dtypes_dict, backend_version)
-valid_numeric_dtypes_dict = {
+valid_numeric_dtypes = {
     "1.9.1 and below": (
         ivy.int8,
         ivy.int32,
@@ -60,37 +60,44 @@ valid_numeric_dtypes_dict = {
         ivy.float64,
     )
 }
-valid_numeric_dtypes = _dtype_from_version(valid_numeric_dtypes_dict, backend_version)
-valid_int_dtypes_dict = {"1.9.1 and below": (ivy.int8, ivy.int32, ivy.int64, ivy.uint8)}
-valid_int_dtypes = _dtype_from_version(valid_int_dtypes_dict, backend_version)
-valid_float_dtypes_dict = {"1.9.1 and below": (ivy.float16, ivy.float32, ivy.float64)}
-valid_float_dtypes = _dtype_from_version(valid_float_dtypes_dict, backend_version)
-valid_uint_dtypes_dict = {"1.9.1 and below": (ivy.uint8,)}
-valid_uint_dtypes = _dtype_from_version(valid_uint_dtypes_dict, backend_version)
-valid_complex_dtypes_dict = {"1.9.1 and below": ()}
-valid_complex_dtypes = _dtype_from_version(valid_complex_dtypes_dict, backend_version)
-invalid_dtypes_dict = {
+valid_int_dtypes = {"1.9.1 and below": (ivy.int8, ivy.int32, ivy.int64, ivy.uint8)}
+valid_float_dtypes = {"1.9.1 and below": (ivy.float16, ivy.float32, ivy.float64)}
+valid_uint_dtypes = {"1.9.1 and below": (ivy.uint8,)}
+valid_complex_dtypes = {"1.9.1 and below": ()}
+
+# leave these untouched
+valid_dtypes = _dtype_from_version(valid_dtypes, backend_version)
+valid_numeric_dtypes = _dtype_from_version(valid_numeric_dtypes, backend_version)
+valid_int_dtypes = _dtype_from_version(valid_int_dtypes, backend_version)
+valid_float_dtypes = _dtype_from_version(valid_float_dtypes, backend_version)
+valid_uint_dtypes = _dtype_from_version(valid_uint_dtypes, backend_version)
+valid_complex_dtypes = _dtype_from_version(valid_complex_dtypes, backend_version)
+
+
+# update these to add new dtypes
+invalid_dtypes = {"1.9.1 and below": (ivy.int16, ivy.uint32, ivy.uint64, ivy.uint16)}
+invalid_numeric_dtypes = {
     "1.9.1 and below": (ivy.int16, ivy.uint32, ivy.uint64, ivy.uint16)
 }
-invalid_dtypes = _dtype_from_version(invalid_dtypes_dict, backend_version)
-invalid_numeric_dtypes_dict = {
-    "1.9.1 and below": (ivy.int16, ivy.uint32, ivy.uint64, ivy.uint16)
-}
-invalid_numeric_dtypes = _dtype_from_version(
-    invalid_numeric_dtypes_dict, backend_version
-)
-invalid_int_dtypes_dict = {
+invalid_int_dtypes = {
     "1.9.1 and below": (ivy.int16, ivy.uint16, ivy.uint32, ivy.uint64)
 }
-invalid_int_dtypes = _dtype_from_version(invalid_int_dtypes_dict, backend_version)
-invalid_float_dtypes_dict = {"1.9.1 and below": (ivy.bfloat16,)}
-invalid_float_dtypes = _dtype_from_version(invalid_float_dtypes_dict, backend_version)
-invalid_uint_dtypes_dict = {"1.9.1 and below": (ivy.uint16, ivy.uint32, ivy.uint64)}
-invalid_uint_dtypes = _dtype_from_version(invalid_uint_dtypes_dict, backend_version)
-invalid_complex_dtypes_dict = {"1.9.1 and below": (ivy.complex64, ivy.complex128)}
-invalid_complex_dtypes = _dtype_from_version(
-    invalid_complex_dtypes_dict, backend_version
-)
+invalid_float_dtypes = {"1.9.1 and below": (ivy.bfloat16,)}
+invalid_uint_dtypes = {"1.9.1 and below": (ivy.uint16, ivy.uint32, ivy.uint64)}
+invalid_complex_dtypes = {"1.9.1 and below": (ivy.complex64, ivy.complex128)}
+
+
+# leave these untouched
+invalid_dtypes = _dtype_from_version(invalid_dtypes, backend_version)
+invalid_numeric_dtypes = _dtype_from_version(invalid_numeric_dtypes, backend_version)
+invalid_int_dtypes = _dtype_from_version(invalid_int_dtypes, backend_version)
+invalid_float_dtypes = _dtype_from_version(invalid_float_dtypes, backend_version)
+invalid_uint_dtypes = _dtype_from_version(invalid_uint_dtypes, backend_version)
+invalid_complex_dtypes = _dtype_from_version(invalid_complex_dtypes, backend_version)
+
+
+
+
 native_inplace_support = True
 supports_gradients = True
 

--- a/ivy/functional/backends/mxnet/__init__.py
+++ b/ivy/functional/backends/mxnet/__init__.py
@@ -96,8 +96,6 @@ invalid_uint_dtypes = _dtype_from_version(invalid_uint_dtypes, backend_version)
 invalid_complex_dtypes = _dtype_from_version(invalid_complex_dtypes, backend_version)
 
 
-
-
 native_inplace_support = True
 supports_gradients = True
 

--- a/ivy/functional/backends/numpy/__init__.py
+++ b/ivy/functional/backends/numpy/__init__.py
@@ -49,7 +49,8 @@ native_bool = np.dtype("bool")
 # valid data types
 # ToDo: Add complex dtypes to valid_dtypes and fix all resulting failures.
 
-valid_dtypes_dict = {
+# update these to add new dtypes
+valid_dtypes = {
     "1.23.0 and below": (
         ivy.int8,
         ivy.int16,
@@ -67,11 +68,7 @@ valid_dtypes_dict = {
         ivy.bool,
     )
 }
-
-
-valid_dtypes = _dtype_from_version(valid_dtypes_dict, backend_version)
-
-valid_numeric_dtypes_dict = {
+valid_numeric_dtypes = {
     "1.23.0 and below": (
         ivy.int8,
         ivy.int16,
@@ -88,9 +85,7 @@ valid_numeric_dtypes_dict = {
         ivy.complex128,
     )
 }
-
-valid_numeric_dtypes = _dtype_from_version(valid_numeric_dtypes_dict, backend_version)
-valid_int_dtypes_dict = {
+valid_int_dtypes = {
     "1.23.0 and below": (
         ivy.int8,
         ivy.int16,
@@ -102,38 +97,42 @@ valid_int_dtypes_dict = {
         ivy.uint64,
     )
 }
-
-valid_int_dtypes = _dtype_from_version(valid_int_dtypes_dict, backend_version)
-
-valid_float_dtypes_dict = {"1.23.0 and below": (ivy.float16, ivy.float32, ivy.float64)}
-valid_float_dtypes = _dtype_from_version(valid_float_dtypes_dict, backend_version)
-
-valid_uint_dtypes_dict = {
+valid_float_dtypes = {"1.23.0 and below": (ivy.float16, ivy.float32, ivy.float64)}
+valid_uint_dtypes = {
     "1.23.0 and below": (ivy.uint8, ivy.uint16, ivy.uint32, ivy.uint64)
 }
-valid_uint_dtypes = _dtype_from_version(valid_uint_dtypes_dict, backend_version)
-valid_complex_dtypes_dict = {"1.23.0 and below": (ivy.complex64, ivy.complex128)}
-valid_complex_dtypes = _dtype_from_version(valid_complex_dtypes_dict, backend_version)
+valid_complex_dtypes = {"1.23.0 and below": (ivy.complex64, ivy.complex128)}
+
+# leave these untouched
+valid_dtypes = _dtype_from_version(valid_dtypes, backend_version)
+valid_numeric_dtypes = _dtype_from_version(valid_numeric_dtypes, backend_version)
+valid_int_dtypes = _dtype_from_version(valid_int_dtypes, backend_version)
+valid_float_dtypes = _dtype_from_version(valid_float_dtypes, backend_version)
+valid_uint_dtypes = _dtype_from_version(valid_uint_dtypes, backend_version)
+valid_complex_dtypes = _dtype_from_version(valid_complex_dtypes, backend_version)
 
 # invalid data types
-invalid_dtypes_dict = {"1.23.0 and below": (ivy.bfloat16,)}
-invalid_dtypes = _dtype_from_version(invalid_dtypes_dict, backend_version)
-invalid_numeric_dtypes_dict = {"1.23.0 and below": (ivy.bfloat16,)}
+# update these to add new dtypes
+invalid_dtypes = {"1.23.0 and below": (ivy.bfloat16,)}
+invalid_numeric_dtypes = {"1.23.0 and below": (ivy.bfloat16,)}
+invalid_int_dtypes = {"1.23.0 and below": ()}
+invalid_float_dtypes = {"1.23.0 and below": (ivy.bfloat16,)}
+invalid_uint_dtypes = {"1.23.0 and below": ()}
+invalid_complex_dtypes = {"1.23.0 and below": ()}
+
+
+# leave these untouched
+invalid_dtypes = _dtype_from_version(invalid_dtypes, backend_version)
 invalid_numeric_dtypes = _dtype_from_version(
-    invalid_numeric_dtypes_dict, backend_version
+    invalid_numeric_dtypes, backend_version
 )
-invalid_int_dtypes_dict = {"1.23.0 and below": ()}
-invalid_int_dtypes = _dtype_from_version(invalid_int_dtypes_dict, backend_version)
-
-invalid_float_dtypes_dict = {"1.23.0 and below": (ivy.bfloat16,)}
-invalid_float_dtypes = _dtype_from_version(invalid_float_dtypes_dict, backend_version)
-
-invalid_uint_dtypes_dict = {"1.23.0 and below": ()}
-invalid_uint_dtypes = _dtype_from_version(invalid_uint_dtypes_dict, backend_version)
-invalid_complex_dtypes_dict = {"1.23.0 and below": ()}
+invalid_int_dtypes = _dtype_from_version(invalid_int_dtypes, backend_version)
+invalid_float_dtypes = _dtype_from_version(invalid_float_dtypes, backend_version)
+invalid_uint_dtypes = _dtype_from_version(invalid_uint_dtypes, backend_version)
 invalid_complex_dtypes = _dtype_from_version(
-    invalid_complex_dtypes_dict, backend_version
+    invalid_complex_dtypes, backend_version
 )
+
 
 native_inplace_support = False
 

--- a/ivy/functional/backends/numpy/__init__.py
+++ b/ivy/functional/backends/numpy/__init__.py
@@ -123,15 +123,11 @@ invalid_complex_dtypes = {"1.23.0 and below": ()}
 
 # leave these untouched
 invalid_dtypes = _dtype_from_version(invalid_dtypes, backend_version)
-invalid_numeric_dtypes = _dtype_from_version(
-    invalid_numeric_dtypes, backend_version
-)
+invalid_numeric_dtypes = _dtype_from_version(invalid_numeric_dtypes, backend_version)
 invalid_int_dtypes = _dtype_from_version(invalid_int_dtypes, backend_version)
 invalid_float_dtypes = _dtype_from_version(invalid_float_dtypes, backend_version)
 invalid_uint_dtypes = _dtype_from_version(invalid_uint_dtypes, backend_version)
-invalid_complex_dtypes = _dtype_from_version(
-    invalid_complex_dtypes, backend_version
-)
+invalid_complex_dtypes = _dtype_from_version(invalid_complex_dtypes, backend_version)
 
 
 native_inplace_support = False

--- a/ivy/functional/backends/paddle/__init__.py
+++ b/ivy/functional/backends/paddle/__init__.py
@@ -85,11 +85,7 @@ valid_int_dtypes = {
     )
 }
 valid_float_dtypes = {"2.4.2 and below": (ivy.float16, ivy.float32, ivy.float64)}
-valid_uint_dtypes = {
-    "2.4.2 and below"(
-        ivy.uint8,
-    )
-}
+valid_uint_dtypes = {"2.4.2 and below": (ivy.uint8,)}
 valid_complex_dtypes = {"2.4.2 and below": (ivy.complex64, ivy.complex128)}
 
 # leave these untouched

--- a/ivy/functional/backends/paddle/__init__.py
+++ b/ivy/functional/backends/paddle/__init__.py
@@ -4,6 +4,7 @@ import paddle as paddle
 
 # local
 import ivy
+from ivy.func_wrapper import _dtype_from_version
 
 backend_version = {"version": paddle.version.full_version}
 
@@ -45,56 +46,92 @@ native_bool = paddle.bool
 
 # valid data types
 # ToDo: Add complex dtypes to valid_dtypes and fix all resulting failures.
-valid_dtypes = (
-    ivy.int8,
-    ivy.int16,
-    ivy.int32,
-    ivy.int64,
-    ivy.uint8,
-    ivy.float16,
-    ivy.float32,
-    ivy.float64,
-    ivy.complex64,
-    ivy.complex128,
-    ivy.bool,
-)
-valid_numeric_dtypes = (
-    ivy.int8,
-    ivy.int16,
-    ivy.int32,
-    ivy.int64,
-    ivy.uint8,
-    ivy.float16,
-    ivy.float32,
-    ivy.float64,
-)
-valid_int_dtypes = (
-    ivy.int8,
-    ivy.int16,
-    ivy.int32,
-    ivy.int64,
-    ivy.uint8,
-)
-valid_float_dtypes = (ivy.float16, ivy.float32, ivy.float64)
-valid_uint_dtypes = (ivy.uint8,)
-valid_complex_dtypes = (ivy.complex64, ivy.complex128)
 
-invalid_dtypes = (
-    ivy.uint16,
-    ivy.uint32,
-    ivy.uint64,
-    ivy.bfloat16,
-)
-invalid_numeric_dtypes = (
-    ivy.uint16,
-    ivy.uint32,
-    ivy.uint64,
-    ivy.bfloat16,
-)
-invalid_int_dtypes = (ivy.uint16, ivy.uint32, ivy.uint64)
-invalid_float_dtypes = (ivy.bfloat16,)
-invalid_uint_dtypes = (ivy.uint16, ivy.uint32, ivy.uint64)
-invalid_complex_dtypes = ()
+# update these to add new dtypes
+valid_dtypes = {
+    "2.4.2 and below": (
+        ivy.int8,
+        ivy.int16,
+        ivy.int32,
+        ivy.int64,
+        ivy.uint8,
+        ivy.float16,
+        ivy.float32,
+        ivy.float64,
+        ivy.complex64,
+        ivy.complex128,
+        ivy.bool,
+    )
+}
+valid_numeric_dtypes = {
+    "2.4.2 and below": (
+        ivy.int8,
+        ivy.int16,
+        ivy.int32,
+        ivy.int64,
+        ivy.uint8,
+        ivy.float16,
+        ivy.float32,
+        ivy.float64,
+    )
+}
+valid_int_dtypes = {
+    "2.4.2 and below": (
+        ivy.int8,
+        ivy.int16,
+        ivy.int32,
+        ivy.int64,
+        ivy.uint8,
+    )
+}
+valid_float_dtypes = {"2.4.2 and below": (ivy.float16, ivy.float32, ivy.float64)}
+valid_uint_dtypes = {
+    "2.4.2 and below"(
+        ivy.uint8,
+    )
+}
+valid_complex_dtypes = {"2.4.2 and below": (ivy.complex64, ivy.complex128)}
+
+# leave these untouched
+valid_dtypes = _dtype_from_version(valid_dtypes, backend_version)
+valid_numeric_dtypes = _dtype_from_version(valid_numeric_dtypes, backend_version)
+valid_int_dtypes = _dtype_from_version(valid_int_dtypes, backend_version)
+valid_float_dtypes = _dtype_from_version(valid_float_dtypes, backend_version)
+valid_uint_dtypes = _dtype_from_version(valid_uint_dtypes, backend_version)
+valid_complex_dtypes = _dtype_from_version(valid_complex_dtypes, backend_version)
+
+
+# update these to add new dtypes
+invalid_dtypes = {
+    "2.4.2 and below": (
+        ivy.uint16,
+        ivy.uint32,
+        ivy.uint64,
+        ivy.bfloat16,
+    )
+}
+
+invalid_numeric_dtypes = {
+    "2.4.2 and below": (
+        ivy.uint16,
+        ivy.uint32,
+        ivy.uint64,
+        ivy.bfloat16,
+    )
+}
+
+invalid_int_dtypes = {"2.4.2 and below": (ivy.uint16, ivy.uint32, ivy.uint64)}
+invalid_float_dtypes = {"2.4.2 and below": (ivy.bfloat16,)}
+invalid_uint_dtypes = {"2.4.2 and below": (ivy.uint16, ivy.uint32, ivy.uint64)}
+invalid_complex_dtypes = {"2.4.2 and below": ()}
+
+# leave these untouched
+invalid_dtypes = _dtype_from_version(invalid_dtypes, backend_version)
+invalid_numeric_dtypes = _dtype_from_version(invalid_numeric_dtypes, backend_version)
+invalid_float_dtypes = _dtype_from_version(invalid_float_dtypes, backend_version)
+invalid_uint_dtypes = _dtype_from_version(invalid_uint_dtypes, backend_version)
+invalid_complex_dtypes = _dtype_from_version(invalid_complex_dtypes, backend_version)
+
 
 native_inplace_support = False
 supports_gradients = True

--- a/ivy/functional/backends/tensorflow/__init__.py
+++ b/ivy/functional/backends/tensorflow/__init__.py
@@ -116,9 +116,7 @@ valid_int_dtypes = {
 valid_float_dtypes = {
     "2.9.1 and below": (ivy.bfloat16, ivy.float16, ivy.float32, ivy.float64)
 }
-valid_uint_dtypes = {
-    "2.9.1 and below": (ivy.uint8, ivy.uint16, ivy.uint32, ivy.uint64)
-}
+valid_uint_dtypes = {"2.9.1 and below": (ivy.uint8, ivy.uint16, ivy.uint32, ivy.uint64)}
 valid_complex_dtypes = {"2.9.1 and below": (ivy.complex64, ivy.complex128)}
 
 # leave these untouched
@@ -140,15 +138,11 @@ invalid_complex_dtypes = {"2.9.1 and below": ()}
 
 # leave these untouched
 invalid_dtypes = _dtype_from_version(invalid_dtypes, backend_version)
-invalid_numeric_dtypes = _dtype_from_version(
-    invalid_numeric_dtypes, backend_version
-)
+invalid_numeric_dtypes = _dtype_from_version(invalid_numeric_dtypes, backend_version)
 invalid_int_dtypes = _dtype_from_version(invalid_int_dtypes, backend_version)
 invalid_float_dtypes = _dtype_from_version(invalid_float_dtypes, backend_version)
 invalid_uint_dtypes = _dtype_from_version(invalid_uint_dtypes, backend_version)
-invalid_complex_dtypes = _dtype_from_version(
-    invalid_complex_dtypes, backend_version
-)
+invalid_complex_dtypes = _dtype_from_version(invalid_complex_dtypes, backend_version)
 
 native_inplace_support = False
 

--- a/ivy/functional/backends/tensorflow/__init__.py
+++ b/ivy/functional/backends/tensorflow/__init__.py
@@ -63,7 +63,8 @@ native_bool = tf.bool
 # valid data types
 # ToDo: Add complex dtypes to valid_dtypes and fix all resulting failures.
 
-valid_dtypes_dict = {
+# update these to add new dtypes
+valid_dtypes = {
     "2.9.1 and below": (
         ivy.int8,
         ivy.int16,
@@ -82,9 +83,7 @@ valid_dtypes_dict = {
         ivy.bool,
     )
 }
-valid_dtypes = _dtype_from_version(valid_dtypes_dict, backend_version)
-
-valid_numeric_dtypes_dict = {
+valid_numeric_dtypes = {
     "2.9.1 and below": (
         ivy.int8,
         ivy.int16,
@@ -102,10 +101,7 @@ valid_numeric_dtypes_dict = {
         ivy.complex128,
     )
 }
-
-valid_numeric_dtypes = _dtype_from_version(valid_numeric_dtypes_dict, backend_version)
-
-valid_int_dtypes_dict = {
+valid_int_dtypes = {
     "2.9.1 and below": (
         ivy.int8,
         ivy.int16,
@@ -117,43 +113,41 @@ valid_int_dtypes_dict = {
         ivy.uint64,
     )
 }
-
-valid_int_dtypes = _dtype_from_version(valid_int_dtypes_dict, backend_version)
-
-valid_float_dtypes_dict = {
+valid_float_dtypes = {
     "2.9.1 and below": (ivy.bfloat16, ivy.float16, ivy.float32, ivy.float64)
 }
-
-valid_float_dtypes = _dtype_from_version(valid_float_dtypes_dict, backend_version)
-
-valid_uint_dtypes_dict = {
+valid_uint_dtypes = {
     "2.9.1 and below": (ivy.uint8, ivy.uint16, ivy.uint32, ivy.uint64)
 }
-valid_uint_dtypes = _dtype_from_version(valid_uint_dtypes_dict, backend_version)
+valid_complex_dtypes = {"2.9.1 and below": (ivy.complex64, ivy.complex128)}
 
-valid_complex_dtypes_dict = {"2.9.1 and below": (ivy.complex64, ivy.complex128)}
-valid_complex_dtypes = _dtype_from_version(valid_complex_dtypes_dict, backend_version)
+# leave these untouched
+valid_dtypes = _dtype_from_version(valid_dtypes, backend_version)
+valid_numeric_dtypes = _dtype_from_version(valid_numeric_dtypes, backend_version)
+valid_int_dtypes = _dtype_from_version(valid_int_dtypes, backend_version)
+valid_float_dtypes = _dtype_from_version(valid_float_dtypes, backend_version)
+valid_uint_dtypes = _dtype_from_version(valid_uint_dtypes, backend_version)
+valid_complex_dtypes = _dtype_from_version(valid_complex_dtypes, backend_version)
 
 # invalid data types
-invalid_dtypes_dict = {"2.9.1 and below": ()}
+# update these to add new dtypes
+invalid_dtypes = {"2.9.1 and below": ()}
+invalid_numeric_dtypes = {"2.9.1 and below": ()}
+invalid_int_dtypes = {"2.9.1 and below": ()}
+invalid_float_dtypes = {"2.9.1 and below": ()}
+invalid_uint_dtypes = {"2.9.1 and below": ()}
+invalid_complex_dtypes = {"2.9.1 and below": ()}
 
-invalid_dtypes = _dtype_from_version(invalid_dtypes_dict, backend_version)
-
-invalid_numeric_dtypes_dict = {"2.9.1 and below": ()}
+# leave these untouched
+invalid_dtypes = _dtype_from_version(invalid_dtypes, backend_version)
 invalid_numeric_dtypes = _dtype_from_version(
-    invalid_numeric_dtypes_dict, backend_version
+    invalid_numeric_dtypes, backend_version
 )
-
-invalid_int_dtypes_dict = {"2.9.1 and below": ()}
-invalid_int_dtypes = _dtype_from_version(invalid_int_dtypes_dict, backend_version)
-invalid_float_dtypes_dict = {"2.9.1 and below": ()}
-invalid_float_dtypes = _dtype_from_version(invalid_float_dtypes_dict, backend_version)
-invalid_uint_dtypes_dict = {"2.9.1 and below": ()}
-invalid_uint_dtypes = _dtype_from_version(invalid_uint_dtypes_dict, backend_version)
-
-invalid_complex_dtypes_dict = {"2.9.1 and below": ()}
+invalid_int_dtypes = _dtype_from_version(invalid_int_dtypes, backend_version)
+invalid_float_dtypes = _dtype_from_version(invalid_float_dtypes, backend_version)
+invalid_uint_dtypes = _dtype_from_version(invalid_uint_dtypes, backend_version)
 invalid_complex_dtypes = _dtype_from_version(
-    invalid_complex_dtypes_dict, backend_version
+    invalid_complex_dtypes, backend_version
 )
 
 native_inplace_support = False

--- a/ivy/functional/backends/torch/__init__.py
+++ b/ivy/functional/backends/torch/__init__.py
@@ -47,7 +47,9 @@ native_bool = torch.bool
 
 # valid data types
 # ToDo: Add complex dtypes to valid_dtypes and fix all resulting failures.
-valid_dtypes_dict = {
+
+# update these to add new dtypes
+valid_dtypes = {
     "1.11.0 and below": (
         ivy.int8,
         ivy.int16,
@@ -65,7 +67,7 @@ valid_dtypes_dict = {
 }
 
 
-valid_numeric_dtypes_dict = {
+valid_numeric_dtypes = {
     "1.11.0 and below": (
         ivy.int8,
         ivy.int16,
@@ -81,55 +83,48 @@ valid_numeric_dtypes_dict = {
     )
 }
 
-valid_int_dtypes_dict = {
+valid_int_dtypes= {
     "1.11.0 and below": (ivy.int8, ivy.int16, ivy.int32, ivy.int64, ivy.uint8)
 }
-valid_float_dtypes_dict = {
+valid_float_dtypes = {
     "1.11.0 and below": (ivy.bfloat16, ivy.float16, ivy.float32, ivy.float64)
 }
-valid_uint_dtypes_dict = {"1.11.0 and below": (ivy.uint8,)}
-valid_complex_dtypes_dict = {"1.11.0 and below": (ivy.complex64, ivy.complex128)}
+valid_uint_dtypes = {"1.11.0 and below": (ivy.uint8,)}
+valid_complex_dtypes = {"1.11.0 and below": (ivy.complex64, ivy.complex128)}
 
-valid_dtypes = _dtype_from_version(valid_dtypes_dict, backend_version)
-valid_numeric_dtypes = _dtype_from_version(valid_numeric_dtypes_dict, backend_version)
-valid_int_dtypes = _dtype_from_version(valid_int_dtypes_dict, backend_version)
-valid_float_dtypes = _dtype_from_version(valid_float_dtypes_dict, backend_version)
-
-
-valid_uint_dtypes = _dtype_from_version(valid_uint_dtypes_dict, backend_version)
-valid_complex_dtypes = _dtype_from_version(valid_complex_dtypes_dict, backend_version)
+# leave these untouched
+valid_dtypes = _dtype_from_version(valid_dtypes, backend_version)
+valid_numeric_dtypes = _dtype_from_version(valid_numeric_dtypes, backend_version)
+valid_int_dtypes = _dtype_from_version(valid_int_dtypes, backend_version)
+valid_float_dtypes = _dtype_from_version(valid_float_dtypes, backend_version)
+valid_uint_dtypes = _dtype_from_version(valid_uint_dtypes, backend_version)
+valid_complex_dtypes = _dtype_from_version(valid_complex_dtypes, backend_version)
 
 # invalid data types
-invalid_dtypes_dict = {
+# update these to add new dtypes
+invalid_dtypes = {
     "1.11.0 and below": (
         ivy.uint16,
         ivy.uint32,
         ivy.uint64,
     )
 }
-invalid_numeric_dtypes_dict = {"1.11.0 and below": (ivy.uint16, ivy.uint32, ivy.uint64)}
+invalid_numeric_dtypes = {"1.11.0 and below": (ivy.uint16, ivy.uint32, ivy.uint64)}
+invalid_int_dtypes = {"1.11.0 and below": (ivy.uint16, ivy.uint32, ivy.uint64)}
+invalid_float_dtypes = {"1.11.0 and below": ()}
+invalid_uint_dtypes = {"1.11.0 and below": (ivy.uint16, ivy.uint32, ivy.uint64)}
+invalid_complex_dtypes = {"1.11.0 and below": ()}
+invalid_dtypes = _dtype_from_version(invalid_dtypes, backend_version)
 
-invalid_int_dtypes_dict = {"1.11.0 and below": (ivy.uint16, ivy.uint32, ivy.uint64)}
-invalid_float_dtypes_dict = {"1.11.0 and below": ()}
-invalid_uint_dtypes_dict = {"1.11.0 and below": (ivy.uint16, ivy.uint32, ivy.uint64)}
-
-invalid_complex_dtypes_dict = {"1.11.0 and below": ()}
-invalid_dtypes = _dtype_from_version(invalid_dtypes_dict, backend_version)
-
-
+# leave these untouched
 invalid_numeric_dtypes = _dtype_from_version(
-    invalid_numeric_dtypes_dict, backend_version
+    invalid_numeric_dtypes, backend_version
 )
-
-
-invalid_int_dtypes = _dtype_from_version(invalid_int_dtypes_dict, backend_version)
-
-invalid_float_dtypes = _dtype_from_version(invalid_float_dtypes_dict, backend_version)
-
-
-invalid_uint_dtypes = _dtype_from_version(invalid_uint_dtypes_dict, backend_version)
+invalid_int_dtypes = _dtype_from_version(invalid_int_dtypes, backend_version)
+invalid_float_dtypes = _dtype_from_version(invalid_float_dtypes, backend_version)
+invalid_uint_dtypes = _dtype_from_version(invalid_uint_dtypes, backend_version)
 invalid_complex_dtypes = _dtype_from_version(
-    invalid_complex_dtypes_dict, backend_version
+    invalid_complex_dtypes, backend_version
 )
 
 native_inplace_support = True

--- a/ivy/functional/backends/torch/__init__.py
+++ b/ivy/functional/backends/torch/__init__.py
@@ -83,7 +83,7 @@ valid_numeric_dtypes = {
     )
 }
 
-valid_int_dtypes= {
+valid_int_dtypes = {
     "1.11.0 and below": (ivy.int8, ivy.int16, ivy.int32, ivy.int64, ivy.uint8)
 }
 valid_float_dtypes = {
@@ -117,15 +117,11 @@ invalid_complex_dtypes = {"1.11.0 and below": ()}
 invalid_dtypes = _dtype_from_version(invalid_dtypes, backend_version)
 
 # leave these untouched
-invalid_numeric_dtypes = _dtype_from_version(
-    invalid_numeric_dtypes, backend_version
-)
+invalid_numeric_dtypes = _dtype_from_version(invalid_numeric_dtypes, backend_version)
 invalid_int_dtypes = _dtype_from_version(invalid_int_dtypes, backend_version)
 invalid_float_dtypes = _dtype_from_version(invalid_float_dtypes, backend_version)
 invalid_uint_dtypes = _dtype_from_version(invalid_uint_dtypes, backend_version)
-invalid_complex_dtypes = _dtype_from_version(
-    invalid_complex_dtypes, backend_version
-)
+invalid_complex_dtypes = _dtype_from_version(invalid_complex_dtypes, backend_version)
 
 native_inplace_support = True
 


### PR DESCRIPTION
1. Updates the decorator logic to not use the last known key
2. Updates the init files, specifically the dictionaries.