### PR TITLE
Update ivy.Array__deepcopy__ to avoid non-leaf tensor errors

### DIFF
--- a/ivy/data_classes/array/array.py
+++ b/ivy/data_classes/array/array.py
@@ -1144,10 +1144,12 @@ class Array(
                 jax_array = ivy.array(np_array)
                 return to_ivy(jax_array)
             return to_ivy(copy.deepcopy(self._data))
-        except:
-            array_copy = ivy.copy_array(self._data)
-            memodict[id(self)] = array_copy
-            return to_ivy(array_copy)
+        except RuntimeError:
+            from ivy.functional.ivy.gradients import _is_variable
+            # paddle and torch don't support the deepcopy protocol on non-leaf tensors
+            if _is_variable(self):
+                return to_ivy(copy.deepcopy(ivy.stop_gradient(self)._data))
+            return to_ivy(copy.deepcopy(self._data))
 
     def __len__(self):
         if not len(self._data.shape):

--- a/ivy/data_classes/array/array.py
+++ b/ivy/data_classes/array/array.py
@@ -1134,20 +1134,9 @@ class Array(
         return ivy.bitwise_right_shift(self._data, other)
 
     def __deepcopy__(self, memodict={}):
-        try:
-            return to_ivy(self._data.__deepcopy__(memodict))
-        except AttributeError:
-            # ToDo: try and find more elegant solution to jax inability to
-            #  deepcopy device arrays
-            if ivy.current_backend_str() == "jax":
-                np_array = copy.deepcopy(self._data)
-                jax_array = ivy.array(np_array)
-                return to_ivy(jax_array)
-            return to_ivy(copy.deepcopy(self._data))
-        except RuntimeError:
-            if ivy.current_backend_str() == "paddle":
-                return to_ivy(copy.deepcopy(self._data.numpy()))
-            return to_ivy(copy.deepcopy(self._data))
+        array_copy = ivy.copy_array(self._data)
+        memodict[id(self)] = array_copy
+        return to_ivy(array_copy)
 
     def __len__(self):
         if not len(self._data.shape):

--- a/ivy/data_classes/array/array.py
+++ b/ivy/data_classes/array/array.py
@@ -1,6 +1,5 @@
 # flake8: noqa
 # global
-import copy
 import functools
 import numpy as np
 from operator import mul


### PR DESCRIPTION
After [this](https://github.com/unifyai/ivy/commit/2ec1da189b0d81b44d4a0826ea74f4130fbd361c) commit, frontend tests started getting errors like [this](https://discord.com/channels/799879767196958751/1028707571743334420/1122582044724170863). The errors are avoided with this updated implementation of `ivy.Array__deepcopy__`.