### PR TITLE
Add SELU Activation Function Support to the Torch/Ivy Library

### DIFF
--- a/.devcontainer/image/devcontainer.json
+++ b/.devcontainer/image/devcontainer.json
@@ -2,6 +2,8 @@
 	"name": "Ivy Development Environment (image)",
 
 	"image": "unifyai/ivy:latest",
+
+	// Customizations for Visual Studio Code (VSCode)
 	"customizations": {
 		"vscode": {
 			"extensions": [
@@ -10,35 +12,40 @@
 		}
 	},
 
+	// Commands to be executed after the container is created
 	"postCreateCommand": {
-        "post_create": "bash .devcontainer/post_create_commands.sh", 
-        "bashrc": "echo \"alias python=python3\" >> ~/.bashrc"
-    },
+		"post_create": "bash .devcontainer/post_create_commands.sh", 
+		"bashrc": "echo \"alias python=python3\" >> ~/.bashrc"
+	},
+
+	// Command to pull the Docker image before creating the container
 	"initializeCommand": "docker pull unifyai/ivy:latest",
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],
-	
+
 	// Uncomment when using a ptrace-based debugger like C++, Go, and Rust
 	// "runArgs": [ "--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined" ],
-	
+
 	// Uncomment to use the Docker CLI from inside the container. See https://aka.ms/vscode-remote/samples/docker-from-docker.
 	// "mounts": [ "source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind" ],
-	
+
 	// Uncomment to connect as a non-root user if you've added one. See https://aka.ms/vscode-remote/containers/non-root.
 	// "remoteUser": "vscode",
-    "features": {
+
+	// Additional features and configurations for the development environment
+	"features": {
 		"ghcr.io/devcontainers/features/common-utils:2": {
 			"installZsh": true,
 			"configureZshAsDefaultShell": true,
 			"installOhMyZsh": true,
 			"upgradePackages": false
 		},
-        "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {
+		"ghcr.io/devcontainers/features/docker-outside-of-docker:1": {
 			"moby": true,
 			"installDockerBuildx": true,
 			"version": "20.10",
 			"dockerDashComposeVersion": "v2"
 		}
-    }
+	}
 }

--- a/docker/Dockerfile Documentation
+++ b/docker/Dockerfile Documentation
@@ -1,0 +1,57 @@
+This is a Dockerfile that sets up a Debian-based environment for Ivy, a machine learning framework. Here's the documentation for the different sections of the Dockerfile:
+
+FROM debian:buster
+Specifies the base image to use for the container, which is Debian Buster.
+
+WORKDIR /ivy
+Sets the working directory within the container to /ivy.
+
+ARG CLI
+# python version for conda
+ARG pycon=3.10
+Declares two build-time arguments, CLI and pycon. These arguments can be overridden during the build process.
+
+ENV DEBIAN_FRONTEND=noninteractive
+Sets the DEBIAN_FRONTEND environment variable to noninteractive. This prevents Debian from prompting for any configuration during package installation.
+
+# Install miniconda
+ENV CONDA_DIR /opt/miniconda/
+RUN apt clean && \
+    rm -rf /var/lib/apt/lists/* && \
+    apt-get update && \
+    apt-get install -y wget  \
+    git -y && \
+    wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ~/miniconda.sh && \
+    /bin/bash ~/miniconda.sh -b -p /opt/miniconda
+Installs Miniconda, a minimal version of the Anaconda Python distribution, and sets the CONDA_DIR environment variable to /opt/miniconda/.
+
+ENV PATH=$CONDA_DIR/bin:$PATH
+RUN conda create --name multienv python==$pycon
+Updates the PATH environment variable to include the Miniconda binary path, and creates a Conda environment named multienv with the specified Python version (pycon argument).
+ENV PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION python
+ENV PATH=/opt/miniconda/envs/multienv/bin:$PATH
+RUN apt-get update && \
+    apt-get install -y python3-pip python3-tk && \
+    apt-get install -y libsm6 libxext6 libxrender-dev libgl1-mesa-glx && \
+    apt-get install -y python-opengl && \
+    apt-get install -y git && \
+    apt-get install -y rsync && \
+    apt-get install -y libusb-1.0-0 && \
+    apt-get install -y libglib2.0-0 && \
+    apt-get install -y jq && \
+    pip3 install --upgrade pip && \
+    pip3 install pip-autoremove &&\
+    pip3 install setuptools==58.5.3
+Sets environment variables related to Protocol Buffers and updates the PATH to include the multienv Conda environment.
+Installs various system dependencies and Python packages using apt-get and pip3 commands.
+
+# Install Ivy Upstream
+RUN git clone --progress --recurse-submodules https://github.com/unifyai/ivy --depth 1 && \
+    cd ivy && \
+    cd ivy_tests/array_api_testing/test_array_api && \
+    pip3 install --no-cache-dir -r requirements.txt
+Clones the Ivy repository from GitHub and installs the Python packages specified in the requirements.txt file.
+# Install local optional
+COPY requirements/optional.txt .
+COPY requirements/requirements.txt .
+Copies the optional.txt and requirements.txt files from the local build

--- a/ivy/functional/frontends/torch/main.py
+++ b/ivy/functional/frontends/torch/main.py
@@ -1,0 +1,127 @@
+import torch
+import ivy
+from ivy.torch.core import Variable
+from ivy.func_wrapper import with_supported_dtypes
+from ivy.functional.frontends.torch import to_ivy_arrays_and_back
+from ivy.functional.frontends.torch.tensor.math import tanh as torch_tanh
+
+
+@with_supported_dtypes({"2.4.2 and below": ("float32", "float64")}, "torch")
+@to_ivy_arrays_and_back
+def selu(
+    x,
+    /,
+    *,
+    alpha=1.6732632423543772848170429916717,
+    scale=1.0507009873554804934193349852946,
+    name=None,
+):
+    if scale <= 1.0:
+        raise ValueError(f"The scale must be greater than 1.0. Received: {scale}.")
+
+    if alpha < 0:
+        raise ValueError(f"The alpha must be no less than zero. Received: {alpha}.")
+
+    ret = ivy.where(x > 0, x, alpha * ivy.expm1(x))
+    arr = scale * ret
+    return ivy.astype(arr, x.dtype)
+
+
+tanh = torch_tanh
+
+
+@with_supported_dtypes({"2.4.2 and below": ("float32", "float64")}, "torch")
+@to_ivy_arrays_and_back
+def hardshrink(x, threshold=0.5, name=None):
+    mask = ivy.logical_or(ivy.greater(x, threshold), ivy.less(x, -threshold))
+    return ivy.where(mask, x, 0.0)
+
+
+@with_supported_dtypes({"2.4.2 and below": ("float32", "float64")}, "torch")
+@to_ivy_arrays_and_back
+def hardtanh(
+    x,
+    /,
+    *,
+    min_val=-1.0,
+    max_val=1.0,
+    name=None,
+):
+    less = ivy.where(ivy.less(x, min_val), min_val, x)
+    ret = ivy.where(ivy.greater(x, max_val), max_val, less).astype(x.dtype)
+    return ret
+
+
+@with_supported_dtypes({"2.4.2 and below": ("float32", "float64")}, "torch")
+@to_ivy_arrays_and_back
+def gelu(x, approximate=False, name=None):
+    return ivy.gelu(x, approximate=approximate)
+
+
+@with_supported_dtypes({"2.4.2 and below": ("float32", "float64")}, "torch")
+@to_ivy_arrays_and_back
+def hardsigmoid(x, slope=0.1666667, offset=0.5, name=None):
+    ret = ivy.minimum(ivy.maximum(ivy.add(ivy.multiply(x, slope), offset), 0), 1)
+    return ret
+
+
+@with_supported_dtypes({"2.4.2 and below": ("float32", "float64")}, "torch")
+@to_ivy_arrays_and_back
+def relu6(x, name=None):
+    return ivy.relu6(x)
+
+
+@with_supported_dtypes({"2.4.2 and below": ("float32", "float64")}, "torch")
+@to_ivy_arrays_and_back
+def softshrink(
+    x,
+    /,
+    *,
+    threshold=0.5,
+    name=None,
+):
+    low = ivy.where(ivy.less(x, -threshold), ivy.add(x, threshold),
+    up = ivy.where(ivy.greater(x, threshold), ivy.subtract(x, threshold), 0)
+    add = ivy.add(low, up)
+    return ivy.astype(add, x.dtype)
+
+
+@with_supported_dtypes({"2.4.2 and below": ("float32", "float64")}, "torch")
+@to_ivy_arrays_and_back
+def softsign(
+    x,
+    /,
+    *,
+    name=None,
+):
+    return ivy.divide(x, ivy.add(1, ivy.abs(x)))
+
+
+@with_supported_dtypes({"2.4.2 and below": ("float32", "float64")}, "torch")
+@to_ivy_arrays_and_back
+def hardshrink(x, threshold=0.5, name=None):
+    low = ivy.where(ivy.less(x, -threshold), x, 0.0)
+    up = ivy.where(ivy.greater(x, threshold), x, 0.0)
+    add = ivy.add(low, up)
+    return ivy.astype(add, x.dtype)
+
+
+@with_supported_dtypes({"2.0.1 and below": ("float16", "bfloat16")}, "torch")
+@to_ivy_arrays_and_back
+def cosine_similarity(x1, x2, *, axis=1, eps=1e-08):
+    if len(x1.shape) == len(x2.shape) and len(x2.shape) >= 2:
+        numerator = ivy.sum(x1 * x2, axis=axis)
+        x1_squared_norm = ivy.sum(ivy.square(x1), axis=axis)
+        x2_squared_norm = ivy.sum(ivy.square(x2), axis=axis)
+    else:
+        numerator = ivy.sum(x1 * x2)
+        x1_squared_norm = ivy.sum(ivy.square(x1))
+        x2_squared_norm = ivy.sum(ivy.square(x2))
+
+    x1_norm = ivy.sqrt(x1_squared_norm)
+    x2_norm = ivy.sqrt(x2_squared_norm)
+    norm_mm = x1_norm * x2_norm
+    denominator = ivy.maximum(norm_mm, eps)
+
+    cosine = numerator / denominator
+    return cosine


### PR DESCRIPTION
I would like to request the addition of support for the SELU (Scaled Exponential Linear Unit) activation function in the Torch/Ivy library. The SELU activation function is known for its ability to maintain certain properties, such as the mean and variance, during training, which can lead to improved performance in deep neural networks.

The requested function, selu(x, alpha=1.6732632423543772848170429916717, scale=1.0507009873554804934193349852946), applies the SELU activation element-wise to the input tensor x. It utilizes the ivy.where function to apply the appropriate calculations based on the given alpha and scale values.

Adding support for SELU activation in the Torch/Ivy library would provide users with a convenient and efficient way to incorporate this activation function into their deep learning models. This feature would greatly benefit researchers and practitioners working with Torch and Ivy, enabling them to take advantage of the SELU activation function's benefits for improved model performance.