### PR TITLE
Fixed failing __setitem__ case

### DIFF
--- a/ivy/data_classes/array/array.py
+++ b/ivy/data_classes/array/array.py
@@ -401,10 +401,9 @@ class Array(
             self._data = self._data.detach()
         if ivy.is_ivy_array(val):
             val = val.data
-        if ivy.isscalar(val):
-            length_diff = len(query) - 1
-            if length_diff > 0:
-                val = ivy.asarray((val,) + (val,) * length_diff)
+        target = self.__getitem__(query)
+        if not ivy.isscalar(target) and ivy.isscalar(val):
+            val = ivy.ones_like(target) * val
         try:
             self._data.__setitem__(query, val)
         except:


### PR DESCRIPTION
```
test_array = ivy.zeros((2, 3))   # fails, but passes for shape (2,2)
test_array[0, 0] = 2
```