### PR TITLE
Updated the `execute_with_gradients` function and `README` examples for better usability

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1551,6 +1551,12 @@ Last but not least, we can also build the training pipeline in pure ivy ⬇️
     # train the model on gpu if it's available
     device = "cuda:0" if ivy.gpu_is_available() else "cpu"
 
+    # training hyperparams
+    optimizer= ivy.Adam(1e-4)
+    batch_size = 64 
+    num_epochs = 20
+    num_classes = 10
+
     model = IvyNet(
         h_w=(28, 28),
         input_channels=1,
@@ -1559,13 +1565,6 @@ Last but not least, we can also build the training pipeline in pure ivy ⬇️
         device=device,
     )
     model_name = type(model).__name__.lower()
-    
-    
-    # training hyperparams
-    optimizer= ivy.Adam(1e-4)
-    batch_size = 64 
-    num_epochs = 20
-    num_classes = 10
     
     
     # training loop

--- a/README.rst
+++ b/README.rst
@@ -294,7 +294,7 @@ but this can easily be changed to your favorite framework, such as TensorFlow, o
         pred = model(x)
 
         # compute loss and gradients
-        loss, grads = ivy.execute_with_gradients(lambda params: loss_fn(*params), (model.v, x, y), xs_grad_idxs=[[0]])
+        loss, grads = ivy.execute_with_gradients(lambda params: loss_fn(*params), (model.v, x, y))
 
         # update parameters
         model.v = optimizer.step(model.v, grads)
@@ -1597,8 +1597,6 @@ Last but not least, we can also build the training pipeline in pure ivy ⬇️
                 loss_probs, grads = ivy.execute_with_gradients(
                     loss_fn,
                     (model.v, model, xbatch, ybatch_encoded),
-                    ret_grad_idxs=[[0]],
-                    xs_grad_idxs=[[0]],
                 )
                 
                 model.v = optimizer.step(model.v, grads["0"])

--- a/ivy/functional/backends/jax/gradients.py
+++ b/ivy/functional/backends/jax/gradients.py
@@ -75,7 +75,7 @@ def execute_with_gradients(
     *,
     retain_grads: bool = False,
     xs_grad_idxs: Optional[Sequence[Sequence[Union[str, int]]]] = [[0]],
-    ret_grad_idxs: Optional[Sequence[Sequence[Union[str, int]]]] = None,
+    ret_grad_idxs: Optional[Sequence[Sequence[Union[str, int]]]] = [[0]],
 ):
     # Conversion of required arrays to float variables and duplicate index chains
     (
@@ -89,7 +89,7 @@ def execute_with_gradients(
     func_ret = func(xs)
 
     # Getting the relevant outputs from the function return for gradient calculation
-    y, ret_idxs = _get_y_and_ret_idxs(func_ret, ret_grad_idxs)
+    ret_grad_idxs, y, ret_idxs = _get_y_and_ret_idxs(func_ret, ret_grad_idxs)
 
     if isinstance(y, ivy.NativeArray):
         # Gradient calculation for a single output
@@ -116,7 +116,6 @@ def execute_with_gradients(
                 ret_grad_idxs=ret_grad_idxs,
             )
         )
-        print("xs_required", xs_required)
         grads_ = grad_fn(xs_required)
         grads = grads_
         if isinstance(ret_idxs, list) and len(ret_idxs):

--- a/ivy/functional/backends/jax/gradients.py
+++ b/ivy/functional/backends/jax/gradients.py
@@ -74,12 +74,13 @@ def execute_with_gradients(
     /,
     *,
     retain_grads: bool = False,
-    xs_grad_idxs: Optional[Sequence[Sequence[Union[str, int]]]] = None,
+    xs_grad_idxs: Optional[Sequence[Sequence[Union[str, int]]]] = [[0]],
     ret_grad_idxs: Optional[Sequence[Sequence[Union[str, int]]]] = None,
 ):
     # Conversion of required arrays to float variables and duplicate index chains
     (
         xs,
+        xs_grad_idxs,
         xs_required,
         required_duplicate_index_chains,
         duplicate_index_chains,
@@ -115,6 +116,7 @@ def execute_with_gradients(
                 ret_grad_idxs=ret_grad_idxs,
             )
         )
+        print("xs_required", xs_required)
         grads_ = grad_fn(xs_required)
         grads = grads_
         if isinstance(ret_idxs, list) and len(ret_idxs):

--- a/ivy/functional/backends/mxnet/gradients.py
+++ b/ivy/functional/backends/mxnet/gradients.py
@@ -26,7 +26,7 @@ def execute_with_gradients(
     /,
     *,
     retain_grads: bool = False,
-    xs_grad_idxs: Optional[Sequence[Sequence[Union[str, int]]]] = None,
+    xs_grad_idxs: Optional[Sequence[Sequence[Union[str, int]]]] = [[0]],
     ret_grad_idxs: Optional[Sequence[Sequence[Union[str, int]]]] = None,
 ):
     raise IvyNotImplementedException()

--- a/ivy/functional/backends/mxnet/gradients.py
+++ b/ivy/functional/backends/mxnet/gradients.py
@@ -27,7 +27,7 @@ def execute_with_gradients(
     *,
     retain_grads: bool = False,
     xs_grad_idxs: Optional[Sequence[Sequence[Union[str, int]]]] = [[0]],
-    ret_grad_idxs: Optional[Sequence[Sequence[Union[str, int]]]] = None,
+    ret_grad_idxs: Optional[Sequence[Sequence[Union[str, int]]]] = [[0]],
 ):
     raise IvyNotImplementedException()
 

--- a/ivy/functional/backends/numpy/gradients.py
+++ b/ivy/functional/backends/numpy/gradients.py
@@ -31,7 +31,7 @@ def execute_with_gradients(
     *,
     retain_grads: bool = False,
     xs_grad_idxs: Optional[Sequence[Sequence[Union[str, int]]]] = [[0]],
-    ret_grad_idxs: Optional[Sequence[Sequence[Union[str, int]]]] = None,
+    ret_grad_idxs: Optional[Sequence[Sequence[Union[str, int]]]] = [[0]],
 ):
     logging.warning(
         "NumPy does not support autograd, "

--- a/ivy/functional/backends/numpy/gradients.py
+++ b/ivy/functional/backends/numpy/gradients.py
@@ -30,7 +30,7 @@ def execute_with_gradients(
     /,
     *,
     retain_grads: bool = False,
-    xs_grad_idxs: Optional[Sequence[Sequence[Union[str, int]]]] = None,
+    xs_grad_idxs: Optional[Sequence[Sequence[Union[str, int]]]] = [[0]],
     ret_grad_idxs: Optional[Sequence[Sequence[Union[str, int]]]] = None,
 ):
     logging.warning(

--- a/ivy/functional/backends/paddle/gradients.py
+++ b/ivy/functional/backends/paddle/gradients.py
@@ -107,7 +107,7 @@ def _grad_func(y, xs, retain_grads):
     {"2.5.0 and below": {"cpu": ("float16",)}}, backend_version
 )
 def execute_with_gradients(
-    func, xs, /, *, retain_grads=False, xs_grad_idxs=[[0]], ret_grad_idxs=None
+    func, xs, /, *, retain_grads=False, xs_grad_idxs=[[0]], ret_grad_idxs=[[0]]
 ):
     # Conversion of required arrays to float variables and duplicate index chains
     xs, xs_grad_idxs, xs1, required_duplicate_index_chains, _ = (
@@ -127,7 +127,9 @@ def execute_with_gradients(
         xs = ivy.set_nest_at_indices(xs, duplicate_indices, None, shallow=False)
 
     # Getting the relevant outputs from the function return for gradient calculation
-    y, ret_idxs = _get_y_and_ret_idxs(func_ret, ret_grad_idxs, create_var=True)
+    ret_grad_idxs, y, ret_idxs = _get_y_and_ret_idxs(
+        func_ret, ret_grad_idxs, create_var=True
+    )
 
     if isinstance(y, ivy.NativeArray):
         # Gradient calculation for a single output

--- a/ivy/functional/backends/paddle/gradients.py
+++ b/ivy/functional/backends/paddle/gradients.py
@@ -107,11 +107,11 @@ def _grad_func(y, xs, retain_grads):
     {"2.5.0 and below": {"cpu": ("float16",)}}, backend_version
 )
 def execute_with_gradients(
-    func, xs, /, *, retain_grads=False, xs_grad_idxs=None, ret_grad_idxs=None
+    func, xs, /, *, retain_grads=False, xs_grad_idxs=[[0]], ret_grad_idxs=None
 ):
     # Conversion of required arrays to float variables and duplicate index chains
-    xs, xs1, required_duplicate_index_chains, _ = _get_required_float_variables(
-        xs, xs_grad_idxs
+    xs, xs_grad_idxs, xs1, required_duplicate_index_chains, _ = (
+        _get_required_float_variables(xs, xs_grad_idxs)
     )
     func_ret = func(xs)
     xs = xs1

--- a/ivy/functional/backends/tensorflow/experimental/gradients.py
+++ b/ivy/functional/backends/tensorflow/experimental/gradients.py
@@ -10,7 +10,7 @@ from ivy.functional.ivy.gradients import _get_required_float_variables
 def bind_custom_gradient_function(func, custom_grad_fn):
     @tf.custom_gradient
     def custom_module(x):
-        x, _, _, _ = _get_required_float_variables(x, xs_grad_idxs=None)
+        x, _, _, _, _ = _get_required_float_variables(x, xs_grad_idxs=None)
         ret = func(x)
 
         def grad(upstream):

--- a/ivy/functional/backends/tensorflow/gradients.py
+++ b/ivy/functional/backends/tensorflow/gradients.py
@@ -69,12 +69,12 @@ def execute_with_gradients(
     /,
     *,
     retain_grads: bool = False,
-    xs_grad_idxs: Optional[Sequence[Sequence[Union[str, int]]]] = None,
+    xs_grad_idxs: Optional[Sequence[Sequence[Union[str, int]]]] = [[0]],
     ret_grad_idxs: Optional[Sequence[Sequence[Union[str, int]]]] = None,
 ):
     # Conversion of required arrays to float variables and duplicate index chains
-    xs, xs_required, required_duplicate_index_chains, _ = _get_required_float_variables(
-        xs, xs_grad_idxs
+    xs, xs_grad_idxs, xs_required, required_duplicate_index_chains, _ = (
+        _get_required_float_variables(xs, xs_grad_idxs)
     )
 
     # Creating a tape to record operations

--- a/ivy/functional/backends/tensorflow/gradients.py
+++ b/ivy/functional/backends/tensorflow/gradients.py
@@ -70,7 +70,7 @@ def execute_with_gradients(
     *,
     retain_grads: bool = False,
     xs_grad_idxs: Optional[Sequence[Sequence[Union[str, int]]]] = [[0]],
-    ret_grad_idxs: Optional[Sequence[Sequence[Union[str, int]]]] = None,
+    ret_grad_idxs: Optional[Sequence[Sequence[Union[str, int]]]] = [[0]],
 ):
     # Conversion of required arrays to float variables and duplicate index chains
     xs, xs_grad_idxs, xs_required, required_duplicate_index_chains, _ = (
@@ -83,7 +83,9 @@ def execute_with_gradients(
         func_ret = func(xs)
 
     # Getting the relevant outputs from the function return for gradient calculation
-    y, ret_idxs = _get_y_and_ret_idxs(func_ret, ret_grad_idxs, reshape=False)
+    ret_grad_idxs, y, ret_idxs = _get_y_and_ret_idxs(
+        func_ret, ret_grad_idxs, reshape=False
+    )
 
     if isinstance(y, ivy.NativeArray):
         # Gradient calculation for a single output

--- a/ivy/functional/backends/torch/gradients.py
+++ b/ivy/functional/backends/torch/gradients.py
@@ -98,14 +98,13 @@ def execute_with_gradients(
     /,
     *,
     retain_grads: bool = False,
-    xs_grad_idxs: Optional[Sequence[Sequence[Union[str, int]]]] = None,
+    xs_grad_idxs: Optional[Sequence[Sequence[Union[str, int]]]] = [[0]],
     ret_grad_idxs: Optional[Sequence[Sequence[Union[str, int]]]] = None,
 ):
     # Conversion of required arrays to float variables and duplicate index chains
-    xs, xs1, required_duplicate_index_chains, _ = _get_required_float_variables(
-        xs, xs_grad_idxs
+    xs, xs_grad_idxs, xs1, required_duplicate_index_chains, _ = (
+        _get_required_float_variables(xs, xs_grad_idxs)
     )
-
     func_ret = func(xs)
     xs = xs1
 

--- a/ivy/functional/backends/torch/gradients.py
+++ b/ivy/functional/backends/torch/gradients.py
@@ -99,7 +99,7 @@ def execute_with_gradients(
     *,
     retain_grads: bool = False,
     xs_grad_idxs: Optional[Sequence[Sequence[Union[str, int]]]] = [[0]],
-    ret_grad_idxs: Optional[Sequence[Sequence[Union[str, int]]]] = None,
+    ret_grad_idxs: Optional[Sequence[Sequence[Union[str, int]]]] = [[0]],
 ):
     # Conversion of required arrays to float variables and duplicate index chains
     xs, xs_grad_idxs, xs1, required_duplicate_index_chains, _ = (
@@ -109,7 +109,9 @@ def execute_with_gradients(
     xs = xs1
 
     # Getting the relevant outputs from the function return for gradient calculation
-    y, ret_idxs = _get_y_and_ret_idxs(func_ret, ret_grad_idxs, create_var=True)
+    ret_grad_idxs, y, ret_idxs = _get_y_and_ret_idxs(
+        func_ret, ret_grad_idxs, create_var=True
+    )
 
     if isinstance(y, ivy.NativeArray):
         # Gradient calculation for a single output

--- a/ivy/functional/ivy/gradients.py
+++ b/ivy/functional/ivy/gradients.py
@@ -192,6 +192,10 @@ def _set_duplicates(xs, duplicate_index_chains):
 
 def _get_y_and_ret_idxs(func_ret, ret_grad_idxs, create_var=False, reshape=True):
     """Get the relevant outputs from the function return value."""
+    if (ivy.is_ivy_container(func_ret) or ivy.is_array(func_ret)) and ret_grad_idxs == [
+        [0]
+    ]:
+        ret_grad_idxs = None
     ret_idxs, ret_values = _get_native_variables_and_indices(
         func_ret, idxs=ret_grad_idxs, create_var=create_var, reshape=reshape
     )
@@ -201,7 +205,7 @@ def _get_y_and_ret_idxs(func_ret, ret_grad_idxs, create_var=False, reshape=True)
         y = ret_values[0]
     else:
         y = ret_values
-    return y, ret_idxs
+    return ret_grad_idxs, y, ret_idxs
 
 
 def _get_native_y(y):
@@ -399,7 +403,7 @@ def execute_with_gradients(
     *,
     retain_grads: bool = False,
     xs_grad_idxs: Optional[Sequence[Sequence[Union[str, int]]]] = [[0]],
-    ret_grad_idxs: Optional[Sequence[Sequence[Union[str, int]]]] = None,
+    ret_grad_idxs: Optional[Sequence[Sequence[Union[str, int]]]] = [[0]],
 ) -> Tuple[ivy.Array, ivy.Array]:
     """
     Call function func with input of xs variables, and return the function result
@@ -422,7 +426,9 @@ def execute_with_gradients(
         default value is ``[[0]]``.
     ret_grad_idxs
         Indices of the returned arrays for which to return computed gradients. If None,
-        gradients are returned for all returned arrays. (Default value = None)
+        gradients are returned for all returned arrays. If the returned object from the
+        ``func`` is an ``ivy.Array`` or ``ivy.Container``, the default value is ``None``
+        otherwise the default value is ``[[0]]``.
 
     Returns
     -------

--- a/ivy_tests/test_ivy/test_functional/test_core/test_gradients.py
+++ b/ivy_tests/test_ivy/test_functional/test_core/test_gradients.py
@@ -1,7 +1,7 @@
 """Collection of tests for unified gradient functions."""
 
 # global
-from hypothesis import strategies as st
+from hypothesis import strategies as st, assume
 import pytest
 import numpy as np
 
@@ -113,6 +113,8 @@ def test_stop_gradient(
 def test_execute_with_gradients(
     *, dtype_and_xs, retain_grads, test_flags, backend_fw, fn_name, on_device
 ):
+    assume(not backend_fw.backend == "numpy")
+
     def func(xs):
         if isinstance(xs, ivy.Container):
             array_idxs = ivy.nested_argwhere(xs, ivy.is_array)


### PR DESCRIPTION
1. Changed the default value of `xs_grad_idxs` in `execute_with_gradients` to `[[0]]` when `xs` is not a `ivy.Array` or `ivy.Container`, as the most common usage would involve `xs` being `(variables, input, output)`.
2. Changed the default value of `ret_grad_idxs` in `execute_with_gradients` to `[[0]]` as well when `ret` from the `func` is not an `ivy.Array` or `ivy.Container`, for consistency with `xs_grad_idxs` and to make it more intuitive.
3. Updated the examples in the `README.rst` to having to pass these arguments for the most common use-case.
4. Moved hyperparameter initialization above model creation in the `README.rst` demo for image classification
5. Skipped the tests for `execute_with_gradients` with the `numpy` backend.