### PR TITLE
Fix the isscalar function from test_frontends/config/tensorflow which is causing tests to fail when called with a tuple

### DIFF
--- a/ivy_tests/test_ivy/test_frontends/config/tensorflow.py
+++ b/ivy_tests/test_ivy/test_frontends/config/tensorflow.py
@@ -103,4 +103,4 @@ def as_native_dev(device: str):
 
 
 def isscalar(x):
-    return tf.experimental.numpy.isscalar(x)
+    return is_native_array(x) and tf.experimental.numpy.isscalar(x)


### PR DESCRIPTION
Fix #20833 