### PR TITLE
remove numpy call from jax asarray

### DIFF
--- a/ivy/functional/backends/jax/creation.py
+++ b/ivy/functional/backends/jax/creation.py
@@ -94,11 +94,7 @@ def asarray(
     if copy is True:
         return _to_device(jnp.array(obj, dtype=dtype, copy=True), device=device)
     else:
-        # jnp.array is much slower than np.array when called on lists
-        # timing the function given a 7 million integer element list
-        # the execution time drops from 323 to 17 seconds
-        obj = np.asarray(_to_array(obj))
-        return _to_device(jnp.array(obj, dtype=dtype), device=device)
+        return _to_device(jnp.asarray(obj, dtype=dtype), device=device)
 
 
 def empty(


### PR DESCRIPTION
I'm not sure we can have a pure numpy call in the jax backend right? I identified this problem as it caused a failure in the graph compiler tests. Here is a minimal example that showcases the problem - throwing an error like `TracerArrayConversionError: The numpy.ndarray conversion method __array__() was called on the JAX Tracer object`.
 But when we change `x = np.asarray(x)` to `x = jnp.asarray(x)` it works fine. Let me know if I'm missing something here 😅

```
class TestFlaxLinear(flax.linen.Module):
    out_size: int

    def setup(self):
        self._linear = flax.linen.Dense(self.out_size)

    def __call__(self, x):
        x = np.asarray(x)
        return self._linear(x)
    
class TestFlaxModule(flax.linen.Module):
    in_size: int
    out_size: int
    device: jaxlib.xla_extension.Device = None
    hidden_size: int = 4

    def setup(self):
        self._linear0 = TestFlaxLinear(self.hidden_size)
        self._linear1 = TestFlaxLinear(self.hidden_size)
        self._linear2 = TestFlaxLinear(self.out_size)

    def __call__(self, x):
        x = jnp.expand_dims(x, 0)
        x = jnp.tanh(self._linear0(x))
        x = jnp.tanh(self._linear1(x))
        return jnp.tanh(self._linear2(x))[0]

if __name__ == "__main__":
    ivy.set_backend('jax')

    test_input = ivy.native_array([[0.1, 0.2]], dtype="float32")
    test_target = ivy.native_array([[0.5, 0.6]], dtype="float32")
    module = TestFlaxModule(2, 2)

    params_jax = (
        module.init(jax.random.PRNGKey(0), test_input)
    )

    def loss_func(weights, input_data, target):
        preds = module.apply(weights, input_data)
        return jnp.mean((target - preds) ** 2)

    loss, param_grads = jax.value_and_grad(loss_func)(params_jax, test_input, test_target)
    print(loss)
```