### PR TITLE
migrate `ivy.deserialize` and `ivy.get` to tensorflow frontend

### DIFF
--- a/ivy/functional/backends/tensorflow/activations.py
+++ b/ivy/functional/backends/tensorflow/activations.py
@@ -78,33 +78,6 @@ def log_softmax(
     return tf.nn.log_softmax(x, axis)
 
 
-def deserialize(
-    name: Union[str, None], /, *, custom_objects: Optional[ivy.Dict] = None
-) -> Union[ivy.Callable, None]:
-    return tf.keras.activations.deserialize(name, custom_objects)
-
-
-def get(
-    identifier: Union[str, ivy.Callable, None],
-    /,
-    *,
-    custom_objects: Optional[ivy.Dict] = None,
-) -> Union[ivy.Callable, None]:
-    if identifier is None:
-        return tf.keras.activations.linear
-
-    if isinstance(identifier, str):
-        identifier = str(identifier)
-        return ivy.deserialize(identifier, custom_objects=custom_objects)
-
-    elif callable(identifier):
-        return identifier
-    else:
-        raise TypeError(
-            f"Could not interpret activation function identifier: {identifier}"
-        )
-
-
 @with_unsupported_dtypes({"2.12.0 and below": ("complex",)}, backend_version)
 def mish(
     x: Tensor,

--- a/ivy/functional/ivy/activations.py
+++ b/ivy/functional/ivy/activations.py
@@ -1,7 +1,6 @@
 """Collection of Ivy activation functions."""
 
-from typing import Union, Optional, Callable
-import sys
+from typing import Union, Optional
 
 # local
 import ivy
@@ -15,86 +14,6 @@ from ivy.func_wrapper import (
     handle_array_like_without_promotion,
 )
 from ivy.utils.exceptions import handle_exceptions
-
-
-# Extra #
-# ------#
-
-
-@handle_exceptions
-def deserialize(
-    name: Union[str, None], /, *, custom_objects: Optional[ivy.Dict] = None
-) -> Union[Callable, None]:
-    """
-    Return activation function given a string identifier.
-
-    Parameters
-    ----------
-    name
-        The name of the activation function.
-    custom_objects
-        Optional dictionary listing user-provided activation functions.
-
-    Returns
-    -------
-    ret
-        Corresponding activation function.
-
-    Examples
-    --------
-    With :code:`str` input:
-
-    >>> name = "sigmoid"
-    >>> sigmoid = ivy.deserialize(name)
-    >>> print(sigmoid)
-    <function sigmoid at XXXXXXXXXXXXXX>
-
-    With :code:`str` and :code:`dict` input:
-
-    >>> name = "custom_fn"
-    >>> objects = {"custom_fn": lambda x: x}
-    >>> custom_fn = ivy.deserialize(name, custom_objects=objects)
-    >>> print(custom_fn)
-    <function custom_fn at XXXXXXXXXXXXXX>
-    """
-    if current_backend().__name__.split(".")[-1] == "tensorflow":
-        return current_backend().deserialize(name, custom_objects=custom_objects)
-
-    if name is None:
-        return None
-
-    module_name = "ivy.functional.ivy.activations"
-    activation_functions = {}
-    module = sys.modules[module_name]
-
-    for fn_name in dir(module):
-        obj = getattr(module, fn_name)
-        if callable(obj) and fn_name in ACTIVATION_FUNCTIONS:
-            activation_functions[fn_name] = obj
-
-    if isinstance(name, str):
-        if custom_objects and name in custom_objects:
-            fn_obj = custom_objects.get(name)
-        else:
-            fn_obj = activation_functions.get(name)
-            if fn_obj is None:
-                raise ValueError(f"Unknown activation function: {name}.")
-        return fn_obj
-
-    else:
-        raise ValueError(f"Could not interpret serialized activation function: {name}")
-
-
-ACTIVATION_FUNCTIONS = [
-    "gelu",
-    "leaky_relu",
-    "log_softmax",
-    "relu",
-    "sigmoid",
-    "silu",
-    "softmax",
-    "softplus",
-]
 
 
 @handle_exceptions
@@ -156,56 +75,6 @@ def gelu(
     }
     """
     return current_backend(x).gelu(x, approximate=approximate, out=out)
-
-
-@handle_exceptions
-def get(
-    name: Union[str, None], /, *, custom_objects: Optional[ivy.Dict] = None
-) -> Union[Callable, None]:
-    """
-    Return activation function given a string identifier.
-
-    Parameters
-    ----------
-    name
-        The name of the activation function.
-    custom_objects
-        Optional dictionary listing user-provided activation functions.
-
-    Returns
-    -------
-    ret
-        Corresponding activation function.
-
-    Examples
-    --------
-    With :code:`str` input:
-
-    >>> name = "sigmoid"
-    >>> sigmoid = ivy.get(name)
-    >>> print(sigmoid)
-    <function sigmoid at XXXXXXXXXXXXXX>
-
-    >>> name = None
-    >>> linear = ivy.get(name)
-    >>> print(linear)
-    <function linear at XXXXXXXXXXXXXX>
-
-    With :code:`str` and :code:`dict` input:
-
-    >>> name = "custom_fn"
-    >>> objects = {"custom_fn": lambda x: x}
-    >>> custom_fn = ivy.get(name, custom_objects=objects)
-    >>> print(custom_fn)
-    <function custom_fn at XXXXXXXXXXXXXX>
-    """
-    if current_backend().__name__.split(".")[-1] == "tensorflow":
-        return current_backend().get(name, custom_objects=custom_objects)
-
-    if name is None:
-        return ivy.linear
-
-    return ivy.deserialize(name, custom_objects=custom_objects)
 
 
 @handle_exceptions


### PR DESCRIPTION
solves https://trello.com/c/DxFNJEtU/2184-migrate-ivyget-and-ivydeserialize-to-the-tensorflow-frontend

The functional APIs have been removed along with their backend implementations.
These functions are then completely implemented in the frontend.
