### PR TITLE
Bug fix for `stop_after_n_found` argument in `nested_argwhere`

### DIFF
--- a/ivy/functional/ivy/nest.py
+++ b/ivy/functional/ivy/nest.py
@@ -739,7 +739,7 @@ def nested_argwhere(
                     break
             else:
                 _indices += [ind]
-            if stop_after_n_found is not None and len(_indices) >= stop_after_n_found:
+            if stop_after_n_found is not None and n >= stop_after_n_found:
                 break
         _indices = [idx for idxs in _indices if idxs for idx in idxs]
         if check_nests and fn(nest):


### PR DESCRIPTION
Currently, there is a bug in the `stop_after_n_found` argument in `nested_argwhere` which stops searching after n elements are searched regardless of whether they satisfied the function passed. The fix solves this issue and makes it to stop searching the nested structure only after n number of results are found which satisfy the function passed.

Task card: https://trello.com/c/ZF1ltc9c/913-fix-the-stopafternfound-argument-in-nestedargwhere