### PR TITLE
Fixing incomplete function behaviour- function of arithmetic_operation

### DIFF
--- a/ivy_tests/test_ivy/test_frontends/test_numpy/test_mathematical_functions/test_arithmetic_operations.py
+++ b/ivy_tests/test_ivy/test_frontends/test_numpy/test_mathematical_functions/test_arithmetic_operations.py
@@ -540,7 +540,7 @@ def test_numpy_mod(
         ],
     ),
     where=np_frontend_helpers.where(),
-    test_with_out=st.just(False),
+    test_with_out=st.just(True),  # Change this to True to test with 'out' argument
     number_positional_args=np_frontend_helpers.get_num_positional_args_ufunc(
         fn_name="modf"
     ),
@@ -559,6 +559,15 @@ def test_numpy_modf(
         input_dtype=input_dtypes,
         test_flags=test_flags,
     )
+
+    # Create two arrays for the 'out' argument (frac_part and int_part)
+    frac_part = np.zeros_like(x[0])
+    int_part = np.zeros_like(x[0])
+
+    # Convert the arrays to numpy.ndarray objects
+    frac_part_np = frontend.to_numpy_array(frac_part)
+    int_part_np = frontend.to_numpy_array(int_part)
+
     np_frontend_helpers.test_frontend_function(
         input_dtypes=input_dtypes,
         frontend=frontend,
@@ -566,7 +575,7 @@ def test_numpy_modf(
         fn_tree=fn_tree,
         on_device=on_device,
         x=x[0],
-        out=None,
+        out=(frac_part_np, int_part_np),  # Provide 'out' as a tuple of arrays
         where=where,
         casting=casting,
         order="K",


### PR DESCRIPTION
While trying to fix `TypeError`: 'out' must be a tuple of arrays. I encountered new error; `AttributeError`: 'str' object has no attribute 'to_numpy_array'
![New_error](https://github.com/unifyai/ivy/assets/111859279/32dba67c-40b5-4865-a66b-ca331b1b16ad)
