### PR TITLE
Fix instantiation of sparse array

### DIFF
--- a/ivy/functional/ivy/experimental/sparse_array.py
+++ b/ivy/functional/ivy/experimental/sparse_array.py
@@ -290,7 +290,7 @@ def _is_data_not_indices_values_and_shape(
             row_indices,
             values,
             dense_shape,
-            format=format,
+            format,
             fn=ivy.exists,
             type="any",
             limit=[0],
@@ -570,6 +570,10 @@ class SparseArray:
     def dense_shape(self):
         return self._dense_shape
 
+    @property
+    def format(self):
+        return self._format
+
     # Setters #
     # --------#
 
@@ -676,6 +680,10 @@ class SparseArray:
             indices=self._coo_indices, values=self._values, dense_shape=dense_shape
         )
         self._dense_shape = dense_shape
+
+    @format.setter
+    def format(self, format):
+        self._format = format
 
     # Instance Methods #
     # ---------------- #


### PR DESCRIPTION
Although SparseArray's `__init__` method allow taking `data` as a parameter to allow instantiating with an existing sparse array. It was failing because of improper use of format argument; this PR fixes that.

i.e, earlier this failed
```python
import ivy
ivy.set_backend('torch')

a = ivy.sparse_array.SparseArray(coo_indices=[[0,1,2], [0,1,2]], values=[1,2,3], dense_shape=(3,3), format='coo')
b = ivy.sparse_array.SparseArray(b)  # error
```

