### PR TITLE
Remove re-computation of sort idxs in paddle's unique_all in case of sorting by value

### DIFF
--- a/ivy/functional/backends/paddle/set.py
+++ b/ivy/functional/backends/paddle/set.py
@@ -53,21 +53,13 @@ def unique_all(
 
     if not by_value:
         sort_idx = paddle.argsort(indices)
-    else:
-        if axis is None:
-            axis = 0
-        values_ = paddle.moveaxis(values, axis, 0)
-        values_ = paddle.reshape(values_, (values_.shape[0], -1))
-        sort_idx = paddle.to_tensor(
-            [i[0] for i in sorted(list(enumerate(values_)), key=lambda x: tuple(x[1]))]
+        values = paddle.gather(values, sort_idx, axis=axis)
+        counts = paddle.gather(counts, sort_idx)
+        indices = paddle.gather(indices, sort_idx)
+        inv_sort_idx = paddle_backend.invert_permutation(sort_idx)
+        inverse_indices = paddle_backend.vmap(lambda y: paddle.gather(inv_sort_idx, y))(
+            inverse_indices
         )
-    values = paddle.gather(values, sort_idx, axis=axis)
-    counts = paddle.gather(counts, sort_idx)
-    indices = paddle.gather(indices, sort_idx)
-    inv_sort_idx = paddle_backend.invert_permutation(sort_idx)
-    inverse_indices = paddle_backend.vmap(lambda y: paddle.gather(inv_sort_idx, y))(
-        inverse_indices
-    )
 
     return Results(
         values.cast(x_dtype),


### PR DESCRIPTION
The current implementation re-compute the sort indexes to rearrange the values returned by `paddle.unique` in case the `by_value` argument is `True` but those values are already correct in that case.

This is one of the cases in which the current implementation is failing and the new one not:
```pyton
import ivy

ivy.set_backend('paddle')
x = ivy.array([[[-1.0000000e+00, -1.0000000e+00, -1.0000000e+00, -3.7252903e-09,
                      -1.0000000e+00, -2.0000000e+00],
                     [-1.0000000e+00, -1.0000000e+00, -1.0000000e+00, -1.0000000e+00,
                      -1.0000000e+00, -1.0000000e+00],
                     [-1.0000000e+00, -1.0000000e+00, -1.0000000e+00, -7.4505806e-09,
                      -1.0000000e+00, -1.0000000e+00]]], dtype=ivy.float64)
axis = 1
by_value = True
res = ivy.unique_all(x, axis=axis, by_value=by_value)
```

The test suite raised the following error in that case:
```
E           AssertionError:  the results from backend paddle and ground truth framework numpy do not match
E            [[[-1.0000000e+00 -1.0000000e+00 -1.0000000e+00 -1.0000000e+00
E              -1.0000000e+00 -1.0000000e+00]
E             [-1.0000000e+00 -1.0000000e+00 -1.0000000e+00 -3.7252903e-09
E              -1.0000000e+00 -2.0000000e+00]
E             [-1.0000000e+00 -1.0000000e+00 -1.0000000e+00 -7.4505806e-09
E              -1.0000000e+00 -1.0000000e+00]]]!=[[[-1.0000000e+00 -1.0000000e+00 -1.0000000e+00 -1.0000000e+00
E              -1.0000000e+00 -1.0000000e+00]
E             [-1.0000000e+00 -1.0000000e+00 -1.0000000e+00 -7.4505806e-09
E              -1.0000000e+00 -1.0000000e+00]
E             [-1.0000000e+00 -1.0000000e+00 -1.0000000e+00 -3.7252903e-09
E              -1.0000000e+00 -2.0000000e+00]]] 
E           
E           
E           Falsifying example: test_unique_all(
E               backend_fw=<module 'ivy.functional.backends.paddle' from '/opt/project/ivy/functional/backends/paddle/__init__.py'>,
E               on_device='cpu',
E               dtype_x_axis=(['float64'],
E                [array([[[-1.0000000e+00, -1.0000000e+00, -1.0000000e+00, -3.7252903e-09,
E                          -1.0000000e+00, -2.0000000e+00],
E                         [-1.0000000e+00, -1.0000000e+00, -1.0000000e+00, -1.0000000e+00,
E                          -1.0000000e+00, -1.0000000e+00],
E                         [-1.0000000e+00, -1.0000000e+00, -1.0000000e+00, -7.4505806e-09,
E                          -1.0000000e+00, -1.0000000e+00]]])],
E                1),
E               none_axis=False,
E               by_value=True,
E               test_flags=FunctionTestFlags(
E                   ground_truth_backend='numpy',
E                   num_positional_args=1,
E                   with_out=False,
E                   instance_method=False,
E                   test_gradients=False,
E                   test_compile=None,
E                   as_variable=[False],
E                   native_arrays=[False],
E                   container=[False],
E               ),
E               fn_name='unique_all',
E           )
E           
E           You can reproduce this example by temporarily adding @reproduce_failure('6.81.2', b'AXicY2RkYGBkYGJkYGVgALEggBEf++AGBgYkProaJmLNoRb74AK87mEEQwgAAGLmAwM=') as a decorator on your test case
```