### PR TITLE
Dice losses.py

### DIFF
--- a/ivy/functional/ivy/losses.py
+++ b/ivy/functional/ivy/losses.py
@@ -383,3 +383,68 @@ def sparse_cross_entropy(
     return ivy.cross_entropy(
         true, pred, axis=axis, epsilon=epsilon, reduction=reduction, out=out
     )
+
+
+
+@handle_exceptions
+@handle_nestable
+@handle_array_like_without_promotion
+@inputs_to_ivy_arrays
+@handle_array_function
+def dice_loss(
+    true: Union[ivy.Array, ivy.NativeArray],
+    pred: Union[ivy.Array, ivy.NativeArray],
+    /,
+    *,
+    axis: int = -1,
+    epsilon: float = 1e-7,
+    reduction: str = "mean",
+    out: Optional[ivy.Array] = None,
+) -> ivy.Array:
+    """
+    Compute Dice loss between predicted and true discrete distributions.
+
+    Parameters
+    ----------
+    true
+        Input array containing true labels.
+    pred
+        Input array containing predicted labels.
+    axis
+        The axis along which to compute the Dice loss. Default: -1.
+    epsilon
+        A float in [0.0, 1.0] specifying the amount of smoothing when calculating
+        the loss. If epsilon is 0, no smoothing will be applied. Default: 1e-7.
+    reduction
+        The reduction type for the output. Options: "none", "sum", "mean". Default: "mean".
+    out
+        Optional output array, for writing the result to. It must have a shape
+        that the inputs broadcast to.
+
+    Returns
+    -------
+    ret
+        The Dice loss between the given distributions.
+
+    Examples
+    --------
+    >>> x = ivy.array([0, 0, 1, 0])
+    >>> y = ivy.array([0.25, 0.25, 0.25, 0.25])
+    >>> print(ivy.dice_loss(x, y))
+    ivy.array(0.6)
+
+    >>> z = ivy.array([0.1, 0.1, 0.7, 0.1])
+    >>> print(ivy.dice_loss(x, z))
+    ivy.array(0.8333333)
+    """
+    ivy.utils.assertions.check_elem_in_list(reduction, ["none", "sum", "mean"])
+    pred = ivy.clip(pred, epsilon, 1 - epsilon)
+    
+    intersection = 2.0 * ivy.reduce_sum(pred * true, axis=axis, keepdims=True)
+    denominator = ivy.reduce_sum(pred, axis=axis, keepdims=True) + ivy.reduce_sum(true, axis=axis, keepdims=True)
+    
+    dice_score = intersection / (denominator + epsilon)
+    
+    return _reduce_loss(reduction, 1 - dice_score, axis, out)
+
+

--- a/ivy/functional/ivy/losses.py
+++ b/ivy/functional/ivy/losses.py
@@ -386,6 +386,7 @@ def sparse_cross_entropy(
 
 
 
+
 @handle_exceptions
 @handle_nestable
 @handle_array_like_without_promotion
@@ -439,12 +440,13 @@ def dice_loss(
     """
     ivy.utils.assertions.check_elem_in_list(reduction, ["none", "sum", "mean"])
     pred = ivy.clip(pred, epsilon, 1 - epsilon)
-    
-    intersection = 2.0 * ivy.reduce_sum(pred * true, axis=axis, keepdims=True)
-    denominator = ivy.reduce_sum(pred, axis=axis, keepdims=True) + ivy.reduce_sum(true, axis=axis, keepdims=True)
-    
-    dice_score = intersection / (denominator + epsilon)
-    
-    return _reduce_loss(reduction, 1 - dice_score, axis, out)
 
+    intersection = 2.0 * ivy.reduce_sum(pred * true, axis=axis, keepdims=True)
+    denominator = ivy.reduce_sum(pred, axis=axis, keepdims=True) + ivy.reduce_sum(
+        true, axis=axis, keepdims=True
+    )
+
+    dice_score = intersection / (denominator + epsilon)
+
+    return _reduce_loss(reduction, 1 - dice_score, axis, out)
 

--- a/ivy/functional/ivy/losses.py
+++ b/ivy/functional/ivy/losses.py
@@ -384,9 +384,6 @@ def sparse_cross_entropy(
         true, pred, axis=axis, epsilon=epsilon, reduction=reduction, out=out
     )
 
-
-
-
 @handle_exceptions
 @handle_nestable
 @handle_array_like_without_promotion

--- a/ivy/stateful/losses.py
+++ b/ivy/stateful/losses.py
@@ -104,3 +104,37 @@ class CrossEntropyLoss(Module):
             epsilon=ivy.default(epsilon, self._epsilon),
             reduction=ivy.default(reduction, self._reduction),
         )
+
+class DiceLoss(Module):
+    def __init__(self, smooth: float = 1.0, reduction: str = "mean"):
+        self._smooth = smooth
+        self._reduction = reduction
+        Module.__init__(self)
+
+    def _forward(self, true, pred, *, smooth=None, reduction=None):
+        """
+        Perform forward pass of the Dice Loss.
+
+        true
+            input array containing true labels.
+        pred
+            input array containing Predicted labels.
+        smooth
+            smoothing value to avoid division by zero in denominator. Default: ``1.0``.
+        reduction
+            ``'mean'``: The output will be averaged.
+            ``'sum'``: The output will be summed.
+            ``'none'``: No reduction will be applied to the output. Default: ``'mean'``.
+
+        Returns
+        -------
+        ret
+            The Dice Loss between the given distributions.
+        """
+        return ivy.dice_loss(
+            true,
+            pred,
+            smooth=ivy.default(smooth, self._smooth),
+            reduction=ivy.default(reduction, self._reduction),
+        )
+

--- a/ivy_tests/test_ivy/test_frontends/test_paddle/test_nn/test_functional/test_loss.py
+++ b/ivy_tests/test_ivy/test_frontends/test_paddle/test_nn/test_functional/test_loss.py
@@ -390,3 +390,48 @@ def test_paddle_margin_ranking_loss(
         margin=margin,
         reduction=reduction,
     )
+
+# dice_loss
+@handle_frontend_test(
+    fn_tree="paddle.nn.functional.dice_loss",
+    dtype_and_x=helpers.dtype_and_values(
+        available_dtypes=helpers.get_dtypes("float"),
+        num_arrays=2,
+        shared_dtype=True,
+        min_num_dims=2,
+        max_num_dims=4,  # Adjust max_num_dims based on your requirements.
+        min_dim_size=1,
+        max_dim_size=10,
+        min_value=0.0,
+        max_value=1.0,
+    ),
+    epsilon=st.floats(
+        min_value=1e-7,
+        max_value=1.0,
+    ),
+    reduction=st.sampled_from(["mean", "sum", "none"]),
+)
+def test_paddle_dice_loss(
+    dtype_and_x,
+    epsilon,
+    reduction,
+    on_device,
+    fn_tree,
+    frontend,
+    test_flags,
+    backend_fw,
+):
+    input_dtype, x = dtype_and_x
+    helpers.test_frontend_function(
+        input_dtypes=input_dtype,
+        frontend=frontend,
+        backend_to_test=backend_fw,
+        test_flags=test_flags,
+        fn_tree=fn_tree,
+        on_device=on_device,
+        input=x[0],
+        target=x[1],
+        epsilon=epsilon,
+        reduction=reduction,
+    )
+

--- a/ivy_tests/test_ivy/test_functional/test_nn/test_losses.py
+++ b/ivy_tests/test_ivy/test_functional/test_nn/test_losses.py
@@ -203,3 +203,55 @@ def test_sparse_cross_entropy(
         epsilon=epsilon,
         reduction=reduction,
     )
+
+
+
+
+
+
+
+# dice_loss
+@handle_test(
+    fn_tree="functional.ivy.dice_loss",
+    dtype_and_pred=helpers.dtype_and_values(
+        available_dtypes=helpers.get_dtypes("float"),
+        min_value=1e-04,
+        max_value=1,
+        allow_inf=False,
+    ),
+    dtype_and_true=helpers.dtype_and_values(
+        available_dtypes=helpers.get_dtypes("float"),
+        min_value=1e-04,
+        max_value=1,
+        allow_inf=False,
+    ),
+    reduction=st.sampled_from(["none", "sum", "mean"]),
+    epsilon=helpers.floats(min_value=0.0, max_value=1.0),
+)
+def test_dice_loss(
+    dtype_and_pred,
+    dtype_and_true,
+    reduction,
+    epsilon,
+    test_flags,
+    backend_fw,
+    fn_name,
+    on_device,
+):
+    pred_dtype, pred = dtype_and_pred
+    true_dtype, true = dtype_and_true
+
+    helpers.test_function(
+        input_dtypes=true_dtype + pred_dtype,
+        test_flags=test_flags,
+        backend_to_test=backend_fw,
+        fn_name=fn_name,
+        on_device=on_device,
+        rtol_=1e-02,
+        atol_=1e-02,
+        pred=pred[0],
+        true=true[0],
+        epsilon=epsilon,
+        reduction=reduction,
+    )
+

--- a/ivy_tests/test_ivy/test_functional/test_nn/test_losses.py
+++ b/ivy_tests/test_ivy/test_functional/test_nn/test_losses.py
@@ -205,11 +205,6 @@ def test_sparse_cross_entropy(
     )
 
 
-
-
-
-
-
 # dice_loss
 @handle_test(
     fn_tree="functional.ivy.dice_loss",

--- a/ivy_tests/test_ivy/test_stateful/test_losses.py
+++ b/ivy_tests/test_ivy/test_stateful/test_losses.py
@@ -137,3 +137,59 @@ def test_cross_entropy_loss(
         atol_=1e-2,
         on_device=on_device,
     )
+
+
+# Dice Loss
+@handle_test(
+    fn_tree="functional.ivy.dice_loss",
+    dtype_and_pred=helpers.dtype_and_values(
+        available_dtypes=helpers.get_dtypes("float"),
+        min_value=0,
+        max_value=1,
+        allow_inf=False,
+        min_num_dims=1,
+        max_num_dims=3,
+        min_dim_size=3,
+    ),
+    dtype_and_target=helpers.dtype_and_values(
+        available_dtypes=helpers.get_dtypes("float"),
+        min_value=0,
+        max_value=1,
+        allow_inf=False,
+        min_num_dims=1,
+        max_num_dims=3,
+        min_dim_size=3,
+    ),
+    reduction=st.sampled_from(["none", "mean", "sum"]),
+    smooth=helpers.floats(min_value=0, max_value=1.0),
+    axis=st.integers(min_value=-1, max_value=1),
+)
+def test_dice_loss(
+    dtype_and_pred,
+    dtype_and_target,
+    reduction,
+    smooth,
+    axis,
+    test_flags,
+    backend_fw,
+    fn_name,
+    on_device,
+):
+    pred_dtype, pred = dtype_and_pred
+    target_dtype, target = dtype_and_target
+
+    helpers.test_function(
+        input_dtypes=pred_dtype + target_dtype,
+        test_flags=test_flags,
+        backend_to_test=backend_fw,
+        fn_name=fn_name,
+        on_device=on_device,
+        rtol_=1e-02,
+        atol_=1e-02,
+        pred=pred[0],
+        target=target[0],
+        reduction=reduction,
+        smooth=smooth,
+        axis=axis,
+    )
+


### PR DESCRIPTION
added the loss function called dice loss into ivy lib


"""
    Compute Dice loss between predicted and true discrete distributions.

    Parameters
    ----------
    true
        Input array containing true labels.
    pred
        Input array containing predicted labels.
    axis
        The axis along which to compute the Dice loss. Default: -1.
    epsilon
        A float in [0.0, 1.0] specifying the amount of smoothing when calculating
        the loss. If epsilon is 0, no smoothing will be applied. Default: 1e-7.
    reduction
        The reduction type for the output. Options: "none", "sum", "mean". Default: "mean".
    out
        Optional output array, for writing the result to. It must have a shape
        that the inputs broadcast to.

    Returns
    -------
    ret
        The Dice loss between the given distributions.

    Examples
    --------
    >>> x = ivy.array([0, 0, 1, 0])
    >>> y = ivy.array([0.25, 0.25, 0.25, 0.25])
    >>> print(ivy.dice_loss(x, y))
    ivy.array(0.6)

    >>> z = ivy.array([0.1, 0.1, 0.7, 0.1])
    >>> print(ivy.dice_loss(x, z))
    ivy.array(0.8333333)
    """