### PR TITLE
do not throw exception when checking int-inf compatibility

### DIFF
--- a/ivy/utils/assertions.py
+++ b/ivy/utils/assertions.py
@@ -194,7 +194,7 @@ def check_fill_value_and_dtype_are_compatible(fill_value, dtype):
     if (
         not (
             (ivy.is_int_dtype(dtype) or ivy.is_uint_dtype(dtype))
-            and isinstance(fill_value, int)
+            and (isinstance(fill_value, int) or ivy.isinf(fill_value))
         )
         and not (
             ivy.is_complex_dtype(dtype) and isinstance(fill_value, (float, complex))


### PR DESCRIPTION
Changed the check_fill_value_and_dtype_are_compatible assertion to not throw for inf fill_value and int dtype. This was causing LongformerModel to fail transpilation, due to function calls like this:

https://github.com/huggingface/transformers/blob/v4.30.0/src/transformers/models/longformer/modeling_longformer.py#L810