### PR TITLE
fix tensorinv tests for paddle backend as it only supports upto `9-D` Tensors

### DIFF
--- a/ivy_tests/test_ivy/test_frontends/test_numpy/test_linear_algebra/test_solving_equations_and_inverting_matrices.py
+++ b/ivy_tests/test_ivy/test_frontends/test_numpy/test_linear_algebra/test_solving_equations_and_inverting_matrices.py
@@ -154,7 +154,7 @@ def test_numpy_tensorinv(
     dtype, x, ind = params
     if ivy.current_backend_str() == "paddle":
         # Paddle only supports ndim from 0 to 9
-        assume(x.shape[0] < 10)
+        assume(x.ndim <= 9)
     helpers.test_frontend_function(
         input_dtypes=dtype,
         test_flags=test_flags,


### PR DESCRIPTION
fixes https://github.com/unifyai/ivy/issues/9774