### PR TITLE
fixed `squeeze` not getting properly called at median

### DIFF
--- a/ivy/functional/frontends/torch/reduction_ops.py
+++ b/ivy/functional/frontends/torch/reduction_ops.py
@@ -83,7 +83,8 @@ def median(input, dim=None, keepdim=False, *, out=None):
         )
         median_values = ivy.take_along_axis(
             input, ivy.expand_dims(median_indices, axis=dim), dim
-        ).squeeze(dim)
+        )
+        median_values = ivy.squeeze(median_values, axis=dim)
 
         if keepdim:
             median_values = ivy.expand_dims(median_values, axis=dim)


### PR DESCRIPTION
Example:
```py
import ivy
import ivy.functional.frontends.torch as torch_frontend

a = torch_frontend.tensor(
    [[ 0.2035,  1.2959,  1.8101, -0.4644],
     [ 1.5027, -0.3270,  0.5905,  0.6538],
     [-1.5745,  1.3330, -0.5596, -0.6548],
     [ 0.1264, -0.5080,  1.6420,  0.1992]])

z = torch_frontend.median(a, dim=1)
print(z)

"""ERROR

TypeError: squeeze() takes 1 positional argument but 2 were given
"""
```
Reason at [torch_frontend_median](https://github.com/unifyai/ivy/blob/master/ivy/functional/frontends/torch/reduction_ops.py#L86):
```py
## Current Implementation
        median_values = ivy.take_along_axis(
            input, ivy.expand_dims(median_indices, axis=dim), dim
        ).squeeze(dim)
"""
    throws error : 
TypeError: squeeze() takes 1 positional argument but 2 were given
"""
# Suggested Change
        median_values = ivy.take_along_axis(
            input, ivy.expand_dims(median_indices, axis=dim), dim
        )
        median_values = ivy.squeeze(median_values, axis=dim) # Change
```
The reason the current implementation  throws an error is because the `squeeze()` function takes only one positional argument, but we are passing two arguments (`dim` and the default` axis=None`). This results in the `TypeError` indicating that the `squeeze() `function takes only one argument.

In the suggested changed part , we have split the operation into two steps. First, we use  `ivy.take_along_axis()` to select the median values along the specified dimension `dim`. Then, we use `ivy.squeeze()` separately to remove the `size-1` dimensions along the same `dim axis`.

By splitting the operation into two steps, we've avoid passing the `dim` argument to the `squeeze()` function, which resolves the error.