### PR TITLE
fixed disparity between native behaviour of `lcm`  and ivy's frontend implementations for it

### DIFF
--- a/ivy/functional/backends/numpy/elementwise.py
+++ b/ivy/functional/backends/numpy/elementwise.py
@@ -378,12 +378,10 @@ def lcm(
     out: Optional[np.ndarray] = None,
 ) -> np.ndarray:
     x1, x2 = promote_types_of_inputs(x1, x2)
-    return np.abs(
-        np.lcm(
-            x1,
-            x2,
-            out=out,
-        )
+    return np.lcm(
+        x1,
+        x2,
+        out=out,
     )
 
 

--- a/ivy/functional/backends/tensorflow/elementwise.py
+++ b/ivy/functional/backends/tensorflow/elementwise.py
@@ -372,7 +372,7 @@ def lcm(
     out: Optional[Union[tf.Tensor, tf.Variable]] = None,
 ) -> Union[tf.Tensor, tf.Variable]:
     x1, x2 = promote_types_of_inputs(x1, x2)
-    return tf.math.abs(tf.experimental.numpy.lcm(x1, x2))
+    return tf.experimental.numpy.lcm(x1, x2)
 
 
 @with_unsupported_dtypes({"2.12.0 and below": ("complex",)}, backend_version)

--- a/ivy/functional/backends/torch/elementwise.py
+++ b/ivy/functional/backends/torch/elementwise.py
@@ -354,7 +354,7 @@ def lcm(
     out: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
     x1, x2 = promote_types_of_inputs(x1, x2)
-    return torch.abs(torch.lcm(x1, x2, out=out))
+    return torch.lcm(x1, x2, out=out)
 
 
 lcm.support_native_out = True

--- a/ivy_tests/test_ivy/test_frontends/test_numpy/test_mathematical_functions/test_miscellaneous.py
+++ b/ivy_tests/test_ivy/test_frontends/test_numpy/test_mathematical_functions/test_miscellaneous.py
@@ -682,7 +682,7 @@ def test_numpy_copysign(
 @handle_frontend_test(
     fn_tree="numpy.lcm",
     dtype_and_inputs=helpers.dtype_and_values(
-        available_dtypes=["int16", "int32", "int64"],
+        available_dtypes=helpers.get_dtypes("integer"),
         num_arrays=2,
         shared_dtype=False,
         min_num_dims=1,


### PR DESCRIPTION
There was some disparity between ivy's frontend implementation of `lcm` and supported framework implementation of  `lcm` function which is shown with an example below! 

Tested with running tests for `numpy ` frontend implementation for it and test-cases are passing for all backends! 

example:
```python

import numpy as np
import jax
import jax.numpy as jnp
import paddle
import torch
import tensorflow as tf
import ivy

import ivy.functional.frontends.tensorflow as tf_frontend
import ivy.functional.frontends.torch as torch_f
import ivy.functional.frontends.numpy as np_frontend
import ivy.functional.frontends.jax as jax_frontend


x1 = np.array(2, dtype=np.int16)
x2 = np.array(16385, dtype=np.int16)

result = np.lcm(x1, x2)
print(f"result of orignal NumPy = {result}")

a = np_frontend.lcm(x1, x2)
print(f"result of numpy frontend = {a}")

x1_t = tf.constant(2, dtype=tf.int16)
x2_t = tf.constant(16385, dtype=tf.int16)
re = tf.experimental.numpy.lcm(x1_t, x2_t)
print(f"result of tf origninal = {re}")

x1_j = jnp.array(2, dtype=jnp.int16)
x2_j = jnp.array(16385, dtype=jnp.int16)

b = jax_frontend.numpy.lcm(x1_j, x2_j)
print(f"result of jax frontend = {b}")

b_ = jax.numpy.lcm(x1, x2)
print(f"result of jax Original = {b_}")

x1_t = torch.tensor(2, dtype=torch.int16)
x2_t = torch.tensor(16385, dtype=torch.int16)

c = torch_f.lcm(x1_t, x2_t)
print(f"result of torch frontend = {c}")

c_ = torch.lcm(x1_t, x2_t)
print(f"result of torch Original = {c_}")

x1_i = ivy.array(2, dtype=ivy.int16)
x2_i = ivy.array(16385, dtype=ivy.int16)

d = ivy.lcm(x1_i, x2_i)
print(f"result of ivy native LCM = {d}")

"""
result of orignal NumPy = -32766
result of numpy frontend = 32766
result of tf origninal = -32766
result of jax frontend = ivy.frontends.jax.DeviceArray(-32766, dtype=int16)
result of jax Original = -32766
result of torch frontend = ivy.frontends.torch.Tensor(32766)
result of torch Original = -32766
result of ivy native LCM = ivy.array(32766)
"""
```

