### PR TITLE
Changed torch.tensordot function because it was causing an issue  Thi…

### DIFF
--- a/ivy/functional/frontends/torch/miscellaneous_ops.py
+++ b/ivy/functional/frontends/torch/miscellaneous_ops.py
@@ -334,6 +334,7 @@ def gcd(input, other, *, out=None):
     return ivy.gcd(input, other, out=out)
 
 
+@with_unsupported_dtypes({"2.0.1 and below": ("float16", "bfloat16")}, "torch")
 @to_ivy_arrays_and_back
 def tensordot(a, b, dims=2, out=None):
     a, b = promote_types_of_torch_inputs(a, b)

--- a/ivy_tests/test_ivy/test_frontends/test_torch/test_miscellaneous_ops.py
+++ b/ivy_tests/test_ivy/test_frontends/test_torch/test_miscellaneous_ops.py
@@ -1093,9 +1093,10 @@ def test_torch_gcd(
 @handle_frontend_test(
     fn_tree="torch.tensordot",
     dtype_values_and_axes=_get_dtype_value1_value2_axis_for_tensordot(
-        helpers.get_dtypes(kind="float")
+        helpers.get_dtypes(kind="float"),
+        min_value=-5,
+        max_value=5,
     ),
-    test_with_out=st.just(False),
 )
 def test_torch_tensordot(
     dtype_values_and_axes,
@@ -1111,7 +1112,7 @@ def test_torch_tensordot(
         fn_tree=fn_tree,
         a=a,
         b=b,
-        rtol=1e-1,
+        rtol=1e-2,
         atol=1e-2,
         dims=dims,
     )


### PR DESCRIPTION
…s issue was <"eturned dtype is float32 and ground truth is float64'> and by < change the unsupported dtype to bfloat16, float16 and allow > it solves the issue because <this function support float and integers dtypes only, Also change the tests to be sure it passes