### PR TITLE
fix failing test in `jax.numpy.linalg.det` frontend for paddle backend

### DIFF
--- a/ivy/functional/backends/paddle/linear_algebra.py
+++ b/ivy/functional/backends/paddle/linear_algebra.py
@@ -101,8 +101,8 @@ def det(x: paddle.Tensor, /, *, out: Optional[paddle.Tensor] = None) -> paddle.T
         paddle.float16,
         paddle.bool,
     ]:
-        return paddle.linalg.det(x.cast("float32")).squeeze().cast(x.dtype)
-    return paddle.linalg.det(x).squeeze()
+        return paddle.linalg.det(x.cast("float32")).cast(x.dtype)
+    return paddle.linalg.det(x)
 
 
 def diagonal(

--- a/ivy_tests/test_ivy/test_frontends/test_jax/test_jax_numpy_linalg.py
+++ b/ivy_tests/test_ivy/test_frontends/test_jax/test_jax_numpy_linalg.py
@@ -98,6 +98,7 @@ def test_jax_numpy_det(
     test_flags,
 ):
     dtype, x = dtype_and_x
+    print(f"input = {x}, dtype = {dtype}, x_o = {x[0]}")
     helpers.test_frontend_function(
         input_dtypes=dtype,
         frontend=frontend,
@@ -106,7 +107,7 @@ def test_jax_numpy_det(
         on_device=on_device,
         rtol=1e-04,
         atol=1e-04,
-        a=x[0],
+        a=x,
     )
 
 

--- a/ivy_tests/test_ivy/test_frontends/test_jax/test_jax_numpy_linalg.py
+++ b/ivy_tests/test_ivy/test_frontends/test_jax/test_jax_numpy_linalg.py
@@ -98,7 +98,6 @@ def test_jax_numpy_det(
     test_flags,
 ):
     dtype, x = dtype_and_x
-    print(f"input = {x}, dtype = {dtype}, x_o = {x[0]}")
     helpers.test_frontend_function(
         input_dtypes=dtype,
         frontend=frontend,


### PR DESCRIPTION
Current the test for `det` function at `jax`  frontend fails for `paddle` backend. The suggested changes rectify this issue!