### PR TITLE
Typo in Compiler Graph Section of Docs fixed

### DIFF
--- a/docs/compiler/compiler.rst
+++ b/docs/compiler/compiler.rst
@@ -193,7 +193,7 @@ are included as nodes or "baked" into the graph.
 
     def fn(x):
         a = torch.randint(0, 100, size=[1])
-        z = x * a
+        z = x ** a
         return z + torch.rand([1])
         
     comp_func = ivy.compile(fn, include_generators=True, args=(x,))


### PR DESCRIPTION
A typo in line 196 of compiler.rst where operation didn't match the graph ouput, in docs, is fixed.