### PR TITLE
fixed spelling mistake while importing helper function in torch frontend test! 

### DIFF
--- a/ivy_tests/test_ivy/test_frontends/test_torch/test_reduction_ops.py
+++ b/ivy_tests/test_ivy/test_frontends/test_torch/test_reduction_ops.py
@@ -10,7 +10,7 @@ from ivy_tests.test_ivy.test_functional.test_core.test_statistical import (
     _get_castable_dtype,
 )
 from ivy_tests.test_ivy.test_functional.test_experimental.test_core.test_statistical import (  # noqa
-    statistical_dtype_values as statistical_dtype_values_experimental,
+    _statistical_dtype_values as statistical_dtype_values_experimental,
 )
 
 


### PR DESCRIPTION
Currently , `intelligent-test-pr` for torch frontend test is reporting an `Module` import error :
```python
_ ERROR collecting ivy_tests/test_ivy/test_frontends/test_torch/test_tensor.py _
ImportError while importing test module '/ivy/ivy_tests/test_ivy/test_frontends/test_torch/test_tensor.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
/opt/miniconda/envs/multienv/lib/python3.8/importlib/__init__.py:127: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
ivy_tests/test_ivy/test_frontends/test_torch/test_tensor.py:9: in <module>
    from ivy_tests.test_ivy.test_frontends.test_torch.test_reduction_ops import (
ivy_tests/test_ivy/test_frontends/test_torch/test_reduction_ops.py:12: in <module>
    from ivy_tests.test_ivy.test_functional.test_experimental.test_core.test_statistical import (  # noqa
E   ImportError: cannot import name 'statistical_dtype_values' from 'ivy_tests.test_ivy.test_functional.test_experimental.test_core.test_statistical' (/ivy/ivy_tests/test_ivy/test_functional/test_experimental/test_core/test_statistical.py)
```
As seen in PR : <https://github.com/unifyai/ivy/pull/15852> `telligent-tests-pr / run_tests (56) (pull_request)` <https://github.com/unifyai/ivy/actions/runs/5078835117/jobs/9123847321?pr=15852>

The it just a very small typo : we're importing `statistical_dtype_values` instead of `_statistical_dtype_values`.

