### PR TITLE
Added round instance method to jax frontend

### DIFF
--- a/ivy/functional/frontends/jax/devicearray.py
+++ b/ivy/functional/frontends/jax/devicearray.py
@@ -221,3 +221,6 @@ class DeviceArray:
             raise TypeError("iteration over a 0-d devicearray not supported")
         for i in range(self.shape[0]):
             yield self[i]
+
+    def round(self, decimals=0):
+        return jax_frontend.numpy.round(self, decimals)

--- a/ivy/functional/frontends/jax/numpy/mathematical_functions.py
+++ b/ivy/functional/frontends/jax/numpy/mathematical_functions.py
@@ -711,4 +711,4 @@ def product(
 
 @to_ivy_arrays_and_back
 def round(x, decimals=0, /):
-    return ivy.round(x, decimals)
+    return ivy.round(x, decimals=decimals)

--- a/ivy_tests/test_ivy/test_frontends/test_jax/test_jax_devicearray.py
+++ b/ivy_tests/test_ivy/test_frontends/test_jax/test_jax_devicearray.py
@@ -1645,3 +1645,40 @@ def test_jax_special_getitem(
         method_flags=method_flags,
         on_device=on_device,
     )
+
+
+@handle_frontend_method(
+    class_tree=CLASS_TREE,
+    init_tree="jax.numpy.array",
+    method_name="round",
+    dtype_x=helpers.dtype_and_values(
+        available_dtypes=helpers.get_dtypes("float"),
+        allow_inf=False,
+    ),
+    decimals=st.one_of(
+        st.integers(min_value=-10, max_value=10),
+    ),
+)
+def test_jax_devicearray_round(
+    dtype_x,
+    decimals,
+    frontend,
+    frontend_method_data,
+    init_flags,
+    method_flags,
+    on_device,
+):
+    input_dtype, x = dtype_x
+    helpers.test_frontend_method(
+        init_input_dtypes=input_dtype,
+        init_all_as_kwargs_np={
+            "object": x[0],
+        },
+        method_input_dtypes=input_dtype,
+        method_all_as_kwargs_np={"decimals": decimals},
+        frontend=frontend,
+        frontend_method_data=frontend_method_data,
+        init_flags=init_flags,
+        method_flags=method_flags,
+        on_device=on_device,
+    )


### PR DESCRIPTION
closes #16956
+ `round` instance method to jax frontend and test.
+ fixed arg to kwarg in `jax.numpy.mathematical_functions.py` (typo)