### PR TITLE
fix shared shape generation related side-effect in dtypes_and_values helper

### DIFF
--- a/ivy_tests/test_ivy/helpers/hypothesis_helpers/array_helpers.py
+++ b/ivy_tests/test_ivy/helpers/hypothesis_helpers/array_helpers.py
@@ -307,6 +307,7 @@ def dtype_and_values(
     ret_shape=False,
     dtype=None,
     array_api_dtypes=False,
+    shape_key="shape",
 ):
     """
     Draws a list of arrays with elements from the given corresponding data types.
@@ -512,7 +513,7 @@ def dtype_and_values(
                     min_dim_size=min_dim_size,
                     max_dim_size=max_dim_size,
                 ),
-                key="shape",
+                key=shape_key,
             )
         )
     values = []


### PR DESCRIPTION
make key into a parameter in dtypes_and_values keeping "shape" as the default value.
previously in this code below the second call to `dtype_and_values` was forced to take shape from the first call.
This can be avoided by passing `shape_key=None` in second call now, avoiding the shape sharing.
```python
@st.composite
def example_check(draw):

    _, value_1 = draw(helpers.dtype_and_values(
        available_dtypes=["float32"],
        min_num_dims=3,
        max_num_dims=3,
    ))

    _, value_2 = draw(helpers.dtype_and_values(
        available_dtypes=["float32"],
        min_num_dims=4,
        max_num_dims=4,
    ))
    return value_1[0].shape, value_2[0].shape

print(example_check().example())
```

also the parameter creates more flexibility for external shape sharing.