### PR TITLE
add 'axis' kwarg to torch.mean frontend

### DIFF
--- a/ivy/functional/frontends/torch/reduction_ops.py
+++ b/ivy/functional/frontends/torch/reduction_ops.py
@@ -53,7 +53,9 @@ def sum(input, dim=None, keepdim=False, *, dtype=None, out=None):
 
 
 @to_ivy_arrays_and_back
-def mean(input, dim=None, keepdim=False, *, out=None):
+def mean(input, dim=None, axis=None, keepdim=False, *, out=None):
+    if dim is None:
+        dim = axis
     return ivy.mean(input, axis=dim, keepdims=keepdim, out=out)
 
 


### PR DESCRIPTION
Despite the fact it is not mentioned in the torch docs, torch.mean can take the kwarg 'axis' and use it in the same way as 'dim'. e.g. torch.mean(x, axis=-1). I've added the capability to handle this kwarg, so it doesn't throw `TypeError: mean() got an unexpected keyword argument 'axis'`.

(this problem was identified by attempting to transpile ImageGPTModel - https://github.com/huggingface/transformers/blob/v4.30.0/src/transformers/models/imagegpt/modeling_imagegpt.py#L171)