### PR TITLE
Update prune_nest_at_indices to make sure indices are in the right order

### DIFF
--- a/ivy/functional/ivy/nest.py
+++ b/ivy/functional/ivy/nest.py
@@ -420,7 +420,13 @@ def prune_nest_at_indices(nest: Iterable, indices: Tuple, /) -> None:
     indices
         A tuple of tuples of indices for the indices at which to prune.
     """
-    [prune_nest_at_index(nest, index) for index in indices]
+    # Delete first deeper elements and elements with larger index
+    indices_sorted = sorted(
+        indices,
+        key=str,
+        reverse=True,
+    )
+    [prune_nest_at_index(nest, index) for index in indices_sorted]
 
 
 @handle_exceptions

--- a/ivy_tests/test_ivy/test_functional/test_core/test_nest.py
+++ b/ivy_tests/test_ivy/test_functional/test_core/test_nest.py
@@ -380,21 +380,19 @@ def test_prune_nest_at_index(nest, index):
 @pytest.mark.parametrize(
     "nest", [{"a": [[0], [1]], "b": {"c": [[[2], [4]], [[6], [8]]]}}]
 )
-@pytest.mark.parametrize("indices", [(("a", 0, 0), ("b", "c", 0))])
+@pytest.mark.parametrize("indices", [(("a", 0), ("a", 0, 0), ("a", 1), ("b", "c", 0))])
 def test_prune_nest_at_indices(nest, indices):
     nest_copy = copy.deepcopy(nest)
-
-    def pnais(n, idxs):
-        [_pnai(n, index) for index in idxs]
-
-    # handling cases where there is nothing to prune
-    try:
-        ivy.prune_nest_at_indices(nest, indices)
-        pnais(nest_copy, indices)
-    except Exception:
-        warnings.warn("Nothing to delete.")
-
-    assert nest == nest_copy
+    ivy.prune_nest_at_indices(nest_copy, indices)
+    print(nest_copy)
+    for idx in indices:
+        try:
+            ele_org = ivy.index_nest(nest, idx)
+            ele_new = ivy.index_nest(nest_copy, idx)
+        except ivy.utils.exceptions.IvyIndexError:
+            return
+        else:
+            assert ele_org != ele_new
 
 
 # insert_into_nest_at_index


### PR DESCRIPTION
`prune_nest_at_indices` doesn't work properly when indices are not in the right order. Here is an example of a case that fails.
```python
xs = [1, 1]
ivy.prune_nest_at_indices(xs, [[0],[1]])
```
Error message: `list assignment index out of range`