### PR TITLE
[Fix] ValueError: Type mismatch in data retrieval in paddle.sinc 

### DIFF
--- a/ivy/functional/backends/paddle/experimental/elementwise.py
+++ b/ivy/functional/backends/paddle/experimental/elementwise.py
@@ -37,7 +37,8 @@ def fmax(
     {"2.4.2 and below": {"cpu": ("float16",)}}, backend_version
 )
 def sinc(x: paddle.Tensor, /, *, out: Optional[paddle.Tensor] = None) -> paddle.Tensor:
-    return paddle.where(x == 0, 1, paddle.divide(paddle.sin(x), x))
+    y = ivy.pi * paddle.where(x == 0, paddle.to_tensor(1.0e-20, dtype=x.dtype), x)
+    return paddle.divide(paddle.sin(y), y)
 
 
 def float_power(


### PR DESCRIPTION
Presently the `paddle.sinc` is raising error as shown by @Ishticode  at [discord](https://discord.com/channels/799879767196958751/1028267758028337193/1118660230440554546) :

```py
a = ivy.array([1.], dtype="float32")
print(ivy.sinc(a))

"""
ValueError: (InvalidArgument) The type of data we are trying to retrieve does not match the type of data currently contained in the container.
E             [Hint: Expected dtype() == paddle::experimental::CppTypeToDataType<T>::Type(), but received dtype():9 != paddle::experimental::CppTypeToDataType<T>::Type():10.] (at /paddle/paddle/phi/core/dense_tensor.cc:143)
"""
```
The problem is due to the use of `paddle.where` ([docs](https://www.paddlepaddle.org.cn/documentation/docs/en/2.2/api/paddle/where_en.html#where))function which expects all three arguments `(condition, x, y)` to be Tensors/scalars of the same data type. 


