### PR TITLE
fix reduce_window

### DIFF
--- a/ivy/functional/ivy/experimental/layers.py
+++ b/ivy/functional/ivy/experimental/layers.py
@@ -2146,7 +2146,7 @@ def reduce_window(
     *,
     window_strides: Union[int, Sequence[int]] = 1,
     padding: Union[str, int, Sequence[Tuple[int, int]]] = "VALID",
-    base_dilation: Union[int, Sequence[int]] = 1,
+    base_dilation: Union[int, Sequence[int]] = None,
     window_dilation: Union[int, Sequence[int]] = 1,
 ) -> ivy.Array:
     """

--- a/ivy/functional/ivy/experimental/layers.py
+++ b/ivy/functional/ivy/experimental/layers.py
@@ -2146,7 +2146,7 @@ def reduce_window(
     *,
     window_strides: Union[int, Sequence[int]] = 1,
     padding: Union[str, int, Sequence[Tuple[int, int]]] = "VALID",
-    base_dilation: Union[int, Sequence[int]] = None,
+    base_dilation: Union[int, Sequence[int]] = 1,
     window_dilation: Union[int, Sequence[int]] = 1,
 ) -> ivy.Array:
     """
@@ -2189,8 +2189,19 @@ def reduce_window(
     # ToDo: add support for window_dilation
     computation = _correct_ivy_callable(computation)
     op, dims, strides = operand, window_dimensions, window_strides
+
+    # handle int arguments
+    if isinstance(dims, int):
+        dims = tuple([dims] * len(op.shape))
     if isinstance(strides, int):
-        strides = tuple([strides] * len(dims))
+        strides = tuple([strides] * len(op.shape))
+    if isinstance(padding, int):
+        padding = tuple([padding] * len(op.shape))
+    if isinstance(base_dilation, int):
+        base_dilation = tuple([base_dilation] * len(op.shape))
+    if isinstance(window_dilation, int):
+        window_dilation = tuple([window_dilation] * len(op.shape))
+
     init_value = _cast_init(init_value, op.dtype)
     identity = _get_identity(computation, operand.dtype, init_value)
     if isinstance(padding, str):

--- a/ivy/functional/ivy/experimental/layers.py
+++ b/ivy/functional/ivy/experimental/layers.py
@@ -2189,6 +2189,8 @@ def reduce_window(
     # ToDo: add support for window_dilation
     computation = _correct_ivy_callable(computation)
     op, dims, strides = operand, window_dimensions, window_strides
+    if isinstance(strides, int):
+        strides = tuple([strides] * len(dims))
     init_value = _cast_init(init_value, op.dtype)
     identity = _get_identity(computation, operand.dtype, init_value)
     if isinstance(padding, str):


### PR DESCRIPTION
It looks like there are some problems with the window_strides and base_dilation args in reduce_window. The minimal example below fails, and I am also getting problems transpiling models which call reduce_window. I've come up with a quick solution here which fixes both of these cases, but I'm sure there is a better way of doing it - so let me know what you think.

Min example:
```
import ivy

if __name__ == '__main__':
    ivy.set_backend('torch')
    x = ivy.random_normal(shape=(4, 4))
    ivy.reduce_window(x, 0, ivy.add, (2, 2))
```
