### PR TITLE
Add ihfft to numpy frontend

### DIFF
--- a/ivy/functional/frontends/numpy/fft/discrete_fourier_transform.py
+++ b/ivy/functional/frontends/numpy/fft/discrete_fourier_transform.py
@@ -3,6 +3,23 @@ from ivy.functional.frontends.numpy.func_wrapper import to_ivy_arrays_and_back
 from ivy.func_wrapper import with_unsupported_dtypes
 
 
+_SWAP_DIRECTION_MAP = {
+    None: "forward",
+    "backward": "forward",
+    "ortho": "ortho",
+    "forward": "backward",
+}
+
+
+def _swap_direction(norm):
+    try:
+        return _SWAP_DIRECTION_MAP[norm]
+    except KeyError:
+        raise ValueError(
+            f'Invalid norm value {norm}; should be "backward", "ortho" or "forward".'
+        ) from None
+
+
 @to_ivy_arrays_and_back
 def ifft(a, n=None, axis=-1, norm=None):
     a = ivy.array(a, dtype=ivy.complex128)
@@ -65,6 +82,17 @@ def rfft(a, n=None, axis=-1, norm=None):
         norm = "backward"
     a = ivy.array(a, dtype=ivy.float64)
     return ivy.dft(a, axis=axis, inverse=False, onesided=True, dft_length=n, norm=norm)
+
+
+@to_ivy_arrays_and_back
+@with_unsupported_dtypes({"1.12.0 and below": ("float16",)}, "numpy")
+def ihfft(a, n=None, axis=-1, norm=None):
+    a = ivy.array(a, dtype=ivy.float64)
+    if n is None:
+        n = a.shape[axis]
+    norm = _swap_direction(norm)
+    output = ivy.conj(rfft(a, n, axis, norm=norm).ivy_array)
+    return output
 
 
 @with_unsupported_dtypes({"2.4.2 and below": ("int",)}, "paddle")

--- a/ivy_tests/test_ivy/test_frontends/test_numpy/test_fft/test_discrete_fourier_transform.py
+++ b/ivy_tests/test_ivy/test_frontends/test_numpy/test_fft/test_discrete_fourier_transform.py
@@ -122,6 +122,35 @@ def test_numpy_rfft(
 
 
 @handle_frontend_test(
+    fn_tree="numpy.fft.ihfft",
+    dtype_input_axis=helpers.dtype_values_axis(
+        available_dtypes=helpers.get_dtypes("float_and_complex"),
+        shape=(2,),
+        min_axis=-1,
+        force_int_axis=True,
+    ),
+    norm=st.sampled_from(["backward", "ortho", "forward"]),
+    n=st.integers(min_value=2, max_value=5),
+)
+def test_numpy_ihfft(
+    dtype_input_axis, norm, n, frontend, test_flags, fn_tree, on_device
+):
+    input_dtype, x, axis = dtype_input_axis
+    helpers.test_frontend_function(
+        input_dtypes=input_dtype,
+        frontend=frontend,
+        test_flags=test_flags,
+        fn_tree=fn_tree,
+        on_device=on_device,
+        test_values=True,
+        a=x[0],
+        n=n,
+        axis=axis,
+        norm=norm,
+    )
+
+
+@handle_frontend_test(
     fn_tree="numpy.fft.fftfreq",
     n=st.integers(min_value=10, max_value=100),
     sample_rate=st.integers(min_value=1, max_value=10),


### PR DESCRIPTION
Close #15707

In this PR:
- The `_SWAP_DIRECTION_MAP` and `_swap_direction(norm)` method are copied directly from numpy, since they are not implemented in the layers yet, and we are going to need these for the `hfft` frontend method in the future.
- The conversion test on Tenserflow is failing due to
  > small error with the backend implementation of tensorflow complex casting

  as mentioned in https://github.com/unifyai/ivy/pull/14451