### PR TITLE
add `fft2` for paddle backend

### DIFF
--- a/ivy/functional/backends/paddle/experimental/layers.py
+++ b/ivy/functional/backends/paddle/experimental/layers.py
@@ -7,6 +7,7 @@ from ivy.utils.exceptions import IvyNotImplementedException, IvyValueError
 from ivy.func_wrapper import (
     with_supported_device_and_dtypes,
     with_unsupported_dtypes,
+    with_supported_dtypes,
 )
 from .. import backend_version
 
@@ -406,3 +407,24 @@ def rfftn(
 ) -> paddle.Tensor:
     result = paddle.fft.rfftn(x, s, axes, norm)
     return result.astype("complex128")
+
+
+@with_supported_dtypes(
+    {
+        "2.5.0 and below": (
+            "complex64",
+            "complex128",
+        )
+    },
+    backend_version,
+)
+def fft2(
+    x: paddle.Tensor,
+    *,
+    dim: Optional[Union[int, Tuple[int]]] = None,
+    norm: Optional[str] = "backward",
+    s: Optional[Union[int, Tuple[int]]] = None,
+    out: Optional[paddle.Tensor] = None,
+) -> paddle.Tensor:
+    res = paddle.fft.fft2(x, s, dim, norm)
+    return res.astype("complex128")

--- a/ivy/functional/backends/tensorflow/experimental/layers.py
+++ b/ivy/functional/backends/tensorflow/experimental/layers.py
@@ -881,6 +881,7 @@ def trans_x_to_s(
     return x_new
 
 
+@with_supported_dtypes({"2.13.0 and below": ("complex",)}, backend_version)
 def fft2(
     x: Union[tf.Tensor, tf.Variable],
     *,


### PR DESCRIPTION
Paddle backend was missing `fft2` while all other supported frameworks already had `fft2` implemented.  Ran test locally for it for paddle backend and all are passing but `fft2` in general is failing  for `tf backend`. 