### PR TITLE
fix test for torch.float_power

### DIFF
--- a/ivy/functional/frontends/torch/pointwise_ops.py
+++ b/ivy/functional/frontends/torch/pointwise_ops.py
@@ -363,6 +363,7 @@ def pow(input, exponent, *, out=None):
     return ivy.pow(input, exponent, out=out)
 
 
+@with_unsupported_dtypes({"1.12.0 and below": ("bfloat16", "float16")}, "jax")
 @to_ivy_arrays_and_back
 def float_power(input, exponent, *, out=None):
     input, exponent = torch_frontend.promote_types_of_torch_inputs(input, exponent)


### PR DESCRIPTION
The problem was when jax take bfloat16 it produce different result from all other frame works also when jax take bfloat16 it returns inf. so I added unsupported dtype (float16,bfloat16) to jax framework 