### PR TITLE
add paddle.tensor.math.pow

### DIFF
--- a/ivy_tests/test_ivy/test_frontends/test_paddle/test_tensor/test_paddle_math.py
+++ b/ivy_tests/test_ivy/test_frontends/test_paddle/test_tensor/test_paddle_math.py
@@ -510,7 +510,7 @@ def test_paddle_sinh(
 @handle_frontend_test(
     fn_tree="paddle.pow",
     dtype_and_x=helpers.dtype_and_values(
-        available_dtypes=helpers.get_dtypes("float"),
+        available_dtypes=helpers.get_dtypes("valid"),
         num_arrays=2,
         allow_inf=False,
         shared_dtype=True,


### PR DESCRIPTION
close #16523
actually, someone else has already added this function. 
But I at least change to get_dtypes("valid").
Tests fail for this, but they passed for the old get_dtypes("float"). 