### PR TITLE
fixed item method not working for single element with more than one dimension

### DIFF
--- a/ivy/functional/frontends/torch/tensor.py
+++ b/ivy/functional/frontends/torch/tensor.py
@@ -1074,9 +1074,12 @@ class Tensor:
         return torch_frontend.bitwise_xor(self, other)
 
     def item(self):
-        if self.ndim == 0 or (self.ndim == 1 and self.shape[0] == 1):
+        if all(dim == 1 for dim in self.shape):
             return self.ivy_array.to_scalar()
-        raise ValueError("only size-1 tensors can be converted to Python scalars")
+        else:
+            raise ValueError(
+                "only one element tensors can be converted to Python scalars"
+            )
 
     @with_unsupported_dtypes({"2.0.1 and below": ("float16",)}, "torch")
     def cumprod(self, dim, dtype):


### PR DESCRIPTION
Example:

As shown by @somaia02  at [discord](https://discord.com/channels/799879767196958751/1028707110697058415/1113894701922271304) that `.item()` fails if we're having a single element that is having more than one dimension for torch frontend.
```python
# This works
import torch
x=torch.tensor([[[1]]])
x.item()

# This raise an error
import ivy.functional.frontends.torch as torch_frontend
y=torch_frontend.tensor([[[1]]])
y.item()


# Current Implementation : 
"""
def item(self):
 if self.ndim == 0 or (self.ndim == 1 and self.shape[0] == 1):
     return self.ivy_array.to_scalar()
"""
# To see what is really happening: 
def condition_check(x):
    if x.ndim == 0:
        print (f"First condition is True and we convert to scalar")
    elif x.ndim == 1 and x.shape[0] == 1:
        print(f"Second condition is True and we convert to scalar ")
    else:
        print(f" we raise an error, x.ndim = {x.ndim}, x.shape[0] = {x.shape[0]}")

y=torch_frontend.tensor([[[1]]])

c = condition_check(y) # we raise an error, x.ndim = 3, x.shape[0] = 1
```
This change handles this edge-case .

```python

# Testing
x = torch.tensor(1)
print(x.item()) # 1

y = torch_f.tensor(1)
print(y.item()) # 1

x_1 = torch.tensor([[[1]]])
print(x_1.item()) # 1

y_1 = torch_f.tensor([[[1]]])
print(y_1.item()) # 1


```