### PR TITLE
rectify `check_shape`

### DIFF
--- a/ivy/utils/assertions.py
+++ b/ivy/utils/assertions.py
@@ -170,7 +170,7 @@ def check_shape(x1, x2, message=""):
             x1, x2, ivy.shape(x1), ivy.shape(x2)
         )
     )
-    if ivy.shape(x1) != ivy.shape(x2):
+    if ivy.any(ivy.shape(x1)[:] != ivy.shape(x2)[:]):
         raise ivy.utils.exceptions.IvyException(message)
 
 

--- a/ivy/utils/assertions.py
+++ b/ivy/utils/assertions.py
@@ -170,7 +170,7 @@ def check_shape(x1, x2, message=""):
             x1, x2, ivy.shape(x1), ivy.shape(x2)
         )
     )
-    if ivy.any(ivy.shape(x1)[:] != ivy.shape(x2)[:]):
+    if ivy.shape(x1)[:] != ivy.shape(x2)[:]:
         raise ivy.utils.exceptions.IvyException(message)
 
 


### PR DESCRIPTION
While working on https://github.com/unifyai/ivy/pull/20160, found that the expression for checking the inequality in shapes wasn't working as expected. The function in the subject does not return an error message (while it should) for arrays differing in shape. 
