### PR TITLE
Fix color support during debugging

### DIFF
--- a/ivy/data_classes/container/base.py
+++ b/ivy/data_classes/container/base.py
@@ -9,6 +9,7 @@ import copy
 import termcolor
 import numpy as np
 import json
+import os
 
 from ivy.utils.exceptions import IvyBackendException, IvyException
 

--- a/ivy/data_classes/container/base.py
+++ b/ivy/data_classes/container/base.py
@@ -3903,6 +3903,8 @@ class ContainerBase(dict, abc.ABC):
             # color keys
             json_dumped_str_split = json_dumped_str.split('":')
             split_size = len(json_dumped_str_split)
+            # Checks if console supports color
+            has_color_support = os.isatty(sys.stdout.fileno()) and os.name != "nt"
             json_dumped_str = '":'.join(
                 [
                     (
@@ -3915,6 +3917,8 @@ class ContainerBase(dict, abc.ABC):
                                     ),
                                     self._default_key_color,
                                 )
+                                if has_color_support
+                                else Container.cont_trim_key(sub_str.split(' "')[-1], self._key_length_limit)
                             ]
                         )
                         if i < split_size - 1


### PR DESCRIPTION
In this pull request, we have introduced conditional coloration for JSON keys in the debug console output. This addresses the issue where hex color codes were appearing in the console output when viewed through debuggers like PyCharm or VSCode.

The core of the change involves checking for color support in the output console before applying any coloration to the keys. Specifically, we are now only coloring the keys if the output console supports color, i.e., if `os.isatty(sys.stdout.fileno()) `is True and the system is not Windows (os.name != "nt").

Also the check os.name != "nt" is done to verify if the current operating system is not Windows. This is important because the Windows command prompt does not natively support ANSI escape sequences (used for color and other terminal effects), so os.isatty(sys.stdout.fileno()) could return True on Windows, even though it doesn't fully support these sequences.