### PR TITLE
`axis` should be key-word argument in squeeze

### DIFF
--- a/ivy/functional/ivy/manipulation.py
+++ b/ivy/functional/ivy/manipulation.py
@@ -748,7 +748,7 @@ def squeeze(
         b: ivy.array([3., 4., 5.])
     }
     """
-    return current_backend(x).squeeze(x, axis, copy=copy, out=out)
+    return current_backend(x).squeeze(x, axis=axis, copy=copy, out=out)
 
 
 @handle_exceptions


### PR DESCRIPTION
Currently ,`axis` is being passed as a positional argument for all backends as seen [in-here](https://github.com/unifyai/ivy/blob/master/ivy/functional/ivy/manipulation.py#L751C44-L751C44) but it should be passed as a keyword argument.

Refs:
- [jax squeeze](https://jax.readthedocs.io/en/latest/_autosummary/jax.numpy.squeeze.html)
-  [tf squeeze](https://www.tensorflow.org/api_docs/python/tf/squeeze)
- [torch squeeze](https://pytorch.org/docs/stable/generated/torch.squeeze.html)
- [numpy squeeze](https://numpy.org/doc/stable/reference/generated/numpy.squeeze.html#numpy.squeeze)


This commit  by @hirwa-nshuti  also fixed this for `numpy` : https://github.com/unifyai/ivy/commit/1f9f0052841da57f97f3e4bb6604140b219ad7bc