### PR TITLE
Fix typo/grammar in README.rst file

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -423,7 +423,7 @@ You can find quite a lot more examples in the corresponding section below, but u
 Documentation
 -------------
 
-The `Ivy Docs page <https://unify.ai/docs/ivy/>`_ holds all the relevant information about Ivy's and it's framework API reference. 
+The `Ivy Docs page <https://unify.ai/docs/ivy/>`_ holds all the relevant information about Ivy and its framework API reference. 
 
 There, you will find the `Design <https://unify.ai/docs/ivy/overview/design.html>`_ page, which is a user-focused guide about the architecture and the building blocks of Ivy. Likewise, you can take a look at the `Deep dive <https://unify.ai/docs/ivy/overview/deep_dive.html>`_, which is oriented towards potential contributors of the code base and explains the nuances of Ivy in full detail 🔎
 


### PR DESCRIPTION
As I am on boarding, I found this in README: 

1. "Ivy's" should be "Ivy." The possessive form "Ivy's" implies that something belongs to Ivy, but in this context, it seems that "Ivy" is being referred to as a proper noun.

2. "it's" should be "its." "It's" is a contraction of "it is" or "it has," whereas "its" is the possessive form of "it." 