### PR TITLE
Changed tests of torch.tensordot instead of adding min_value and max_…

### DIFF
--- a/ivy_tests/test_ivy/test_frontends/test_torch/test_miscellaneous_ops.py
+++ b/ivy_tests/test_ivy/test_frontends/test_torch/test_miscellaneous_ops.py
@@ -1094,8 +1094,8 @@ def test_torch_gcd(
     fn_tree="torch.tensordot",
     dtype_values_and_axes=_get_dtype_value1_value2_axis_for_tensordot(
         helpers.get_dtypes(kind="float"),
-        min_value=-5,
-        max_value=5,
+        min_value=-10,
+        max_value=10,
     ),
 )
 def test_torch_tensordot(
@@ -1105,6 +1105,11 @@ def test_torch_tensordot(
     fn_tree,
 ):
     dtype, a, b, dims = dtype_values_and_axes
+    if ivy.current_backend_str() == "paddle":
+        # Paddle only supports ndim from 0 to 9
+        assume(a.shape[0] < 10)
+        assume(b.shape[0] < 10)
+
     helpers.test_frontend_function(
         input_dtypes=dtype,
         test_flags=test_flags,


### PR DESCRIPTION
…value to 5 and -5 to skip this error < Invalid dimension to be accessed. Now only supports access to dimension 0 to 9 for paddle framework> I add assume to skip tests when dim >9  for paddle framework
Close 