### PR TITLE
Removed functorch from requirements

### DIFF
--- a/requirements/optional.txt
+++ b/requirements/optional.txt
@@ -14,7 +14,6 @@ tensorflow-addons # unpinned, we test for latest version now, mod_name=tensorflo
 tensorflow-probability # unpinned, we test for latest version now, mod_name=tensorflow_probability
 torch # unpinned, we test for latest version now
 torch-scatter # unpinned, mod_name=torch_scatter
-functorch # unpinned, we test for latest version now
 scipy # unpinned
 dm-haiku # unpinned mod_name=haiku
 flax

--- a/requirements/optional_gpu.txt
+++ b/requirements/optional_gpu.txt
@@ -13,7 +13,6 @@ tensorflow-addons # unpinned, we test for latest version now, mod_name=tensorflo
 tensorflow-probability # unpinned, we test for latest version now, mod_name=tensorflow_probability
 torch # unpinned, we test for latest version now
 torch-scatter # unpinned, mod_name=torch_scatter
-functorch # unpinned, we test for latest version now
 scipy # unpinned
 dm-haiku # unpinned mod_name=haiku
 flax

--- a/requirements/optional_m1_2.txt
+++ b/requirements/optional_m1_2.txt
@@ -1,5 +1,4 @@
 torch-scatter # torch_scatter requires a prior existing installation of torch, hence 2 optional files
-functorch
 scipy
 dm-haiku  # mod_name=haiku
 flax


### PR DESCRIPTION
![image](https://github.com/unifyai/ivy/assets/59740725/d8b836e0-5f47-4a03-874b-043a3e5e243b)
New version of pytorch comes with functorch