### PR TITLE
Implement `handle_versioned_function` decorator to lazily dispatch the function to a version-specific implementation

### DIFF
--- a/ivy/functional/frontends/__init__.py
+++ b/ivy/functional/frontends/__init__.py
@@ -1,6 +1,5 @@
-import importlib
-
-
+# Update this dict to match the latest released
+# version for the frameworks
 versions = {
     "torch": "2.0.1",
     "tensorflow": "2.9.0",
@@ -9,83 +8,3 @@ versions = {
     "scipy": "1.10.1",
     "paddle": "2.4.2",
 }
-
-
-def fn_name_from_version_specific_fn_name(name, version):
-    """
-
-    Parameters
-    ----------
-    name
-        the version specific name of the function for which the version support is to be
-        provided.
-    version
-        the version of the current framework for which the support is to be provided,
-        the version is inferred by importing the framework in the case of frontend
-        version support and defaults to the highest available version in case of import
-        failure
-    Returns
-    -------
-        the name of the original function which will then point to the version specific
-        function
-
-    """
-    version = str(version)
-    if version.find("+") != -1:
-        version = tuple(map(int, version[: version.index("+")].split(".")))
-        # version = int(version[: version.index("+")].replace(".", ""))
-    else:
-        version = tuple(map(int, version.split(".")))
-        # version = int(version.replace(".", ""))
-    if "_to_" in name:
-        i = name.index("_v_")
-        e = name.index("_to_")
-        version_start = name[i + 3 : e]
-        version_start = tuple(map(int, version_start.split("p")))
-        version_end = name[e + 4 :]
-        version_end = tuple(map(int, version_end.split("p")))
-        if version_start <= version <= version_end:
-            return name[0:i]
-    elif "_and_above" in name:
-        i = name.index("_v_")
-        e = name.index("_and_")
-        version_start = name[i + 3 : e]
-        version_start = tuple(map(int, version_start.split("p")))
-        if version >= version_start:
-            return name[0:i]
-    else:
-        i = name.index("_v_")
-        e = name.index("_and_")
-        version_start = name[i + 3 : e]
-        version_start = tuple(map(int, version_start.split("p")))
-        if version <= version_start:
-            return name[0:i]
-
-
-def set_frontend_to_specific_version(frontend):
-    """
-
-    Parameters
-    ----------
-    frontend
-        the frontend module for which we provide the version support
-
-    Returns
-    -------
-        The function doesn't return anything and updates the frontend __dict__
-        to make the original function name to point to the version specific one
-    """
-    f = str(frontend.__name__)
-    f = f[f.index("frontends") + 10 :]
-    str_f = str(f)
-    try:
-        f = importlib.import_module(f)
-        f_version = f.__version__
-    except (ImportError, AttributeError):
-        f_version = versions[str_f]
-
-    for i in list(frontend.__dict__):
-        if "_v_" in i:
-            orig_name = fn_name_from_version_specific_fn_name(i, f_version)
-            if orig_name:
-                frontend.__dict__[orig_name] = frontend.__dict__[i]

--- a/ivy/functional/frontends/jax/__init__.py
+++ b/ivy/functional/frontends/jax/__init__.py
@@ -2,7 +2,6 @@
 import sys
 
 # local
-from ivy.functional.frontends import set_frontend_to_specific_version
 from . import config
 from . import devicearray
 from .devicearray import DeviceArray
@@ -17,8 +16,3 @@ from ._src import tree_util
 
 
 _frontend_array = numpy.array
-
-# setting to specific version #
-# --------------------------- #
-
-set_frontend_to_specific_version(sys.modules[__name__])

--- a/ivy/functional/frontends/numpy/__init__.py
+++ b/ivy/functional/frontends/numpy/__init__.py
@@ -4,7 +4,6 @@ import sys
 # local
 import ivy
 from ivy.utils.exceptions import handle_exceptions
-from ivy.functional.frontends import set_frontend_to_specific_version
 from typing import Union, Iterable, Tuple
 from numbers import Number
 from .data_type_routines import dtype
@@ -713,8 +712,3 @@ nextafter = ufunc("_nextafter")
 conjugate = ufunc("_conjugate")
 lcm = ufunc("_lcm")
 gcd = ufunc("_gcd")
-
-# setting to specific version #
-# --------------------------- #
-
-set_frontend_to_specific_version(sys.modules[__name__])

--- a/ivy/functional/frontends/paddle/__init__.py
+++ b/ivy/functional/frontends/paddle/__init__.py
@@ -1,7 +1,6 @@
 import sys
 import ivy
 from ivy.utils.exceptions import handle_exceptions
-from ivy.functional.frontends import set_frontend_to_specific_version
 
 
 # global
@@ -237,8 +236,3 @@ from .tensor.tensor import Tensor
 
 
 _frontend_array = Tensor
-
-# setting to specific version #
-# --------------------------- #
-
-set_frontend_to_specific_version(sys.modules[__name__])

--- a/ivy/functional/frontends/scipy/__init__.py
+++ b/ivy/functional/frontends/scipy/__init__.py
@@ -2,7 +2,6 @@
 import sys
 
 # local
-from ivy.functional.frontends import set_frontend_to_specific_version
 from . import cluster
 from . import constants
 from . import fft
@@ -24,8 +23,3 @@ import ivy.functional.frontends.numpy as np
 
 
 array = _frontend_array = np.array
-
-# setting to specific version #
-# --------------------------- #
-
-set_frontend_to_specific_version(sys.modules[__name__])

--- a/ivy/functional/frontends/tensorflow/__init__.py
+++ b/ivy/functional/frontends/tensorflow/__init__.py
@@ -4,7 +4,6 @@ import sys
 # local
 import ivy
 from ivy.utils.exceptions import handle_exceptions
-from ivy.functional.frontends import set_frontend_to_specific_version
 from numbers import Number
 from typing import Union, Tuple, Iterable
 from .dtypes import DType
@@ -111,8 +110,3 @@ from . import sparse
 
 
 _frontend_array = constant
-
-# setting to specific version #
-# --------------------------- #
-
-set_frontend_to_specific_version(sys.modules[__name__])

--- a/ivy/functional/frontends/torch/__init__.py
+++ b/ivy/functional/frontends/torch/__init__.py
@@ -6,7 +6,6 @@ from typing import Union, Tuple, Iterable
 # local
 import ivy
 from ivy.utils.exceptions import handle_exceptions
-from ivy.functional.frontends import set_frontend_to_specific_version
 
 
 # Constructing dtypes are required as ivy.<dtype>
@@ -285,8 +284,3 @@ from .func import *
 
 
 _frontend_array = tensor
-
-# setting to specific version #
-# --------------------------- #
-
-set_frontend_to_specific_version(sys.modules[__name__])

--- a/ivy/functional/frontends/torch/creation_ops.py
+++ b/ivy/functional/frontends/torch/creation_ops.py
@@ -1,6 +1,6 @@
 # local
 import ivy
-from ivy.func_wrapper import with_unsupported_dtypes
+from ivy.func_wrapper import handle_versioned_function, with_unsupported_dtypes
 from ivy.functional.frontends.torch.func_wrapper import to_ivy_arrays_and_back
 
 
@@ -50,13 +50,13 @@ def ones(*args, size=None, out=None, dtype=None, device=None, requires_grad=Fals
 
 
 @to_ivy_arrays_and_back
-def ones_like_v_0p3p0_to_0p3p1(input, out=None):
-    return ivy.ones_like(input, out=None)
+def heaviside(input, values, *, out=None):
+    return ivy.heaviside(input, values, out=out)
 
 
 @to_ivy_arrays_and_back
-def heaviside(input, values, *, out=None):
-    return ivy.heaviside(input, values, out=out)
+def ones_like_v_0p3p0_to_0p3p1(input, out=None):
+    return ivy.ones_like(input, out=None)
 
 
 @to_ivy_arrays_and_back
@@ -71,6 +71,12 @@ def ones_like_v_0p4p0_and_above(
 ):
     ret = ivy.ones_like(input, dtype=dtype, device=device)
     return ret
+
+
+@handle_versioned_function
+@to_ivy_arrays_and_back
+def ones_like(*args, **kwargs):
+    pass
 
 
 @to_ivy_arrays_and_back

--- a/ivy_tests/test_ivy/test_misc/test_func_wrapper.py
+++ b/ivy_tests/test_ivy/test_misc/test_func_wrapper.py
@@ -120,6 +120,29 @@ def test_handle_mixed_function(x, weight, expected):
 
 
 @pytest.mark.parametrize(
+    ("x", "version", "expected"),
+    [
+        ([[2, 2, 2], [1, 1, 1]], "0.3.1", False),
+        ([[2, 2, 2], [1, 1, 1]], "0.4.1", True),
+    ],
+)
+def test_handle_versioned_function(x, version, expected):
+    from ivy.functional.frontends import torch as ivy_torch
+    import torch
+
+    x = ivy.array(x)
+    fw_version = torch.__version__
+    torch.__version__ = version
+    test_fn = "ivy.functional.frontends.torch.ones_like_v_0p4p0_and_above"
+
+    with patch(test_fn) as test_mock_function:
+        ivy_torch.ones_like(x)
+        assert test_mock_function.called == expected
+
+    torch.__version__ = fw_version
+
+
+@pytest.mark.parametrize(
     "array_to_update",
     [0, 1, 2, 3, 4],
 )


### PR DESCRIPTION
This PR implements a new decorator to lazily dispatch the function to a version-specific implementation only when the function is actually called by the user rather than at import-time, as previously implemented.

The previous policy was implemented s.t. for the frontends, we iterated over the frontend's `__dict__` at import-time to change the mapping based on the framework version installed on the user's machine by importing the native framework (`paddle`, `torch`, `tensorflow` etc.). This caused the frontend imports to slow down since we not only imported a native framework at import-time but we also iterated over the entirety of the frontend’s `__dict__` in order to find the version-specific functions. A small point to note that currently a similar policy is applied in the backends as well but this PR focuses on refactoring the frontends based on my discussion with @RickSanchezStoic on Discord and also since the frontends directly affect the transpiler.

The updated policy shall now dictate that the dispatching takes place inside a decorator called `handle_versioned_function` which gets applied to the function we want to provide version support for. As an example, currently there are two functions in the torch frontend that support versioning: `ones_like_v_0p3p0_to_0p3p1` and `ones_like_v_0p4p0_and_above`

We will add another function with the actual function name i.e. `ones_like` with a generic signature but with no logic inside (this is the policy that should be followed moving forward). The decorator will then be applied to `ones_like` and will handle the dispatching at run-time based on the versioning logic which was previously being handled at import-time. 

This should significantly reduce the time it takes to import the frontends since now we only dispatch when that function is explicitly called and we don't need to iterate over the entirety of the frontend's `__dict__` in order to make the dispatch. I've also added a test to demonstrate the usability and working of the decorator. I'll update the relevant sections in the docs to also reflect this new policy once this PR is merged. Although this policy is designed for the frontends, I've deliberately tried to keep it generic in the sense that if we want to apply this policy to the backends as well, we would just need to add some logic under the `TODO` inside the decorator (kind of similar to what's been added for the frontend block) if we want to apply this decorator to the backend functions as well.

[Relevant Trello Task](https://trello.com/c/uwQed2On/1965-implement-a-handleversionedfunction-decorator-for-lazy-version-specific-dispatch)

