### PR TITLE
Fix bug in Array.__repr__ with implicit backend

### DIFF
--- a/ivy/data_classes/array/array.py
+++ b/ivy/data_classes/array/array.py
@@ -367,7 +367,7 @@ class Array(
                 self._post_repr = ")"
         sig_fig = ivy.array_significant_figures
         dec_vals = ivy.array_decimal_values
-        if self.backend == "" or ivy.is_local():
+        if self.backend in ["", "none"] or ivy.is_local():
             # If the array was constructed using implicit backend
             backend = ivy.current_backend()
         else:


### PR DESCRIPTION
Before this, when trying to run Ivy with an interactive terminal like iPython, we'd see this behaviour:
```py
In [1]: import ivy
In [2]: ivy.abs(-5)
Out[2]: ... KeyError: 'none'
In [3]: ivy.set_backend('numpy')
Out[3]: <module 'ivy.functional.backends.numpy' from '/home/joe/dev/ivy/ivy/functional/backends/numpy/__init__.py'>
In [4]: ivy.abs(-5)
Out[4]: ivy.array(5)
```
i.e. the functions wouldn't work with an implicit backend. Turns out, this wasn't related to the functions at all, but was a bug in the Array.\_\_repr\_\_ method, since it was expecting the default value of `Ivy.backend` to be `''` rather than `'none'`.