### PR TITLE
Fix building haiku and flax modules with no params

### DIFF
--- a/ivy/stateful/converters.py
+++ b/ivy/stateful/converters.py
@@ -170,7 +170,7 @@ class ModuleConverters:
                 params_dict = _hk_flat_map_to_dict(params_hk)
                 self._hk_params = ivy.Container(params_dict, dynamic_backend=False)
                 param_iterator = self._hk_params.cont_to_iterator()
-                _, param0 = next(param_iterator)
+                _, param0 = next(param_iterator, ["_", 0])
                 if hasattr(param0, "device"):
                     self._dev = ivy.as_ivy_dev(param0.device())
                 else:
@@ -301,7 +301,7 @@ class ModuleConverters:
                 params_dict = flax.core.unfreeze(params_fx)
                 self._fx_params = ivy.Container(params_dict, dynamic_backend=False)
                 param_iterator = self._fx_params.cont_to_iterator()
-                _, param0 = next(param_iterator)
+                _, param0 = next(param_iterator, ["_", 0])
                 self._dev = ivy.as_ivy_dev(ivy.dev(param0))
 
             def _forward(self, *a, **kw):


### PR DESCRIPTION
```python
import transformers

model = transformers.models.resnet.modeling_flax_resnet.Identity()
args = (jnp.ones((1, 10, 10)),)
params_v = model.init(jax.random.PRNGKey(0), *args)
ivy.transpile(model, to="torch", params_v=params_v, args=args)
```
Traceback:
```python
  File "ivy/stateful/converters.py", line 304, in _build
    _, param0 = next(param_iterator)

StopIteration: 
```