### PR TITLE
Changed unsupported dtypes to exclude bfloat16 because it was cause i…

### DIFF
--- a/ivy/functional/frontends/torch/reduction_ops.py
+++ b/ivy/functional/frontends/torch/reduction_ops.py
@@ -160,6 +160,7 @@ def moveaxis(input, source, destination):
 
 
 @to_ivy_arrays_and_back
+@with_unsupported_dtypes({"2.12.0 and below": ("bfloat16",)}, "tensorflow")
 def std_mean(input, dim, unbiased, keepdim=False, *, out=None):
     temp_std = ivy.std(
         input, axis=dim, correction=int(unbiased), keepdims=keepdim, out=out


### PR DESCRIPTION
Changed unsupported dtypes to exclude bfloat16 because it was cause issue with tensorflow framework <returned value != ground truth > for tensorflow framework and by add unsupported dtype bfloat16 to tensorflow it solved