### PR TITLE
fixed failing test for `torch.einsum` when dtype=float16

### DIFF
--- a/ivy/functional/frontends/torch/miscellaneous_ops.py
+++ b/ivy/functional/frontends/torch/miscellaneous_ops.py
@@ -306,6 +306,7 @@ def lcm(input, other, *, out=None):
 
 
 @to_ivy_arrays_and_back
+@with_unsupported_dtypes({"2.0.1 and below": ("float16",)}, "torch")
 def einsum(equation, *operands):
     return ivy.einsum(equation, *operands)
 


### PR DESCRIPTION
Currently, the test for `torch.einsum` fails if `dtype=float16`. Fix this by adding the `@unsupported_decorator` in the function definition. 

All test are passing now! 

The issue was raised by <https://github.com/Bloemenstraat> at [discordl](https://discord.com/channels/799879767196958751/1028267758028337193/1110146132618792981) 

Here is the trace for the error:
```python
/opt/fw/torch/torch/functional.py:378: in einsum
    return _VF.einsum(equation, operands)  # type: ignore[attr-defined]
E   RuntimeError: "bmm" not implemented for 'Half'
E   Falsifying example: test_torch_einsum(
E       on_device='cpu',
E       frontend='torch',
E       eq_n_op_n_shp=('ij,j', (array([[ 0,  1,  2,  3,  4],
E                [ 5,  6,  7,  8,  9],
E                [10, 11, 12, 13, 14],
E                [15, 16, 17, 18, 19],
E                [20, 21, 22, 23, 24]]), array([0, 1, 2, 3, 4])), (5,)),
E       dtype=['float16'],
E       test_flags=FrontendFunctionTestFlags(
E           num_positional_args=0,
E           with_out=False,
E           inplace=False,
E           as_variable=[False],
E           native_arrays=[False],
E           generate_frontend_arrays=False,
E       ),
E       fn_tree='ivy.functional.frontends.torch.einsum',
E   )
E   
E   You can reproduce this example by temporarily adding @reproduce_failure('6.75.3', b'AAIDAAAAAAAA') as a decorator on your test case
```
