### PR TITLE
Fix failing test for tensor.test_torch_instance_heaviside

### DIFF
--- a/ivy/functional/frontends/torch/tensor.py
+++ b/ivy/functional/frontends/torch/tensor.py
@@ -605,6 +605,9 @@ class Tensor:
     def dim(self):
         return self.ivy_array.ndim
 
+    @with_supported_dtypes(
+        {"2.5.0 and below": ("float32", "float64", "int32", "int64")}, "paddle"
+    )
     def heaviside(self, values, *, out=None):
         return torch_frontend.heaviside(self, values, out=out)
 


### PR DESCRIPTION
This PR fixes #17730 and #17731 caused by unsupported datatypes.