### PR TITLE
update the latest version in numpy and frontend init 

### DIFF
--- a/docs/overview/deep_dive/ivy_frontends.rst
+++ b/docs/overview/deep_dive/ivy_frontends.rst
@@ -402,7 +402,7 @@ For these reasons, all frontend functions which correspond to functions with lim
 
 .. code-block:: python
 
-   @with_unsupported_dtypes({"2.9.0 and below": ("float16", "bfloat16")}, "tensorflow")
+   @with_unsupported_dtypes({"2.12.0 and below": ("float16", "bfloat16")}, "tensorflow")
 
 The same logic applies to unsupported devices.
 Even if the wrapped Ivy function supports more devices, we should still flag the frontend function supported devices to be the same as those supported by the function in the native framework.

--- a/ivy/functional/backends/jax/__init__.py
+++ b/ivy/functional/backends/jax/__init__.py
@@ -81,7 +81,7 @@ native_bool = jnp.dtype("bool")
 
 # update these to add new dtypes
 valid_dtypes = {
-    "0.4.12 and below": (
+    "0.4.13 and below": (
         ivy.int8,
         ivy.int16,
         ivy.int32,
@@ -100,7 +100,7 @@ valid_dtypes = {
     )
 }
 valid_numeric_dtypes = {
-    "0.4.12 and below": (
+    "0.4.13 and below": (
         ivy.int8,
         ivy.int16,
         ivy.int32,
@@ -119,7 +119,7 @@ valid_numeric_dtypes = {
 }
 
 valid_int_dtypes = {
-    "0.4.12 and below": (
+    "0.4.13 and below": (
         ivy.int8,
         ivy.int16,
         ivy.int32,
@@ -132,12 +132,12 @@ valid_int_dtypes = {
 }
 
 valid_uint_dtypes = {
-    "0.4.12 and below": (ivy.uint8, ivy.uint16, ivy.uint32, ivy.uint64)
+    "0.4.13 and below": (ivy.uint8, ivy.uint16, ivy.uint32, ivy.uint64)
 }
 valid_float_dtypes = {
-    "0.4.12 and below": (ivy.bfloat16, ivy.float16, ivy.float32, ivy.float64)
+    "0.4.13 and below": (ivy.bfloat16, ivy.float16, ivy.float32, ivy.float64)
 }
-valid_complex_dtypes = {"0.4.12 and below": (ivy.complex64, ivy.complex128)}
+valid_complex_dtypes = {"0.4.13 and below": (ivy.complex64, ivy.complex128)}
 
 
 # leave these untouched
@@ -152,12 +152,12 @@ valid_complex_dtypes = _dtype_from_version(valid_complex_dtypes, backend_version
 # invalid data types
 
 # update these to add new dtypes
-invalid_dtypes = {"0.4.12 and below": ()}
-invalid_numeric_dtypes = {"0.4.12 and below": ()}
-invalid_int_dtypes = {"0.4.12 and below": ()}
-invalid_float_dtypes = {"0.4.12 and below": ()}
-invalid_uint_dtypes = {"0.4.12 and below": ()}
-invalid_complex_dtypes = {"0.4.12 and below": ()}
+invalid_dtypes = {"0.4.13 and below": ()}
+invalid_numeric_dtypes = {"0.4.13 and below": ()}
+invalid_int_dtypes = {"0.4.13 and below": ()}
+invalid_float_dtypes = {"0.4.13 and below": ()}
+invalid_uint_dtypes = {"0.4.13 and below": ()}
+invalid_complex_dtypes = {"0.4.13 and below": ()}
 
 # leave these untouched
 invalid_dtypes = _dtype_from_version(invalid_dtypes, backend_version)

--- a/ivy/functional/backends/jax/elementwise.py
+++ b/ivy/functional/backends/jax/elementwise.py
@@ -76,7 +76,7 @@ def atanh(x: JaxArray, /, *, out: Optional[JaxArray] = None) -> JaxArray:
     return jnp.arctanh(x)
 
 
-@with_unsupported_dtypes({"0.4.12 and below": ("complex",)}, backend_version)
+@with_unsupported_dtypes({"0.4.13 and below": ("complex",)}, backend_version)
 def bitwise_and(
     x1: Union[int, JaxArray],
     x2: Union[int, JaxArray],
@@ -88,14 +88,14 @@ def bitwise_and(
     return jnp.bitwise_and(x1, x2)
 
 
-@with_unsupported_dtypes({"0.4.12 and below": ("complex",)}, backend_version)
+@with_unsupported_dtypes({"0.4.13 and below": ("complex",)}, backend_version)
 def bitwise_invert(
     x: Union[int, JaxArray], /, *, out: Optional[JaxArray] = None
 ) -> JaxArray:
     return jnp.bitwise_not(x)
 
 
-@with_unsupported_dtypes({"0.4.12 and below": ("complex",)}, backend_version)
+@with_unsupported_dtypes({"0.4.13 and below": ("complex",)}, backend_version)
 def bitwise_left_shift(
     x1: Union[int, JaxArray],
     x2: Union[int, JaxArray],
@@ -107,7 +107,7 @@ def bitwise_left_shift(
     return jnp.left_shift(x1, x2)
 
 
-@with_unsupported_dtypes({"0.4.12 and below": ("complex",)}, backend_version)
+@with_unsupported_dtypes({"0.4.13 and below": ("complex",)}, backend_version)
 def bitwise_or(
     x1: Union[int, JaxArray],
     x2: Union[int, JaxArray],
@@ -119,7 +119,7 @@ def bitwise_or(
     return jnp.bitwise_or(x1, x2)
 
 
-@with_unsupported_dtypes({"0.4.12 and below": ("complex",)}, backend_version)
+@with_unsupported_dtypes({"0.4.13 and below": ("complex",)}, backend_version)
 def bitwise_right_shift(
     x1: Union[int, JaxArray],
     x2: Union[int, JaxArray],
@@ -131,7 +131,7 @@ def bitwise_right_shift(
     return jnp.right_shift(x1, x2)
 
 
-@with_unsupported_dtypes({"0.4.12 and below": ("complex",)}, backend_version)
+@with_unsupported_dtypes({"0.4.13 and below": ("complex",)}, backend_version)
 def bitwise_xor(
     x1: Union[int, JaxArray],
     x2: Union[int, JaxArray],
@@ -143,7 +143,7 @@ def bitwise_xor(
     return jnp.bitwise_xor(x1, x2)
 
 
-@with_unsupported_dtypes({"0.4.12 and below": ("complex",)}, backend_version)
+@with_unsupported_dtypes({"0.4.13 and below": ("complex",)}, backend_version)
 def ceil(x: JaxArray, /, *, out: Optional[JaxArray] = None) -> JaxArray:
     if "int" in str(x.dtype):
         return x
@@ -155,7 +155,7 @@ def cos(x: JaxArray, /, *, out: Optional[JaxArray] = None) -> JaxArray:
     return jnp.cos(x)
 
 
-@with_unsupported_dtypes({"0.4.12 and below": ("float16",)}, backend_version)
+@with_unsupported_dtypes({"0.4.13 and below": ("float16",)}, backend_version)
 def cosh(x: JaxArray, /, *, out: Optional[JaxArray] = None) -> JaxArray:
     return jnp.cosh(x)
 
@@ -195,7 +195,7 @@ def expm1(x: JaxArray, /, *, out: Optional[JaxArray] = None) -> JaxArray:
     return jnp.expm1(x)
 
 
-@with_unsupported_dtypes({"0.4.12 and below": ("complex",)}, backend_version)
+@with_unsupported_dtypes({"0.4.13 and below": ("complex",)}, backend_version)
 def floor(x: JaxArray, /, *, out: Optional[JaxArray] = None) -> JaxArray:
     if "int" in str(x.dtype):
         return x
@@ -203,7 +203,7 @@ def floor(x: JaxArray, /, *, out: Optional[JaxArray] = None) -> JaxArray:
         return jnp.floor(x)
 
 
-@with_unsupported_dtypes({"0.4.12 and below": ("complex",)}, backend_version)
+@with_unsupported_dtypes({"0.4.13 and below": ("complex",)}, backend_version)
 def floor_divide(
     x1: Union[float, JaxArray],
     x2: Union[float, JaxArray],
@@ -415,7 +415,7 @@ def pow(
     return jnp.power(x1, x2)
 
 
-@with_unsupported_dtypes({"0.4.12 and below": ("complex",)}, backend_version)
+@with_unsupported_dtypes({"0.4.13 and below": ("complex",)}, backend_version)
 def remainder(
     x1: Union[float, JaxArray],
     x2: Union[float, JaxArray],
@@ -510,7 +510,7 @@ def tanh(x: JaxArray, /, *, out: Optional[JaxArray] = None) -> JaxArray:
     return jnp.tanh(x)
 
 
-@with_unsupported_dtypes({"0.4.12 and below": ("complex",)}, backend_version)
+@with_unsupported_dtypes({"0.4.13 and below": ("complex",)}, backend_version)
 def trunc(x: JaxArray, /, *, out: Optional[JaxArray] = None) -> JaxArray:
     if "int" in str(x.dtype):
         return x
@@ -550,7 +550,7 @@ def angle(
 # ------#
 
 
-@with_unsupported_dtypes({"0.4.12 and below": ("complex",)}, backend_version)
+@with_unsupported_dtypes({"0.4.13 and below": ("complex",)}, backend_version)
 def erf(x: JaxArray, /, *, out: Optional[JaxArray] = None) -> JaxArray:
     return jax.scipy.special.erf(x)
 
@@ -601,7 +601,7 @@ def isreal(x: JaxArray, /, *, out: Optional[JaxArray] = None) -> JaxArray:
     return jnp.isreal(x)
 
 
-@with_unsupported_dtypes({"0.4.12 and below": ("complex",)}, backend_version)
+@with_unsupported_dtypes({"0.4.13 and below": ("complex",)}, backend_version)
 def fmod(
     x1: JaxArray,
     x2: JaxArray,

--- a/ivy/functional/backends/jax/experimental/layers.py
+++ b/ivy/functional/backends/jax/experimental/layers.py
@@ -413,7 +413,7 @@ def avg_pool3d(
     return res
 
 
-@with_supported_dtypes({"0.4.12 and below": ("float32", "float64")}, backend_version)
+@with_supported_dtypes({"0.4.13 and below": ("float32", "float64")}, backend_version)
 def dct(
     x: JaxArray,
     /,
@@ -766,7 +766,6 @@ def fft2(
     return jnp.fft.fft2(x, s, dim, norm).astype(jnp.complex128)
 
 
-
 def ifftn(
     x: JaxArray,
     s: Optional[Union[int, Tuple[int]]] = None,
@@ -777,8 +776,9 @@ def ifftn(
 ) -> JaxArray:
     return jnp.fft.ifftn(x, s, axes, norm)
 
+
 @with_unsupported_dtypes(
-    {"0.4.12 and below": ("bfloat16", "float16", "complex")}, backend_version
+    {"0.4.13 and below": ("bfloat16", "float16", "complex")}, backend_version
 )
 def embedding(
     weights: JaxArray,
@@ -797,4 +797,3 @@ def embedding(
         embeddings = jnp.where(
             norms < -max_norm, embeddings * -max_norm / norms, embeddings
         )
-

--- a/ivy/functional/backends/jax/experimental/random.py
+++ b/ivy/functional/backends/jax/experimental/random.py
@@ -57,7 +57,7 @@ def beta(
     return to_device(jax.random.beta(rng_input, a, b, shape, dtype), device)
 
 
-@with_unsupported_dtypes({"0.4.12 and below": ("bfloat16",)}, backend_version)
+@with_unsupported_dtypes({"0.4.13 and below": ("bfloat16",)}, backend_version)
 def gamma(
     alpha: Union[float, JaxArray],
     beta: Union[float, JaxArray],

--- a/ivy/functional/backends/jax/experimental/sorting.py
+++ b/ivy/functional/backends/jax/experimental/sorting.py
@@ -21,7 +21,7 @@ def invert_permutation(
 
 
 # lexsort
-@with_unsupported_dtypes({"0.4.12 and below": ("bfloat16",)}, backend_version)
+@with_unsupported_dtypes({"0.4.13 and below": ("bfloat16",)}, backend_version)
 def lexsort(
     keys: JaxArray,
     /,

--- a/ivy/functional/backends/jax/experimental/statistical.py
+++ b/ivy/functional/backends/jax/experimental/statistical.py
@@ -8,7 +8,7 @@ from . import backend_version
 
 
 @with_unsupported_dtypes(
-    {"0.4.12 and below": ("bfloat16",)},
+    {"0.4.13 and below": ("bfloat16",)},
     backend_version,
 )
 def histogram(
@@ -119,7 +119,7 @@ def histogram(
 
 
 @with_unsupported_dtypes(
-    {"0.4.12 and below": ("complex64", "complex128")}, backend_version
+    {"0.4.13 and below": ("complex64", "complex128")}, backend_version
 )
 def median(
     input: JaxArray,

--- a/ivy/functional/backends/jax/general.py
+++ b/ivy/functional/backends/jax/general.py
@@ -422,7 +422,7 @@ def vmap(
     )
 
 
-@with_unsupported_dtypes({"0.4.12 and below": ("float16", "bfloat16")}, backend_version)
+@with_unsupported_dtypes({"0.4.13 and below": ("float16", "bfloat16")}, backend_version)
 def isin(
     elements: JaxArray,
     test_elements: JaxArray,
@@ -438,6 +438,6 @@ def itemsize(x: JaxArray) -> int:
     return x.itemsize
 
 
-@with_unsupported_dtypes({"0.4.12 and below": ("bfloat16",)}, backend_version)
+@with_unsupported_dtypes({"0.4.13 and below": ("bfloat16",)}, backend_version)
 def strides(x: JaxArray) -> Tuple[int]:
     return to_numpy(x).strides

--- a/ivy/functional/backends/jax/linear_algebra.py
+++ b/ivy/functional/backends/jax/linear_algebra.py
@@ -20,7 +20,7 @@ from ivy import promote_types_of_inputs
 
 
 @with_unsupported_dtypes(
-    {"0.4.12 and below": ("bfloat16", "float16", "complex")},
+    {"0.4.13 and below": ("bfloat16", "float16", "complex")},
     backend_version,
 )
 def cholesky(
@@ -34,7 +34,7 @@ def cholesky(
     return ret
 
 
-@with_unsupported_dtypes({"0.4.12 and below": ("complex",)}, backend_version)
+@with_unsupported_dtypes({"0.4.13 and below": ("complex",)}, backend_version)
 def cross(
     x1: JaxArray,
     x2: JaxArray,
@@ -51,14 +51,14 @@ def cross(
 
 
 @with_unsupported_dtypes(
-    {"0.4.12 and below": ("bfloat16", "float16", "complex")},
+    {"0.4.13 and below": ("bfloat16", "float16", "complex")},
     backend_version,
 )
 def det(x: JaxArray, /, *, out: Optional[JaxArray] = None) -> JaxArray:
     return jnp.linalg.det(x)
 
 
-@with_unsupported_dtypes({"0.4.12 and below": ("float16", "bfloat16")}, backend_version)
+@with_unsupported_dtypes({"0.4.13 and below": ("float16", "bfloat16")}, backend_version)
 def eig(x: JaxArray, /, *, out: Optional[JaxArray] = None) -> Tuple[JaxArray]:
     result_tuple = NamedTuple(
         "eig", [("eigenvalues", JaxArray), ("eigenvectors", JaxArray)]
@@ -67,7 +67,7 @@ def eig(x: JaxArray, /, *, out: Optional[JaxArray] = None) -> Tuple[JaxArray]:
     return result_tuple(eigenvalues, eigenvectors)
 
 
-@with_unsupported_dtypes({"0.4.12 and below": ("complex",)}, backend_version)
+@with_unsupported_dtypes({"0.4.13 and below": ("complex",)}, backend_version)
 def diagonal(
     x: JaxArray,
     /,
@@ -104,7 +104,7 @@ def tensorsolve(
 
 
 @with_unsupported_dtypes(
-    {"0.4.12 and below": ("bfloat16", "float16", "complex")},
+    {"0.4.13 and below": ("bfloat16", "float16", "complex")},
     backend_version,
 )
 def eigh(
@@ -118,7 +118,7 @@ def eigh(
 
 
 @with_unsupported_dtypes(
-    {"0.4.12 and below": ("bfloat16", "float16", "complex")},
+    {"0.4.13 and below": ("bfloat16", "float16", "complex")},
     backend_version,
 )
 def eigvalsh(
@@ -127,14 +127,14 @@ def eigvalsh(
     return jnp.linalg.eigvalsh(x, UPLO=UPLO)
 
 
-@with_unsupported_dtypes({"0.4.12 and below": ("complex",)}, backend_version)
+@with_unsupported_dtypes({"0.4.13 and below": ("complex",)}, backend_version)
 def inner(x1: JaxArray, x2: JaxArray, /, *, out: Optional[JaxArray] = None) -> JaxArray:
     x1, x2 = ivy.promote_types_of_inputs(x1, x2)
     return jnp.inner(x1, x2)
 
 
 @with_unsupported_dtypes(
-    {"0.4.12 and below": ("bfloat16", "float16", "complex")},
+    {"0.4.13 and below": ("bfloat16", "float16", "complex")},
     backend_version,
 )
 def inv(
@@ -152,7 +152,7 @@ def inv(
 
 
 @with_unsupported_dtypes(
-    {"0.4.12 and below": ("bfloat16", "float16", "complex")},
+    {"0.4.13 and below": ("bfloat16", "float16", "complex")},
     backend_version,
 )
 def matmul(
@@ -178,7 +178,7 @@ def matmul(
 
 
 @with_unsupported_dtypes(
-    {"0.4.12 and below": ("bfloat16", "float16", "complex")},
+    {"0.4.13 and below": ("bfloat16", "float16", "complex")},
     backend_version,
 )
 def matrix_norm(
@@ -199,13 +199,13 @@ def matrix_norm(
     return jnp.linalg.norm(x, ord=ord, axis=axis, keepdims=keepdims)
 
 
-@with_unsupported_dtypes({"0.4.12 and below": ("complex",)}, backend_version)
+@with_unsupported_dtypes({"0.4.13 and below": ("complex",)}, backend_version)
 def matrix_power(x: JaxArray, n: int, /, *, out: Optional[JaxArray] = None) -> JaxArray:
     return jnp.linalg.matrix_power(x, n)
 
 
 @with_unsupported_dtypes(
-    {"0.4.12 and below": ("bfloat16", "float16", "complex")},
+    {"0.4.13 and below": ("bfloat16", "float16", "complex")},
     backend_version,
 )
 def matrix_rank(
@@ -236,7 +236,7 @@ def matrix_rank(
 
 
 @with_unsupported_dtypes(
-    {"0.4.12 and below": ("int", "float16", "complex")},
+    {"0.4.13 and below": ("int", "float16", "complex")},
     backend_version,
 )
 def matrix_transpose(
@@ -248,7 +248,7 @@ def matrix_transpose(
 
 
 @with_unsupported_dtypes(
-    {"0.4.12 and below": ("bfloat16", "float16", "complex")},
+    {"0.4.13 and below": ("bfloat16", "float16", "complex")},
     backend_version,
 )
 def outer(
@@ -263,7 +263,7 @@ def outer(
 
 
 @with_unsupported_dtypes(
-    {"0.4.12 and below": ("bfloat16", "float16", "complex")},
+    {"0.4.13 and below": ("bfloat16", "float16", "complex")},
     backend_version,
 )
 def pinv(
@@ -281,7 +281,7 @@ def pinv(
 
 
 @with_unsupported_dtypes(
-    {"0.4.12 and below": ("bfloat16", "float16", "complex")},
+    {"0.4.13 and below": ("bfloat16", "float16", "complex")},
     backend_version,
 )
 def qr(
@@ -293,7 +293,7 @@ def qr(
 
 
 @with_unsupported_dtypes(
-    {"0.4.12 and below": ("bfloat16", "float16", "complex")},
+    {"0.4.13 and below": ("bfloat16", "float16", "complex")},
     backend_version,
 )
 def slogdet(
@@ -306,7 +306,7 @@ def slogdet(
 
 
 @with_unsupported_dtypes(
-    {"0.4.12 and below": ("bfloat16", "float16", "complex")},
+    {"0.4.13 and below": ("bfloat16", "float16", "complex")},
     backend_version,
 )
 def solve(
@@ -348,7 +348,7 @@ def solve(
 
 
 @with_unsupported_dtypes(
-    {"0.4.12 and below": ("bfloat16", "float16", "complex")},
+    {"0.4.13 and below": ("bfloat16", "float16", "complex")},
     backend_version,
 )
 def svd(
@@ -365,14 +365,14 @@ def svd(
 
 
 @with_unsupported_dtypes(
-    {"0.4.12 and below": ("bfloat16", "float16", "complex")},
+    {"0.4.13 and below": ("bfloat16", "float16", "complex")},
     backend_version,
 )
 def svdvals(x: JaxArray, /, *, out: Optional[JaxArray] = None) -> JaxArray:
     return jnp.linalg.svd(x, compute_uv=False)
 
 
-@with_unsupported_dtypes({"0.4.12 and below": ("complex",)}, backend_version)
+@with_unsupported_dtypes({"0.4.13 and below": ("complex",)}, backend_version)
 def tensordot(
     x1: JaxArray,
     x2: JaxArray,
@@ -386,7 +386,7 @@ def tensordot(
 
 
 @with_unsupported_dtypes(
-    {"0.4.12 and below": ("bfloat16", "float16", "complex")},
+    {"0.4.13 and below": ("bfloat16", "float16", "complex")},
     backend_version,
 )
 def trace(
@@ -401,7 +401,7 @@ def trace(
     return jnp.trace(x, offset=offset, axis1=axis1, axis2=axis2, out=out)
 
 
-@with_unsupported_dtypes({"0.4.12 and below": ("complex",)}, backend_version)
+@with_unsupported_dtypes({"0.4.13 and below": ("complex",)}, backend_version)
 def vecdot(
     x1: JaxArray, x2: JaxArray, /, *, axis: int = -1, out: Optional[JaxArray] = None
 ) -> JaxArray:
@@ -409,7 +409,7 @@ def vecdot(
     return jnp.tensordot(x1, x2, axes=(axis, axis))
 
 
-@with_unsupported_dtypes({"0.4.12 and below": ("complex",)}, backend_version)
+@with_unsupported_dtypes({"0.4.13 and below": ("complex",)}, backend_version)
 def vector_norm(
     x: JaxArray,
     /,
@@ -443,7 +443,7 @@ def vector_norm(
 # ------#
 
 
-@with_unsupported_dtypes({"0.4.12 and below": ("complex",)}, backend_version)
+@with_unsupported_dtypes({"0.4.13 and below": ("complex",)}, backend_version)
 def diag(
     x: JaxArray,
     /,
@@ -455,7 +455,7 @@ def diag(
 
 
 @with_unsupported_dtypes(
-    {"0.4.12 and below": ("bfloat16", "float16", "complex")},
+    {"0.4.13 and below": ("bfloat16", "float16", "complex")},
     backend_version,
 )
 def vander(
@@ -471,7 +471,7 @@ def vander(
 
 @with_unsupported_dtypes(
     {
-        "0.4.12 and below": (
+        "0.4.13 and below": (
             "complex",
             "unsigned",
         )

--- a/ivy/functional/backends/jax/manipulation.py
+++ b/ivy/functional/backends/jax/manipulation.py
@@ -243,7 +243,7 @@ def clip(
     return jnp.where(x < x_min, x_min, x)
 
 
-@with_unsupported_dtypes({"0.4.12 and below": ("uint64",)}, backend_version)
+@with_unsupported_dtypes({"0.4.13 and below": ("uint64",)}, backend_version)
 def constant_pad(
     x: JaxArray,
     /,

--- a/ivy/functional/backends/jax/random.py
+++ b/ivy/functional/backends/jax/random.py
@@ -93,7 +93,7 @@ def random_normal(
     )
 
 
-@with_unsupported_dtypes({"0.4.12 and below": ("bfloat16",)}, backend_version)
+@with_unsupported_dtypes({"0.4.13 and below": ("bfloat16",)}, backend_version)
 def multinomial(
     population_size: int,
     num_samples: int,

--- a/ivy/functional/backends/jax/searching.py
+++ b/ivy/functional/backends/jax/searching.py
@@ -12,7 +12,7 @@ from ivy.func_wrapper import with_unsupported_dtypes
 # ------------------ #
 
 
-@with_unsupported_dtypes({"0.4.12 and below": ("complex",)}, backend_version)
+@with_unsupported_dtypes({"0.4.13 and below": ("complex",)}, backend_version)
 def argmax(
     x: JaxArray,
     /,
@@ -38,7 +38,7 @@ def argmax(
     return ret
 
 
-@with_unsupported_dtypes({"0.4.12 and below": ("complex",)}, backend_version)
+@with_unsupported_dtypes({"0.4.13 and below": ("complex",)}, backend_version)
 def argmin(
     x: JaxArray,
     /,

--- a/ivy/functional/backends/jax/sorting.py
+++ b/ivy/functional/backends/jax/sorting.py
@@ -77,7 +77,7 @@ def searchsorted(
 
 
 # msort
-@with_unsupported_dtypes({"0.4.12 and below": ("complex",)}, backend_version)
+@with_unsupported_dtypes({"0.4.13 and below": ("complex",)}, backend_version)
 def msort(
     a: Union[JaxArray, list, tuple],
     /,

--- a/ivy/functional/backends/jax/statistical.py
+++ b/ivy/functional/backends/jax/statistical.py
@@ -141,7 +141,7 @@ def var(
 # ------#
 
 
-@with_unsupported_dtypes({"0.4.12 and below": "bfloat16"}, backend_version)
+@with_unsupported_dtypes({"0.4.13 and below": "bfloat16"}, backend_version)
 def cumprod(
     x: JaxArray,
     /,
@@ -177,7 +177,7 @@ def cumprod(
         return jnp.flip(x, axis=axis)
 
 
-@with_unsupported_dtypes({"0.4.12 and below": "bfloat16"}, backend_version)
+@with_unsupported_dtypes({"0.4.13 and below": "bfloat16"}, backend_version)
 def cummin(
     x: JaxArray,
     /,

--- a/ivy/functional/backends/numpy/data_type.py
+++ b/ivy/functional/backends/numpy/data_type.py
@@ -133,7 +133,7 @@ def broadcast_arrays(*arrays: np.ndarray) -> List[np.ndarray]:
         raise ivy.utils.exceptions.IvyBroadcastShapeError(e)
 
 
-@with_unsupported_dtypes({"1.24.3 and below": ("complex",)}, backend_version)
+@with_unsupported_dtypes({"1.25.0 and below": ("complex",)}, backend_version)
 def broadcast_to(
     x: np.ndarray,
     /,
@@ -216,7 +216,7 @@ def as_ivy_dtype(
         )
 
 
-@with_unsupported_dtypes({"1.24.3 and below": ("bfloat16",)}, backend_version)
+@with_unsupported_dtypes({"1.25.0 and below": ("bfloat16",)}, backend_version)
 def as_native_dtype(dtype_in: Union[np.dtype, str, bool, int, float], /) -> np.dtype:
     if dtype_in is int:
         return ivy.default_int_dtype(as_native=True)

--- a/ivy/functional/backends/numpy/elementwise.py
+++ b/ivy/functional/backends/numpy/elementwise.py
@@ -87,7 +87,7 @@ atan.support_native_out = True
 
 
 @_scalar_output_to_0d_array
-@with_unsupported_dtypes({"1.24.3 and below": ("complex",)}, backend_version)
+@with_unsupported_dtypes({"1.25.0 and below": ("complex",)}, backend_version)
 def atan2(
     x1: np.ndarray, x2: np.ndarray, /, *, out: Optional[np.ndarray] = None
 ) -> np.ndarray:
@@ -107,7 +107,7 @@ atanh.support_native_out = True
 
 
 @_scalar_output_to_0d_array
-@with_unsupported_dtypes({"1.24.3 and below": ("complex",)}, backend_version)
+@with_unsupported_dtypes({"1.25.0 and below": ("complex",)}, backend_version)
 def bitwise_and(
     x1: Union[int, bool, np.ndarray],
     x2: Union[int, bool, np.ndarray],
@@ -123,7 +123,7 @@ bitwise_and.support_native_out = True
 
 
 @_scalar_output_to_0d_array
-@with_unsupported_dtypes({"1.24.3 and below": ("complex",)}, backend_version)
+@with_unsupported_dtypes({"1.25.0 and below": ("complex",)}, backend_version)
 def bitwise_invert(
     x: Union[int, bool, np.ndarray], /, *, out: Optional[np.ndarray] = None
 ) -> np.ndarray:
@@ -134,7 +134,7 @@ bitwise_invert.support_native_out = True
 
 
 @_scalar_output_to_0d_array
-@with_unsupported_dtypes({"1.24.3 and below": ("complex",)}, backend_version)
+@with_unsupported_dtypes({"1.25.0 and below": ("complex",)}, backend_version)
 def bitwise_left_shift(
     x1: Union[int, bool, np.ndarray],
     x2: Union[int, bool, np.ndarray],
@@ -150,7 +150,7 @@ bitwise_left_shift.support_native_out = True
 
 
 @_scalar_output_to_0d_array
-@with_unsupported_dtypes({"1.24.3 and below": ("complex",)}, backend_version)
+@with_unsupported_dtypes({"1.25.0 and below": ("complex",)}, backend_version)
 def bitwise_or(
     x1: Union[int, bool, np.ndarray],
     x2: Union[int, bool, np.ndarray],
@@ -166,7 +166,7 @@ bitwise_or.support_native_out = True
 
 
 @_scalar_output_to_0d_array
-@with_unsupported_dtypes({"1.24.3 and below": ("complex",)}, backend_version)
+@with_unsupported_dtypes({"1.25.0 and below": ("complex",)}, backend_version)
 def bitwise_right_shift(
     x1: Union[int, bool, np.ndarray],
     x2: Union[int, bool, np.ndarray],
@@ -182,7 +182,7 @@ bitwise_right_shift.support_native_out = True
 
 
 @_scalar_output_to_0d_array
-@with_unsupported_dtypes({"1.24.3 and below": ("complex",)}, backend_version)
+@with_unsupported_dtypes({"1.25.0 and below": ("complex",)}, backend_version)
 def bitwise_xor(
     x1: Union[int, bool, np.ndarray],
     x2: Union[int, bool, np.ndarray],
@@ -197,7 +197,7 @@ def bitwise_xor(
 bitwise_xor.support_native_out = True
 
 
-@with_unsupported_dtypes({"1.24.3 and below": ("complex",)}, backend_version)
+@with_unsupported_dtypes({"1.25.0 and below": ("complex",)}, backend_version)
 @_scalar_output_to_0d_array
 def ceil(x: np.ndarray, /, *, out: Optional[np.ndarray] = None) -> np.ndarray:
     if "int" in str(x.dtype):
@@ -220,7 +220,7 @@ def cos(x: np.ndarray, /, *, out: Optional[np.ndarray] = None) -> np.ndarray:
 cos.support_native_out = True
 
 
-@with_unsupported_dtypes({"1.24.3 and below": ("float16",)}, backend_version)
+@with_unsupported_dtypes({"1.25.0 and below": ("float16",)}, backend_version)
 @_scalar_output_to_0d_array
 def cosh(x: np.ndarray, /, *, out: Optional[np.ndarray] = None) -> np.ndarray:
     return np.cosh(x, out=out)
@@ -293,7 +293,7 @@ expm1.support_native_out = True
 
 
 @_scalar_output_to_0d_array
-@with_unsupported_dtypes({"1.24.3 and below": ("complex",)}, backend_version)
+@with_unsupported_dtypes({"1.25.0 and below": ("complex",)}, backend_version)
 def floor(x: np.ndarray, /, *, out: Optional[np.ndarray] = None) -> np.ndarray:
     if "int" in str(x.dtype):
         ret = np.copy(x)
@@ -308,7 +308,7 @@ floor.support_native_out = True
 
 
 @_scalar_output_to_0d_array
-@with_unsupported_dtypes({"1.24.3 and below": ("complex",)}, backend_version)
+@with_unsupported_dtypes({"1.25.0 and below": ("complex",)}, backend_version)
 def floor_divide(
     x1: Union[float, np.ndarray],
     x2: Union[float, np.ndarray],
@@ -490,7 +490,7 @@ log2.support_native_out = True
 
 
 @_scalar_output_to_0d_array
-@with_unsupported_dtypes({"1.24.3 and below": ("complex",)}, backend_version)
+@with_unsupported_dtypes({"1.25.0 and below": ("complex",)}, backend_version)
 def logaddexp(
     x1: np.ndarray, x2: np.ndarray, /, *, out: Optional[np.ndarray] = None
 ) -> np.ndarray:
@@ -622,7 +622,7 @@ pow.support_native_out = True
 
 
 @_scalar_output_to_0d_array
-@with_unsupported_dtypes({"1.24.3 and below": ("complex",)}, backend_version)
+@with_unsupported_dtypes({"1.25.0 and below": ("complex",)}, backend_version)
 def remainder(
     x1: Union[float, np.ndarray],
     x2: Union[float, np.ndarray],
@@ -862,7 +862,7 @@ reciprocal.support_native_out = True
 
 
 @_scalar_output_to_0d_array
-@with_unsupported_dtypes({"1.24.3 and below": ("complex",)}, backend_version)
+@with_unsupported_dtypes({"1.25.0 and below": ("complex",)}, backend_version)
 def deg2rad(x: np.ndarray, /, *, out: Optional[np.ndarray] = None) -> np.ndarray:
     return np.deg2rad(x, out=out)
 
@@ -871,7 +871,7 @@ deg2rad.support_native_out = True
 
 
 @_scalar_output_to_0d_array
-@with_unsupported_dtypes({"1.24.3 and below": ("complex",)}, backend_version)
+@with_unsupported_dtypes({"1.25.0 and below": ("complex",)}, backend_version)
 def rad2deg(x: np.ndarray, /, *, out: Optional[np.ndarray] = None) -> np.ndarray:
     return np.rad2deg(x, out=out)
 
@@ -888,7 +888,7 @@ isreal.support_native_out = False
 
 
 @_scalar_output_to_0d_array
-@with_unsupported_dtypes({"1.24.3 and below": ("complex",)}, backend_version)
+@with_unsupported_dtypes({"1.25.0 and below": ("complex",)}, backend_version)
 def fmod(
     x1: np.ndarray,
     x2: np.ndarray,

--- a/ivy/functional/backends/numpy/experimental/activations.py
+++ b/ivy/functional/backends/numpy/experimental/activations.py
@@ -50,7 +50,7 @@ def relu6(x: np.ndarray, /, *, out: Optional[np.ndarray] = None) -> np.ndarray:
 relu6.support_native_out = True
 
 
-@with_unsupported_dtypes({"1.24.3 and below": ("bool",)}, backend_version)
+@with_unsupported_dtypes({"1.25.0 and below": ("bool",)}, backend_version)
 @_scalar_output_to_0d_array
 def logsigmoid(input: np.ndarray, /, *, out: Optional[np.ndarray] = None) -> np.ndarray:
     return -(np.log1p(np.exp(-(input))))

--- a/ivy/functional/backends/numpy/experimental/elementwise.py
+++ b/ivy/functional/backends/numpy/experimental/elementwise.py
@@ -10,7 +10,7 @@ from . import backend_version
 
 
 @_scalar_output_to_0d_array
-@with_unsupported_dtypes({"1.24.3 and below": ("bfloat16",)}, backend_version)
+@with_unsupported_dtypes({"1.25.0 and below": ("bfloat16",)}, backend_version)
 def sinc(x: np.ndarray, /, *, out: Optional[np.ndarray] = None) -> np.ndarray:
     return np.sinc(x).astype(x.dtype)
 

--- a/ivy/functional/backends/numpy/experimental/general.py
+++ b/ivy/functional/backends/numpy/experimental/general.py
@@ -7,7 +7,7 @@ from . import backend_version
 from ivy import with_unsupported_dtypes
 
 
-@with_unsupported_dtypes({"1.24.3 and below": ("complex",)}, backend_version)
+@with_unsupported_dtypes({"1.25.0 and below": ("complex",)}, backend_version)
 def reduce(
     operand: np.ndarray,
     init_value: Union[int, float],

--- a/ivy/functional/backends/numpy/experimental/layers.py
+++ b/ivy/functional/backends/numpy/experimental/layers.py
@@ -641,7 +641,7 @@ def fft(
     return np.fft.fft(x, n, dim, norm).astype(out_dtype)
 
 
-@with_supported_dtypes({"1.24.3 and below": ("float32", "float64")}, backend_version)
+@with_supported_dtypes({"1.25.0 and below": ("float32", "float64")}, backend_version)
 def dct(
     x: np.ndarray,
     /,
@@ -902,6 +902,7 @@ def ifftn(
 ) -> np.ndarray:
     return np.fft.ifftn(x, s, axes, norm).astype(x.dtype)
 
+
 @with_unsupported_dtypes({"1.25.0 and below": ("complex",)}, backend_version)
 def embedding(
     weights: np.ndarray,
@@ -921,4 +922,3 @@ def embedding(
             norms < -max_norm, embeddings * -max_norm / norms, embeddings
         )
     return embeddings
-

--- a/ivy/functional/backends/numpy/experimental/linear_algebra.py
+++ b/ivy/functional/backends/numpy/experimental/linear_algebra.py
@@ -97,7 +97,7 @@ kron.support_native_out = False
 
 
 @with_supported_dtypes(
-    {"1.24.3 and below": ("float32", "float64", "complex64", "complex128")},
+    {"1.25.0 and below": ("float32", "float64", "complex64", "complex128")},
     backend_version,
 )
 def matrix_exp(

--- a/ivy/functional/backends/numpy/experimental/norms.py
+++ b/ivy/functional/backends/numpy/experimental/norms.py
@@ -4,7 +4,7 @@ from ivy.func_wrapper import with_unsupported_dtypes
 from . import backend_version
 
 
-@with_unsupported_dtypes({"1.23.0 and below": ("float16",)}, backend_version)
+@with_unsupported_dtypes({"1.25.0 and below": ("float16",)}, backend_version)
 def l1_normalize(
     x: np.ndarray,
     /,

--- a/ivy/functional/backends/numpy/experimental/searching.py
+++ b/ivy/functional/backends/numpy/experimental/searching.py
@@ -7,7 +7,7 @@ from ivy.func_wrapper import with_supported_dtypes
 from . import backend_version
 
 
-@with_supported_dtypes({"1.24.3 and below": ("int32", "int64")}, backend_version)
+@with_supported_dtypes({"1.25.0 and below": ("int32", "int64")}, backend_version)
 def unravel_index(
     indices: np.ndarray,
     shape: Tuple[int],

--- a/ivy/functional/backends/numpy/experimental/statistical.py
+++ b/ivy/functional/backends/numpy/experimental/statistical.py
@@ -7,7 +7,7 @@ from . import backend_version
 
 
 @with_unsupported_dtypes(
-    {"1.24.3 and below": ("bfloat16",)},
+    {"1.25.0 and below": ("bfloat16",)},
     backend_version,
 )
 def histogram(

--- a/ivy/functional/backends/numpy/general.py
+++ b/ivy/functional/backends/numpy/general.py
@@ -436,7 +436,7 @@ def vmap(
     return _vmap
 
 
-@with_unsupported_dtypes({"1.24.3 and below": ("bfloat16",)}, backend_version)
+@with_unsupported_dtypes({"1.25.0 and below": ("bfloat16",)}, backend_version)
 def isin(
     elements: np.ndarray,
     test_elements: np.ndarray,

--- a/ivy/functional/backends/numpy/linear_algebra.py
+++ b/ivy/functional/backends/numpy/linear_algebra.py
@@ -19,7 +19,7 @@ from . import backend_version
 # -------------------#
 
 
-@with_unsupported_dtypes({"1.24.3 and below": ("float16", "complex")}, backend_version)
+@with_unsupported_dtypes({"1.25.0 and below": ("float16", "complex")}, backend_version)
 def cholesky(
     x: np.ndarray, /, *, upper: bool = False, out: Optional[np.ndarray] = None
 ) -> np.ndarray:
@@ -31,7 +31,7 @@ def cholesky(
     return ret
 
 
-@with_unsupported_dtypes({"1.24.3 and below": ("float16",)}, backend_version)
+@with_unsupported_dtypes({"1.25.0 and below": ("float16",)}, backend_version)
 def cross(
     x1: np.ndarray,
     x2: np.ndarray,
@@ -47,7 +47,7 @@ def cross(
 
 
 @_scalar_output_to_0d_array
-@with_unsupported_dtypes({"1.24.3 and below": ("float16",)}, backend_version)
+@with_unsupported_dtypes({"1.25.0 and below": ("float16",)}, backend_version)
 def det(x: np.ndarray, /, *, out: Optional[np.ndarray] = None) -> np.ndarray:
     return np.linalg.det(x)
 
@@ -64,7 +64,7 @@ def diagonal(
     return np.diagonal(x, offset=offset, axis1=axis1, axis2=axis2)
 
 
-@with_unsupported_dtypes({"1.24.3 and below": ("float16",)}, backend_version)
+@with_unsupported_dtypes({"1.25.0 and below": ("float16",)}, backend_version)
 def eigh(
     x: np.ndarray, /, *, UPLO: str = "L", out: Optional[np.ndarray] = None
 ) -> Tuple[np.ndarray]:
@@ -75,7 +75,7 @@ def eigh(
     return result_tuple(eigenvalues, eigenvectors)
 
 
-@with_unsupported_dtypes({"1.24.3 and below": ("float16",)}, backend_version)
+@with_unsupported_dtypes({"1.25.0 and below": ("float16",)}, backend_version)
 def eigvalsh(
     x: np.ndarray, /, *, UPLO: str = "L", out: Optional[np.ndarray] = None
 ) -> np.ndarray:
@@ -91,7 +91,7 @@ def inner(
 
 
 @with_unsupported_dtypes(
-    {"1.24.3 and below": ("bfloat16", "float16", "complex")},
+    {"1.25.0 and below": ("bfloat16", "float16", "complex")},
     backend_version,
 )
 def inv(
@@ -113,7 +113,7 @@ def inv(
             return ret
 
 
-@with_unsupported_dtypes({"1.24.3 and below": ("float16", "bfloat16")}, backend_version)
+@with_unsupported_dtypes({"1.25.0 and below": ("float16", "bfloat16")}, backend_version)
 def matmul(
     x1: np.ndarray,
     x2: np.ndarray,
@@ -143,7 +143,7 @@ matmul.support_native_out = True
 
 
 @_scalar_output_to_0d_array
-@with_unsupported_dtypes({"1.24.3 and below": ("float16", "bfloat16")}, backend_version)
+@with_unsupported_dtypes({"1.25.0 and below": ("float16", "bfloat16")}, backend_version)
 def matrix_norm(
     x: np.ndarray,
     /,
@@ -165,7 +165,7 @@ def matrix_power(
 
 
 @with_unsupported_dtypes(
-    {"1.24.3 and below": ("float16", "bfloat16", "complex")},
+    {"1.25.0 and below": ("float16", "bfloat16", "complex")},
     backend_version,
 )
 @_scalar_output_to_0d_array
@@ -204,7 +204,7 @@ def matrix_transpose(
     return np.swapaxes(x, -1, -2)
 
 
-@with_unsupported_dtypes({"1.24.3 and below": ("float16",)}, backend_version)
+@with_unsupported_dtypes({"1.25.0 and below": ("float16",)}, backend_version)
 def outer(
     x1: np.ndarray,
     x2: np.ndarray,
@@ -219,7 +219,7 @@ def outer(
 outer.support_native_out = True
 
 
-@with_unsupported_dtypes({"1.24.3 and below": ("float16",)}, backend_version)
+@with_unsupported_dtypes({"1.25.0 and below": ("float16",)}, backend_version)
 def pinv(
     x: np.ndarray,
     /,
@@ -233,7 +233,7 @@ def pinv(
         return np.linalg.pinv(x, rtol)
 
 
-@with_unsupported_dtypes({"1.24.3 and below": ("float16",)}, backend_version)
+@with_unsupported_dtypes({"1.25.0 and below": ("float16",)}, backend_version)
 def qr(
     x: np.ndarray,
     /,
@@ -246,7 +246,7 @@ def qr(
     return res(q, r)
 
 
-@with_unsupported_dtypes({"1.24.3 and below": ("float16",)}, backend_version)
+@with_unsupported_dtypes({"1.25.0 and below": ("float16",)}, backend_version)
 def slogdet(
     x: np.ndarray,
     /,
@@ -261,7 +261,7 @@ def slogdet(
     return results(sign, logabsdet)
 
 
-@with_unsupported_dtypes({"1.24.3 and below": ("float16",)}, backend_version)
+@with_unsupported_dtypes({"1.25.0 and below": ("float16",)}, backend_version)
 def solve(
     x1: np.ndarray,
     x2: np.ndarray,
@@ -286,7 +286,7 @@ def solve(
     return ret
 
 
-@with_unsupported_dtypes({"1.24.3 and below": ("float16",)}, backend_version)
+@with_unsupported_dtypes({"1.25.0 and below": ("float16",)}, backend_version)
 def svd(
     x: np.ndarray, /, *, compute_uv: bool = True, full_matrices: bool = True
 ) -> Union[np.ndarray, Tuple[np.ndarray, ...]]:
@@ -300,7 +300,7 @@ def svd(
         return results(D)
 
 
-@with_unsupported_dtypes({"1.24.3 and below": ("float16",)}, backend_version)
+@with_unsupported_dtypes({"1.25.0 and below": ("float16",)}, backend_version)
 def svdvals(x: np.ndarray, /, *, out: Optional[np.ndarray] = None) -> np.ndarray:
     return np.linalg.svd(x, compute_uv=False)
 
@@ -329,7 +329,7 @@ def tensordot(
 
 
 @_scalar_output_to_0d_array
-@with_unsupported_dtypes({"1.24.3 and below": ("float16", "bfloat16")}, backend_version)
+@with_unsupported_dtypes({"1.25.0 and below": ("float16", "bfloat16")}, backend_version)
 def trace(
     x: np.ndarray,
     /,
@@ -357,7 +357,7 @@ def vecdot(
     return np.tensordot(x1, x2, axes=(axis, axis))
 
 
-@with_unsupported_dtypes({"1.24.3 and below": ("float16",)}, backend_version)
+@with_unsupported_dtypes({"1.25.0 and below": ("float16",)}, backend_version)
 def eig(x: np.ndarray, /, *, out: Optional[np.ndarray] = None) -> Tuple[np.ndarray]:
     result_tuple = NamedTuple(
         "eig", [("eigenvalues", np.ndarray), ("eigenvectors", np.ndarray)]
@@ -423,7 +423,7 @@ def vander(
 
 @with_unsupported_dtypes(
     {
-        "1.24.3 and below": (
+        "1.25.0 and below": (
             "complex",
             "unsigned",
         )

--- a/ivy/functional/backends/numpy/manipulation.py
+++ b/ivy/functional/backends/numpy/manipulation.py
@@ -209,7 +209,7 @@ def split(
     return np.split(x, num_or_size_splits, axis)
 
 
-@with_unsupported_dtypes({"1.24.3 and below": ("uint64",)}, backend_version)
+@with_unsupported_dtypes({"1.25.0 and below": ("uint64",)}, backend_version)
 def repeat(
     x: np.ndarray,
     /,

--- a/ivy/functional/backends/numpy/random.py
+++ b/ivy/functional/backends/numpy/random.py
@@ -51,7 +51,7 @@ def random_normal(
     return np.asarray(np.random.normal(mean, std, shape), dtype=dtype)
 
 
-@with_unsupported_dtypes({"1.24.3 and below": ("bfloat16",)}, backend_version)
+@with_unsupported_dtypes({"1.25.0 and below": ("bfloat16",)}, backend_version)
 def multinomial(
     population_size: int,
     num_samples: int,

--- a/ivy/functional/backends/numpy/sorting.py
+++ b/ivy/functional/backends/numpy/sorting.py
@@ -39,7 +39,7 @@ def sort(
 
 
 # msort
-@with_unsupported_dtypes({"1.24.3 and below": ("complex",)}, backend_version)
+@with_unsupported_dtypes({"1.25.0 and below": ("complex",)}, backend_version)
 def msort(
     a: Union[np.ndarray, list, tuple], /, *, out: Optional[np.ndarray] = None
 ) -> np.ndarray:

--- a/ivy/functional/backends/numpy/statistical.py
+++ b/ivy/functional/backends/numpy/statistical.py
@@ -171,7 +171,7 @@ var.support_native_out = True
 # ------#
 
 
-@with_unsupported_dtypes({"1.24.3 and below": "bfloat16"}, backend_version)
+@with_unsupported_dtypes({"1.25.0 and below": "bfloat16"}, backend_version)
 def cumprod(
     x: np.ndarray,
     /,
@@ -208,7 +208,7 @@ def cumprod(
 cumprod.support_native_out = True
 
 
-@with_unsupported_dtypes({"1.24.3 and below": "bfloat16"}, backend_version)
+@with_unsupported_dtypes({"1.25.0 and below": "bfloat16"}, backend_version)
 def cummin(
     x: np.ndarray,
     /,

--- a/ivy/functional/backends/tensorflow/linear_algebra.py
+++ b/ivy/functional/backends/tensorflow/linear_algebra.py
@@ -202,7 +202,7 @@ def inv(
             return ret
 
 
-@with_unsupported_dtypes({"1.24.3 and below": ("float16", "bfloat16")}, backend_version)
+@with_unsupported_dtypes({"1.25.0 and below": ("float16", "bfloat16")}, backend_version)
 def matmul(
     x1: Union[tf.Tensor, tf.Variable],
     x2: Union[tf.Tensor, tf.Variable],

--- a/ivy/functional/frontends/__init__.py
+++ b/ivy/functional/frontends/__init__.py
@@ -3,9 +3,9 @@ import importlib
 
 versions = {
     "torch": "2.0.1",
-    "tensorflow": "2.9.0",
-    "numpy": "1.23.2",
-    "jax": "0.3.16",
+    "tensorflow": "2.12.0",
+    "numpy": "1.25.0",
+    "jax": "0.4.12",
     "scipy": "1.10.1",
     "paddle": "2.4.2",
 }

--- a/ivy/functional/frontends/__init__.py
+++ b/ivy/functional/frontends/__init__.py
@@ -7,7 +7,7 @@ versions = {
     "numpy": "1.25.0",
     "jax": "0.4.12",
     "scipy": "1.10.1",
-    "paddle": "2.4.2",
+    "paddle": "2.5.0",
 }
 
 

--- a/ivy/functional/frontends/__init__.py
+++ b/ivy/functional/frontends/__init__.py
@@ -5,7 +5,7 @@ versions = {
     "torch": "2.0.1",
     "tensorflow": "2.12.0",
     "numpy": "1.25.0",
-    "jax": "0.4.12",
+    "jax": "0.4.13",
     "scipy": "1.10.1",
     "paddle": "2.5.0",
 }

--- a/ivy/functional/frontends/jax/nn/non_linear_activations.py
+++ b/ivy/functional/frontends/jax/nn/non_linear_activations.py
@@ -265,7 +265,7 @@ def sigmoid(x):
 
 
 @with_supported_dtypes(
-    {"0.4.12 and below": ("complex", "float")},
+    {"0.4.13 and below": ("complex", "float")},
     "jax",
 )
 @to_ivy_arrays_and_back

--- a/ivy/functional/frontends/jax/numpy/creation.py
+++ b/ivy/functional/frontends/jax/numpy/creation.py
@@ -144,7 +144,7 @@ def full(shape, fill_value, dtype=None):
 @to_ivy_arrays_and_back
 @with_unsupported_dtypes(
     {
-        "0.4.12 and below": (
+        "0.4.13 and below": (
             "float16",
             "bfloat16",
         )
@@ -169,7 +169,7 @@ def meshgrid(*x, copy=True, sparse=False, indexing="xy"):
 @to_ivy_arrays_and_back
 @with_unsupported_dtypes(
     {
-        "0.4.12 and below": (
+        "0.4.13 and below": (
             "float16",
             "bfloat16",
         )

--- a/ivy/functional/frontends/jax/numpy/linalg.py
+++ b/ivy/functional/frontends/jax/numpy/linalg.py
@@ -107,7 +107,7 @@ def tensorsolve(a, b, axes=None):
 
 
 @to_ivy_arrays_and_back
-@with_unsupported_dtypes({"0.4.12 and below": ("float16", "bfloat16")}, "jax")
+@with_unsupported_dtypes({"0.4.13 and below": ("float16", "bfloat16")}, "jax")
 def tensorinv(a, ind=2):
     old_shape = ivy.shape(a)
     prod = 1

--- a/ivy/functional/frontends/jax/numpy/mathematical_functions.py
+++ b/ivy/functional/frontends/jax/numpy/mathematical_functions.py
@@ -385,7 +385,7 @@ def fmin(x1, x2):
 
 
 @with_unsupported_dtypes(
-    {"0.4.12 and below": ("uint16",)},
+    {"0.4.13 and below": ("uint16",)},
     "jax",
 )
 @to_ivy_arrays_and_back
@@ -439,7 +439,7 @@ def sinc(x, /):
 
 @with_unsupported_dtypes(
     {
-        "0.4.12 and below": (
+        "0.4.13 and below": (
             "bfloat16",
             "float16",
         )
@@ -474,7 +474,7 @@ def vdot(a, b):
 
 
 @with_unsupported_dtypes(
-    {"0.4.12 and below": ("bfloat16",)},
+    {"0.4.13 and below": ("bfloat16",)},
     "jax",
 )
 @to_ivy_arrays_and_back
@@ -579,7 +579,7 @@ def polyadd(a1, a2):
 
 
 @with_unsupported_dtypes(
-    {"0.4.12 and below": ("float16",)},
+    {"0.4.13 and below": ("float16",)},
     "jax",
 )
 @to_ivy_arrays_and_back
@@ -599,7 +599,7 @@ def polyder(p, m=1):
 
 
 @with_unsupported_dtypes(
-    {"0.4.12 and below": ("float16",)},
+    {"0.4.13 and below": ("float16",)},
     "jax",
 )
 @to_ivy_arrays_and_back

--- a/ivy/functional/frontends/jax/numpy/searching_sorting.py
+++ b/ivy/functional/frontends/jax/numpy/searching_sorting.py
@@ -15,7 +15,7 @@ from ivy.func_wrapper import (
 @to_ivy_arrays_and_back
 @with_unsupported_dtypes(
     {
-        "0.4.12 and below": (
+        "0.4.13 and below": (
             "float16",
             "bfloat16",
         )

--- a/ivy/functional/frontends/jax/numpy/statistical.py
+++ b/ivy/functional/frontends/jax/numpy/statistical.py
@@ -373,7 +373,7 @@ def nancumprod(a, axis=None, dtype=None, out=None):
 
 
 @handle_jax_dtype
-@with_unsupported_dtypes({"0.4.12 and below": ("bfloat16",)}, "jax")
+@with_unsupported_dtypes({"0.4.13 and below": ("bfloat16",)}, "jax")
 @to_ivy_arrays_and_back
 def std(a, axis=None, dtype=None, out=None, ddof=0, keepdims=False, *, where=None):
     axis = tuple(axis) if isinstance(axis, list) else axis
@@ -445,7 +445,7 @@ def nanmedian(
 
 
 @to_ivy_arrays_and_back
-@with_unsupported_dtypes({"0.4.12 and below": ("float16", "bfloat16")}, "jax")
+@with_unsupported_dtypes({"0.4.13 and below": ("float16", "bfloat16")}, "jax")
 def correlate(a, v, mode="valid", precision=None):
     if ivy.get_num_dims(a) != 1 or ivy.get_num_dims(v) != 1:
         raise ValueError("correlate() only support 1-dimensional inputs.")

--- a/ivy/functional/frontends/jax/random.py
+++ b/ivy/functional/frontends/jax/random.py
@@ -35,7 +35,7 @@ def _get_seed(key):
 @to_ivy_arrays_and_back
 @with_unsupported_dtypes(
     {
-        "0.4.12 and below": (
+        "0.4.13 and below": (
             "float16",
             "bfloat16",
         )
@@ -51,7 +51,7 @@ def beta(key, a, b, shape=None, dtype=None):
 @to_ivy_arrays_and_back
 @with_unsupported_dtypes(
     {
-        "0.4.12 and below": (
+        "0.4.13 and below": (
             "float16",
             "bfloat16",
         )
@@ -75,7 +75,7 @@ def cauchy(key, shape=(), dtype="float64"):
 @handle_jax_dtype
 @to_ivy_arrays_and_back
 @with_unsupported_dtypes(
-    {"0.4.12 and below": ("unsigned", "int8", "int16")},
+    {"0.4.13 and below": ("unsigned", "int8", "int16")},
     "jax",
 )
 def poisson(key, lam, shape=None, dtype=None):
@@ -87,7 +87,7 @@ def poisson(key, lam, shape=None, dtype=None):
 @to_ivy_arrays_and_back
 @with_unsupported_dtypes(
     {
-        "0.4.12 and below": (
+        "0.4.13 and below": (
             "float16",
             "bfloat16",
         )
@@ -103,7 +103,7 @@ def gamma(key, a, shape=None, dtype="float64"):
 @to_ivy_arrays_and_back
 @with_unsupported_dtypes(
     {
-        "0.4.12 and below": (
+        "0.4.13 and below": (
             "float16",
             "bfloat16",
         )
@@ -125,7 +125,7 @@ def gumbel(key, shape=(), dtype="float64"):
 @handle_jax_dtype
 @to_ivy_arrays_and_back
 @with_unsupported_dtypes(
-    {"0.4.12 and below": ("unsigned", "int8", "int16")},
+    {"0.4.13 and below": ("unsigned", "int8", "int16")},
     "jax",
 )
 def rademacher(key, shape, dtype="int64"):
@@ -139,7 +139,7 @@ def rademacher(key, shape, dtype="int64"):
 @to_ivy_arrays_and_back
 @with_unsupported_dtypes(
     {
-        "0.4.12 and below": (
+        "0.4.13 and below": (
             "float16",
             "bfloat16",
         )
@@ -165,7 +165,7 @@ def t(key, df, shape=(), dtype="float64"):
 @handle_jax_dtype
 @to_ivy_arrays_and_back
 @with_unsupported_dtypes(
-    {"0.4.12 and below": ("unsigned", "int8", "int16")},
+    {"0.4.13 and below": ("unsigned", "int8", "int16")},
     "jax",
 )
 def randint(key, shape, minval, maxval, dtype="int64"):

--- a/ivy/functional/frontends/numpy/fft/discrete_fourier_transform.py
+++ b/ivy/functional/frontends/numpy/fft/discrete_fourier_transform.py
@@ -29,7 +29,7 @@ def ifft(a, n=None, axis=-1, norm=None):
 
 
 @to_ivy_arrays_and_back
-@with_unsupported_dtypes({"1.24.3 and below": ("float16",)}, "numpy")
+@with_unsupported_dtypes({"1.25.0 and below": ("float16",)}, "numpy")
 def ifftshift(x, axes=None):
     x = ivy.asarray(x)
 
@@ -55,7 +55,7 @@ def fft(a, n=None, axis=-1, norm=None):
 
 
 @to_ivy_arrays_and_back
-@with_unsupported_dtypes({"1.24.3 and below": ("float16",)}, "numpy")
+@with_unsupported_dtypes({"1.25.0 and below": ("float16",)}, "numpy")
 def fftshift(x, axes=None):
     x = ivy.asarray(x)
 
@@ -75,7 +75,7 @@ def fftshift(x, axes=None):
     return roll
 
 
-@with_unsupported_dtypes({"1.24.3 and below": ("float16",)}, "numpy")
+@with_unsupported_dtypes({"1.25.0 and below": ("float16",)}, "numpy")
 @to_ivy_arrays_and_back
 def rfft(a, n=None, axis=-1, norm=None):
     if norm is None:
@@ -84,7 +84,7 @@ def rfft(a, n=None, axis=-1, norm=None):
     return ivy.dft(a, axis=axis, inverse=False, onesided=True, dft_length=n, norm=norm)
 
 
-@with_unsupported_dtypes({"1.24.3 and below": ("float16",)}, "numpy")
+@with_unsupported_dtypes({"1.25.0 and below": ("float16",)}, "numpy")
 @to_ivy_arrays_and_back
 def ihfft(a, n=None, axis=-1, norm=None):
     if n is None:
@@ -94,7 +94,7 @@ def ihfft(a, n=None, axis=-1, norm=None):
     return output
 
 
-@with_unsupported_dtypes({"1.24.3 and below": ("int",)}, "numpy")
+@with_unsupported_dtypes({"1.25.0 and below": ("int",)}, "numpy")
 @to_ivy_arrays_and_back
 def fftfreq(n, d=1.0):
     if not isinstance(

--- a/ivy/functional/frontends/numpy/linalg/norms_and_other_numbers.py
+++ b/ivy/functional/frontends/numpy/linalg/norms_and_other_numbers.py
@@ -10,7 +10,7 @@ from ivy.func_wrapper import with_unsupported_dtypes
 
 
 # solve
-@with_unsupported_dtypes({"1.24.3 and below": ("float16",)}, "numpy")
+@with_unsupported_dtypes({"1.25.0 and below": ("float16",)}, "numpy")
 @to_ivy_arrays_and_back
 @from_zero_dim_arrays_to_scalar
 def norm(x, ord=None, axis=None, keepdims=False):

--- a/ivy/functional/frontends/numpy/linalg/solving_equations_and_inverting_matrices.py
+++ b/ivy/functional/frontends/numpy/linalg/solving_equations_and_inverting_matrices.py
@@ -10,7 +10,7 @@ from ivy.functional.frontends.numpy.linalg.norms_and_other_numbers import matrix
 
 
 # solve
-@with_unsupported_dtypes({"1.24.3 and below": ("float16",)}, "numpy")
+@with_unsupported_dtypes({"1.25.0 and below": ("float16",)}, "numpy")
 @to_ivy_arrays_and_back
 def solve(a, b):
     a, b = promote_types_of_numpy_inputs(a, b)
@@ -18,7 +18,7 @@ def solve(a, b):
 
 
 # inv
-@with_unsupported_dtypes({"1.24.3 and below": ("float16",)}, "numpy")
+@with_unsupported_dtypes({"1.25.0 and below": ("float16",)}, "numpy")
 @to_ivy_arrays_and_back
 def inv(a):
     return ivy.inv(a)
@@ -26,14 +26,14 @@ def inv(a):
 
 # pinv
 # TODO: add hermitian functionality
-@with_unsupported_dtypes({"1.24.3 and below": ("float16",)}, "numpy")
+@with_unsupported_dtypes({"1.25.0 and below": ("float16",)}, "numpy")
 @to_ivy_arrays_and_back
 def pinv(a, rcond=1e-15, hermitian=False):
     return ivy.pinv(a, rtol=rcond)
 
 
 @to_ivy_arrays_and_back
-@with_unsupported_dtypes({"1.24.3 and below": ("float16", "blfloat16")}, "numpy")
+@with_unsupported_dtypes({"1.25.0 and below": ("float16", "blfloat16")}, "numpy")
 def tensorinv(a, ind=2):
     old_shape = ivy.shape(a)
     prod = 1
@@ -52,7 +52,7 @@ def tensorinv(a, ind=2):
 # TODO: replace this with function from API
 # As the compositon provides unstable results
 @to_ivy_arrays_and_back
-@with_unsupported_dtypes({"1.24.3 and below": ("float16",)}, "numpy")
+@with_unsupported_dtypes({"1.25.0 and below": ("float16",)}, "numpy")
 def lstsq(a, b, rcond="warn"):
     solution = ivy.matmul(
         ivy.pinv(a, rtol=1e-15).astype(ivy.float64), b.astype(ivy.float64)

--- a/ivy/functional/frontends/numpy/mathematical_functions/miscellaneous.py
+++ b/ivy/functional/frontends/numpy/mathematical_functions/miscellaneous.py
@@ -334,7 +334,7 @@ def _lcm(
 @to_ivy_arrays_and_back
 @from_zero_dim_arrays_to_scalar
 @with_supported_dtypes(
-    {"1.24.3 and below": ("int8", "int16", "int32", "int64")}, "numpy"
+    {"1.25.0 and below": ("int8", "int16", "int32", "int64")}, "numpy"
 )  # Add
 def _gcd(
     x1,

--- a/ivy/functional/frontends/numpy/statistics/averages_and_variances.py
+++ b/ivy/functional/frontends/numpy/statistics/averages_and_variances.py
@@ -200,7 +200,7 @@ def cov(
 @handle_numpy_out
 @handle_numpy_dtype
 @to_ivy_arrays_and_back
-@with_unsupported_dtypes({"2.9.0 and below": ("float16", "bfloat16")}, "tensorflow")
+@with_unsupported_dtypes({"2.25.0 and below": ("float16", "bfloat16")}, "tensorflow")
 def nanvar(a, axis=None, dtype=None, out=None, ddof=0, keepdims=False, *, where=True):
     is_nan = ivy.isnan(a)
     axis = tuple(axis) if isinstance(axis, list) else axis

--- a/ivy/functional/frontends/numpy/statistics/histograms.py
+++ b/ivy/functional/frontends/numpy/statistics/histograms.py
@@ -3,7 +3,7 @@ from ivy.functional.frontends.numpy.func_wrapper import to_ivy_arrays_and_back
 from ivy.func_wrapper import with_supported_dtypes
 
 
-@with_supported_dtypes({"1.24.3 and below": ("int64",)}, "numpy")
+@with_supported_dtypes({"1.25.0 and below": ("int64",)}, "numpy")
 @to_ivy_arrays_and_back
 def bincount(x, /, weights=None, minlength=0):
     return ivy.bincount(x, weights=weights, minlength=minlength)

--- a/ivy/functional/frontends/paddle/fft.py
+++ b/ivy/functional/frontends/paddle/fft.py
@@ -7,7 +7,7 @@ from ivy.functional.frontends.paddle.func_wrapper import (
 
 
 @with_supported_dtypes(
-    {"2.4.2 and below": ("complex64", "complex128")},
+    {"2.5.0 and below": ("complex64", "complex128")},
     "paddle",
 )
 @to_ivy_arrays_and_back

--- a/ivy/functional/frontends/paddle/nn/functional/activation.py
+++ b/ivy/functional/frontends/paddle/nn/functional/activation.py
@@ -5,7 +5,7 @@ from ivy.functional.frontends.paddle.func_wrapper import to_ivy_arrays_and_back
 from ivy.functional.frontends.paddle.tensor.math import tanh as paddle_tanh
 
 
-@with_supported_dtypes({"2.4.2 and below": ("float32", "float64")}, "paddle")
+@with_supported_dtypes({"2.5.0 and below": ("float32", "float64")}, "paddle")
 @to_ivy_arrays_and_back
 def selu(
     x,
@@ -29,14 +29,14 @@ def selu(
 tanh = paddle_tanh
 
 
-@with_supported_dtypes({"2.4.2 and below": ("float32", "float64")}, "paddle")
+@with_supported_dtypes({"2.5.0 and below": ("float32", "float64")}, "paddle")
 @to_ivy_arrays_and_back
 def hardshrink(x, threshold=0.5, name=None):
     mask = ivy.logical_or(ivy.greater(x, threshold), ivy.less(x, -threshold))
     return ivy.where(mask, x, 0.0)
 
 
-@with_supported_dtypes({"2.4.2 and below": ("float32", "float64")}, "paddle")
+@with_supported_dtypes({"2.5.0 and below": ("float32", "float64")}, "paddle")
 @to_ivy_arrays_and_back
 def hardswish(x, name=None):
     relu6_val = ivy.relu6(ivy.add(x, 3))
@@ -44,7 +44,7 @@ def hardswish(x, name=None):
     return ret
 
 
-@with_supported_dtypes({"2.4.2 and below": ("float32", "float64")}, "paddle")
+@with_supported_dtypes({"2.5.0 and below": ("float32", "float64")}, "paddle")
 @to_ivy_arrays_and_back
 def hardtanh(
     x,
@@ -59,26 +59,26 @@ def hardtanh(
     return ret
 
 
-@with_supported_dtypes({"2.4.2 and below": ("float32", "float64")}, "paddle")
+@with_supported_dtypes({"2.5.0 and below": ("float32", "float64")}, "paddle")
 @to_ivy_arrays_and_back
 def gelu(x, approximate=False, name=None):
     return ivy.gelu(x, approximate=approximate)
 
 
-@with_supported_dtypes({"2.4.2 and below": ("float32", "float64")}, "paddle")
+@with_supported_dtypes({"2.5.0 and below": ("float32", "float64")}, "paddle")
 @to_ivy_arrays_and_back
 def hardsigmoid(x, slope=0.1666667, offset=0.5, name=None):
     ret = ivy.minimum(ivy.maximum(ivy.add(ivy.multiply(x, slope), offset), 0), 1)
     return ret
 
 
-@with_supported_dtypes({"2.4.2 and below": ("float32", "float64")}, "paddle")
+@with_supported_dtypes({"2.5.0 and below": ("float32", "float64")}, "paddle")
 @to_ivy_arrays_and_back
 def relu6(x, name=None):
     return ivy.relu6(x)
 
 
-@with_supported_dtypes({"2.4.2 and below": ("float32", "float64")}, "paddle")
+@with_supported_dtypes({"2.5.0 and below": ("float32", "float64")}, "paddle")
 @to_ivy_arrays_and_back
 def softshrink(
     x,
@@ -93,7 +93,7 @@ def softshrink(
     return ivy.astype(add, x.dtype)
 
 
-@with_supported_dtypes({"2.4.2 and below": ("float32", "float64")}, "paddle")
+@with_supported_dtypes({"2.5.0 and below": ("float32", "float64")}, "paddle")
 @to_ivy_arrays_and_back
 def softsign(
     x,
@@ -104,7 +104,7 @@ def softsign(
     return ivy.divide(x, ivy.add(1, ivy.abs(x)))
 
 
-@with_supported_dtypes({"2.4.2 and below": ("float32", "float64")}, "paddle")
+@with_supported_dtypes({"2.5.0 and below": ("float32", "float64")}, "paddle")
 @to_ivy_arrays_and_back
 def log_softmax(x, axis=-1, dtype=None, name=None):
     x = ivy.astype(x, dtype) if dtype else x
@@ -113,13 +113,13 @@ def log_softmax(x, axis=-1, dtype=None, name=None):
     return ret
 
 
-@with_supported_dtypes({"2.4.2 and below": ("float32", "float64")}, "paddle")
+@with_supported_dtypes({"2.5.0 and below": ("float32", "float64")}, "paddle")
 @to_ivy_arrays_and_back
 def prelu(x, weight, data_format="NCHW", name=None):
     return ivy.add(ivy.maximum(0, x), ivy.multiply(weight, ivy.minimum(0, x)))
 
 
-@with_supported_dtypes({"2.4.2 and below": ("float32", "float64")}, "paddle")
+@with_supported_dtypes({"2.5.0 and below": ("float32", "float64")}, "paddle")
 @to_ivy_arrays_and_back
 def celu(
     x,
@@ -133,7 +133,7 @@ def celu(
     return ret
 
 
-@with_supported_dtypes({"2.4.2 and below": ("float32", "float64")}, "paddle")
+@with_supported_dtypes({"2.5.0 and below": ("float32", "float64")}, "paddle")
 @to_ivy_arrays_and_back
 def rrelu(
     x,
@@ -174,7 +174,7 @@ def rrelu(
     # return ret.astype(x.dtype)
 
 
-@with_supported_dtypes({"2.4.2 and below": ("float32", "float64")}, "paddle")
+@with_supported_dtypes({"2.5.0 and below": ("float32", "float64")}, "paddle")
 @to_ivy_arrays_and_back
 def tanhshrink(
     x,
@@ -185,7 +185,7 @@ def tanhshrink(
     return ivy.subtract(x, ivy.tanh(x))
 
 
-@with_supported_dtypes({"2.4.2 and below": ("float32", "float64")}, "paddle")
+@with_supported_dtypes({"2.5.0 and below": ("float32", "float64")}, "paddle")
 @to_ivy_arrays_and_back
 def relu_(x, name=None):
     ret = ivy.relu(x)
@@ -193,7 +193,7 @@ def relu_(x, name=None):
     return x
 
 
-@with_supported_dtypes({"2.4.2 and below": ("float32", "float64")}, "paddle")
+@with_supported_dtypes({"2.5.0 and below": ("float32", "float64")}, "paddle")
 @to_ivy_arrays_and_back
 def mish(x, name=None):
     return ivy.mish(x)

--- a/ivy/functional/frontends/paddle/nn/functional/common.py
+++ b/ivy/functional/frontends/paddle/nn/functional/common.py
@@ -4,7 +4,7 @@ from ivy.functional.frontends.paddle.func_wrapper import to_ivy_arrays_and_back
 from ivy.func_wrapper import with_supported_dtypes
 
 
-@with_supported_dtypes({"2.4.2 and below": ("float32", "float64")}, "paddle")
+@with_supported_dtypes({"2.5.0 and below": ("float32", "float64")}, "paddle")
 @to_ivy_arrays_and_back
 def cosine_similarity(x1, x2, *, axis=1, eps=1e-08):
     if len(x1.shape) == len(x2.shape) and len(x2.shape) >= 2:

--- a/ivy/functional/frontends/paddle/nn/functional/loss.py
+++ b/ivy/functional/frontends/paddle/nn/functional/loss.py
@@ -23,7 +23,7 @@ def _get_reduction_func(reduction):
 
 
 @with_supported_dtypes(
-    {"2.4.2 and below": ("float32",)},
+    {"2.5.0 and below": ("float32",)},
     "paddle",
 )
 @inputs_to_ivy_arrays

--- a/ivy/functional/frontends/paddle/tensor/creation.py
+++ b/ivy/functional/frontends/paddle/tensor/creation.py
@@ -13,7 +13,7 @@ def to_tensor(data, /, *, dtype=None, place=None, stop_gradient=True):
     return Tensor(array, dtype=dtype, place=place)
 
 
-@with_unsupported_dtypes({"2.4.2 and below": "int8"}, "paddle")
+@with_unsupported_dtypes({"2.5.0 and below": "int8"}, "paddle")
 @to_ivy_arrays_and_back
 def ones(shape, /, *, dtype=None, name=None):
     dtype = "float32" if dtype is None else dtype
@@ -21,7 +21,7 @@ def ones(shape, /, *, dtype=None, name=None):
 
 
 @with_unsupported_dtypes(
-    {"2.4.2 and below": ("uint8", "int8", "complex64", "complex128")}, "paddle"
+    {"2.5.0 and below": ("uint8", "int8", "complex64", "complex128")}, "paddle"
 )
 @to_ivy_arrays_and_back
 def ones_like(x, /, *, dtype=None, name=None):
@@ -29,7 +29,7 @@ def ones_like(x, /, *, dtype=None, name=None):
     return ivy.ones_like(x, dtype=dtype)
 
 
-@with_unsupported_dtypes({"2.4.2 and below": "int8"}, "paddle")
+@with_unsupported_dtypes({"2.5.0 and below": "int8"}, "paddle")
 @to_ivy_arrays_and_back
 def zeros(shape, /, *, dtype=None, name=None):
     dtype = "float32" if dtype is None else dtype
@@ -37,7 +37,7 @@ def zeros(shape, /, *, dtype=None, name=None):
 
 
 @with_unsupported_dtypes(
-    {"2.4.2 and below": ("uint8", "int8", "complex64", "complex128")}, "paddle"
+    {"2.5.0 and below": ("uint8", "int8", "complex64", "complex128")}, "paddle"
 )
 @to_ivy_arrays_and_back
 def zeros_like(x, /, *, dtype=None, name=None):
@@ -57,7 +57,7 @@ def full_like(x, fill_value, /, *, dtype=None, name=None):
     return ivy.full_like(x, fill_value, dtype=dtype)
 
 
-@with_unsupported_dtypes({"2.4.2 and below": ("float16", "bfloat16")}, "paddle")
+@with_unsupported_dtypes({"2.5.0 and below": ("float16", "bfloat16")}, "paddle")
 @to_ivy_arrays_and_back
 def arange(start, end=None, step=1, dtype=None, name=None):
     return ivy.arange(start, end, step=step, dtype=dtype)

--- a/ivy/functional/frontends/paddle/tensor/linalg.py
+++ b/ivy/functional/frontends/paddle/tensor/linalg.py
@@ -8,7 +8,7 @@ from ivy.functional.frontends.paddle.func_wrapper import (
 
 
 @with_supported_dtypes(
-    {"2.4.2 and below": ("float32", "float64", "int32", "int64")}, "paddle"
+    {"2.5.0 and below": ("float32", "float64", "int32", "int64")}, "paddle"
 )
 @to_ivy_arrays_and_back
 def cross(x, y, /, *, axis=9, name=None):
@@ -17,7 +17,7 @@ def cross(x, y, /, *, axis=9, name=None):
 
 
 # matmul
-@with_unsupported_dtypes({"2.4.2 and below": ("float16", "bfloat16")}, "paddle")
+@with_unsupported_dtypes({"2.5.0 and below": ("float16", "bfloat16")}, "paddle")
 @to_ivy_arrays_and_back
 def matmul(x, y, transpose_x=False, transpose_y=False, name=None):
     x, y = promote_types_of_paddle_inputs(x, y)
@@ -25,7 +25,7 @@ def matmul(x, y, transpose_x=False, transpose_y=False, name=None):
 
 
 # norm
-@with_supported_dtypes({"2.4.2 and below": ("float32", "float64")}, "paddle")
+@with_supported_dtypes({"2.5.0 and below": ("float32", "float64")}, "paddle")
 @to_ivy_arrays_and_back
 def norm(x, p="fro", axis=None, keepdim=False, name=None):
     if axis is None and p is not None:
@@ -108,7 +108,7 @@ def eigh(x, UPLO="L", name=None):
 
 
 # pinv
-@with_unsupported_dtypes({"2.4.2 and below": ("float16", "bfloat16")}, "paddle")
+@with_unsupported_dtypes({"2.5.0 and below": ("float16", "bfloat16")}, "paddle")
 @to_ivy_arrays_and_back
 def pinv(x, rcond=1e-15, hermitian=False, name=None):
     # TODO: Add hermitian functionality
@@ -116,21 +116,21 @@ def pinv(x, rcond=1e-15, hermitian=False, name=None):
 
 
 # solve
-@with_unsupported_dtypes({"2.4.2 and below": ("float16", "bfloat16")}, "paddle")
+@with_unsupported_dtypes({"2.5.0 and below": ("float16", "bfloat16")}, "paddle")
 @to_ivy_arrays_and_back
 def solve(x1, x2, name=None):
     return ivy.solve(x1, x2)
 
 
 # cholesky
-@with_supported_dtypes({"2.4.2 and below": ("float32", "float64")}, "paddle")
+@with_supported_dtypes({"2.5.0 and below": ("float32", "float64")}, "paddle")
 @to_ivy_arrays_and_back
 def cholesky(x, /, *, upper=False, name=None):
     return ivy.cholesky(x, upper=upper)
 
 
 # bmm
-@with_unsupported_dtypes({"2.4.2 and below": ("float16", "bfloat16")}, "paddle")
+@with_unsupported_dtypes({"2.5.0 and below": ("float16", "bfloat16")}, "paddle")
 @to_ivy_arrays_and_back
 def bmm(x, y, transpose_x=False, transpose_y=False, name=None):
     if len(ivy.shape(x)) != 3 or len(ivy.shape(y)) != 3:
@@ -140,7 +140,7 @@ def bmm(x, y, transpose_x=False, transpose_y=False, name=None):
 
 
 # matrix_power
-@with_unsupported_dtypes({"2.4.2 and below": ("float16", "bfloat16")}, "paddle")
+@with_unsupported_dtypes({"2.5.0 and below": ("float16", "bfloat16")}, "paddle")
 @to_ivy_arrays_and_back
 def matrix_power(x, n, name=None):
     return ivy.matrix_power(x, n)

--- a/ivy/functional/frontends/paddle/tensor/logic.py
+++ b/ivy/functional/frontends/paddle/tensor/logic.py
@@ -12,7 +12,7 @@ from ivy.functional.frontends.paddle.func_wrapper import (
 
 
 @with_unsupported_dtypes(
-    {"2.4.2 and below": ("uint8", "int8", "int16", "complex64", "complex128")}, "paddle"
+    {"2.5.0 and below": ("uint8", "int8", "int16", "complex64", "complex128")}, "paddle"
 )
 @to_ivy_arrays_and_back
 def equal(x, y, /, *, name=None):
@@ -20,7 +20,7 @@ def equal(x, y, /, *, name=None):
 
 
 @with_unsupported_dtypes(
-    {"2.4.2 and below": ("uint8", "int8", "int16", "complex64", "complex128")}, "paddle"
+    {"2.5.0 and below": ("uint8", "int8", "int16", "complex64", "complex128")}, "paddle"
 )
 @to_ivy_arrays_and_back
 def not_equal(x, y, /, *, name=None):
@@ -29,7 +29,7 @@ def not_equal(x, y, /, *, name=None):
 
 @with_unsupported_dtypes(
     {
-        "2.4.2 and below": (
+        "2.5.0 and below": (
             "uint8",
             "int8",
             "int16",
@@ -46,7 +46,7 @@ def equal_all(x, y, /, *, name=None):
 
 
 @with_unsupported_dtypes(
-    {"2.4.2 and below": ("bool", "uint8", "int8", "int16", "complex64", "complex128")},
+    {"2.5.0 and below": ("bool", "uint8", "int8", "int16", "complex64", "complex128")},
     "paddle",
 )
 @to_ivy_arrays_and_back
@@ -55,7 +55,7 @@ def greater_than(x, y, /, *, name=None):
 
 
 @with_unsupported_dtypes(
-    {"2.4.2 and below": ("bool", "uint8", "int8", "int16", "complex64", "complex128")},
+    {"2.5.0 and below": ("bool", "uint8", "int8", "int16", "complex64", "complex128")},
     "paddle",
 )
 @to_ivy_arrays_and_back
@@ -64,7 +64,7 @@ def greater_equal(x, y, /, *, name=None):
 
 
 @with_unsupported_dtypes(
-    {"2.4.2 and below": ("bool", "uint8", "int8", "int16", "complex64", "complex128")},
+    {"2.5.0 and below": ("bool", "uint8", "int8", "int16", "complex64", "complex128")},
     "paddle",
 )
 @to_ivy_arrays_and_back
@@ -73,7 +73,7 @@ def less_than(x, y, /, *, name=None):
 
 
 @with_unsupported_dtypes(
-    {"2.4.2 and below": ("bool", "uint8", "int8", "int16", "complex64", "complex128")},
+    {"2.5.0 and below": ("bool", "uint8", "int8", "int16", "complex64", "complex128")},
     "paddle",
 )
 @to_ivy_arrays_and_back
@@ -83,7 +83,7 @@ def less_equal(x, y, /, *, name=None):
 
 @with_supported_dtypes(
     {
-        "2.4.2 and below": (
+        "2.5.0 and below": (
             "bool",
             "int8",
             "int16",
@@ -103,7 +103,7 @@ def logical_or(x, y, /, *, name=None, out=None):
 
 @with_supported_dtypes(
     {
-        "2.4.2 and below": (
+        "2.5.0 and below": (
             "bool",
             "int8",
             "int16",
@@ -123,7 +123,7 @@ def logical_xor(x, y, /, *, name=None, out=None):
 
 @with_supported_dtypes(
     {
-        "2.4.2 and below": (
+        "2.5.0 and below": (
             "bool",
             "int8",
             "int16",
@@ -143,7 +143,7 @@ def logical_not(x, /, *, name=None, out=None):
 
 @with_supported_dtypes(
     {
-        "2.4.2 and below": (
+        "2.5.0 and below": (
             "bool",
             "uint8",
             "int8",
@@ -162,7 +162,7 @@ def bitwise_or(x, y, name=None, out=None):
 
 @with_supported_dtypes(
     {
-        "2.4.2 and below": (
+        "2.5.0 and below": (
             "bool",
             "uint8",
             "int8",
@@ -181,7 +181,7 @@ def bitwise_and(x, y, /, *, name=None, out=None):
 
 @with_supported_dtypes(
     {
-        "2.4.2 and below": (
+        "2.5.0 and below": (
             "bool",
             "uint8",
             "int8",
@@ -200,7 +200,7 @@ def bitwise_xor(x, y, /, *, name=None, out=None):
 
 @with_supported_dtypes(
     {
-        "2.4.2 and below": (
+        "2.5.0 and below": (
             "float32",
             "float64",
             "bool",
@@ -227,7 +227,7 @@ def is_tensor(x):
 
 @with_supported_dtypes(
     {
-        "2.4.2 and below": (
+        "2.5.0 and below": (
             "float32",
             "float64",
         )

--- a/ivy/functional/frontends/paddle/tensor/manipulation.py
+++ b/ivy/functional/frontends/paddle/tensor/manipulation.py
@@ -11,7 +11,7 @@ def reshape(x, shape):
     return ivy.reshape(x, shape)
 
 
-@with_unsupported_dtypes({"2.4.2 and below": ("float16", "bfloat16")}, "paddle")
+@with_unsupported_dtypes({"2.5.0 and below": ("float16", "bfloat16")}, "paddle")
 @to_ivy_arrays_and_back
 def abs(x, name=None):
     return ivy.abs(x)
@@ -25,14 +25,14 @@ def stack(x, axis=0, name=None):
     return ivy.stack(x, axis=axis)
 
 
-@with_unsupported_dtypes({"2.4.2 and below": ("int8", "int16")}, "paddle")
+@with_unsupported_dtypes({"2.5.0 and below": ("int8", "int16")}, "paddle")
 @to_ivy_arrays_and_back
 def concat(x, axis, name=None):
     return ivy.concat(x, axis=axis)
 
 
 @with_unsupported_dtypes(
-    {"2.4.2 and below": ("int8", "uint8", "int16", "float16")},
+    {"2.5.0 and below": ("int8", "uint8", "int16", "float16")},
     "paddle",
 )
 @to_ivy_arrays_and_back

--- a/ivy/functional/frontends/paddle/tensor/math.py
+++ b/ivy/functional/frontends/paddle/tensor/math.py
@@ -6,183 +6,183 @@ from ivy.functional.frontends.paddle.func_wrapper import (
 )
 
 
-@with_unsupported_dtypes({"2.4.2 and below": ("float16", "bfloat16")}, "paddle")
+@with_unsupported_dtypes({"2.5.0 and below": ("float16", "bfloat16")}, "paddle")
 @to_ivy_arrays_and_back
 def sin(x, name=None):
     return ivy.sin(x)
 
 
-@with_unsupported_dtypes({"2.4.2 and below": ("float16", "bfloat16")}, "paddle")
+@with_unsupported_dtypes({"2.5.0 and below": ("float16", "bfloat16")}, "paddle")
 @to_ivy_arrays_and_back
 def cos(x, name=None):
     return ivy.cos(x)
 
 
-@with_unsupported_dtypes({"2.4.2 and below": ("float16", "bfloat16")}, "paddle")
+@with_unsupported_dtypes({"2.5.0 and below": ("float16", "bfloat16")}, "paddle")
 @to_ivy_arrays_and_back
 def acos(x, name=None):
     return ivy.acos(x)
 
 
-@with_unsupported_dtypes({"2.4.2 and below": ("float16", "bfloat16")}, "paddle")
+@with_unsupported_dtypes({"2.5.0 and below": ("float16", "bfloat16")}, "paddle")
 @to_ivy_arrays_and_back
 def cosh(x, name=None):
     return ivy.cosh(x)
 
 
-@with_supported_dtypes({"2.4.2 and below": ("float32", "float64")}, "paddle")
+@with_supported_dtypes({"2.5.0 and below": ("float32", "float64")}, "paddle")
 @to_ivy_arrays_and_back
 def tanh(x, name=None):
     return ivy.tanh(x)
 
 
-@with_unsupported_dtypes({"2.4.2 and below": ("float16", "bfloat16")}, "paddle")
+@with_unsupported_dtypes({"2.5.0 and below": ("float16", "bfloat16")}, "paddle")
 @to_ivy_arrays_and_back
 def acosh(x, name=None):
     return ivy.acosh(x)
 
 
-@with_supported_dtypes({"2.4.2 and below": ("float32", "float64")}, "paddle")
+@with_supported_dtypes({"2.5.0 and below": ("float32", "float64")}, "paddle")
 @to_ivy_arrays_and_back
 def asin(x, name=None):
     return ivy.asin(x)
 
 
-@with_unsupported_dtypes({"2.4.2 and below": ("float16", "bfloat16")}, "paddle")
+@with_unsupported_dtypes({"2.5.0 and below": ("float16", "bfloat16")}, "paddle")
 @to_ivy_arrays_and_back
 def log(x, name=None):
     return ivy.log(x)
 
 
-@with_unsupported_dtypes({"2.4.2 and below": ("float16", "bfloat16")}, "paddle")
+@with_unsupported_dtypes({"2.5.0 and below": ("float16", "bfloat16")}, "paddle")
 @to_ivy_arrays_and_back
 def divide(x, y, name=None):
     return ivy.divide(x, y)
 
 
-@with_unsupported_dtypes({"2.4.2 and below": ("float16", "bfloat16")}, "paddle")
+@with_unsupported_dtypes({"2.5.0 and below": ("float16", "bfloat16")}, "paddle")
 @to_ivy_arrays_and_back
 def abs(x, name=None):
     return ivy.abs(x)
 
 
-@with_unsupported_dtypes({"2.4.2 and below": ("float16", "bfloat16")}, "paddle")
+@with_unsupported_dtypes({"2.5.0 and below": ("float16", "bfloat16")}, "paddle")
 @to_ivy_arrays_and_back
 def multiply(x, y, name=None):
     return ivy.multiply(x, y)
 
 
 @with_unsupported_dtypes(
-    {"2.4.2 and below": ("bool", "unsigned", "int8", "float16", "bfloat16")}, "paddle"
+    {"2.5.0 and below": ("bool", "unsigned", "int8", "float16", "bfloat16")}, "paddle"
 )
 @to_ivy_arrays_and_back
 def add(x, y, name=None):
     return ivy.add(x, y)
 
 
-@with_unsupported_dtypes({"2.4.2 and below": ("float16", "bfloat16")}, "paddle")
+@with_unsupported_dtypes({"2.5.0 and below": ("float16", "bfloat16")}, "paddle")
 @to_ivy_arrays_and_back
 def subtract(x, y, name=None):
     return ivy.subtract(x, y)
 
 
-@with_supported_dtypes({"2.4.2 and below": ("float32", "float64")}, "paddle")
+@with_supported_dtypes({"2.5.0 and below": ("float32", "float64")}, "paddle")
 @to_ivy_arrays_and_back
 def sqrt(x, name=None):
     return ivy.sqrt(x)
 
 
-@with_unsupported_dtypes({"2.4.2 and below": ("float16", "bfloat16")}, "paddle")
+@with_unsupported_dtypes({"2.5.0 and below": ("float16", "bfloat16")}, "paddle")
 @to_ivy_arrays_and_back
 def atanh(x, name=None):
     return ivy.atanh(x)
 
 
-@with_unsupported_dtypes({"2.4.2 and below": ("float16", "bfloat16")}, "paddle")
+@with_unsupported_dtypes({"2.5.0 and below": ("float16", "bfloat16")}, "paddle")
 @to_ivy_arrays_and_back
 def atan(x, name=None):
     return ivy.atan(x)
 
 
-@with_unsupported_dtypes({"2.4.2 and below": ("float16", "bfloat16")}, "paddle")
+@with_unsupported_dtypes({"2.5.0 and below": ("float16", "bfloat16")}, "paddle")
 @to_ivy_arrays_and_back
 def round(x, name=None):
     return ivy.round(x)
 
 
-@with_unsupported_dtypes({"2.4.2 and below": ("float16", "bfloat16")}, "paddle")
+@with_unsupported_dtypes({"2.5.0 and below": ("float16", "bfloat16")}, "paddle")
 @to_ivy_arrays_and_back
 def ceil(x, name=None):
     return ivy.ceil(x)
 
 
-@with_supported_dtypes({"2.4.2 and below": ("float32", "float64")}, "paddle")
+@with_supported_dtypes({"2.5.0 and below": ("float32", "float64")}, "paddle")
 @to_ivy_arrays_and_back
 def sinh(x, name=None):
     return ivy.sinh(x)
 
 
-@with_unsupported_dtypes({"2.4.2 and below": ("float16", "bfloat16")}, "paddle")
+@with_unsupported_dtypes({"2.5.0 and below": ("float16", "bfloat16")}, "paddle")
 @to_ivy_arrays_and_back
 def pow(x, y, name=None):
     return ivy.pow(x, y)
 
 
-@with_unsupported_dtypes({"2.4.2 and below": ("float16", "bfloat16")}, "paddle")
+@with_unsupported_dtypes({"2.5.0 and below": ("float16", "bfloat16")}, "paddle")
 @to_ivy_arrays_and_back
 def floor(x, name=None):
     return ivy.floor(x)
 
 
-@with_unsupported_dtypes({"2.4.2 and below": ("float16", "bfloat16")}, "paddle")
+@with_unsupported_dtypes({"2.5.0 and below": ("float16", "bfloat16")}, "paddle")
 @to_ivy_arrays_and_back
 def remainder(x, y, name=None):
     return ivy.remainder(x, y)
 
 
-@with_unsupported_dtypes({"2.4.2 and below": ("float16", "bfloat16")}, "paddle")
+@with_unsupported_dtypes({"2.5.0 and below": ("float16", "bfloat16")}, "paddle")
 @to_ivy_arrays_and_back
 def log2(x, name=None):
     return ivy.log2(x)
 
 
-@with_unsupported_dtypes({"2.4.2 and below": ("float16", "bfloat16")}, "paddle")
+@with_unsupported_dtypes({"2.5.0 and below": ("float16", "bfloat16")}, "paddle")
 @to_ivy_arrays_and_back
 def log1p(x, name=None):
     return ivy.log1p(x)
 
 
-@with_unsupported_dtypes({"2.4.2 and below": ("float16", "bfloat16")}, "paddle")
+@with_unsupported_dtypes({"2.5.0 and below": ("float16", "bfloat16")}, "paddle")
 @to_ivy_arrays_and_back
 def rad2deg(x, name=None):
     return ivy.rad2deg(x)
 
 
-@with_unsupported_dtypes({"2.4.2 and below": ("float16", "bfloat16")}, "paddle")
+@with_unsupported_dtypes({"2.5.0 and below": ("float16", "bfloat16")}, "paddle")
 @to_ivy_arrays_and_back
 def deg2rad(x, name=None):
     return ivy.deg2rad(x)
 
 
-@with_unsupported_dtypes({"2.4.2 and below": ("float16", "bfloat16")}, "paddle")
+@with_unsupported_dtypes({"2.5.0 and below": ("float16", "bfloat16")}, "paddle")
 @to_ivy_arrays_and_back
 def tan(x, name=None):
     return ivy.tan(x)
 
 
-@with_supported_dtypes({"2.4.2 and below": ("float32", "float64")}, "paddle")
+@with_supported_dtypes({"2.5.0 and below": ("float32", "float64")}, "paddle")
 @to_ivy_arrays_and_back
 def square(x, name=None):
     return ivy.square(x)
 
 
-@with_unsupported_dtypes({"2.4.2 and below": ("float16", "bfloat16")}, "paddle")
+@with_unsupported_dtypes({"2.5.0 and below": ("float16", "bfloat16")}, "paddle")
 @to_ivy_arrays_and_back
 def neg(x, name=None):
     return ivy.negative(x)
 
 
-@with_supported_dtypes({"2.4.2 and below": ("float32", "float64")}, "paddle")
+@with_supported_dtypes({"2.5.0 and below": ("float32", "float64")}, "paddle")
 @to_ivy_arrays_and_back
 def exp(x, name=None):
     return ivy.exp(x)

--- a/ivy/functional/frontends/paddle/tensor/random.py
+++ b/ivy/functional/frontends/paddle/tensor/random.py
@@ -7,7 +7,7 @@ from ivy.functional.frontends.paddle.func_wrapper import (
 
 
 @with_supported_dtypes(
-    {"2.4.2 and below": ("float32", "float64")},
+    {"2.5.0 and below": ("float32", "float64")},
     "paddle",
 )
 @to_ivy_arrays_and_back
@@ -21,7 +21,7 @@ def randint(low=0, high=None, shape=[1], dtype=None, name=None):
 
 
 @with_supported_dtypes(
-    {"2.4.2 and below": ("float32", "float64")},
+    {"2.5.0 and below": ("float32", "float64")},
     "paddle",
 )
 @to_ivy_arrays_and_back

--- a/ivy/functional/frontends/paddle/tensor/search.py
+++ b/ivy/functional/frontends/paddle/tensor/search.py
@@ -7,7 +7,7 @@ from ivy.functional.frontends.paddle.func_wrapper import (
 
 
 @with_supported_dtypes(
-    {"2.4.2 and below": ("float32", "float64", "int16", "int32", "int64", "uint8")},
+    {"2.5.0 and below": ("float32", "float64", "int16", "int32", "int64", "uint8")},
     "paddle",
 )
 @to_ivy_arrays_and_back
@@ -16,7 +16,7 @@ def argmax(x, /, *, axis=None, keepdim=False, dtype="int64", name=None):
 
 
 @with_supported_dtypes(
-    {"2.4.2 and below": ("float32", "float64", "int16", "int32", "int64", "uint8")},
+    {"2.5.0 and below": ("float32", "float64", "int16", "int32", "int64", "uint8")},
     "paddle",
 )
 @to_ivy_arrays_and_back

--- a/ivy/functional/frontends/paddle/tensor/stat.py
+++ b/ivy/functional/frontends/paddle/tensor/stat.py
@@ -6,7 +6,7 @@ from ivy.functional.frontends.paddle.func_wrapper import (
 )
 
 
-@with_unsupported_dtypes({"2.4.2 and below": ("float16", "bfloat16")}, "paddle")
+@with_unsupported_dtypes({"2.5.0 and below": ("float16", "bfloat16")}, "paddle")
 @to_ivy_arrays_and_back
 def mean(input, axis=None, keepdim=False, out=None):
     ret = ivy.mean(input, axis=axis, keepdims=keepdim, out=out)
@@ -14,7 +14,7 @@ def mean(input, axis=None, keepdim=False, out=None):
     return ret
 
 
-@with_unsupported_dtypes({"2.4.2 and below": ("complex", "int8")}, "paddle")
+@with_unsupported_dtypes({"2.5.0 and below": ("complex", "int8")}, "paddle")
 @to_ivy_arrays_and_back
 def numel(x, name=None):
     prod = ivy.prod(x.size, dtype=ivy.int64)

--- a/ivy/functional/frontends/paddle/tensor/tensor.py
+++ b/ivy/functional/frontends/paddle/tensor/tensor.py
@@ -94,72 +94,72 @@ class Tensor:
     def dim(self):
         return self.ivy_array.ndim
 
-    @with_unsupported_dtypes({"2.4.2 and below": ("float16", "bfloat16")}, "paddle")
+    @with_unsupported_dtypes({"2.5.0 and below": ("float16", "bfloat16")}, "paddle")
     def abs(self):
         return paddle_frontend.abs(self)
 
-    @with_unsupported_dtypes({"2.4.2 and below": ("float16", "bfloat16")}, "paddle")
+    @with_unsupported_dtypes({"2.5.0 and below": ("float16", "bfloat16")}, "paddle")
     def ceil(self):
         return paddle_frontend.ceil(self)
 
-    @with_unsupported_dtypes({"2.4.2 and below": ("float16",)}, "paddle")
+    @with_unsupported_dtypes({"2.5.0 and below": ("float16",)}, "paddle")
     def asinh(self, name=None):
         return ivy.asinh(self._ivy_array)
 
-    @with_supported_dtypes({"2.4.2 and below": ("float32", "float64")}, "paddle")
+    @with_supported_dtypes({"2.5.0 and below": ("float32", "float64")}, "paddle")
     def asin(self, name=None):
         return ivy.asin(self._ivy_array)
 
-    @with_supported_dtypes({"2.4.2 and below": ("float32", "float64")}, "paddle")
+    @with_supported_dtypes({"2.5.0 and below": ("float32", "float64")}, "paddle")
     def log(self, name=None):
         return ivy.log(self._ivy_array)
 
-    @with_supported_dtypes({"2.4.2 and below": ("float32", "float64")}, "paddle")
+    @with_supported_dtypes({"2.5.0 and below": ("float32", "float64")}, "paddle")
     def sin(self, name=None):
         return ivy.sin(self._ivy_array)
 
-    @with_supported_dtypes({"2.4.2 and below": ("float32", "float64")}, "paddle")
+    @with_supported_dtypes({"2.5.0 and below": ("float32", "float64")}, "paddle")
     def sinh(self, name=None):
         return ivy.sinh(self._ivy_array)
 
-    @with_unsupported_dtypes({"2.4.2 and below": ("float16", "bfloat16")}, "paddle")
+    @with_unsupported_dtypes({"2.5.0 and below": ("float16", "bfloat16")}, "paddle")
     def argmax(self, axis=None, keepdim=False, dtype=None, name=None):
         return ivy.argmax(self._ivy_array, axis=axis, keepdims=keepdim, dtype=dtype)
 
-    @with_supported_dtypes({"2.4.2 and below": ("float32", "float64")}, "paddle")
+    @with_supported_dtypes({"2.5.0 and below": ("float32", "float64")}, "paddle")
     def sqrt(self, name=None):
         return ivy.sqrt(self._ivy_array)
 
-    @with_supported_dtypes({"2.4.2 and below": ("float32", "float64")}, "paddle")
+    @with_supported_dtypes({"2.5.0 and below": ("float32", "float64")}, "paddle")
     def cos(self, name=None):
         return ivy.cos(self._ivy_array)
 
-    @with_unsupported_dtypes({"2.4.2 and below": ("float16", "bfloat16")}, "paddle")
+    @with_unsupported_dtypes({"2.5.0 and below": ("float16", "bfloat16")}, "paddle")
     def exp(self, name=None):
         return ivy.exp(self._ivy_array)
 
-    @with_supported_dtypes({"2.4.2 and below": ("float32", "float64")}, "paddle")
+    @with_supported_dtypes({"2.5.0 and below": ("float32", "float64")}, "paddle")
     def erf(self, name=None):
         return ivy.erf(self._ivy_array)
 
-    @with_unsupported_dtypes({"2.4.2 and below": ("float16", "bfloat16")}, "paddle")
+    @with_unsupported_dtypes({"2.5.0 and below": ("float16", "bfloat16")}, "paddle")
     def subtract(self, y, name=None):
         y_ivy = _to_ivy_array(y)
         return ivy.subtract(self._ivy_array, y_ivy)
 
-    @with_unsupported_dtypes({"2.4.2 and below": ("float16", "bfloat16")}, "paddle")
+    @with_unsupported_dtypes({"2.5.0 and below": ("float16", "bfloat16")}, "paddle")
     def log10(self, name=None):
         return ivy.log10(self._ivy_array)
 
-    @with_unsupported_dtypes({"2.4.2 and below": ("float16", "bfloat16")}, "paddle")
+    @with_unsupported_dtypes({"2.5.0 and below": ("float16", "bfloat16")}, "paddle")
     def argsort(self, axis=-1, descending=False, name=None):
         return ivy.argsort(self._ivy_array, axis=axis, descending=descending)
 
-    @with_unsupported_dtypes({"2.4.2 and below": ("float16", "bfloat16")}, "paddle")
+    @with_unsupported_dtypes({"2.5.0 and below": ("float16", "bfloat16")}, "paddle")
     def floor(self, name=None):
         return ivy.floor(self._ivy_array)
 
-    @with_supported_dtypes({"2.4.2 and below": ("float32", "float64")}, "paddle")
+    @with_supported_dtypes({"2.5.0 and below": ("float32", "float64")}, "paddle")
     def tanh(self, name=None):
         return ivy.tanh(self._ivy_array)
 
@@ -168,35 +168,35 @@ class Tensor:
         return ivy.add(self._ivy_array)
 
     @with_supported_dtypes(
-        {"2.4.2 and below": ("float16", "float32", "float64", "int32", "int64")},
+        {"2.5.0 and below": ("float16", "float32", "float64", "int32", "int64")},
         "paddle",
     )
     def isinf(self, name=None):
         return ivy.isinf(self._ivy_array)
 
-    @with_supported_dtypes({"2.4.2 and below": ("float32", "float64")}, "paddle")
+    @with_supported_dtypes({"2.5.0 and below": ("float32", "float64")}, "paddle")
     def square(self, name=None):
         return ivy.square(self._ivy_array)
 
-    @with_supported_dtypes({"2.4.2 and below": ("float32", "float64")}, "paddle")
+    @with_supported_dtypes({"2.5.0 and below": ("float32", "float64")}, "paddle")
     def cholesky(self, upper=False, name=None):
         return ivy.cholesky(self._ivy_array, upper=upper)
 
-    @with_unsupported_dtypes({"2.4.2 and below": ("float16", "bfloat16")}, "paddle")
+    @with_unsupported_dtypes({"2.5.0 and below": ("float16", "bfloat16")}, "paddle")
     def multiply(self, y, name=None):
         return paddle_frontend.multiply(self, y)
 
     @with_supported_dtypes(
-        {"2.4.2 and below": ("float16", "float32", "float64", "int32", "int64")},
+        {"2.5.0 and below": ("float16", "float32", "float64", "int32", "int64")},
         "paddle",
     )
     def isfinite(self, name=None):
         return ivy.isfinite(self._ivy_array)
 
-    @with_supported_dtypes({"2.4.2 and below": ("float16", "bfloat16")}, "paddle")
+    @with_supported_dtypes({"2.5.0 and below": ("float16", "bfloat16")}, "paddle")
     def all(self, axis=None, keepdim=False, dtype=None, name=None):
         return ivy.all(self.ivy_array, axis=axis, keepdims=keepdim, dtype=dtype)
 
-    @with_unsupported_dtypes({"2.4.2 and below": ("float16", "bfloat16")}, "paddle")
+    @with_unsupported_dtypes({"2.5.0 and below": ("float16", "bfloat16")}, "paddle")
     def sort(self, axis=-1, descending=False, name=None):
         return ivy.sort(self._ivy_array, axis=axis, descending=descending)

--- a/ivy/functional/frontends/tensorflow/compat/v1/nn.py
+++ b/ivy/functional/frontends/tensorflow/compat/v1/nn.py
@@ -7,7 +7,7 @@ import ivy.functional.frontends.tensorflow.nn as tf_nn
 
 # should have float16 as well but sqrt doesn't support it
 @to_ivy_arrays_and_back
-@with_supported_dtypes({"2.9.0 and below": ("float32",)}, "tensorflow")
+@with_supported_dtypes({"2.12.0 and below": ("float32",)}, "tensorflow")
 def fused_batch_norm(
     x,
     scale,
@@ -80,7 +80,7 @@ def fused_batch_norm(
         return y, old_mean, old_var
 
 
-@with_unsupported_dtypes({"2.9.0 and below": ("float16",)}, "tensorflow")
+@with_unsupported_dtypes({"2.12.0 and below": ("float16",)}, "tensorflow")
 def depthwise_conv2d(
     input,
     filter,
@@ -105,7 +105,7 @@ def depthwise_conv2d(
 
 @with_unsupported_dtypes(
     {
-        "2.9.0 and below": (
+        "2.12.0 and below": (
             "float16",
             "bfloat16",
         )
@@ -138,7 +138,7 @@ def separable_conv2d(
 
 @to_ivy_arrays_and_back
 @with_unsupported_dtypes(
-    {"2.9.0 and below": ("float16",)},
+    {"2.12.0 and below": ("float16",)},
     "tensorflow",
 )
 def max_pool(value, ksize, strides, padding, data_format="NHWC", name=None, input=None):

--- a/ivy/functional/frontends/tensorflow/general_functions.py
+++ b/ivy/functional/frontends/tensorflow/general_functions.py
@@ -27,7 +27,7 @@ def argsort(values, axis=-1, direction="ASCENDING", stable=False, name=None):
 
 
 @to_ivy_arrays_and_back
-@with_unsupported_dtypes({"2.9.0 and below": ("float16",)}, "tensorflow")
+@with_unsupported_dtypes({"2.12.0 and below": ("float16",)}, "tensorflow")
 def clip_by_value(t, clip_value_min, clip_value_max):
     ivy.utils.assertions.check_all_or_any_fn(
         clip_value_min,
@@ -72,7 +72,7 @@ def clip_by_norm(t, clip_norm, axes=None):
     return t_clip
 
 
-@with_unsupported_dtypes({"2.9.0 and below": ("float16", "bfloat16")}, "tensorflow")
+@with_unsupported_dtypes({"2.12.0 and below": ("float16", "bfloat16")}, "tensorflow")
 @handle_tf_dtype
 @to_ivy_arrays_and_back
 def eye(num_rows, num_columns=None, batch_shape=None, dtype=ivy.float32, name=None):
@@ -115,7 +115,7 @@ def foldl(
     return result
 
 
-@with_unsupported_dtypes({"2.9.0 and below": ("float16", "bfloat16")}, "tensorflow")
+@with_unsupported_dtypes({"2.12.0 and below": ("float16", "bfloat16")}, "tensorflow")
 @handle_tf_dtype
 @to_ivy_arrays_and_back
 def ones(shape, dtype=ivy.float32, name=None):

--- a/ivy/functional/frontends/tensorflow/image/cropping.py
+++ b/ivy/functional/frontends/tensorflow/image/cropping.py
@@ -7,7 +7,7 @@ from ivy.functional.frontends.tensorflow.func_wrapper import to_ivy_arrays_and_b
 from ivy.func_wrapper import with_supported_dtypes
 
 
-@with_supported_dtypes({"2.9.0 and below": ("float",)}, "tensorflow")
+@with_supported_dtypes({"2.12.0 and below": ("float",)}, "tensorflow")
 @to_ivy_arrays_and_back
 def extract_patches(images, sizes, strides, rates, padding):
     depth = images.shape[-1]

--- a/ivy/functional/frontends/tensorflow/linalg.py
+++ b/ivy/functional/frontends/tensorflow/linalg.py
@@ -42,7 +42,7 @@ def eigvalsh(tensor, name=None):
 @to_ivy_arrays_and_back
 @with_supported_dtypes(
     {
-        "2.9.0 and below": (
+        "2.12.0 and below": (
             "float16",
             "float32",
             "float64",
@@ -86,7 +86,7 @@ def matmul(
 
 
 @to_ivy_arrays_and_back
-@with_unsupported_dtypes({"2.9.0 and below": ("float16", "bfloat16")}, "tensorflow")
+@with_unsupported_dtypes({"2.12.0 and below": ("float16", "bfloat16")}, "tensorflow")
 def solve(matrix, rhs):
     matrix, rhs = check_tensorflow_casting(matrix, rhs)
     return ivy.solve(matrix, rhs)
@@ -94,7 +94,7 @@ def solve(matrix, rhs):
 
 @to_ivy_arrays_and_back
 @with_supported_dtypes(
-    {"2.9.0 and below": ("float16", "float32", "float64", "complex64", "complex128")},
+    {"2.12.0 and below": ("float16", "float32", "float64", "complex64", "complex128")},
     "tensorflow",
 )
 def logdet(matrix, name=None):
@@ -107,7 +107,7 @@ def slogdet(input, name=None):
 
 
 @to_ivy_arrays_and_back
-@with_unsupported_dtypes({"2.9.0 and below": ("float16", "bfloat16")}, "tensorflow")
+@with_unsupported_dtypes({"2.12.0 and below": ("float16", "bfloat16")}, "tensorflow")
 def cholesky_solve(chol, rhs, name=None):
     chol, rhs = check_tensorflow_casting(chol, rhs)
     y = ivy.solve(chol, rhs)
@@ -121,7 +121,7 @@ def pinv(a, rcond=None, validate_args=False, name=None):
 
 @to_ivy_arrays_and_back
 @with_supported_dtypes(
-    {"2.9.0 and below": ("float32", "float64", "int32")}, "tensorflow"
+    {"2.12.0 and below": ("float32", "float64", "int32")}, "tensorflow"
 )
 def tensordot(a, b, axes, name=None):
     a, b = check_tensorflow_casting(a, b)
@@ -154,7 +154,7 @@ def tensorsolve(a, b, axes):
 
 @handle_tf_dtype
 @to_ivy_arrays_and_back
-@with_unsupported_dtypes({"2.9.0 and below": ("float16", "bfloat16")}, "tensorflow")
+@with_unsupported_dtypes({"2.12.0 and below": ("float16", "bfloat16")}, "tensorflow")
 def eye(num_rows, num_columns=None, batch_shape=None, dtype=ivy.float32, name=None):
     return ivy.eye(num_rows, num_columns, batch_shape=batch_shape, dtype=dtype)
 
@@ -177,7 +177,7 @@ norm.supported_dtypes = (
 
 
 @to_ivy_arrays_and_back
-@with_supported_dtypes({"2.9.0 and below": ("float32", "float64")}, "tensorflow")
+@with_supported_dtypes({"2.12.0 and below": ("float32", "float64")}, "tensorflow")
 def normalize(tensor, ord="euclidean", axis=None, name=None):
     tensor = tf_frontend.convert_to_tensor(
         tensor, dtype=ivy.dtype(tensor), dtype_hint="Any"
@@ -188,7 +188,7 @@ def normalize(tensor, ord="euclidean", axis=None, name=None):
 
 
 @to_ivy_arrays_and_back
-@with_supported_dtypes({"2.9.0 and below": ("float32", "float64")}, "tensorflow")
+@with_supported_dtypes({"2.12.0 and below": ("float32", "float64")}, "tensorflow")
 def l2_normalize(x, axis=None, epsilon=1e-12, name=None):
     square_sum = ivy.sum(ivy.square(x), axis=axis, keepdims=True)
     x_inv_norm = ivy.reciprocal(ivy.sqrt(ivy.maximum(square_sum, epsilon)))

--- a/ivy/functional/frontends/tensorflow/math.py
+++ b/ivy/functional/frontends/tensorflow/math.py
@@ -10,7 +10,7 @@ from ivy.functional.frontends.tensorflow.func_wrapper import (
 
 
 @with_supported_dtypes(
-    {"2.9.0 and below": ("float16", "float32", "float64", "complex64", "complex128")},
+    {"2.12.0 and below": ("float16", "float32", "float64", "complex64", "complex128")},
     "tensorflow",
 )
 @to_ivy_arrays_and_back
@@ -364,7 +364,7 @@ def subtract(x, y, name=None):
 
 @with_supported_dtypes(
     {
-        "2.9.0 and below": (
+        "2.12.0 and below": (
             "bfloat16",
             "float16",
             "float32",
@@ -389,7 +389,7 @@ def squared_difference(x, y, name=None):
 
 @with_supported_dtypes(
     {
-        "2.9.0 and below": (
+        "2.12.0 and below": (
             "bfloat16",
             "float16",
             "float32",
@@ -516,7 +516,7 @@ def sigmoid(x, name=None):
 
 
 @with_supported_dtypes(
-    {"2.9.0 and below": ("float16", "float32", "float64", "complex64", "complex128")},
+    {"2.12.0 and below": ("float16", "float32", "float64", "complex64", "complex128")},
     "tensorflow",
 )
 @to_ivy_arrays_and_back
@@ -538,7 +538,7 @@ def nextafter(x1, x2, name=None):
     {
         "1.2.0": ("float16", "complex64", "complex128"),
         "1.8.0 and below": ("float16",),
-        "2.9.0 and below": ("int8", "int16", "uint8", "uint16", "uint32", "uint64"),
+        "2.12.0 and below": ("int8", "int16", "uint8", "uint16", "uint32", "uint64"),
     },
     "tensorflow",
 )

--- a/ivy/functional/frontends/tensorflow/nn.py
+++ b/ivy/functional/frontends/tensorflow/nn.py
@@ -119,7 +119,7 @@ def conv3d(
     )
 
 
-@with_unsupported_dtypes({"2.9.0 and below": ("bfloat16",)}, "tensorflow")
+@with_unsupported_dtypes({"2.12.0 and below": ("bfloat16",)}, "tensorflow")
 @to_ivy_arrays_and_back
 def conv3d_transpose(
     input,
@@ -428,7 +428,7 @@ def softmax(logits, axis=None, name=None):
     return ivy.softmax(logits, axis=axis)
 
 
-@with_unsupported_dtypes({"2.9.0 and below": "float16"}, "tensorflow")
+@with_unsupported_dtypes({"2.12.0 and below": "float16"}, "tensorflow")
 @to_ivy_arrays_and_back
 def leaky_relu(features, alpha=0.2, name=None):
     return ivy.leaky_relu(features, alpha=alpha)

--- a/ivy/functional/frontends/tensorflow/random.py
+++ b/ivy/functional/frontends/tensorflow/random.py
@@ -7,7 +7,7 @@ from ivy.func_wrapper import with_unsupported_dtypes
 
 
 @with_unsupported_dtypes(
-    {"2.9.0 and below": ("int8", "int16", "unsigned")}, "tensorflow"
+    {"2.12.0 and below": ("int8", "int16", "unsigned")}, "tensorflow"
 )
 @to_ivy_arrays_and_back
 def uniform(shape, minval=0, maxval=None, dtype=ivy.float32, seed=None, name=None):
@@ -22,7 +22,7 @@ def uniform(shape, minval=0, maxval=None, dtype=ivy.float32, seed=None, name=Non
 
 
 @with_unsupported_dtypes(
-    {"2.9.0 and below": ("int8", "int16", "int32", "int64", "unsigned")}, "tensorflow"
+    {"2.12.0 and below": ("int8", "int16", "int32", "int64", "unsigned")}, "tensorflow"
 )
 @to_ivy_arrays_and_back
 def normal(shape, mean=0.0, stddev=1.0, dtype=ivy.float32, seed=None, name=None):
@@ -31,7 +31,7 @@ def normal(shape, mean=0.0, stddev=1.0, dtype=ivy.float32, seed=None, name=None)
 
 # implement random shuffle
 @with_unsupported_dtypes(
-    {"2.9.0 and below": ("int8", "int16", "in32", "int64", "unsigned")}, "tensorflow"
+    {"2.12.0 and below": ("int8", "int16", "in32", "int64", "unsigned")}, "tensorflow"
 )
 @to_ivy_arrays_and_back
 def shuffle(value, seed=None, name=None):
@@ -48,7 +48,7 @@ def stateless_uniform(
 
 
 @with_unsupported_dtypes(
-    {"2.9.0 and below": ("int8", "int16", "unsigned")}, "tensorflow"
+    {"2.12.0 and below": ("int8", "int16", "unsigned")}, "tensorflow"
 )
 @to_ivy_arrays_and_back
 @handle_tf_dtype
@@ -61,7 +61,7 @@ def poisson(shape, lam, dtype=ivy.float32, seed=None, name=None):
 
 
 @with_unsupported_dtypes(
-    {"2.9.0 and below": ("int8", "int16", "unsigned")}, "tensorflow"
+    {"2.12.0 and below": ("int8", "int16", "unsigned")}, "tensorflow"
 )
 @to_ivy_arrays_and_back
 def stateless_normal(
@@ -73,7 +73,7 @@ def stateless_normal(
 
 
 @with_unsupported_dtypes(
-    {"2.9.0 and below": ("int8", "int16", "unsigned")}, "tensorflow"
+    {"2.12.0 and below": ("int8", "int16", "unsigned")}, "tensorflow"
 )
 @to_ivy_arrays_and_back
 def stateless_poisson(shape, seed, lam, dtype=ivy.int32, name=None):

--- a/ivy/functional/frontends/torch/miscellaneous_ops.py
+++ b/ivy/functional/frontends/torch/miscellaneous_ops.py
@@ -114,7 +114,7 @@ def triu_indices(row, col, offset=0, dtype="int64", device="cpu", layout=None):
 
 
 @with_supported_dtypes(
-    {"2.4.2 and below": ("float64", "float32", "int32", "int64")}, "paddle"
+    {"2.5.0 and below": ("float64", "float32", "int32", "int64")}, "paddle"
 )
 @to_ivy_arrays_and_back
 def triu(input, diagonal=0, *, out=None):

--- a/ivy/functional/frontends/torch/pointwise_ops.py
+++ b/ivy/functional/frontends/torch/pointwise_ops.py
@@ -428,7 +428,7 @@ def frac(input, *, out=None):
     return input - ivy.sign(input) * ivy.floor(ivy.abs(input))
 
 
-@with_unsupported_dtypes({"2.9.0 and below": ("bfloat16",)}, "tensorflow")
+@with_unsupported_dtypes({"2.0.1 and below": ("bfloat16",)}, "tensorflow")
 @to_ivy_arrays_and_back
 def xlogy(input, other, *, out=None):
     return ivy.xlogy(input, other, out=out)
@@ -535,7 +535,7 @@ def sgn(input, *, out=None):
         return ivy.sign(input, out=out)
 
 
-@with_unsupported_dtypes({"2.9.0 and below": ("bfloat16",)}, "tensorflow")
+@with_unsupported_dtypes({"2.0.1 and below": ("bfloat16",)}, "tensorflow")
 @to_ivy_arrays_and_back
 def nan_to_num(input, nan=0.0, posinf=None, neginf=None, *, out=None):
     return ivy.nan_to_num(input, nan=nan, posinf=posinf, neginf=neginf, out=out)


### PR DESCRIPTION
Hey @RickSanchezStoic 

Referring to my setup, we don't have pinned versions the numpy was updated to `2.25.0` and some tests were failing mostly for the numpy backend due to that.

I updated the version to `2.25.0` and updated the versions in the frontends init file as it was pretty out of date.

```python
import jax
import tensorflow as tf
import torch
import paddle

print('numpy version: {}'.format(np.__version__))
print('jax version: {}'.format(jax.__version__))
print('tensorflow version: {}'.format(tf.__version__))
print('torch version: {}'.format(torch.__version__))
print('paddle version: {}'.format(paddle.__version__))

"""
numpy version: 1.25.0
jax version: 0.4.12
tensorflow version: 2.12.0
torch version: 2.0.1+cpu
paddle version: 2.4.2
"""
```