### PR TITLE
refactor `inv` adjoint=True to work for `N-D` input.

### DIFF
--- a/ivy/functional/backends/jax/linear_algebra.py
+++ b/ivy/functional/backends/jax/linear_algebra.py
@@ -144,10 +144,13 @@ def inv(
     adjoint: bool = False,
     out: Optional[JaxArray] = None,
 ) -> JaxArray:
-    if jnp.any(jnp.linalg.det(x.astype("float64")) == 0):
-        return x
     if adjoint:
-        x = jnp.transpose(x)
+        if x.ndim < 2:
+            raise ValueError("Input must be at least 2D")
+        permutation = list(range(x.ndim))
+        permutation[-2], permutation[-1] = permutation[-1], permutation[-2]
+        x_adj = jnp.transpose(x, permutation).conj()
+        return jnp.linalg.inv(x_adj)
     return jnp.linalg.inv(x)
 
 

--- a/ivy/functional/backends/numpy/linear_algebra.py
+++ b/ivy/functional/backends/numpy/linear_algebra.py
@@ -101,16 +101,14 @@ def inv(
     adjoint: bool = False,
     out: Optional[np.ndarray] = None,
 ) -> np.ndarray:
-    if np.any(np.linalg.det(x.astype("float64")) == 0):
-        return x
-    else:
-        if adjoint is False:
-            ret = np.linalg.inv(x)
-            return ret
-        else:
-            x = np.transpose(x)
-            ret = np.linalg.inv(x)
-            return ret
+    if adjoint:
+        if x.ndim < 2:
+            raise ValueError("Input must be at least 2D")
+        permutation = list(range(x.ndim))
+        permutation[-2], permutation[-1] = permutation[-1], permutation[-2]
+        x_adj = np.transpose(x, permutation).conj()
+        return np.linalg.inv(x_adj)
+    return np.linalg.inv(x)
 
 
 @with_unsupported_dtypes({"1.25.0 and below": ("float16", "bfloat16")}, backend_version)

--- a/ivy/functional/backends/tensorflow/linear_algebra.py
+++ b/ivy/functional/backends/tensorflow/linear_algebra.py
@@ -182,7 +182,15 @@ def inner(
     return tf.experimental.numpy.inner(x1, x2)
 
 
-@with_unsupported_dtypes({"2.13.0 and below": ("float16", "bfloat16")}, backend_version)
+@with_unsupported_dtypes(
+    {
+        "2.13.0 and below": (
+            "float16",
+            "bfloat16",
+        )
+    },
+    backend_version,
+)
 def inv(
     x: Union[tf.Tensor, tf.Variable],
     /,
@@ -190,16 +198,7 @@ def inv(
     adjoint: bool = False,
     out: Optional[Union[tf.Tensor, tf.Variable]] = None,
 ) -> Union[tf.Tensor, tf.Variable]:
-    if tf.math.reduce_any(tf.linalg.det(tf.cast(x, dtype="float64")) == 0):
-        return x
-    else:
-        if adjoint is False:
-            ret = tf.linalg.inv(x)
-            return ret
-        else:
-            x = tf.linalg.adjoint(x)
-            ret = tf.linalg.inv(x)
-            return ret
+    return tf.linalg.inv(x, adjoint=adjoint)
 
 
 @with_unsupported_dtypes({"1.25.0 and below": ("float16", "bfloat16")}, backend_version)

--- a/ivy/functional/backends/torch/linear_algebra.py
+++ b/ivy/functional/backends/torch/linear_algebra.py
@@ -143,20 +143,18 @@ def inv(
     adjoint: bool = False,
     out: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
-    if torch.linalg.det == 0:
-        ret = x
-        if ivy.exists(out):
-            return ivy.inplace_update(out, ret)
+    if adjoint:
+        if x.dim() < 2:
+            raise ValueError("Input must be at least 2D")
+        x_adj = x.transpose(-2, -1).conj()
+        ret = torch.linalg.inv(x_adj)
     else:
-        if adjoint is False:
-            ret = torch.inverse(x, out=out)
-            return ret
-        else:
-            x = torch.t(x)
-            ret = torch.inverse(x, out=out)
-            if ivy.exists(out):
-                return ivy.inplace_update(out, ret)
-            return ret
+        ret = torch.linalg.inv(x)
+
+    if ivy.exists(out):
+        return ivy.inplace_update(out, ret)
+
+    return ret
 
 
 inv.support_native_out = True

--- a/ivy/functional/frontends/tensorflow/linalg.py
+++ b/ivy/functional/frontends/tensorflow/linalg.py
@@ -308,3 +308,19 @@ def band_part(input, num_lower, num_upper, name=None):
         (num_upper < 0) | ((n - m) <= num_upper)
     )
     return ivy.where(mask, input, ivy.zeros_like(input))
+
+
+@to_ivy_arrays_and_back
+@with_supported_dtypes(
+    {
+        "2.13.0 and below": (
+            "float32",
+            "float64",
+            "complex64",
+            "complex128",
+        )
+    },
+    "tensorflow",
+)
+def inv(input, adjoint=False, name=None):
+    return ivy.inv(input, adjoint=adjoint)

--- a/ivy_tests/test_ivy/test_frontends/test_tensorflow/test_linalg.py
+++ b/ivy_tests/test_ivy/test_frontends/test_tensorflow/test_linalg.py
@@ -916,3 +916,42 @@ def test_tensorflow_band_part(
         num_lower=num_lower,
         num_upper=num_upper,
     )
+
+
+# inv
+@handle_frontend_test(
+    fn_tree="tensorflow.linalg.inv",
+    dtype_and_x=helpers.dtype_and_values(
+        available_dtypes=helpers.get_dtypes("valid"),
+        min_value=-100,
+        max_value=100,
+        shape=helpers.ints(min_value=1, max_value=20).map(lambda x: tuple([x, x])),
+    ).filter(
+        lambda x: "bfloat16" not in x[0]
+        and np.linalg.cond(x[1][0]) < 1 / sys.float_info.epsilon
+        and np.linalg.det(np.asarray(x[1][0])) != 0
+    ),
+    adjoint=st.booleans(),
+    test_with_out=st.just(False),
+)
+def test_tensorflow_inv(
+    *,
+    dtype_and_x,
+    on_device,
+    fn_tree,
+    frontend,
+    test_flags,
+    adjoint,
+):
+    dtype, x = dtype_and_x
+    helpers.test_frontend_function(
+        input_dtypes=dtype,
+        rtol=1e-01,
+        atol=1e-01,
+        frontend=frontend,
+        test_flags=test_flags,
+        fn_tree=fn_tree,
+        on_device=on_device,
+        input=x[0],
+        adjoint=adjoint,
+    )


### PR DESCRIPTION
- Refactor the `adjoint=True` in `inv`  to work with `N-D` inputs for `NumPy`, `Jax` and `Torch`.
- Added `inv` to TensorFlow frontend and write test.
 
Ran test locally for both changes (test are passing for all backends)

@zaeemansari70  @DragosStoican 