### PR TITLE
fixed paddle.tanh not supporting `float16` dtype natively

### DIFF
--- a/ivy/functional/frontends/paddle/tensor/math.py
+++ b/ivy/functional/frontends/paddle/tensor/math.py
@@ -30,7 +30,7 @@ def cosh(x, name=None):
     return ivy.cosh(x)
 
 
-@with_unsupported_dtypes({"2.4.2 and below": ("float16", "bfloat16")}, "paddle")
+@with_supported_dtypes({"2.4.2 and below": ("float32", "float64")}, "paddle")
 @to_ivy_arrays_and_back
 def tanh(x, name=None):
     return ivy.tanh(x)

--- a/ivy/functional/frontends/paddle/tensor/tensor.py
+++ b/ivy/functional/frontends/paddle/tensor/tensor.py
@@ -150,9 +150,7 @@ class Tensor:
     def floor(self, name=None):
         return ivy.floor(self._ivy_array)
 
-    @with_supported_dtypes(
-        {"2.4.2 and below": ("float16", "float32", "float64")}, "paddle"
-    )
+    @with_supported_dtypes({"2.4.2 and below": ("float32", "float64")}, "paddle")
     def tanh(self, name=None):
         return ivy.tanh(self._ivy_array)
 
@@ -167,7 +165,7 @@ class Tensor:
     @with_supported_dtypes({"2.4.2 and below": ("float32", "float64")}, "paddle")
     def cholesky(self, upper=False, name=None):
         return ivy.cholesky(self._ivy_array, upper=upper)
-    
+
     @with_supported_dtypes({"2.4.2 and below": ("float16", "bfloat16")}, "paddle")
     def all(self, axis=None, keepdim=False, dtype=None, name=None):
         return ivy.all(self.ivy_array, axis=axis, keepdims=keepdim, dtype=dtype)

--- a/ivy_tests/test_ivy/test_frontends/test_paddle/test_tensor/test_paddle_math.py
+++ b/ivy_tests/test_ivy/test_frontends/test_paddle/test_tensor/test_paddle_math.py
@@ -116,7 +116,7 @@ def test_paddle_cosh(
     fn_tree="paddle.tensor.math.tanh",
     aliases=["paddle.tanh", "paddle.nn.functional.tanh"],
     dtype_and_x=helpers.dtype_and_values(
-        available_dtypes=helpers.get_dtypes("float"),
+        available_dtypes=helpers.get_dtypes("valid"),
     ),
 )
 def test_paddle_tanh(

--- a/ivy_tests/test_ivy/test_frontends/test_paddle/test_tensor/test_paddle_tensor.py
+++ b/ivy_tests/test_ivy/test_frontends/test_paddle/test_tensor/test_paddle_tensor.py
@@ -715,7 +715,7 @@ def test_paddle_sqrt(
     init_tree="paddle.to_tensor",
     method_name="tanh",
     dtype_and_x=helpers.dtype_and_values(
-        available_dtypes=helpers.get_dtypes("float"),
+        available_dtypes=helpers.get_dtypes("valid"),
     ),
 )
 def test_paddle_tanh(
@@ -843,6 +843,7 @@ def test_paddle_cholesky(
         method_flags=method_flags,
         on_device=on_device,
     )
+
 
 # all
 @handle_frontend_method(


### PR DESCRIPTION
The problem is `paddle.tanh` is that even though in [doc](https://www.paddlepaddle.org.cn/documentation/docs/en/api/paddle/tanh_en.html#tanh),  it shows that it supports `float16` dtype but when you run an example with `dtype=float16` it raise an error.

```python
import paddle

x = paddle.to_tensor([-0.4, -0.2, 0.1, 0.3],dtype='float16')
out = paddle.tanh(x)
print(out)
m = paddle.nn.Tanh()
out_1 = m(x)
print(out_1)
"""
  File "/workspaces/ivy/useless.py", line 24, in <module>
    out = paddle.tanh(x)
  File "/opt/fw/paddle/paddle/tensor/math.py", line 3543, in tanh
    return _C_ops.tanh( x )

RuntimeError: (NotFound) The kernel with key (CPU, NCHW, float16) of kernel `tanh` is not registered.
  [Hint: Expected kernel_iter == iter->second.end() && kernel_key.backend() == Backend::CPU != true, but received kernel_iter == iter->second.end() && kernel_key.backend() == Backend::CPU:1 == true:1.] (at /paddle/paddle/phi/core/kernel_factory.cc:147)
"""
```



