### PR TITLE
Fix(dtatypes.py): can_cast always return true

### DIFF
--- a/ivy/functional/ivy/data_type.py
+++ b/ivy/functional/ivy/data_type.py
@@ -559,8 +559,8 @@ def can_cast(
     if isinstance(from_, (ivy.Array, ivy.NativeArray)):
         from_ = from_.dtype
     try:
-        ivy.promote_types(from_, to)
-        return True
+        dtype = ivy.promote_types(from_, to)
+        return dtype == to
     except KeyError:
         return False
 


### PR DESCRIPTION
-------------------------------------------------------
- This PR aims at closing this issue -> #19704

Original Code:

```
def can_cast(from_: Union[ivy.Dtype, ivy.Array, ivy.NativeArray], to: ivy.Dtype, /) -> bool:
    if isinstance(from_, (ivy.Array, ivy.NativeArray)):
        from_ = from_.dtype
    try:
        ivy.promote_types(from_, to)
        return True
    except:
        return False
```

Fixed Code:
```
def can_cast(from_: Union[ivy.Dtype, ivy.Array, ivy.NativeArray], to: ivy.Dtype, /) -> bool:
    try:
        dtype = ivy.promote_types(from_, to)
        return dtype == to
    except KeyError:
        return False
```
The fixed code compares the resulting dtype after attempting to promote from_ to to using ivy.promote_types(from_, to). If the promotion succeeds and the resulting dtype matches to, the function returns True, indicating a valid cast. If a KeyError occurs during the promotion process, the function returns False, indicating an invalid cast. This modification ensures the function returns True only when the cast is valid according to type promotion rules and False otherwise, resolving the issue with the original code.

