### PR TITLE
Add ELU and Max functions to Paddle's activations and math modules

### DIFF
--- a/ivy/functional/backends/paddle/activations.py
+++ b/ivy/functional/backends/paddle/activations.py
@@ -167,8 +167,8 @@ def elu(
 ) -> paddle.Tensor:
     if x.dtype in unsupported_dtypes:
         if paddle.is_complex(x):
-            return paddle_backend.where(
-                x > 0, x, alpha * (paddle_backend.exp(x) - 1)
+            return paddle.complex(
+                F.elu(x.real(), alpha=alpha), F.elu(x.imag(), alpha=alpha)
             )
         return F.elu(x.cast("float32"), alpha=alpha).cast(x.dtype)
     return F.elu(x, alpha=alpha)

--- a/ivy/functional/backends/paddle/activations.py
+++ b/ivy/functional/backends/paddle/activations.py
@@ -156,3 +156,18 @@ def mish(x: paddle.Tensor, /, *, out: Optional[paddle.Tensor] = None) -> paddle.
             return x * paddle_backend.tanh(paddle_backend.log1p(paddle_backend.exp(x)))
         return F.mish(x.cast("float32")).cast(x.dtype)
     return F.mish(x)
+
+def elu(
+    x: paddle.Tensor,
+    /,
+    *,
+    alpha: float = 1.0,
+    out: Optional[paddle.Tensor] = None,
+) -> paddle.Tensor:
+    if x.dtype in unsupported_dtypes:
+        if paddle.is_complex(x):
+            return paddle.complex(
+                F.elu(x.real(), alpha=alpha), F.elu(x.imag(), alpha=alpha)
+            )
+        return F.elu(x.cast("float32"), alpha=alpha).cast(x.dtype)
+    return F.elu(x, alpha=alpha)

--- a/ivy/functional/backends/paddle/activations.py
+++ b/ivy/functional/backends/paddle/activations.py
@@ -167,8 +167,8 @@ def elu(
 ) -> paddle.Tensor:
     if x.dtype in unsupported_dtypes:
         if paddle.is_complex(x):
-            return paddle.complex(
-                F.elu(x.real(), alpha=alpha), F.elu(x.imag(), alpha=alpha)
+            return paddle_backend.where(
+                x > 0, x, alpha * (paddle_backend.exp(x) - 1)
             )
         return F.elu(x.cast("float32"), alpha=alpha).cast(x.dtype)
     return F.elu(x, alpha=alpha)

--- a/ivy/functional/backends/paddle/activations.py
+++ b/ivy/functional/backends/paddle/activations.py
@@ -158,17 +158,11 @@ def mish(x: paddle.Tensor, /, *, out: Optional[paddle.Tensor] = None) -> paddle.
     return F.mish(x)
 
 
-def elu(
-    x: paddle.Tensor,
-    /,
-    *,
-    alpha: float = 1.0,
-    out: Optional[paddle.Tensor] = None,
-) -> paddle.Tensor:
+def elu(x: paddle.Tensor, /, *, out: Optional[paddle.Tensor] = None) -> paddle.Tensor:
     if x.dtype in unsupported_dtypes:
         if paddle.is_complex(x):
-            return paddle.complex(
-                F.elu(x.real(), alpha=alpha), F.elu(x.imag(), alpha=alpha)
-            )
-        return F.elu(x.cast("float32"), alpha=alpha).cast(x.dtype)
-    return F.elu(x, alpha=alpha)
+            return paddle.complex(F.elu(x.real()), F.elu(x.imag()))
+        if x.dtype == "bool":
+            raise TypeError(f"elu(): Unsupported dtype {x.dtype}")
+        return F.elu(x.cast("float32")).cast(x.dtype)
+    return F.elu(x)

--- a/ivy/functional/backends/paddle/activations.py
+++ b/ivy/functional/backends/paddle/activations.py
@@ -157,6 +157,7 @@ def mish(x: paddle.Tensor, /, *, out: Optional[paddle.Tensor] = None) -> paddle.
         return F.mish(x.cast("float32")).cast(x.dtype)
     return F.mish(x)
 
+
 def elu(
     x: paddle.Tensor,
     /,

--- a/ivy/functional/frontends/paddle/tensor/math.py
+++ b/ivy/functional/frontends/paddle/tensor/math.py
@@ -71,31 +71,31 @@ def divide(x, y, name=None):
 def sqrt(x, name=None):
     return ivy.sqrt(x)
 
-  
+
 @with_unsupported_dtypes({"2.4.2 and below": ("float16", "bfloat16")}, "paddle")
 @to_ivy_arrays_and_back
 def atanh(x, name=None):
     return ivy.atanh(x)
 
-  
+
 @with_unsupported_dtypes({"2.4.2 and below": ("float16", "bfloat16")}, "paddle")
 @to_ivy_arrays_and_back
 def atan(x, name=None):
     return ivy.atan(x)
 
-  
+
 @with_unsupported_dtypes({"2.4.2 and below": ("float16", "bfloat16")}, "paddle")
 @to_ivy_arrays_and_back
 def round(x, name=None):
     return ivy.round(x)
 
-  
+
 @with_unsupported_dtypes({"2.4.2 and below": ("float16", "bfloat16")}, "paddle")
 @to_ivy_arrays_and_back
 def ceil(x, name=None):
     return ivy.ceil(x)
-  
-  
+
+
 @with_unsupported_dtypes({"2.4.2 and below": ("float16", "bfloat16")}, "paddle")
 @to_ivy_arrays_and_back
 def max(x, axis=None, keepdims=False, name=None):

--- a/ivy/functional/frontends/paddle/tensor/math.py
+++ b/ivy/functional/frontends/paddle/tensor/math.py
@@ -58,3 +58,9 @@ def log(x, name=None):
 @to_ivy_arrays_and_back
 def divide(x, y, name=None):
     return ivy.divide(x, y)
+
+
+@with_unsupported_dtypes({"2.4.2 and below": ("float16", "bfloat16")}, "paddle")
+@to_ivy_arrays_and_back
+def max(x, axis=None, keepdims=False, name=None):
+    return ivy.max(x, axis=axis, keepdims=keepdims)


### PR DESCRIPTION
I added the ELU and Max functions to Paddle's activations and math modules. These functions are commonly used in deep learning models and provide more flexibility and convenience to users. The ELU function outperforms ReLU in some cases and is differentiable everywhere. The Max function is widely used in deep learning applications. I thoroughly tested these additions and believe they will improve the framework's functionality and performance.

Best regards,
Nordin