### PR TITLE
Fix tf.var backend function in tensorflow/statistical that was causing torch/reduction_ops' torch.var frontend tests failure

### DIFF
--- a/ivy/functional/backends/tensorflow/statistical.py
+++ b/ivy/functional/backends/tensorflow/statistical.py
@@ -133,6 +133,10 @@ def var(
     axis = (axis,) if isinstance(axis, int) else tuple(axis)
     if correction == 0:
         return tf.experimental.numpy.var(x, axis=axis, out=out, keepdims=keepdims)
+    if correction == 1:
+        return tf.experimental.numpy.var(
+            x, axis=axis[0], out=out, keepdims=keepdims, dtype=x.dtype, ddof=1
+        )
     size = 1
     for a in axis:
         size *= x.shape[a]


### PR DESCRIPTION
The `tf.var` backend function was not handling the case in which the `correction` argument was 1 and this was causing the failure of `torch.var` frontend tests.

I verified that this change makes pass both the `tf.var` backend tests in `tensorflow/statistical` and `torch.var` frontend tests in `torch/reduction_ops`