### PR TITLE
fix ivy.dropout returning native arrays/tensors

### DIFF
--- a/ivy/functional/ivy/layers.py
+++ b/ivy/functional/ivy/layers.py
@@ -9,6 +9,7 @@ from ivy.utils.backend import current_backend
 from ivy.func_wrapper import (
     handle_array_function,
     inputs_to_ivy_arrays,
+    outputs_to_ivy_arrays,
     to_native_arrays_and_back,
     inputs_to_native_shapes,
     handle_out_argument,
@@ -184,6 +185,7 @@ linear.mixed_backend_wrappers = {
 @handle_array_like_without_promotion
 @handle_out_argument
 @inputs_to_ivy_arrays
+@outputs_to_ivy_arrays
 @handle_array_function
 def dropout(
     x: Union[ivy.Array, ivy.NativeArray],

--- a/ivy/functional/ivy/layers.py
+++ b/ivy/functional/ivy/layers.py
@@ -9,7 +9,6 @@ from ivy.utils.backend import current_backend
 from ivy.func_wrapper import (
     handle_array_function,
     inputs_to_ivy_arrays,
-    outputs_to_ivy_arrays,
     to_native_arrays_and_back,
     inputs_to_native_shapes,
     handle_out_argument,
@@ -185,7 +184,6 @@ linear.mixed_backend_wrappers = {
 @handle_array_like_without_promotion
 @handle_out_argument
 @inputs_to_ivy_arrays
-@outputs_to_ivy_arrays
 @handle_array_function
 def dropout(
     x: Union[ivy.Array, ivy.NativeArray],
@@ -351,6 +349,16 @@ def dropout(
     if scale:
         x = ivy.multiply(x, 1.0 / (1.0 - prob), out=out)
     return x if not ivy.exists(out) else ivy.inplace_update(out, x)
+
+
+dropout.mixed_backend_wrappers = {
+    "to_add": (
+        "handle_out_argument",
+        "inputs_to_native_arrays",
+        "outputs_to_ivy_arrays",
+    ),
+    "to_skip": ("inputs_to_ivy_arrays",),
+}
 
 
 # Attention #


### PR DESCRIPTION
Fixes problem where ivy.dropout can return things like tf.EagerTensor instead of ivy.Array.

Min example:
```
import ivy

if __name__ == '__main__':
    ivy.set_backend("tensorflow")

    x = ivy.random_normal(shape=(5, 5, 5))
    x = ivy.dropout(x, 0.1)
    print(type(x))
    x = x.reshape((25, 5))
```