### PR TITLE
fix jitting jax backend split

### DIFF
--- a/ivy/functional/backends/jax/manipulation.py
+++ b/ivy/functional/backends/jax/manipulation.py
@@ -3,6 +3,7 @@ import math
 from numbers import Number
 from typing import Union, Tuple, Optional, List, Sequence, Iterable
 import jax.numpy as jnp
+import numpy as np
 
 # local
 import ivy
@@ -179,7 +180,7 @@ def split(
                 int(remainder * num_or_size_splits)
             ]
     if isinstance(num_or_size_splits, (list, tuple)):
-        num_or_size_splits = jnp.cumsum(jnp.array(num_or_size_splits[:-1]))
+        num_or_size_splits = np.cumsum(np.array(num_or_size_splits[:-1]))
     return jnp.split(x, num_or_size_splits, axis)
 
 


### PR DESCRIPTION
Currently the jax backend `split` fails to jit compile, due to the `num_or_size_splits` arg being converted into a jax array. This causes this argument to be traced by jax's jit, causing it to fail as the jit expects this argument to be a constant. So just fixed this by using numpy instead.

I think it could be a good idea to add jax jitting to the jax backend tests maybe @vedpatwardhan 