### PR TITLE
Automate squashing unifyai/docs into 1 commit

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,9 +7,36 @@ on:
     tags:
       - v*
   workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * 0'  # Runs at 00:00 every Sunday
 
 jobs:
   update-docs:
     name: Update docs
     uses: unifyai/workflows/.github/workflows/docs.yml@master
     secrets: inherit
+
+  squash:
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+      with:
+        ref: master  
+        fetch-depth: 0  
+
+    - name: Setup Git user
+      run: |
+        git config --global user.email "github-actions[bot]@users.noreply.github.com"
+        git config --global user.name "GitHub Actions Bot"
+
+    - name: Pull latest changes
+      run: git pull origin master 
+
+    - name: Squash commits
+      run: |
+        git reset $(git commit-tree HEAD^{tree} -m "Weekly squash commit")
+        
+    - name: Force push single commit
+      run: git push -f origin master


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow that will automatically squash all commits in the repository into a single commit every week at `00:00` every Sunday. This addition is aimed at reducing clutter and improving the readability of ivys repository's commit history. The key to mitigating race conditions in this workflow is the `git pull origin` master step. By pulling the latest changes right before squashing the commits, the workflow ensures that it is working with the most up-to-date version of the repository. This reduces the chance of losing updates due to race conditions.

Another possible solution that I could think of: 

**Implement a locking mechanism**: To prevent other CI jobs from committing while the squash operation is underway, we could use a simple locking mechanism. This can be a file in the repository that signals when the squash operation is ongoing. Other CI/CD processes should be configured to check for this lock before performing any operations.

Let me know your thoughts and feedback