### PR TITLE
Fixes Dropout's unintended behavior of automatic dtype change

### DIFF
--- a/ivy/functional/ivy/layers.py
+++ b/ivy/functional/ivy/layers.py
@@ -340,6 +340,7 @@ def dropout(
         0,
         1,
     )
+    mask = ivy.astype(mask, dtype)
     x = x * mask
     if scale:
         x = ivy.multiply(x, 1 / (1 - prob), out=out)

--- a/ivy/functional/ivy/layers.py
+++ b/ivy/functional/ivy/layers.py
@@ -340,7 +340,10 @@ def dropout(
         0,
         1,
     )
-    mask = ivy.astype(mask, dtype)
+    if dtype is None:
+        mask = ivy.astype(mask, x.dtype)
+    else:
+        mask = ivy.astype(mask, dtype)
     x = x * mask
     if scale:
         x = ivy.multiply(x, 1 / (1 - prob), out=out)

--- a/ivy/functional/ivy/layers.py
+++ b/ivy/functional/ivy/layers.py
@@ -337,13 +337,9 @@ def dropout(
     mask = ivy.where(
         ivy.random_uniform(shape=noise_shape, device=ivy.dev(x), dtype=dtype, seed=seed)
         < prob,
-        0,
-        1,
+        ivy.zeros(shape=noise_shape, device=ivy.dev(x), dtype=dtype),
+        ivy.ones(shape=noise_shape, device=ivy.dev(x), dtype=dtype),
     )
-    if dtype is None:
-        mask = ivy.astype(mask, x.dtype)
-    else:
-        mask = ivy.astype(mask, dtype)
     x = x * mask
     if scale:
         x = ivy.multiply(x, 1 / (1 - prob), out=out)


### PR DESCRIPTION
https://trello.com/c/AmIDttaV/1834-fix-dropouts-automatic-dtype-changing-behaviour

Also handles error arising when user is on GPU and passes input on CPU due to temp vars being incorrectly created on GPU

Following code piece earlier threw two issues
```
import ivy

ivy.set_torch_backend()

x = ivy.random_normal(shape=(100, 1000), dtype='float32', device='cpu')

ivy.dropout(x, 0.2, dtype='float32')
```
1. Output was float64 even after being explicitly set to float32
2. Couldn't handle when input device is CPU and threw following error - 
```
IvyBackendException: torch: dropout: torch: where: Expected all tensors to be on the same device, but found at least two devices, cuda:0 and cpu!
```