### PR TITLE
Add __iter__ method to Sequential

### DIFF
--- a/ivy/stateful/sequential.py
+++ b/ivy/stateful/sequential.py
@@ -45,6 +45,9 @@ class Sequential(Module):
         self._submodules = list(sub_modules)
         Module.__init__(self, device=device, v=v, dtype=dtype)
 
+    def __iter__(self):
+        return iter(self._submodules)
+
     def _forward(self, inputs):
         """
         Perform forward pass of the Linear layer.

--- a/ivy/stateful/sequential.py
+++ b/ivy/stateful/sequential.py
@@ -50,7 +50,7 @@ class Sequential(Module):
 
     def _forward(self, inputs):
         """
-        Perform forward pass of the Linear layer.
+        Perform forward pass of the Sequential container.
 
         Parameters
         ----------
@@ -60,7 +60,7 @@ class Sequential(Module):
         Returns
         -------
         ret
-            The outputs following the linear operation and bias addition.
+            The output after each of the layers in the Sequential has been applied.
         """
         x = inputs
         for i, submod in enumerate(self._submodules):


### PR DESCRIPTION
Small quality of life improvement to allow you to iterate over a sequential container e.g. for loops. Also updated the docstring for the forward pass as it was previously the docstring for Linear I think.