### PR TITLE
Changed torch.triu function because it was causing an issue with padd…

### DIFF
--- a/ivy/functional/frontends/torch/miscellaneous_ops.py
+++ b/ivy/functional/frontends/torch/miscellaneous_ops.py
@@ -113,6 +113,9 @@ def triu_indices(row, col, offset=0, dtype="int64", device="cpu", layout=None):
     return ivy.stack(ivy.nonzero(sample_matrix)).astype(dtype)
 
 
+@with_supported_dtypes(
+    {"2.4.2 and below": ("float64", "float32", "int32", "int64")}, "paddle"
+)
 @to_ivy_arrays_and_back
 def triu(input, diagonal=0, *, out=None):
     return ivy.triu(input, k=diagonal, out=out)


### PR DESCRIPTION
…le framework issue was <NotFound) The kernel with key (CPU, NCHW, complex64) of kernel `tril_triu` is not registered.

  [Hint: Expected kernel_iter == iter->second.end() && kernel_key.backend() == Backend::CPU != true, but received kernel_iter == iter->second.end() && kernel_key.backend() == Backend::CPU:1 == true:1.] (at /paddle/paddle/phi/core/kernel_factory.cc:147> and by < change the supported dtype for paddle backend> it solves the issue because paddle support specific types for triu function