### PR TITLE
fix torch.frexp tests 

### DIFF
--- a/ivy/functional/backends/numpy/experimental/elementwise.py
+++ b/ivy/functional/backends/numpy/experimental/elementwise.py
@@ -281,9 +281,9 @@ def ldexp(
 
 
 def frexp(
-    x: np.ndarray,
-    /,
-    *,
-    out: Union[Tuple[np.ndarray, np.ndarray], Tuple[None, None]] = (None, None),
+    x: np.ndarray, /, *, out: Optional[Tuple[np.ndarray, np.ndarray]] = None
 ) -> Tuple[np.ndarray, np.ndarray]:
-    return np.frexp(x, out=out)
+    if out is None:
+        return np.frexp(x, out=(None, None))
+    else:
+        return np.frexp(x, out=out)

--- a/ivy_tests/test_ivy/test_frontends/test_torch/test_pointwise_ops.py
+++ b/ivy_tests/test_ivy/test_frontends/test_torch/test_pointwise_ops.py
@@ -2479,7 +2479,6 @@ def test_torch_frexp(
         fn_tree=fn_tree,
         on_device=on_device,
         input=input[0],
-        out=None,
     )
 
 


### PR DESCRIPTION
The problem was because of numpy backend causes problem in which the out argument must be tuple not single value we can't add out=None even though it doesn't make sense for it to fail with out=None based on its documentation so I changed the implementation of numpy backend to add simple if condition if out= None I will pass out=(None,None).