### PR TITLE
Fixing build/test config on all Dockerfiles

### DIFF
--- a/.devcontainer/post_create_commands.sh
+++ b/.devcontainer/post_create_commands.sh
@@ -1,11 +1,19 @@
 #!/bin/bash
+# Used as a common callback for all of the `devcontainer.json` file variants after
+#   the end of the Docker image creation step.
 
+# Pull the newest available submodule sources.
 git submodule update --init --recursive
 
+# Install the Python package locally.
 python3 -m pip install --user -e .
 
+# Install the pre-commit hook package manager.
 python3 -m pip install pre-commit
 
+# Tell git to specifically treat the newly populated directory in the container, 
+#   `/workspaces/ivy`, as a safe workspace.
 git config --global --add safe.directory /workspaces/ivy
 
+# Install the pre-commit hooks.
 ( cd /workspaces/ivy/ && pre-commit install)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster
+FROM debian:bullseye
 WORKDIR /ivy
 ARG CLI
 # python version for conda
@@ -74,6 +74,10 @@ RUN pip install --upgrade -r  requirements.txt &&\
 
 # add all the directories to environment path so that python knows where to find them
 ENV PYTHONPATH "/opt/fw/mxnet:/opt/fw/numpy:/opt/fw/jax:/opt/fw/torch:/opt/fw/tensorflow:/opt/fw/paddle:/opt/miniconda/envs/multienv/bin"
+
+
+# setup the default array api with the environment variable specified in `_array_module.py`
+ENV ARRAY_API_TESTS_MODULE "numpy"
 
 COPY run_tests_CLI/test_dependencies.py .
 RUN python3 test_dependencies.py -fp requirements.txt,optional.txt && \

--- a/docker/DockerfileApplied
+++ b/docker/DockerfileApplied
@@ -6,3 +6,6 @@ FROM unifyai/ivy:latest as base
 
 COPY requirements/optional_applied.txt .
 RUN pip3 install --no-cache-dir -r optional_applied.txt
+
+# setup the default array api with the environment variable specified in `_array_module.py`
+ENV ARRAY_API_TESTS_MODULE "numpy"

--- a/docker/DockerfileGPU
+++ b/docker/DockerfileGPU
@@ -61,8 +61,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 # Install TensorRT if not building for PowerPC
 RUN apt-get update && \
-        apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu1804/x86_64/7fa2af80.pub && \
-        echo "deb https://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu1804/x86_64 /"  > /etc/apt/sources.list.d/tensorRT.list && \
+        apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu2004/x86_64/7fa2af80.pub && \
+        echo "deb https://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu2004/x86_64 /"  > /etc/apt/sources.list.d/tensorRT.list && \
         apt-get update && \
         apt-get install -y --no-install-recommends libnvinfer${LIBNVINFER_MAJOR_VERSION}=${LIBNVINFER}+cuda11.0 \
         libnvinfer-plugin${LIBNVINFER_MAJOR_VERSION}=${LIBNVINFER}+cuda11.0 \
@@ -127,3 +127,6 @@ RUN python3 test_dependencies.py -fp requirements.txt,optional_gpu.txt && \
     rm -rf requirements.txt && \
     rm -rf optional_gpu.txt && \
     rm -rf test_dependencies.py
+
+# setup the default array api with the environment variable specified in `_array_module.py`
+ENV ARRAY_API_TESTS_MODULE "numpy"

--- a/docker/DockerfileGPUMultiCuda
+++ b/docker/DockerfileGPUMultiCuda
@@ -1,12 +1,26 @@
-# uses the base image which has cuda and cudnn installed(multiple versions) and then installs the
-# latest frameworks and the requirements
-FROM unifyai/multicuda:base
+# Builds the image from nvidia's hosted NGC container for amd64/arm64, which has
+#   cuda, cudnn, and tensorrt.
+FROM nvcr.io/nvidia/tensorrt:23.05-py3
 WORKDIR /ivy
-ARG fw
 
+ARG fw
 ARG pycon=3.10
 
+
+# Copied the multicuda base operations into this containers construction
 ENV DEBIAN_FRONTEND=noninteractive
+ENV TZ=UTC
+RUN grep security /etc/apt/sources.list | tee /etc/apt/security.sources.list && \
+    apt-get update && \
+    apt-get upgrade -o Dir::Etc::SourceList=/etc/apt/security.sources.list -y &&\
+    apt-get -y update && \
+    apt-get install -y gnupg  \
+    curl  \
+    wget  \
+    software-properties-common  \
+    gcc  \
+    nano
+
 
 # Install miniconda
 ENV CONDA_DIR /opt/miniconda/
@@ -77,7 +91,8 @@ ENV PYTHONPATH "/opt/fw/mxnet:/opt/fw/numpy:/opt/fw/jax:/opt/fw/torch:/opt/fw/te
 
 
 
-
+# setup the default array api with the environment variable specified in `_array_module.py`
+ENV ARRAY_API_TESTS_MODULE "numpy"
 
 COPY run_tests_CLI/test_dependencies.py .
 RUN python3 test_dependencies.py -fp requirements.txt,optional_gpu.txt && \

--- a/docker/DockerfileGPUMultiCuda-base
+++ b/docker/DockerfileGPUMultiCuda-base
@@ -1,5 +1,5 @@
 # is used to create a base image where we then manually install cuda and cudnn
-FROM debian:buster
+FROM debian:bullseye
 WORKDIR /ivy
 
 
@@ -19,5 +19,6 @@ RUN grep security /etc/apt/sources.list | tee /etc/apt/security.sources.list && 
     gcc  \
     nano
 
-
+# setup the default array api with the environment variable specified in `_array_module.py`
+ENV ARRAY_API_TESTS_MODULE "numpy"
 

--- a/docker/DockerfileMultiversion
+++ b/docker/DockerfileMultiversion
@@ -1,4 +1,4 @@
-FROM debian:buster
+FROM debian:bullseye
 WORKDIR /ivy
 
 
@@ -49,8 +49,6 @@ RUN python3 multiversion_framework_directory.py  $fw
 
 ENV PATH=/opt/miniconda/envs/multienv/bin:$PATH
 
-
-
-
-
+# setup the default array api with the environment variable specified in `_array_module.py`
+ENV ARRAY_API_TESTS_MODULE "numpy"
 


### PR DESCRIPTION
I've been setting up a development environment for the repo recently, but have run into some issues during the build and test processes for the docker containers. Debian, as the base image, is pointlessly old as far as I can tell. Along with that, the base image for `DockerfileGPUMultiCuda` was missing TensorRT, and appears to be an analog of the container hosted by Nvidia's NGC found [here](https://catalog.ngc.nvidia.com/orgs/nvidia/containers/tensorrt). No computing architectures have been newly excluded from the base image as far as I can tell. A list of what has been done is as follows:

- On all `Dockerfile` instances, a new `ENV` call has been added that sets the `ARRAY_API_TESTS_MODULE` to `numpy`. 
- Changed the base image of all Debian based containers to the new version of "oldstable," denoted `bullseye`.
- Changed the base image of the `DockerfileGPUMultiCuda` from the [unifyai](https://hub.docker.com/r/unifyai/multicuda) image to the [NGC](https://catalog.ngc.nvidia.com/orgs/nvidia/containers/tensorrt) hosted image to add TensorRT.
- _Accidentally modified a sub-module then unmodified it._