### PR TITLE
Torch creation ops sparse coo tensor

### DIFF
--- a/ivy/functional/frontends/torch/creation_ops.py
+++ b/ivy/functional/frontends/torch/creation_ops.py
@@ -324,8 +324,7 @@ def sparse_coo_tensor(
     check_invariants=None,
 ):
     return ivy.SparseArray(
-        coo_indices=indices, values=values, dense_shape=size,
-                           format="coo"
+        coo_indices=indices, values=values, dense_shape=size, format="coo"
     )
 
 
@@ -346,7 +345,7 @@ def sparse_csr_tensor(
         dense_shape=size,
         format="csr",
         crow_indices=crow_indices,
-        col_indices=col_indices
+        col_indices=col_indices,
     )
 
 
@@ -367,7 +366,7 @@ def sparse_csc_tensor(
         dense_shape=size,
         format="csc",
         ccol_indices=ccol_indices,
-        row_indices=row_indices
+        row_indices=row_indices,
     )
 
 
@@ -388,7 +387,8 @@ def sparse_bsr_tensor(
         dense_shape=size,
         format="bsr",
         crow_indices=crow_indices,
-        col_indices=col_indices)
+        col_indices=col_indices,
+    )
 
 
 @outputs_to_frontend_arrays
@@ -408,5 +408,5 @@ def sparse_bsc_tensor(
         dense_shape=size,
         format="bsc",
         ccol_indices=ccol_indices,
-        row_indices=row_indices
+        row_indices=row_indices, 
     )

--- a/ivy/functional/frontends/torch/creation_ops.py
+++ b/ivy/functional/frontends/torch/creation_ops.py
@@ -408,5 +408,5 @@ def sparse_bsc_tensor(
         dense_shape=size,
         format="bsc",
         ccol_indices=ccol_indices,
-        row_indices=row_indices, 
+        row_indices=row_indices,
     )

--- a/ivy/functional/frontends/torch/creation_ops.py
+++ b/ivy/functional/frontends/torch/creation_ops.py
@@ -1,7 +1,8 @@
 # local
 import ivy
 from ivy.func_wrapper import with_unsupported_dtypes
-from ivy.functional.frontends.torch.func_wrapper import to_ivy_arrays_and_back
+from ivy.functional.frontends.torch.func_wrapper import to_ivy_arrays_and_back, \
+    outputs_to_frontend_arrays
 
 
 @to_ivy_arrays_and_back
@@ -307,3 +308,85 @@ def frombuffer(
     requires_grad=False,
 ):
     return ivy.frombuffer(buffer, dtype=dtype, count=count, offset=offset)
+
+
+@outputs_to_frontend_arrays
+def sparse_coo_tensor(
+    indices,
+    values,
+    size=None,
+    *,
+    dtype=None,
+    device=None,
+    requires_grad=False,
+    check_invariants=None):
+    return ivy.SparseArray(coo_indices=indices, values=values, dense_shape=size,
+                           format="coo")
+
+
+@outputs_to_frontend_arrays
+def sparse_csr_tensor(
+    crow_indices,
+    col_indices,
+    values,
+    size=None,
+    *,
+    dtype=None,
+    device=None,
+    requires_grad=False,
+    check_invariants=None,
+):
+    return ivy.SparseArray(values=values, dense_shape=size, format="csr",
+                           crow_indices=crow_indices,
+                           col_indices=col_indices)
+
+
+@outputs_to_frontend_arrays
+def sparse_csc_tensor(
+    ccol_indices,
+    row_indices,
+    values,
+    size=None,
+    *,
+    dtype=None,
+    device=None,
+    requires_grad=False,
+    check_invariants=None,
+):
+    return ivy.SparseArray(values=values, dense_shape=size, format="csc",
+                           ccol_indices=ccol_indices,
+                           row_indices=row_indices)
+
+
+@outputs_to_frontend_arrays
+def sparse_bsr_tensor(
+    crow_indices,
+    col_indices,
+    values,
+    size=None,
+    *,
+    dtype=None,
+    device=None,
+    requires_grad=False,
+    check_invariants=None,
+):
+    return ivy.SparseArray(values=values, dense_shape=size, format="bsr",
+                           crow_indices=crow_indices,
+                           col_indices=col_indices)
+
+
+@outputs_to_frontend_arrays
+def sparse_bsc_tensor(
+    ccol_indices,
+    row_indices,
+    values,
+    size=None,
+    *,
+    dtype=None,
+    device=None,
+    requires_grad=False,
+    check_invariants=None,
+):
+    return ivy.SparseArray(values=values, dense_shape=size, format="bsc",
+                           ccol_indices=ccol_indices,
+                           row_indices=row_indices)

--- a/ivy/functional/frontends/torch/creation_ops.py
+++ b/ivy/functional/frontends/torch/creation_ops.py
@@ -1,8 +1,10 @@
 # local
 import ivy
 from ivy.func_wrapper import with_unsupported_dtypes
-from ivy.functional.frontends.torch.func_wrapper import to_ivy_arrays_and_back, \
-    outputs_to_frontend_arrays
+from ivy.functional.frontends.torch.func_wrapper import (
+    to_ivy_arrays_and_back,
+    outputs_to_frontend_arrays,
+)
 
 
 @to_ivy_arrays_and_back
@@ -319,9 +321,12 @@ def sparse_coo_tensor(
     dtype=None,
     device=None,
     requires_grad=False,
-    check_invariants=None):
-    return ivy.SparseArray(coo_indices=indices, values=values, dense_shape=size,
-                           format="coo")
+    check_invariants=None,
+):
+    return ivy.SparseArray(
+        coo_indices=indices, values=values, dense_shape=size,
+                           format="coo"
+    )
 
 
 @outputs_to_frontend_arrays
@@ -336,9 +341,13 @@ def sparse_csr_tensor(
     requires_grad=False,
     check_invariants=None,
 ):
-    return ivy.SparseArray(values=values, dense_shape=size, format="csr",
-                           crow_indices=crow_indices,
-                           col_indices=col_indices)
+    return ivy.SparseArray(
+        values=values,
+        dense_shape=size,
+        format="csr",
+        crow_indices=crow_indices,
+        col_indices=col_indices
+    )
 
 
 @outputs_to_frontend_arrays
@@ -353,9 +362,13 @@ def sparse_csc_tensor(
     requires_grad=False,
     check_invariants=None,
 ):
-    return ivy.SparseArray(values=values, dense_shape=size, format="csc",
-                           ccol_indices=ccol_indices,
-                           row_indices=row_indices)
+    return ivy.SparseArray(
+        values=values,
+        dense_shape=size,
+        format="csc",
+        ccol_indices=ccol_indices,
+        row_indices=row_indices
+    )
 
 
 @outputs_to_frontend_arrays
@@ -370,9 +383,12 @@ def sparse_bsr_tensor(
     requires_grad=False,
     check_invariants=None,
 ):
-    return ivy.SparseArray(values=values, dense_shape=size, format="bsr",
-                           crow_indices=crow_indices,
-                           col_indices=col_indices)
+    return ivy.SparseArray(
+        values=values,
+        dense_shape=size,
+        format="bsr",
+        crow_indices=crow_indices,
+        col_indices=col_indices)
 
 
 @outputs_to_frontend_arrays
@@ -387,6 +403,10 @@ def sparse_bsc_tensor(
     requires_grad=False,
     check_invariants=None,
 ):
-    return ivy.SparseArray(values=values, dense_shape=size, format="bsc",
-                           ccol_indices=ccol_indices,
-                           row_indices=row_indices)
+    return ivy.SparseArray(
+        values=values,
+        dense_shape=size,
+        format="bsc",
+        ccol_indices=ccol_indices,
+        row_indices=row_indices
+    )

--- a/ivy/functional/frontends/torch/tensor.py
+++ b/ivy/functional/frontends/torch/tensor.py
@@ -15,6 +15,8 @@ from ivy.functional.frontends.torch.func_wrapper import (
     _to_ivy_array,
     numpy_to_torch_style_args,
 )
+import copy
+from ivy.utils.exceptions import IvyAttributeError
 
 
 class Tensor:
@@ -1494,6 +1496,46 @@ class Tensor:
         ):
             reps = reps[0]
         return torch_frontend.tile(self, reps)
+
+    def is_sparse(self):
+        return ivy.is_ivy_sparse_array(self.ivy_array)
+
+    def to_dense(self):
+        if not self.is_sparse():
+            return self
+        cp_obj = copy.deepcopy(self)
+        cp_obj.ivy_array = self.ivy_array.to_dense_array()
+        return self
+
+    def values(self):
+        if self.is_sparse():
+            return self.ivy_array.values
+        raise IvyAttributeError("Only sparse arrays have values")
+
+    def indices(self):
+        if self.is_sparse() and self.ivy_array.indices is not None:
+            return self.ivy_array.indices
+        raise IvyAttributeError("Only sparse COO arrays have indices")
+
+    def crow_indices(self):
+        if self.is_sparse() and self.ivy_array.crow_indices is not None:
+            return self.ivy_array.crow_indices
+        raise IvyAttributeError("Only sparse CSR or BSR arrays have crow_indices")
+
+    def col_indices(self):
+        if self.is_sparse() and self.ivy_array.col_indices is not None:
+            return self.ivy_array.col_indices
+        raise IvyAttributeError("Only sparse CSR or BSR arrays have col_indices")
+
+    def ccol_indices(self):
+        if self.is_sparse() and self.ivy_array.ccol_indices is not None:
+            return self.ivy_array.ccol_indices
+        raise IvyAttributeError("Only sparse CSC or BSC arrays have ccol_indices")
+
+    def row_indices(self):
+        if self.is_sparse() and self.ivy_array.row_indices is not None:
+            return self.ivy_array.row_indices
+        raise IvyAttributeError("Only sparse CSC or BSC arrays have row_indices")
 
 
 class Size(tuple):


### PR DESCRIPTION
1. In pytorch frontend, enable create Tensor (sparse) based on using ivy.SparseArray (however, it seems that no operation support this type)
  Available create type: coo, csc, bsr, bsc, csr
2. Some in-class methods in pytorch frontend Tensor for sparse only