### PR TITLE
Fixed scatter_nd broadcast error in tf backend

### DIFF
--- a/ivy/functional/backends/tensorflow/general.py
+++ b/ivy/functional/backends/tensorflow/general.py
@@ -472,7 +472,10 @@ def scatter_nd(
         if sum(indices.shape) < sum(indices_shape):
             indices = ivy.broadcast_to(indices, indices_shape)._data
         else:
-            updates = ivy.broadcast_to(updates, expected_shape)._data
+            # updates = ivy.broadcast_to(updates, expected_shape)._data
+            # replaced ivy.broadcast_to because it asserts len(x1_shape)>len(x2_shape)
+            if _check_broadcastable(updates.shape, expected_shape):
+                updates = ivy.reshape(updates, expected_shape)._data
     # implementation
     target = out
     target_given = ivy.exists(target)
@@ -502,6 +505,16 @@ def scatter_nd(
 
 
 scatter_nd.support_native_out = True
+
+
+def _check_broadcastable(x1, x2):
+    # ivy.assertions.check_one_way_broadcastable but not checking if len(x1) > len(x2)
+    for a, b in zip(x1[::-1], x2[::-1]):
+        if a == 1 or a == b:
+            pass
+        else:
+            return False
+    return True
 
 
 def shape(


### PR DESCRIPTION
```
import jax
jax.config.update('jax_enable_x64', True)
import ivy

# ivy.set_jax_backend()
# ivy.set_torch_backend()
# ivy.set_numpy_backend()
ivy.set_tensorflow_backend()
x = ivy.zeros((1, 1, 2, 1))
y = ivy.ones((1, 1, 2, 1))
x[:, :, :, :] = y   # fails only for tensorflow
```