### PR TITLE
Prevent overflow for logaddexp2 in the tensorflow backend when using `ivy` compositions

### DIFF
--- a/ivy/functional/backends/tensorflow/elementwise.py
+++ b/ivy/functional/backends/tensorflow/elementwise.py
@@ -516,7 +516,7 @@ def logaddexp2(
     if not ivy.is_float_dtype(x1):
         x1 = tf.cast(x1, ivy.default_float_dtype(as_native=True))
         x2 = tf.cast(x2, ivy.default_float_dtype(as_native=True))
-    return ivy.log2(ivy.exp2(x1) + ivy.exp2(x2))
+    return tf.experimental.numpy.logaddexp2(x1, x2)
 
 
 def logical_and(

--- a/ivy/functional/backends/tensorflow/elementwise.py
+++ b/ivy/functional/backends/tensorflow/elementwise.py
@@ -516,7 +516,13 @@ def logaddexp2(
     if not ivy.is_float_dtype(x1):
         x1 = tf.cast(x1, ivy.default_float_dtype(as_native=True))
         x2 = tf.cast(x2, ivy.default_float_dtype(as_native=True))
-    return tf.experimental.numpy.logaddexp2(x1, x2)
+    amax = ivy.maximum(x1, x2)
+    delta = x1 - x2
+    return ivy.where(
+        ivy.isnan(delta),
+        x1 + x2,
+        amax + ivy.log1p(ivy.exp2(-ivy.abs(delta))) / ivy.log(2.0).astype(amax.dtype),
+    )
 
 
 def logical_and(


### PR DESCRIPTION
fixes https://github.com/unifyai/ivy/issues/8219