### PR TITLE
Fix `IvyWithGlobalProps` for `ivy.with_backend`

### DIFF
--- a/ivy/__init__.py
+++ b/ivy/__init__.py
@@ -1439,4 +1439,13 @@ class IvyWithGlobalProps(sys.modules[__name__].__class__):
         self.__dict__[name] = value
 
 
-sys.modules[__name__].__class__ = IvyWithGlobalProps
+if (
+    "ivy" in sys.modules.keys()
+    and sys.modules["ivy"].utils._importlib.IS_COMPILING_WITH_BACKEND
+):
+    # Required for with_backend internal compilation
+    sys.modules["ivy"].utils._importlib.import_cache[
+        __name__
+    ].__class__ = IvyWithGlobalProps
+else:
+    sys.modules[__name__].__class__ = IvyWithGlobalProps

--- a/ivy/__init__.py
+++ b/ivy/__init__.py
@@ -1443,7 +1443,7 @@ if (
     "ivy" in sys.modules.keys()
     and sys.modules["ivy"].utils._importlib.IS_COMPILING_WITH_BACKEND
 ):
-    # Required for with_backend internal compilation
+    # Required for ivy.with_backend internal compilation
     sys.modules["ivy"].utils._importlib.import_cache[
         __name__
     ].__class__ = IvyWithGlobalProps

--- a/ivy/utils/_importlib.py
+++ b/ivy/utils/_importlib.py
@@ -19,10 +19,10 @@ IS_COMPILING_WITH_BACKEND = False
 class LocalIvyImporter:
     def __init__(self):
         self.finder = ast_helpers.IvyPathFinder()
-        global IS_COMPILING_WITH_BACKEND
-        IS_COMPILING_WITH_BACKEND = True
 
     def __enter__(self):
+        global IS_COMPILING_WITH_BACKEND
+        IS_COMPILING_WITH_BACKEND = True
         sys.meta_path.insert(0, self.finder)
         path_hooks.insert(0, self.finder)
 

--- a/ivy/utils/_importlib.py
+++ b/ivy/utils/_importlib.py
@@ -13,10 +13,14 @@ path_hooks = []
 # assumes they exist in sys.modules.
 MODULES_TO_SKIP = ["ivy.compiler"]
 
+IS_COMPILING_WITH_BACKEND = False
+
 
 class LocalIvyImporter:
     def __init__(self):
         self.finder = ast_helpers.IvyPathFinder()
+        global IS_COMPILING_WITH_BACKEND
+        IS_COMPILING_WITH_BACKEND = True
 
     def __enter__(self):
         sys.meta_path.insert(0, self.finder)
@@ -25,6 +29,8 @@ class LocalIvyImporter:
     def __exit__(self, *exc):
         path_hooks.remove(self.finder)
         sys.meta_path.remove(self.finder)
+        global IS_COMPILING_WITH_BACKEND
+        IS_COMPILING_WITH_BACKEND = False
 
 
 def _clear_cache():


### PR DESCRIPTION
The internal `ivy.with_backend` object wasn't getting updated due to updating `sys.modules`, which local ivy backends doesn't exist in, it only exists in Ivy cache.