### PR TITLE
Add support for list and tuple input in meshgrid function for torch_frontend

### DIFF
--- a/ivy/functional/frontends/torch/miscellaneous_ops.py
+++ b/ivy/functional/frontends/torch/miscellaneous_ops.py
@@ -47,6 +47,8 @@ def roll(input, shifts, dims=None):
 def meshgrid(*tensors, indexing=None):
     if indexing is None:
         indexing = "ij"
+    if len(tensors) == 1 and isinstance(tensors[0], (list, tuple)):
+        tensors = tensors[0]
     return tuple(ivy.meshgrid(*tensors, indexing=indexing))
 
 


### PR DESCRIPTION


Currently, the `torch_frontend.meshgrid` :
```python
x = [torch.tensor([1, 2, 3]), torch.tensor([4, 5, 6])]
print(torch_frontend.meshgrid(x))
```
raises an error :
```python
RuntimeError: torch.meshgrid: Expected 0D or 1D tensor in the tensor list but got:  1  2  3
 4  5  6
[ torch.LongTensor{2,3} ]
```
This fixes this and add support for ` list` and `tuple` input in `meshgrid` function.

Close #Issue_number

Discussion on the same at `# ivy-frontend` channel at [Discord](https://discord.com/channels/799879767196958751/998782045494976522/1118525133322199140)  for additional context! 
```python
import ivy
import ivy.functional.frontends.torch as torch_frontend

x = [torch.tensor([1, 2, 3]), torch.tensor([4, 5, 6])]

print(torch_frontend.meshgrid(x))
"""PRINT

(ivy.frontends.torch.Tensor([[1, 1, 1],
       [2, 2, 2],
       [3, 3, 3]]), ivy.frontends.torch.Tensor([[4, 5, 6],
       [4, 5, 6],
       [4, 5, 6]]))
"""
```