### PR TITLE
Fix TODO: Ensure array is created on default device

### DIFF
--- a/ivy/functional/frontends/jax/numpy/creation.py
+++ b/ivy/functional/frontends/jax/numpy/creation.py
@@ -23,6 +23,11 @@ def array(object, dtype=None, copy=True, order="K", ndmin=0):
     ret = ivy.array(object, dtype=dtype)
     if ivy.get_num_dims(ret) < ndmin:
         ret = ivy.expand_dims(ret, axis=list(range(ndmin - ivy.get_num_dims(ret))))
+
+    # Moving array to the default device
+    default_device = ivy.get_default_device()
+    ret = ivy.to_device(ret, default_device)
+
     if ret.shape == () and dtype is None:
         return DeviceArray(ret, weak_type=True)
     return DeviceArray(ret)


### PR DESCRIPTION
By ensuring that all arrays are created on the default device, we can avoid unnecessary cross-device data transfers, thus improving overall performance and ensuring compatibility with various hardware configurations.