### PR TITLE
added AdaptiveAvgPool1d stateful and test

### DIFF
--- a/ivy/functional/ivy/experimental/layers.py
+++ b/ivy/functional/ivy/experimental/layers.py
@@ -1878,6 +1878,7 @@ def _mask(vals, length, range_max, dim):
 
 
 @handle_nestable
+@inputs_to_ivy_arrays
 def adaptive_avg_pool1d(
     input: Union[ivy.Array, ivy.NativeArray],
     output_size: int,

--- a/ivy/stateful/layers.py
+++ b/ivy/stateful/layers.py
@@ -1733,7 +1733,8 @@ class AvgPool3D(Module):
         ceil_mode
             Whether to use ceil or floor for creating the output shape.
         divisor_override
-            If specified, it will be used as divisor, otherwise kernel_size will be used.
+            If specified, it will be used as divisor,
+            otherwise kernel_size will be used.
         """
         self._kernel_size = kernel_size
         self._stride = strides
@@ -1802,8 +1803,52 @@ class AdaptiveAvgPool2d(Module):
         -------
             The output array of the layer.
         """
-        # TODO: test again once adaptive_avg_pool2d is implemnted for the missing backends.
+        # TODO: test again once adaptive_avg_pool2d is
+        #  implemented for the missing backends.
         return ivy.adaptive_avg_pool2d(
+            x,
+            self._output_size,
+        )
+
+
+class AdaptiveAvgPool1d(Module):
+    def __init__(
+        self,
+        output_size,
+        device=None,
+        dtype=None,
+    ):
+        # TODO: add data_format param
+        """
+        Class for applying a 1D adaptive average pooling over mini-batch of inputs.
+
+        Parameters
+        ----------
+        output_size
+            An integer or tuple/list of a single integer
+            specifying new size of output channels.
+        device
+            device on which to create the layer's variables 'cuda:0', 'cuda:1', 'cpu'
+        """
+        self._output_size = output_size
+        Module.__init__(self, device=device, dtype=dtype)
+
+    def _forward(self, x):
+        """
+        Forward pass of the layer.
+
+        Parameters
+        ----------
+        x
+            The input array to the layer.
+
+        Returns
+        -------
+            The output array of the layer.
+        """
+        # TODO: test again once adaptive_avg_pool2d is
+        #  implemented for the missing backends.
+        return ivy.adaptive_avg_pool1d(
             x,
             self._output_size,
         )

--- a/ivy_tests/test_ivy/test_stateful/test_layers.py
+++ b/ivy_tests/test_ivy/test_stateful/test_layers.py
@@ -1344,3 +1344,37 @@ def test_adaptive_avg_pool2d_layer(
         test_gradients=test_gradients,
         on_device=on_device,
     )
+
+
+@handle_method(
+    method_tree="AdaptiveAvgPool1d.__call__",
+    dt_arr_size=array_for_adaptive(max_dim_size=3, min_dim_size=2, num_out_size=1),
+)
+def test_adaptive_avg_pool1d_layer(
+    *,
+    dt_arr_size,
+    test_gradients,
+    on_device,
+    class_name,
+    method_name,
+    ground_truth_backend,
+    init_flags,
+    method_flags,
+):
+    input_dtype, x, out_size = dt_arr_size
+    helpers.test_method(
+        ground_truth_backend=ground_truth_backend,
+        init_flags=init_flags,
+        method_flags=method_flags,
+        init_all_as_kwargs_np={
+            "output_size": out_size,
+            "device": on_device,
+            "dtype": input_dtype[0],
+        },
+        method_input_dtypes=input_dtype,
+        method_all_as_kwargs_np={"x": x[0]},
+        class_name=class_name,
+        method_name=method_name,
+        test_gradients=test_gradients,
+        on_device=on_device,
+    )


### PR DESCRIPTION
closes #16665
Mostly followed the implementation of `AdaptiveAvgPool2d` so was pretty simple. Had to add `@inputs_to_ivy_arrays` decorator to `ivy.experimental.adaptive_avg_pool1d` to sort out some type promotion issues to pass the tests.

Also fixed some formatting errors in stateful.layers file discovered by the pre-commit hook. (2 lines too long, wouldn't let me commit).