### PR TITLE
Added topk function to Paddle Frontend

### DIFF
--- a/ivy/functional/frontends/paddle/tensor/search.py
+++ b/ivy/functional/frontends/paddle/tensor/search.py
@@ -62,9 +62,9 @@ def searchsorted(sorted_sequence, values, out_int32=False, right=False, name=Non
 
 
 @with_supported_dtypes(
-    {"2.5.0 and below": ("float32", "float64", "int32", "int64")},
+    {"2.5.1 and below": ("float32", "float64", "int32", "int64")},
     "paddle",
 )
 @to_ivy_arrays_and_back
-def topk(x, k, /, *, axis=None, largest=True, sorted=True, name=None):
+def topk(x, k, axis=None, largest=True, sorted=True, name=None):
     return ivy.top_k(x, k, axis=axis, largest=largest, sorted=sorted)

--- a/ivy/functional/frontends/paddle/tensor/search.py
+++ b/ivy/functional/frontends/paddle/tensor/search.py
@@ -59,3 +59,12 @@ def searchsorted(sorted_sequence, values, out_int32=False, right=False, name=Non
     if out_int32:
         ret = ivy.astype(ret, "int32")
     return ret
+
+
+@with_supported_dtypes(
+    {"2.5.0 and below": ("float32", "float64", "int32", "int64")},
+    "paddle",
+)
+@to_ivy_arrays_and_back
+def topk(x, k, /, *, axis=None, largest=True, sorted=True, name=None):
+    return ivy.top_k(x, k, axis=axis, largest=largest, sorted=sorted)

--- a/ivy_tests/test_ivy/test_frontends/test_paddle/test_tensor/test_search.py
+++ b/ivy_tests/test_ivy/test_frontends/test_paddle/test_tensor/test_search.py
@@ -163,3 +163,35 @@ def test_paddle_searchsorted(
         out_int32=out_int32,
         right=right,
     )
+
+
+@handle_frontend_test(
+    fn_tree="paddle.topk",
+    dtype_x_and_axis=helpers.dtype_values_axis(
+        available_dtypes=helpers.get_dtypes("valid")
+    ),
+    k=st.integers(min_value=0, max_value=5),
+    sorted=st.booleans(),
+    largest=st.booleans(),
+)
+def test_paddle_topk(
+    *,
+    dtype_x_and_axis,
+    k,
+    sorted,
+    largest,
+    fn_tree,
+    frontend,
+    test_flags,
+):
+    input_dtypes, x, axis = dtype_x_and_axis
+    helpers.test_frontend_function(
+        input_dtypes=input_dtypes,
+        frontend=frontend,
+        test_flags=test_flags,
+        fn_tree=fn_tree,
+        k=k,
+        sorted=sorted,
+        largest=largest,
+        # test_with_out=test_with_out
+    )

--- a/ivy_tests/test_ivy/test_frontends/test_paddle/test_tensor/test_search.py
+++ b/ivy_tests/test_ivy/test_frontends/test_paddle/test_tensor/test_search.py
@@ -173,7 +173,7 @@ def test_paddle_searchsorted(
         valid_axis=True,
         force_int_axis=True,
     ),
-    k = st.data(),
+    k=st.data(),
     sorted=st.booleans(),
     largest=st.booleans(),
 )

--- a/ivy_tests/test_ivy/test_frontends/test_paddle/test_tensor/test_search.py
+++ b/ivy_tests/test_ivy/test_frontends/test_paddle/test_tensor/test_search.py
@@ -183,6 +183,8 @@ def test_paddle_topk(
     fn_tree,
     frontend,
     test_flags,
+    on_device,
+    backend_fw,
 ):
     input_dtypes, x, axis = dtype_x_and_axis
     helpers.test_frontend_function(
@@ -190,6 +192,8 @@ def test_paddle_topk(
         frontend=frontend,
         test_flags=test_flags,
         fn_tree=fn_tree,
+        on_device=on_device,
+        fw=backend_fw,
         k=k,
         sorted=sorted,
         largest=largest,

--- a/ivy_tests/test_ivy/test_frontends/test_paddle/test_tensor/test_search.py
+++ b/ivy_tests/test_ivy/test_frontends/test_paddle/test_tensor/test_search.py
@@ -168,9 +168,12 @@ def test_paddle_searchsorted(
 @handle_frontend_test(
     fn_tree="paddle.topk",
     dtype_x_and_axis=helpers.dtype_values_axis(
-        available_dtypes=helpers.get_dtypes("valid")
+        available_dtypes=helpers.get_dtypes("valid"),
+        min_num_dims=1,
+        valid_axis=True,
+        force_int_axis=True,
     ),
-    k=st.integers(min_value=0, max_value=5),
+    k = st.data(),
     sorted=st.booleans(),
     largest=st.booleans(),
 )
@@ -180,21 +183,25 @@ def test_paddle_topk(
     k,
     sorted,
     largest,
+    on_device,
     fn_tree,
     frontend,
-    test_flags,
-    on_device,
     backend_fw,
+    test_flags,
 ):
     input_dtypes, x, axis = dtype_x_and_axis
+    k = k.draw(st.integers(min_value=1, max_value=x[0].shape[axis]))
     helpers.test_frontend_function(
         input_dtypes=input_dtypes,
         frontend=frontend,
+        backend_to_test=backend_fw,
         test_flags=test_flags,
         fn_tree=fn_tree,
         on_device=on_device,
-        fw=backend_fw,
+        x=x[0],
         k=k,
-        sorted=sorted,
+        axis=axis,
         largest=largest,
+        sorted=sorted,
+        test_values=False,
     )

--- a/ivy_tests/test_ivy/test_frontends/test_paddle/test_tensor/test_search.py
+++ b/ivy_tests/test_ivy/test_frontends/test_paddle/test_tensor/test_search.py
@@ -193,5 +193,4 @@ def test_paddle_topk(
         k=k,
         sorted=sorted,
         largest=largest,
-        # test_with_out=test_with_out
     )


### PR DESCRIPTION
Close #19817

- Added topk function for Paddle in its [frontend/search](https://github.com/unifyai/ivy/blob/master/ivy/functional/frontends/paddle/tensor/search.py) file 
- Added test for the topk function in the respective [test file](https://github.com/unifyai/ivy/blob/master/ivy_tests/test_ivy/test_frontends/test_paddle/test_tensor/test_search.py)