### PR TITLE
Fixes the unintended behavior created by ivy.Array.__getattr__

### DIFF
--- a/ivy/data_classes/array/array.py
+++ b/ivy/data_classes/array/array.py
@@ -28,7 +28,7 @@ from .set import _ArrayWithSet
 from .sorting import _ArrayWithSorting
 from .statistical import _ArrayWithStatistical
 from .utility import _ArrayWithUtility
-from ivy.func_wrapper import handle_view_indexing, outputs_to_ivy_arrays
+from ivy.func_wrapper import handle_view_indexing
 from .experimental import (
     _ArrayWithSearchingExperimental,
     _ArrayWithActivationsExperimental,
@@ -425,13 +425,7 @@ class Array(
         return super().__getattribute__(item)
 
     def __getattr__(self, item):
-        try:
-            attr = self._data.__getattribute__(item)
-        except AttributeError:
-            attr = self._data.__getattr__(item)
-        if callable(attr):
-            return outputs_to_ivy_arrays(attr)
-        return to_ivy(attr)
+        raise AttributeError(f"'ivy.Array' object has no attribute '{item}'")
 
     @handle_view_indexing
     def __getitem__(self, query):

--- a/ivy/data_classes/array/array.py
+++ b/ivy/data_classes/array/array.py
@@ -28,7 +28,7 @@ from .set import _ArrayWithSet
 from .sorting import _ArrayWithSorting
 from .statistical import _ArrayWithStatistical
 from .utility import _ArrayWithUtility
-from ivy.func_wrapper import handle_view_indexing
+from ivy.func_wrapper import handle_view_indexing, outputs_to_ivy_arrays
 from .experimental import (
     _ArrayWithSearchingExperimental,
     _ArrayWithActivationsExperimental,
@@ -429,6 +429,8 @@ class Array(
             attr = self._data.__getattribute__(item)
         except AttributeError:
             attr = self._data.__getattr__(item)
+        if callable(attr):
+            return outputs_to_ivy_arrays(attr)
         return to_ivy(attr)
 
     @handle_view_indexing


### PR DESCRIPTION
Fixed this https://trello.com/c/yLipjrid. 
The issue arises because the `to_ivy` function that's used expects arrays or iterables (e.g. `ivy.Array,` or `ivy.NativeArray`) but native framework methods like torch's `permute` get passed to it. I fixed this by adding a check for callables and converting the callables' output to ivy arrays.
