### PR TITLE
Fix torch.as_strided for non-contiguous tensors

### DIFF
--- a/ivy/data_classes/array/array.py
+++ b/ivy/data_classes/array/array.py
@@ -134,16 +134,14 @@ class Array(
         _ArrayWithSortingExperimental.__init__(self),
         _ArrayWithStatisticalExperimental.__init__(self),
         _ArrayWithUtilityExperimental.__init__(self),
-        self._view_attributes(data),
         self._init(data, dynamic_backend)
+        self._view_attributes(data)
 
     def _init(self, data, dynamic_backend=None):
         if ivy.is_ivy_array(data):
             self._data = data.data
         elif ivy.is_native_array(data):
             self._data = data
-            if hasattr(data, '_base'):
-                self._base = data._base
         elif isinstance(data, np.ndarray):
             self._data = ivy.asarray(data)._data
         else:

--- a/ivy/data_classes/array/array.py
+++ b/ivy/data_classes/array/array.py
@@ -134,14 +134,16 @@ class Array(
         _ArrayWithSortingExperimental.__init__(self),
         _ArrayWithStatisticalExperimental.__init__(self),
         _ArrayWithUtilityExperimental.__init__(self),
+        self._view_attributes(data),
         self._init(data, dynamic_backend)
-        self._view_attributes(data)
 
     def _init(self, data, dynamic_backend=None):
         if ivy.is_ivy_array(data):
             self._data = data.data
         elif ivy.is_native_array(data):
             self._data = data
+            if hasattr(data, '_base'):
+                self._base = data._base
         elif isinstance(data, np.ndarray):
             self._data = ivy.asarray(data)._data
         else:

--- a/ivy/functional/frontends/torch/creation_ops.py
+++ b/ivy/functional/frontends/torch/creation_ops.py
@@ -260,6 +260,8 @@ def as_strided(input, size, stride, storage_offset=None):
         ind = ind + ivy.reshape(ivy.arange(size_i), r_size) * stride_i
     if storage_offset:
         ind = ind + storage_offset
+    if hasattr(input, '_base'):
+        return ivy.gather(ivy.flatten(input._base), ind)
     return ivy.gather(ivy.flatten(input), ind)
 
 

--- a/ivy/functional/frontends/torch/creation_ops.py
+++ b/ivy/functional/frontends/torch/creation_ops.py
@@ -260,7 +260,7 @@ def as_strided(input, size, stride, storage_offset=None):
         ind = ind + ivy.reshape(ivy.arange(size_i), r_size) * stride_i
     if storage_offset:
         ind = ind + storage_offset
-    if hasattr(input, '_base'):
+    if input._base is not None:
         return ivy.gather(ivy.flatten(input._base), ind)
     return ivy.gather(ivy.flatten(input), ind)
 

--- a/ivy/functional/frontends/torch/creation_ops.py
+++ b/ivy/functional/frontends/torch/creation_ops.py
@@ -260,8 +260,9 @@ def as_strided(input, size, stride, storage_offset=None):
         ind = ind + ivy.reshape(ivy.arange(size_i), r_size) * stride_i
     if storage_offset:
         ind = ind + storage_offset
-    if input._base is not None:
-        return ivy.gather(ivy.flatten(input._base), ind)
+    base = input._base if input._base is not None else input.data._base if hasattr(input.data, '_base') else input.data.base if hasattr(input.data, 'base') else None
+    if base is not None:
+        return ivy.gather(ivy.flatten(base), ind)
     return ivy.gather(ivy.flatten(input), ind)
 
 

--- a/ivy/functional/frontends/torch/creation_ops.py
+++ b/ivy/functional/frontends/torch/creation_ops.py
@@ -260,7 +260,15 @@ def as_strided(input, size, stride, storage_offset=None):
         ind = ind + ivy.reshape(ivy.arange(size_i), r_size) * stride_i
     if storage_offset:
         ind = ind + storage_offset
-    base = input._base if input._base is not None else input.data._base if hasattr(input.data, '_base') else input.data.base if hasattr(input.data, 'base') else None
+    base = (
+        input._base
+        if input._base is not None
+        else (
+            input.data._base
+            if hasattr(input.data, "_base")
+            else input.data.base if hasattr(input.data, "base") else None
+        )
+    )
     if base is not None:
         return ivy.gather(ivy.flatten(base), ind)
     return ivy.gather(ivy.flatten(input), ind)


### PR DESCRIPTION
So that this is True:
```
ivy.set_torch_backend()
size = [12, 1, 512, 64]
stride = [64, 196608, 768, 1]
x = torch.rand((12, 1, 64, 512)).transpose(-1, -2)
orig = torch.as_strided(x, size, stride).detach().numpy()
front = torch_frontend.as_strided(x, size, stride).ivy_array.data.detach().numpy()
print(np.allclose(orig, front))
```