### PR TITLE
Make dtype_and_values take dtype without passing available_dtypes as well

### DIFF
--- a/ivy_tests/test_ivy/helpers/hypothesis_helpers/array_helpers.py
+++ b/ivy_tests/test_ivy/helpers/hypothesis_helpers/array_helpers.py
@@ -486,7 +486,7 @@ def dtype_and_values(
         min_dim_size = draw(min_dim_size)
     if isinstance(max_dim_size, st._internal.SearchStrategy):
         max_dim_size = draw(max_dim_size)
-    if isinstance(available_dtypes, st._internal.SearchStrategy):
+    if isinstance(available_dtypes, st._internal.SearchStrategy) and dtype is None:
         available_dtypes = draw(available_dtypes)
     if not isinstance(num_arrays, int):
         num_arrays = draw(num_arrays)


### PR DESCRIPTION
When dtype_and_values is called with dtype only and not available_dtypes I get an error no function to prune. I don't know how to reproduce this outside the test file I'm working on but this is an example of the problem:
```
# This works
helpers.dtype_and_values(dtype=["float64"], available_dtypes=("float64"))

# This doesn't
helpers.dtype_and_values(dtype=["float64"])
```
If I pass dtype, I shouldn't have to pass available_dtypes as well. 