### PR TITLE
Adding `hermitian` parameter to `ivy.pinv`

### DIFF
--- a/ivy/functional/backends/jax/linear_algebra.py
+++ b/ivy/functional/backends/jax/linear_algebra.py
@@ -274,10 +274,13 @@ def pinv(
     /,
     *,
     rtol: Optional[Union[float, Tuple[float]]] = None,
+    hermitian: Optional[bool] = False,
     out: Optional[JaxArray] = None,
 ) -> JaxArray:
     if rtol is None:
         ret = jnp.linalg.pinv(x)
+    elif hermitian:
+        ret = jnp.linalg.pinv(x, hermitian=hermitian)
     else:
         ret = jnp.linalg.pinv(x, rtol)
     return ret

--- a/ivy/functional/backends/jax/linear_algebra.py
+++ b/ivy/functional/backends/jax/linear_algebra.py
@@ -277,12 +277,9 @@ def pinv(
     hermitian: Optional[bool] = False,
     out: Optional[JaxArray] = None,
 ) -> JaxArray:
-    if rtol is None:
-        ret = jnp.linalg.pinv(x)
-    elif hermitian:
-        ret = jnp.linalg.pinv(x, hermitian=hermitian)
-    else:
-        ret = jnp.linalg.pinv(x, rtol)
+    if rtol is None and not hermitian:
+        ret = jnp.linalg.pinv(x, rcond=0)
+    ret = jnp.linalg.pinv(x, rcond=rtol, hermitian=hermitian)
     return ret
 
 

--- a/ivy/functional/backends/numpy/linear_algebra.py
+++ b/ivy/functional/backends/numpy/linear_algebra.py
@@ -226,12 +226,9 @@ def pinv(
     hermitian: Optional[bool] = False,
     out: Optional[np.ndarray] = None,
 ) -> np.ndarray:
-    if rtol is None:
-        return np.linalg.pinv(x)
-    elif hermitian:
-        return np.linalg.pinv(x, hermitian=hermitian)
-    else:
-        return np.linalg.pinv(x, rtol)
+    if rtol is None and not hermitian:
+        return np.linalg.pinv(x, rcond=0)
+    return np.linalg.pinv(x, rcond=rtol, hermitian=hermitian)
 
 
 @with_unsupported_dtypes({"1.25.1 and below": ("float16",)}, backend_version)

--- a/ivy/functional/backends/numpy/linear_algebra.py
+++ b/ivy/functional/backends/numpy/linear_algebra.py
@@ -223,10 +223,13 @@ def pinv(
     /,
     *,
     rtol: Optional[Union[float, Tuple[float]]] = None,
+    hermitian: Optional[bool] = False,
     out: Optional[np.ndarray] = None,
 ) -> np.ndarray:
     if rtol is None:
         return np.linalg.pinv(x)
+    elif hermitian:
+        return np.linalg.pinv(x, hermitian=hermitian)
     else:
         return np.linalg.pinv(x, rtol)
 

--- a/ivy/functional/backends/paddle/linear_algebra.py
+++ b/ivy/functional/backends/paddle/linear_algebra.py
@@ -419,11 +419,9 @@ def pinv(
     hermitian: Optional[bool] = False,
     out: Optional[paddle.Tensor] = None,
 ) -> paddle.Tensor:
-    if rtol is None:
-        return paddle.linalg.pinv(x)
-    elif hermitian:
-        return paddle.linalg.pinv(x, hermitian=hermitian)
-    return paddle.linalg.pinv(x, rcond=rtol)
+    if rtol is None and not hermitian:
+        return paddle.linalg.pinv(x, rcond=0)
+    return paddle.linalg.pinv(x, rcond=rtol, hermitian=hermitian)
 
 
 def tensorsolve(

--- a/ivy/functional/backends/paddle/linear_algebra.py
+++ b/ivy/functional/backends/paddle/linear_algebra.py
@@ -11,7 +11,11 @@ from ivy import inf
 from ivy.utils.exceptions import IvyNotImplementedException
 import ivy.functional.backends.paddle as paddle_backend
 from . import backend_version
-from ivy.func_wrapper import with_unsupported_device_and_dtypes, with_unsupported_dtypes
+from ivy.func_wrapper import (
+    with_unsupported_device_and_dtypes,
+    with_unsupported_dtypes,
+    with_supported_dtypes,
+)
 from .elementwise import _elementwise_helper
 
 # Array API Standard #
@@ -403,15 +407,22 @@ def outer(
     return paddle.outer(x1, x2).cast(ret_dtype)
 
 
+@with_supported_dtypes(
+    {"2.5.0 and below": ("float32", "float64")},
+    backend_version,
+)
 def pinv(
     x: paddle.Tensor,
     /,
     *,
     rtol: Optional[Union[float, Tuple[float]]] = None,
+    hermitian: Optional[bool] = False,
     out: Optional[paddle.Tensor] = None,
 ) -> paddle.Tensor:
     if rtol is None:
         return paddle.linalg.pinv(x)
+    elif hermitian:
+        return paddle.linalg.pinv(x, hermitian=hermitian)
     return paddle.linalg.pinv(x, rcond=rtol)
 
 

--- a/ivy/functional/backends/tensorflow/linear_algebra.py
+++ b/ivy/functional/backends/tensorflow/linear_algebra.py
@@ -446,8 +446,8 @@ def pinv(
     hermitian: Optional[bool] = False,
     out: Optional[Union[tf.Tensor, tf.Variable]] = None,
 ) -> Union[tf.Tensor, tf.Variable]:
-    if rtol is None:
-        ret = tf.linalg.pinv(x)
+    if rtol is None and not hermitian:
+        ret = tf.linalg.pinv(x, rcond=0)
     if hermitian:
         s, u = tf.linalg.eigh(x)
         s_abs = tf.abs(s)

--- a/ivy/functional/backends/torch/linear_algebra.py
+++ b/ivy/functional/backends/torch/linear_algebra.py
@@ -303,10 +303,13 @@ def pinv(
     /,
     *,
     rtol: Optional[Union[float, Tuple[float]]] = None,
+    hermitian: Optional[bool] = False,
     out: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
     if rtol is None:
         return torch.linalg.pinv(x, out=out)
+    if hermitian:
+        return torch.linalg.pinv(x, hermitian=hermitian, out=out)
     return torch.linalg.pinv(x, rtol, out=out)
 
 

--- a/ivy/functional/backends/torch/linear_algebra.py
+++ b/ivy/functional/backends/torch/linear_algebra.py
@@ -306,11 +306,9 @@ def pinv(
     hermitian: Optional[bool] = False,
     out: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
-    if rtol is None:
-        return torch.linalg.pinv(x, out=out)
-    if hermitian:
-        return torch.linalg.pinv(x, hermitian=hermitian, out=out)
-    return torch.linalg.pinv(x, rtol, out=out)
+    if rtol is None and not hermitian:
+        return torch.linalg.pinv(x, rtol=0, out=out)
+    return torch.linalg.pinv(x, rtol=rtol, hermitian=hermitian, out=out)
 
 
 pinv.support_native_out = True

--- a/ivy/functional/ivy/linear_algebra.py
+++ b/ivy/functional/ivy/linear_algebra.py
@@ -1320,8 +1320,8 @@ def matrix_rank(
         Default: ``None``.
     
     hermitian
-        indicates whether ``x`` is Hermitian. When ``hermitian=True``, ``x`` is assumed to be Hermitian,
-        enabling a more efficient method for finding eigenvalues, but x is not checked inside the function. 
+        indicates whether ``x`` is Hermitian. When ``hermitian=True``, ``x`` is assumed to be Hermitian, # noqa: E501
+        enabling a more efficient method for finding eigenvalues, but x is not checked inside the function. # noqa: E501
         Instead, We just use the lower triangular of the matrix to compute.
         Default: ``False``.
     out
@@ -1580,6 +1580,7 @@ def pinv(
     /,
     *,
     rtol: Optional[Union[float, Tuple[float]]] = None,
+    hermitian: Optional[bool] = False,
     out: Optional[ivy.Array] = None,
 ) -> ivy.Array:
     """Return the (Moore-Penrose) pseudo-inverse of a matrix (or a stack of matrices)
@@ -1601,6 +1602,9 @@ def pinv(
         ``max(M, N) * eps``, where ``eps`` must be the machine epsilon associated with
         the floating-point data type determined by :ref:`type-promotion` (as applied to
         ``x``). Default: ``None``.
+    hermitian
+        If ``True``, the input array is assumed to be Hermitian, enabling a more
+        efficient method for finding singular values. Defaults to ``False``.
     out
         optional output array, for writing the result to. It must have a shape that the
         inputs broadcast to.
@@ -1638,7 +1642,7 @@ def pinv(
     ivy.array([[-2., 1.],[1.5, -0.5]])
 
     """
-    return current_backend(x).pinv(x, rtol=rtol, out=out)
+    return current_backend(x).pinv(x, rtol=rtol, hermitian=hermitian, out=out)
 
 
 @handle_exceptions

--- a/ivy_tests/test_ivy/test_functional/test_core/test_linalg.py
+++ b/ivy_tests/test_ivy/test_functional/test_core/test_linalg.py
@@ -822,7 +822,7 @@ def test_pinv(*, h_dtype_x, rtol, test_flags, backend_fw, fn_name, on_device):
         on_device=on_device,
         rtol_=1e-2,
         atol_=1e-2,
-        x=x[0],
+        x=x,
         rtol=rtol,
         hermitian=h,
     )


### PR DESCRIPTION
This PR adds the `hermitian` parameter to `ivy.linalg.pinv`. If the input is a hermitian matrix and the flag is set to `True`, a more efficient calculation is performed on the matrix.