### PR TITLE
Fix torch.reduction_ops.unique which was calling ivy.unique_all with wrong arguments order

### DIFF
--- a/ivy/functional/frontends/torch/reduction_ops.py
+++ b/ivy/functional/frontends/torch/reduction_ops.py
@@ -294,7 +294,7 @@ def logsumexp(input, dim, keepdim=False, *, out=None):
 def unique(input, sorted=True, return_inverse=False, return_counts=False, dim=None):
     if dim is not None:
         sorted = True
-    results = ivy.unique_all(input, by_value=sorted, axis=dim)
+    results = ivy.unique_all(input, axis=dim, by_value=sorted)
 
     fields = ["output"]
     if return_inverse:


### PR DESCRIPTION
This was causing `test_torch_unique` failing for all backends. This fix solves the failures for all backends but paddle, which is failing for a different reason.