### PR TITLE
changed wrong positional argument name

### DIFF
--- a/ivy/functional/frontends/tensorflow/linalg.py
+++ b/ivy/functional/frontends/tensorflow/linalg.py
@@ -247,8 +247,8 @@ def cross(a, b, name=None):
 
 
 @to_ivy_arrays_and_back
-def svd(a, /, *, full_matrices=False, compute_uv=True, name=None):
-    return ivy.svd(a, compute_uv=compute_uv, full_matrices=full_matrices)
+def svd(tensor, /, *, full_matrices=False, compute_uv=True, name=None):
+    return ivy.svd(tensor, compute_uv=compute_uv, full_matrices=full_matrices)
 
 
 @to_ivy_arrays_and_back

--- a/ivy_tests/test_ivy/test_frontends/test_tensorflow/test_linalg.py
+++ b/ivy_tests/test_ivy/test_frontends/test_tensorflow/test_linalg.py
@@ -797,7 +797,7 @@ def test_tensorflow_svd(
         test_values=False,
         atol=1e-03,
         rtol=1e-05,
-        a=x,
+        tensor=x,
         full_matrices=full_matrices,
         compute_uv=compute_uv,
     )


### PR DESCRIPTION
In the tensorflow frontend for svd in linalg, positional argument was named as 'a' instead of tensor as in original tensorflow docs 
https://www.tensorflow.org/api_docs/python/tf/linalg/svd