### PR TITLE
fix jax expand for shapes with more dims than input

### DIFF
--- a/ivy/functional/backends/jax/experimental/manipulation.py
+++ b/ivy/functional/backends/jax/experimental/manipulation.py
@@ -327,6 +327,8 @@ def expand(
     out: Optional[JaxArray] = None,
 ) -> JaxArray:
     shape = list(shape)
+    if len(shape) > len(x.shape):
+        x = jnp.expand_dims(x, range(len(shape) - len(x.shape)))
     for i, dim in enumerate(shape):
         if dim < 0:
             shape[i] = x.shape[i]


### PR DESCRIPTION
Fix a bug where the jax backend expand function cannot handle shapes which have more dims than the input, and one of the final dims is negative.

Min example:
```
import ivy

ivy.set_backend('torch')
x = ivy.random_normal(shape=(4))
x = x.expand((1, -1))
print(x.shape)

ivy.set_backend('jax')
x = ivy.random_normal(shape=(4))
x = x.expand((1, -1))
print(x.shape)
```