### PR TITLE
added nanmin, nanmax experimental features

### DIFF
--- a/ivy/data_classes/array/experimental/statistical.py
+++ b/ivy/data_classes/array/experimental/statistical.py
@@ -180,6 +180,104 @@ class _ArrayWithStatisticalExperimental(abc.ABC):
             self._data, axis=axis, keepdims=keepdims, dtype=dtype, out=out
         )
 
+    def nanmin(
+        self: ivy.Array,
+        /,
+        *,
+        axis: Optional[Union[Tuple[int], int]] = None,
+        keepdims: bool = False,
+        dtype: Optional[Union[ivy.Dtype, ivy.NativeDtype]] = None,
+        out: Optional[ivy.Array] = None,
+    ) -> ivy.Array:
+        """
+        ivy.Array instance method variant of ivy.nanmin. This method simply wraps the
+        function, and so the docstring for ivy.nanmin also applies to this method with
+        minimal changes.
+
+        Parameters
+        ----------
+        self
+            Input array.
+        axis
+            Axis or axes along which the minimum is computed.
+            The default is to compute the minimum of the flattened array.
+        keepdims
+            If this is set to True, the axes which are reduced are left in the result
+            as dimensions with size one. With this option, the result will broadcast
+            correctly against the original array. If the value is anything but the default,
+            then keepdims will be passed through to the min method of the underlying data type.
+            If the method does not implement keepdims any exceptions will be raised.
+        dtype
+            The desired data type of returned tensor. Default is None.
+        out
+            optional output array, for writing the result to.
+
+        Returns
+        -------
+        ret
+            The nanmin of the array elements.
+
+        Examples
+        --------
+        >>> a = ivy.array([[1, ivy.nan], [3, 4]])
+        >>> a.nanmin()
+        1.0
+        >>> a.nanmin(axis=0)
+        ivy.array([1.,  4.])
+        """
+        return ivy.nanmin(
+            self._data, axis=axis, keepdims=keepdims, dtype=dtype, out=out
+        )
+
+    def nanmax(
+        self: ivy.Array,
+        /,
+        *,
+        axis: Optional[Union[Tuple[int], int]] = None,
+        keepdims: bool = False,
+        dtype: Optional[Union[ivy.Dtype, ivy.NativeDtype]] = None,
+        out: Optional[ivy.Array] = None,
+    ) -> ivy.Array:
+        """
+        ivy.Array instance method variant of ivy.nanmax. This method simply wraps the
+        function, and so the docstring for ivy.nanmax also applies to this method with
+        minimal changes.
+
+        Parameters
+        ----------
+        self
+            Input array.
+        axis
+            Axis or axes along which the maximum is computed.
+            The default is to compute the maximum of the flattened array.
+        keepdims
+            If this is set to True, the axes which are reduced are left in the result
+            as dimensions with size one. With this option, the result will broadcast
+            correctly against the original array. If the value is anything but the default,
+            then keepdims will be passed through to the max method of the underlying data type.
+            If the method does not implement keepdims any exceptions will be raised.
+        dtype
+            The desired data type of returned tensor. Default is None.
+        out
+            optional output array, for writing the result to.
+
+        Returns
+        -------
+        ret
+            The nanmax of the array elements.
+
+        Examples
+        --------
+        >>> a = ivy.array([[1, ivy.nan], [3, 4]])
+        >>> a.nanmax()
+        4.0
+        >>> a.nanmax(axis=0)
+        ivy.array([3.,  4.])
+        """
+        return ivy.nanmax(
+            self._data, axis=axis, keepdims=keepdims, dtype=dtype, out=out
+        )
+
     def quantile(
         self: ivy.Array,
         q: Union[ivy.Array, float],

--- a/ivy/data_classes/container/experimental/statistical.py
+++ b/ivy/data_classes/container/experimental/statistical.py
@@ -444,6 +444,230 @@ class _ContainerWithStatisticalExperimental(ContainerBase):
         )
 
     @staticmethod
+    def static_nanmin(
+        input: ivy.Container,
+        /,
+        *,
+        axis: Optional[Union[Tuple[int], int]] = None,
+        keepdims: bool = False,
+        dtype: Optional[Union[ivy.Dtype, ivy.NativeDtype]] = None,
+        key_chains: Optional[Union[List[str], Dict[str, str]]] = None,
+        to_apply: bool = True,
+        prune_unapplied: bool = False,
+        map_sequences: bool = False,
+        out: Optional[ivy.Array] = None,
+    ) -> ivy.Container:
+        """
+        ivy.Container static method variant of ivy.nanmin. This method simply wraps 
+        the function, and so the docstring for ivy.nanmin also applies to this method 
+        with minimal changes.
+
+        Parameters
+        ----------
+        self
+            Input container including arrays.
+        axis
+            Axis or axes along which the minimum is computed. 
+            The default is to compute the minimum of the flattened array.
+        keepdims
+            If this is set to True, the axes which are reduced are left in the result 
+            as dimensions with size one. With this option, the result will broadcast correctly 
+            against the original a.
+        dtype
+            The desired data type of returned tensor. Default is None.
+        out
+            optional output array, for writing the result to.
+
+        Returns
+        -------
+        ret
+            The nanmin of the array elements in the input container.
+        
+        Functional Examples
+        -------------------
+        >>> a = ivy.Container(x=ivy.array([[1, ivy.nan], [3, 4]]),\
+                                y=ivy.array([[ivy.nan, 1, 2], [1, 2, 3]])
+        >>> a.nanmin()
+        {
+            x: 1.,
+            y: 1.
+        }
+        """
+        return ContainerBase.cont_multi_map_in_function(
+            "nanmin",
+            input,
+            axis=axis,
+            keepdims=keepdims,
+            dtype=dtype,
+            key_chains=key_chains,
+            to_apply=to_apply,
+            prune_unapplied=prune_unapplied,
+            map_sequences=map_sequences,
+            out=out,
+        )
+
+    def nanmin(
+        self: ivy.Container,
+        /,
+        *,
+        axis: Optional[Union[Tuple[int], int]] = None,
+        keepdims: bool = False,
+        dtype: Optional[Union[ivy.Dtype, ivy.NativeDtype]] = None,
+        out: Optional[ivy.Container] = None,
+    ) -> ivy.Container:
+        """
+        ivy.Container static method variant of ivy.nanmin. This method simply wraps 
+        the function, and so the docstring for ivy.nanmin also applies to this method 
+        with minimal changes.
+
+        Parameters
+        ----------
+        self
+            Input container including arrays.
+        axis
+            Axis or axes along which the minimum is computed. 
+            The default is to compute the minimum of the flattened array.
+        keepdims
+            If this is set to True, the axes which are reduced are left in the result 
+            as dimensions with size one. With this option, the result will broadcast correctly 
+            against the original a.
+        dtype
+            The desired data type of returned tensor. Default is None.
+        out
+            optional output array, for writing the result to.
+
+        Returns
+        -------
+        ret
+            The nanmin of the array elements in the input container.
+            
+        Functional Examples
+        -------------------
+        >>> a = ivy.Container(x=ivy.array([[1, ivy.nan], [3, 4]]), \
+                                y=ivy.array([[ivy.nan, 1, 2], [1, 2, 3]])
+        >>> a.nanmin()
+        {
+            x: 1.,
+            y: 1.
+        }
+        """
+        return self.static_nanmin(
+            self, axis=axis, keepdims=keepdims, dtype=dtype, out=out
+        )
+
+    @staticmethod
+    def static_nanmax(
+        input: ivy.Container,
+        /,
+        *,
+        axis: Optional[Union[Tuple[int], int]] = None,
+        keepdims: bool = False,
+        dtype: Optional[Union[ivy.Dtype, ivy.NativeDtype]] = None,
+        key_chains: Optional[Union[List[str], Dict[str, str]]] = None,
+        to_apply: bool = True,
+        prune_unapplied: bool = False,
+        map_sequences: bool = False,
+        out: Optional[ivy.Array] = None,
+    ) -> ivy.Container:
+        """
+        ivy.Container static method variant of ivy.nanmax. This method simply wraps 
+        the function, and so the docstring for ivy.nanmax also applies to this method 
+        with minimal changes.
+
+        Parameters
+        ----------
+        self
+            Input container including arrays.
+        axis
+            Axis or axes along which the maximum is computed. 
+            The default is to compute the maximum of the flattened array.
+        keepdims
+            If this is set to True, the axes which are reduced are left in the result 
+            as dimensions with size one. With this option, the result will broadcast correctly 
+            against the original a.
+        dtype
+            The desired data type of returned tensor. Default is None.
+        out
+            optional output array, for writing the result to.
+
+        Returns
+        -------
+        ret
+            The nanmax of the array elements in the input container.
+        
+        Functional Examples
+        -------------------
+        >>> a = ivy.Container(x=ivy.array([[1, ivy.nan], [3, 4]]), \
+                                y=ivy.array([[ivy.nan, 1, 2], [1, 2, 3]])
+        >>> a.nanmax()
+        {
+            x: 4.,
+            y: 3.
+        }
+        """
+        return ContainerBase.cont_multi_map_in_function(
+            "nanmax",
+            input,
+            axis=axis,
+            keepdims=keepdims,
+            dtype=dtype,
+            key_chains=key_chains,
+            to_apply=to_apply,
+            prune_unapplied=prune_unapplied,
+            map_sequences=map_sequences,
+            out=out,
+        )
+
+    def nanmax(
+        self: ivy.Container,
+        /,
+        *,
+        axis: Optional[Union[Tuple[int], int]] = None,
+        keepdims: bool = False,
+        dtype: Optional[Union[ivy.Dtype, ivy.NativeDtype]] = None,
+        out: Optional[ivy.Container] = None,
+    ) -> ivy.Container:
+        """
+        ivy.Container static method variant of ivy.nanmax. This method simply wraps 
+        the function, and so the docstring for ivy.nanmax also applies to this method 
+        with minimal changes.
+
+        Parameters
+        ----------
+        self
+            Input container including arrays.
+        axis
+            Axis or axes along which the maximum is computed. 
+            The default is to compute the maximum of the flattened array.
+        keepdims
+            If this is set to True, the axes which are reduced are left in the result 
+            as dimensions with size one. With this option, the result will broadcast correctly 
+            against the original a.
+        dtype
+            The desired data type of returned tensor. Default is None.
+        out
+            optional output array, for writing the result to.
+
+        Returns
+        -------
+        ret
+            The nanmax of the array elements in the input container.
+            
+        Functional Examples
+        -------------------
+        >>> a = ivy.Container(x=ivy.array([[1, ivy.nan], [3, 4]]), \
+                                y=ivy.array([[ivy.nan, 1, 2], [1, 2, 3]])
+        >>> a.nanmax()
+        {
+            x: 4.,
+            y: 3.
+        }
+        """
+        return self.static_nanmax(
+            self, axis=axis, keepdims=keepdims, dtype=dtype, out=out
+        )
+
+    @staticmethod
     def static_quantile(
         a: Union[ivy.Container, ivy.Array, ivy.NativeArray],
         q: Union[ivy.Array, float],

--- a/ivy/functional/backends/jax/experimental/statistical.py
+++ b/ivy/functional/backends/jax/experimental/statistical.py
@@ -160,6 +160,34 @@ def nanmean(
     return jnp.nanmean(a, axis=axis, keepdims=keepdims, dtype=dtype, out=out)
 
 
+def nanmin(
+    a: JaxArray,
+    /,
+    *,
+    axis: Optional[Union[int, Tuple[int]]] = None,
+    keepdims: bool = False,
+    dtype: Optional[jnp.dtype] = None,
+    out: Optional[JaxArray] = None,
+) -> JaxArray:
+    if isinstance(axis, list):
+        axis = tuple(axis)
+    return jnp.nanmin(a, axis=axis, keepdims=keepdims, dtype=dtype, out=out)
+
+
+def nanmax(
+    a: JaxArray,
+    /,
+    *,
+    axis: Optional[Union[int, Tuple[int]]] = None,
+    keepdims: bool = False,
+    dtype: Optional[jnp.dtype] = None,
+    out: Optional[JaxArray] = None,
+) -> JaxArray:
+    if isinstance(axis, list):
+        axis = tuple(axis)
+    return jnp.nanmax(a, axis=axis, keepdims=keepdims, dtype=dtype, out=out)
+
+
 def quantile(
     a: JaxArray,
     q: Union[float, JaxArray],

--- a/ivy/functional/backends/numpy/experimental/statistical.py
+++ b/ivy/functional/backends/numpy/experimental/statistical.py
@@ -165,6 +165,40 @@ def nanmean(
 nanmean.support_native_out = True
 
 
+def nanmin(
+    a: np.ndarray,
+    /,
+    *,
+    axis: Optional[Union[int, Tuple[int]]] = None,
+    keepdims: bool = False,
+    dtype: Optional[np.dtype] = None,
+    out: Optional[np.ndarray] = None,
+) -> np.ndarray:
+    if isinstance(axis, list):
+        axis = tuple(axis)
+    return np.nanmin(a, axis=axis, keepdims=keepdims, dtype=dtype, out=out)
+
+
+nanmin.support_native_out = True
+
+
+def nanmax(
+    a: np.ndarray,
+    /,
+    *,
+    axis: Optional[Union[int, Tuple[int]]] = None,
+    keepdims: bool = False,
+    dtype: Optional[np.dtype] = None,
+    out: Optional[np.ndarray] = None,
+) -> np.ndarray:
+    if isinstance(axis, list):
+        axis = tuple(axis)
+    return np.nanmax(a, axis=axis, keepdims=keepdims, dtype=dtype, out=out)
+
+
+nanmax.support_native_out = True
+
+
 def quantile(
     a: np.ndarray,
     q: Union[float, np.ndarray],

--- a/ivy/functional/backends/paddle/experimental/statistical.py
+++ b/ivy/functional/backends/paddle/experimental/statistical.py
@@ -94,6 +94,88 @@ def nanmean(
     return ret.astype(ret_dtype)
 
 
+def nanmin(
+    a: paddle.Tensor,
+    /,
+    *,
+    axis: Optional[Union[int, Tuple[int]]] = None,
+    keepdims: Optional[bool] = False,
+    dtype: Optional[paddle.dtype] = None,
+    out: Optional[paddle.Tensor] = None,
+) -> paddle.Tensor:
+    # Replace NaNs with positive infinity for min operation
+    a = paddle.where(paddle.isnan(a), float("inf"), a)
+
+    if a.dtype not in [paddle.int64, paddle.float32, paddle.float64]:
+        if paddle.is_complex(a):
+            ret = paddle.complex(
+                paddle.min(a.real(), axis=axis, keepdim=keepdims),
+                paddle.min(a.imag(), axis=axis, keepdim=keepdims),
+            )
+        else:
+            ret = paddle.min(a.astype("float32"), axis=axis, keepdim=keepdims)
+    else:
+        ret = paddle.min(a, axis=axis, keepdim=keepdims)
+
+    if paddle.all(paddle.isinf(ret)):
+        ret = paddle.full_like(ret, float("nan")) if keepdims else float("nan")
+
+    if isinstance(axis, Sequence):
+        if len(axis) == a.ndim:
+            axis = None
+    if (a.ndim == 1 or axis is None) and not keepdims:
+        ret = ret.squeeze()
+
+    if dtype is not None:
+        ret = ret.astype(dtype)
+
+    if out is not None:
+        out.assign(ret)
+        return out
+    return ret
+
+
+def nanmax(
+    a: paddle.Tensor,
+    /,
+    *,
+    axis: Optional[Union[int, Tuple[int]]] = None,
+    keepdims: Optional[bool] = False,
+    dtype: Optional[paddle.dtype] = None,
+    out: Optional[paddle.Tensor] = None,
+) -> paddle.Tensor:
+    # Replace NaNs with negative infinity for max operation
+    a = paddle.where(paddle.isnan(a), float("-inf"), a)
+
+    if a.dtype not in [paddle.int64, paddle.float32, paddle.float64]:
+        if paddle.is_complex(a):
+            ret = paddle.complex(
+                paddle.max(a.real(), axis=axis, keepdim=keepdims),
+                paddle.max(a.imag(), axis=axis, keepdim=keepdims),
+            )
+        else:
+            ret = paddle.max(a.astype("float32"), axis=axis, keepdim=keepdims)
+    else:
+        ret = paddle.max(a, axis=axis, keepdim=keepdims)
+
+    if paddle.all(paddle.isinf(ret)):
+        ret = paddle.full_like(ret, float("nan")) if keepdims else float("nan")
+
+    if isinstance(axis, Sequence):
+        if len(axis) == a.ndim:
+            axis = None
+    if (a.ndim == 1 or axis is None) and not keepdims:
+        ret = ret.squeeze()
+
+    if dtype is not None:
+        ret = ret.astype(dtype)
+
+    if out is not None:
+        out.assign(ret)
+        return out
+    return ret
+
+
 def _compute_quantile(
     x, q, axis=None, keepdim=False, ignore_nan=False, interpolation="linear"
 ):

--- a/ivy/functional/backends/tensorflow/experimental/statistical.py
+++ b/ivy/functional/backends/tensorflow/experimental/statistical.py
@@ -103,6 +103,65 @@ def nanmean(
     return tf.experimental.numpy.nanmean(a, axis=axis, keepdims=keepdims, dtype=dtype)
 
 
+def nanmin(
+    a: Union[tf.Tensor, tf.Variable],
+    /,
+    *,
+    axis: Optional[Union[int, Tuple[int]]] = None,
+    keepdims: bool = False,
+    dtype: Optional[tf.DType] = None,
+    out: Optional[Union[tf.Tensor, tf.Variable]] = None,
+) -> Union[tf.Tensor, tf.Variable]:
+    replaced_tensor = tf.where(tf.math.is_nan(a), tf.fill(a.shape, float("inf")), a)
+
+    if axis is None:
+        result = tf.math.reduce_min(replaced_tensor)
+    else:
+        result = tf.math.reduce_min(replaced_tensor, axis=axis, keepdims=keepdims)
+
+    # If all inputs are nan, return nan
+    if tf.reduce_all(tf.math.is_nan(a)):
+        result = tf.fill(result.shape, float("nan"))
+
+    if dtype is not None:
+        result = tf.cast(result, dtype)
+
+    if out is not None:
+        out.assign(result)
+        return out
+
+    return result
+
+
+def nanmax(
+    a: Union[tf.Tensor, tf.Variable],
+    /,
+    *,
+    axis: Optional[Union[int, Tuple[int]]] = None,
+    keepdims: bool = False,
+    dtype: Optional[tf.DType] = None,
+    out: Optional[Union[tf.Tensor, tf.Variable]] = None,
+) -> Union[tf.Tensor, tf.Variable]:
+    replaced_tensor = tf.where(tf.math.is_nan(a), tf.fill(a.shape, float("-inf")), a)
+
+    if axis is None:
+        result = tf.math.reduce_max(replaced_tensor)
+    else:
+        result = tf.math.reduce_max(replaced_tensor, axis=axis, keepdims=keepdims)
+
+    # If all inputs are nan, return nan
+    if tf.reduce_all(tf.math.is_nan(a)):
+        result = tf.fill(result.shape, float("nan"))
+
+    if dtype is not None:
+        result = tf.cast(result, dtype)
+
+    if out is not None:
+        out.assign(result)
+        return out
+    return result
+
+
 def quantile(
     a: Union[tf.Tensor, tf.Variable],
     q: Union[tf.Tensor, float],

--- a/ivy/functional/backends/torch/experimental/statistical.py
+++ b/ivy/functional/backends/torch/experimental/statistical.py
@@ -183,6 +183,66 @@ def nanmean(
 nanmean.support_native_out = True
 
 
+def nanmin(
+    a: torch.Tensor,
+    /,
+    *,
+    axis: Optional[Union[int, Tuple[int]]] = None,
+    keepdims: bool = False,
+    dtype: Optional[torch.dtype] = None,
+    out: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    replaced_tensor = torch.where(torch.isnan(a), float("inf"), a)
+    result = (
+        torch.min(replaced_tensor, dim=axis, keepdim=keepdims)[0]
+        if axis is not None
+        else torch.min(replaced_tensor).values
+    )
+    if torch.all(torch.isnan(a)):
+        result = torch.full(result.shape, float("nan"))
+
+    if dtype is not None:
+        result = result.to(dtype)
+
+    if out is not None:
+        out.copy_(result)
+        return out
+    return result
+
+
+nanmin.support_native_out = True
+
+
+def nanmax(
+    a: torch.Tensor,
+    /,
+    *,
+    axis: Optional[Union[int, Tuple[int]]] = None,
+    keepdims: bool = False,
+    dtype: Optional[torch.dtype] = None,
+    out: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    replaced_tensor = torch.where(torch.isnan(a), float("-inf"), a)
+    result = (
+        torch.max(replaced_tensor, dim=axis, keepdim=keepdims)[0]
+        if axis is not None
+        else torch.max(replaced_tensor).values
+    )
+    if torch.all(torch.isnan(a)):
+        result = torch.full(result.shape, float("nan"))
+
+    if dtype is not None:
+        result = result.to(dtype)
+
+    if out is not None:
+        out.copy_(result)
+        return out
+    return result
+
+
+nanmax.support_native_out = True
+
+
 @with_unsupported_dtypes({"2.0.1 and below": ("bfloat16", "float16")}, backend_version)
 def quantile(
     a: torch.Tensor,

--- a/ivy/functional/ivy/experimental/statistical.py
+++ b/ivy/functional/ivy/experimental/statistical.py
@@ -246,6 +246,114 @@ def nanmean(
 @handle_nestable
 @handle_out_argument
 @to_native_arrays_and_back
+@infer_dtype
+def nanmin(
+    a: ivy.Array,
+    /,
+    *,
+    axis: Optional[Union[Tuple[int], int]] = None,
+    keepdims: bool = False,
+    dtype: Optional[Union[ivy.Dtype, ivy.NativeDtype]] = None,
+    out: Optional[ivy.Array] = None,
+) -> ivy.Array:
+    """
+    Compute the minimum of all non-NaN elements along the specified dimensions.
+
+    Parameters
+    ----------
+    a
+        Input array.
+    axis
+        Axis or axes along which the minima are computed.
+        The default is to compute the minima of the flattened array.
+    keepdims
+        If this is set to True, the axes which are reduced are left in the result
+        as dimensions with size one. With this option, the result will broadcast
+        correctly against the original a. If the value is anything but the default,
+        then keepdims will be passed through to the min method of sub-classes
+        of ndarray. If the sub-classes methods does not implement keepdims any
+        exceptions will be raised.
+    dtype
+        The desired data type of returned tensor. Default is None.
+    out
+        optional output array, for writing the result to.
+
+    Returns
+    -------
+    ret
+        The nanmin of the array elements.
+
+    Functional Examples
+    -------------------
+    >>> a = ivy.array([[1, ivy.nan], [3, 4]])
+    >>> ivy.nanmin(a)
+    1.0
+    >>> ivy.nanmin(a, axis=0)
+    ivy.array([1.,  4.])
+    """
+    return ivy.current_backend(a).nanmin(
+        a, axis=axis, keepdims=keepdims, dtype=dtype, out=out
+    )
+
+
+@handle_exceptions
+@handle_nestable
+@handle_out_argument
+@to_native_arrays_and_back
+@infer_dtype
+def nanmax(
+    a: ivy.Array,
+    /,
+    *,
+    axis: Optional[Union[Tuple[int], int]] = None,
+    keepdims: bool = False,
+    dtype: Optional[Union[ivy.Dtype, ivy.NativeDtype]] = None,
+    out: Optional[ivy.Array] = None,
+) -> ivy.Array:
+    """
+    Compute the maximum of all non-NaN elements along the specified dimensions.
+
+    Parameters
+    ----------
+    a
+        Input array.
+    axis
+        Axis or axes along which the maxima are computed.
+        The default is to compute the maxima of the flattened array.
+    keepdims
+        If this is set to True, the axes which are reduced are left in the result
+        as dimensions with size one. With this option, the result will broadcast
+        correctly against the original a. If the value is anything but the default,
+        then keepdims will be passed through to the max method of sub-classes
+        of ndarray. If the sub-classes methods does not implement keepdims any
+        exceptions will be raised.
+    dtype
+        The desired data type of returned tensor. Default is None.
+    out
+        optional output array, for writing the result to.
+
+    Returns
+    -------
+    ret
+        The nanmax of the array elements.
+
+    Functional Examples
+    -------------------
+    >>> a = ivy.array([[1, ivy.nan], [3, 4]])
+    >>> ivy.nanmax(a)
+    4.0
+    >>> ivy.nanmax(a, axis=0)
+    ivy.array([3.,  4.])
+    """
+    return ivy.current_backend(a).nanmax(
+        a, axis=axis, keepdims=keepdims, dtype=dtype, out=out
+    )
+
+
+@handle_exceptions
+@handle_nestable
+@handle_out_argument
+@to_native_arrays_and_back
 def quantile(
     a: ivy.Array,
     q: Union[ivy.Array, float],


### PR DESCRIPTION
#3856 extending experimental api, including nanmin and nanmax function for numpy, jax, paddle, tensorflow and pytorch backends.