### PR TITLE
Add dependency installer script for making the package installation process in doc-builder more generic

### DIFF
--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -1,0 +1,10 @@
+pip install torch
+ver=$(pip show torch | grep Version | cut -d ' ' -f2)
+pip install torch-scatter -f https://data.pyg.org/whl/torch-$ver+cpu.html
+pip install -r requirements/requirements.txt
+if [[ $(arch) == 'arm64' ]]; then
+      pip install -r requirements/optional_m1_1.txt
+      pip install -r requirements/optional_m1_2.txt
+else
+    pip install -r requirements/optional.txt
+fi

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -1,6 +1,3 @@
-pip install torch
-ver=$(pip show torch | grep Version | cut -d ' ' -f2)
-pip install torch-scatter -f https://data.pyg.org/whl/torch-$ver+cpu.html
 pip install -r requirements/requirements.txt
 if [[ $(arch) == 'arm64' ]]; then
       pip install -r requirements/optional_m1_1.txt


### PR DESCRIPTION
Currently, the doc-builder installs the packages required for each project by going through if-else statements as there are slight changes in the commands used for each project. Adding install_dependencies.sh script will allow the doc builder to generalise this process by having to just look for this script in the project directory.

The PR is related to the below task:
https://trello.com/c/VG4SYszL