### PR TITLE
change the logical_and implmentation in paddle backend as it is not s…

### DIFF
--- a/ivy/functional/backends/paddle/elementwise.py
+++ b/ivy/functional/backends/paddle/elementwise.py
@@ -530,16 +530,22 @@ def logical_xor(
     return paddle.logical_xor(x1, x2)
 
 
+@with_unsupported_device_and_dtypes(
+    {"2.5.0 and below": {"cpu": ("complex64", "complex128")}},
+    backend_version,
+)
 def logical_and(
     x1: paddle.Tensor, x2: paddle.Tensor, /, *, out: Optional[paddle.Tensor] = None
 ) -> paddle.Tensor:
     x1, x2, ret_dtype = _elementwise_helper(x1, x2)
     if ret_dtype in [paddle.uint8, paddle.float16, paddle.complex64, paddle.complex128]:
-        if paddle.is_complex(x1):
-            return paddle.logical_and(
-                paddle.logical_and(x1.real(), x2.real()),
-                paddle.logical_and(x1.imag(), x2.imag()),
-            )
+        # this logic works well when both inputs are complex but when one of them
+        # is casted from real to complex, the imaginary part is zero which messes
+        # if paddle.is_complex(x1):
+        #     return paddle.logical_and(
+        #         paddle.logical_and(x1.real(), x2.real()),
+        #         paddle.logical_and(x1.imag(), x2.imag()),
+        #     )
         return paddle.logical_and(x1.astype("float32"), x2.astype("float32"))
     return paddle.logical_and(x1, x2)
 


### PR DESCRIPTION
…upported for complex number and it was make error in torch.logical_and when it pass complex number and generate this error the results from backend paddle and ground truth framework torch do not match