### PR TITLE
slicing ivy.Shape now return ivy Shape instance

### DIFF
--- a/ivy/__init__.py
+++ b/ivy/__init__.py
@@ -327,7 +327,11 @@ class Shape:
         return super().__getattribute__(item)
 
     def __getitem__(self, key):
-        return self._shape[key] if self._shape is not None else None
+        try:
+            self._shape = self._shape[key]
+            return self
+        except (TypeError, IndexError):
+            return None
 
     def __len__(self):
         return len(self._shape) if self._shape is not None else 0


### PR DESCRIPTION
Problem - Slicing ivy.Shape object returns a native shape instead. Here’s a code snippet for reproducing this bug-:

```
ivy.set_backend("torch")
x = ivy.random_uniform(shape=(1, 2, 3))
print(type(x.shape)) # <class 'ivy.Shape'>
print(type(x.shape[:-1])) # <class 'torch.Size'>
```
Slicing shapes now returns ivy.Shape instances

