### PR TITLE
Add "float16" to torch/set's unique_all unsupported dtypes to fix `test_unique_values`

### DIFF
--- a/ivy/functional/backends/torch/set.py
+++ b/ivy/functional/backends/torch/set.py
@@ -11,7 +11,10 @@ import ivy
 
 @with_unsupported_dtypes(
     {
-        "2.0.1 and below": "complex",
+        "2.0.1 and below": (
+            "complex",
+            "float16",
+        ),
     },
     backend_version,
 )

--- a/ivy/functional/backends/torch/set.py
+++ b/ivy/functional/backends/torch/set.py
@@ -11,10 +11,7 @@ import ivy
 
 @with_unsupported_dtypes(
     {
-        "2.0.1 and below": (
-            "complex",
-            "float16",
-        ),
+        "2.0.1 and below": ("complex", "float16"),
     },
     backend_version,
 )


### PR DESCRIPTION
This was causing test_unique_all test failing for the torch backend due to ""unique_dim" not implemented for 'Half'"

The following is the relevant part of the output of the failing test:

```shell
E           During the handling of the above exception, another exception occurred:
E            "unique_dim" not implemented for 'Half'
E           Falsifying example: test_unique_all(
E               backend_fw=<module 'ivy.functional.backends.torch' from '/Users/Fabrizio/Work/ivy/ivy/functional/backends/torch/__init__.py'>,
E               on_device='cpu',
E               dtype_x_axis=(['float16'], [array([-1.], dtype=float16)], 0),
E               none_axis=False,
E               by_value=False,
E               test_flags=FunctionTestFlags(
E                   num_positional_args=1,
E                   with_out=False,
E                   instance_method=False,
E                   test_gradients=False,
E                   test_compile=None,
E                   as_variable=[False],
E                   native_arrays=[False],
E                   container=[False],
E               ),
E               ground_truth_backend='numpy',
E               fn_name='unique_all',
E           )
E           
E           You can reproduce this example by temporarily adding @reproduce_failure('6.76.0', b'AXicY2RkAAMoBaeBAAAAbgAF') as a decorator on your test case

../../../../ivy/utils/exceptions.py:246: IvyBackendException

```

