### PR TITLE
Fix ContextManager

### DIFF
--- a/ivy/utils/backend/handler.py
+++ b/ivy/utils/backend/handler.py
@@ -463,6 +463,8 @@ def set_backend(backend: str, dynamic: bool = False):
         if verbosity.level > 0:
             verbosity.cprint("backend stack: {}".format(backend_stack))
 
+    return ivy
+
 
 def set_numpy_backend():
     """

--- a/ivy/utils/backend/handler.py
+++ b/ivy/utils/backend/handler.py
@@ -26,7 +26,7 @@ class ContextManager:
         self.module = module
 
     def __enter__(self):
-        set_backend(self.module)
+        return set_backend(self.module)
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         previous_backend()


### PR DESCRIPTION
- Updated `set_backend` to return global Ivy
- Updated ContextManager to return value from `set_backend`, to allow usage as: `with ContextManager('tensorflow') as ivy_tf:`