### PR TITLE
Changed unsupported dtypes to exclude complex because it was cause is…

### DIFF
--- a/ivy/functional/frontends/torch/tensor.py
+++ b/ivy/functional/frontends/torch/tensor.py
@@ -666,6 +666,7 @@ class Tensor:
     def argwhere(self):
         return torch_frontend.argwhere(self)
 
+    @with_unsupported_dtypes({"2.0.1 and below": ("complex",)}, "torch")
     def argmax(self, dim=None, keepdim=False):
         return torch_frontend.argmax(self, dim=dim, keepdim=keepdim)
 


### PR DESCRIPTION
Changed unsupported dtypes to exclude complex because it was cause issue with unsupported dtype for this function this issue was <"argmax_cpu" not implemented for 'ComplexFloat' > for all frameworks and by add unsupported dtype complex it solved