### PR TITLE
Implementing Eig Function To paddle.Tensor - To Fix

### DIFF
--- a/ivy/functional/frontends/paddle/tensor/tensor.py
+++ b/ivy/functional/frontends/paddle/tensor/tensor.py
@@ -4,7 +4,6 @@ import ivy.functional.frontends.paddle as paddle_frontend
 from ivy.func_wrapper import (
     with_supported_dtypes,
     with_unsupported_dtypes,
-    with_supported_device_and_dtypes,
 )
 from ivy.functional.frontends.paddle.func_wrapper import _to_ivy_array
 
@@ -245,8 +244,8 @@ class Tensor:
     def logical_xor(self, y, out=None, name=None):
         return paddle_frontend.logical_xor(self, y, out=out)
 
-    @with_supported_device_and_dtypes(
-        {"2.5.0 and below": {"cpu": ("float32", "float64", "complex128", "complex64")}},
+    @with_supported_dtypes(
+        {"2.5.0 and below": ("float32", "float64", "complex128", "complex64")},
         "paddle",
     )
     def eig(self):

--- a/ivy/functional/frontends/paddle/tensor/tensor.py
+++ b/ivy/functional/frontends/paddle/tensor/tensor.py
@@ -1,7 +1,11 @@
 # local
 import ivy
 import ivy.functional.frontends.paddle as paddle_frontend
-from ivy.func_wrapper import with_supported_dtypes, with_unsupported_dtypes
+from ivy.func_wrapper import (
+    with_supported_dtypes,
+    with_unsupported_dtypes,
+    with_supported_device_and_dtypes,
+)
 from ivy.functional.frontends.paddle.func_wrapper import _to_ivy_array
 
 
@@ -240,3 +244,10 @@ class Tensor:
     )
     def logical_xor(self, y, out=None, name=None):
         return paddle_frontend.logical_xor(self, y, out=out)
+
+    @with_supported_device_and_dtypes(
+        {"2.5.0 and below": {"cpu": ("float32", "float64", "complex128", "complex64")}},
+        "paddle",
+    )
+    def eig(self):
+        return ivy.eig(self._ivy_array)

--- a/ivy_tests/test_ivy/test_frontends/test_paddle/test_tensor/test_paddle_tensor.py
+++ b/ivy_tests/test_ivy/test_frontends/test_paddle/test_tensor/test_paddle_tensor.py
@@ -1323,17 +1323,22 @@ def test_paddle_logical_xor(
     class_tree=CLASS_TREE,
     init_tree="paddle.to_tensor",
     method_name="eig",
-    dtype_and_x=_get_dtype_and_square_matrix(),
+    dtypes_and_x=helpers.dtype_and_values(
+        available_dtypes=helpers.get_dtypes("valid"), shape=[2, 2]
+    ),
 )
 def test_paddle_eig(
-    dtype_and_x, frontend_method_data, init_flags, method_flags, frontend, on_device
+    dtypes_and_x,
+    frontend_method_data,
+    init_flags,
+    method_flags,
+    frontend,
+    on_device,
 ):
-    input_dtype, x = dtype_and_x
-    x = np.matmul(x.T, x) + np.identity(x.shape[0]) * 1e-3
-
+    input_dtype, x = dtypes_and_x
     helpers.test_frontend_method(
         init_input_dtypes=input_dtype,
-        init_all_as_kwargs_np={"data": x},
+        init_all_as_kwargs_np={"data": x[0]},
         method_input_dtypes=input_dtype,
         method_all_as_kwargs_np={},
         frontend_method_data=frontend_method_data,

--- a/ivy_tests/test_ivy/test_frontends/test_paddle/test_tensor/test_paddle_tensor.py
+++ b/ivy_tests/test_ivy/test_frontends/test_paddle/test_tensor/test_paddle_tensor.py
@@ -1316,3 +1316,29 @@ def test_paddle_logical_xor(
         frontend=frontend,
         on_device=on_device,
     )
+
+
+# eig
+@handle_frontend_method(
+    class_tree=CLASS_TREE,
+    init_tree="paddle.to_tensor",
+    method_name="eig",
+    dtype_and_x=_get_dtype_and_square_matrix(),
+)
+def test_paddle_eig(
+    dtype_and_x, frontend_method_data, init_flags, method_flags, frontend, on_device
+):
+    input_dtype, x = dtype_and_x
+    x = np.matmul(x.T, x) + np.identity(x.shape[0]) * 1e-3
+
+    helpers.test_frontend_method(
+        init_input_dtypes=input_dtype,
+        init_all_as_kwargs_np={"data": x},
+        method_input_dtypes=input_dtype,
+        method_all_as_kwargs_np={},
+        frontend_method_data=frontend_method_data,
+        init_flags=init_flags,
+        method_flags=method_flags,
+        frontend=frontend,
+        on_device=on_device,
+    )

--- a/ivy_tests/test_ivy/test_frontends/test_paddle/test_tensor/test_paddle_tensor.py
+++ b/ivy_tests/test_ivy/test_frontends/test_paddle/test_tensor/test_paddle_tensor.py
@@ -9,6 +9,9 @@ import ivy
 import ivy_tests.test_ivy.helpers as helpers
 from ivy.functional.frontends.paddle import Tensor
 from ivy_tests.test_ivy.helpers import handle_frontend_method
+from test_paddle_linalg import (
+    _get_dtype_and_square_matrix as get_dtype_and_square_matrix_complex,
+)
 
 CLASS_TREE = "ivy.functional.frontends.paddle.Tensor"
 
@@ -1323,11 +1326,9 @@ def test_paddle_logical_xor(
     class_tree=CLASS_TREE,
     init_tree="paddle.to_tensor",
     method_name="eig",
-    dtypes_and_x=helpers.dtype_and_values(
-        available_dtypes=helpers.get_dtypes("valid"), shape=[2, 2]
-    ),
+    dtypes_and_x=get_dtype_and_square_matrix_complex(real_and_complex_only=True),
 )
-def test_paddle_eig(
+def test_paddle_instance_eig(
     dtypes_and_x,
     frontend_method_data,
     init_flags,
@@ -1338,7 +1339,7 @@ def test_paddle_eig(
     input_dtype, x = dtypes_and_x
     helpers.test_frontend_method(
         init_input_dtypes=input_dtype,
-        init_all_as_kwargs_np={"data": x[0]},
+        init_all_as_kwargs_np={"data": x},
         method_input_dtypes=input_dtype,
         method_all_as_kwargs_np={},
         frontend_method_data=frontend_method_data,
@@ -1346,4 +1347,5 @@ def test_paddle_eig(
         method_flags=method_flags,
         frontend=frontend,
         on_device=on_device,
+        test_values=False,
     )


### PR DESCRIPTION
Close #17958 

Hi! I'm trying to implement the [eig frontend function ](https://www.paddlepaddle.org.cn/documentation/docs/en/api/paddle/linalg/eig_en.html), but I'm running into some errors when running the tests. 

For the sake of Iterating quickly, I've limited the shape of the input matrix only to [2,2], I'll add additional cases when I'll figure out how to solve the issue.

The error I get is an assertion error: 

> AssertionError:  the results from backend jax and ground truth framework paddle do not match
> E            [[0.20412415-0.54006172j 0.20412415+0.54006172j]
> E            [0.81649658+0.j         0.81649658-0.j        ]]!=[[-0.20412415+0.54006172j -0.20412415-0.54006172j]
> E            [-0.81649658+0.j         -0.81649658-0.j        ]] 

Plus, the datatype of the two matrices is different, one has a _complex64_ datatype, the other _complex128_.

I started digging into other Ivy's files and found another eig testing function being implemented in [ivy_tests/test_ivy/test_frontends/test_paddle/test_tensor/test_paddle_linalg.py](https://github.com/unifyai/ivy/blob/master/ivy_tests/test_ivy/test_frontends/test_paddle/test_tensor/test_paddle_linalg.py) [Line 282]. What I've noticed here is that this test runs into the same problem I'm facing, the only difference is that this test function has `Test_values=False` so it runs without calling out any errors. 

If i set `Test_values=False` in my test function then I get no errors too, but I think that might defy the purpose of testing. This is my first time contributing to Ivy, so there might be something I'm not seeing, could someone help me figure this out? 

Thanks!