### PR TITLE
Update numpy version to 1.25.2 on all the backend related files

### DIFF
--- a/ivy/functional/backends/numpy/__init__.py
+++ b/ivy/functional/backends/numpy/__init__.py
@@ -51,7 +51,7 @@ native_bool = np.dtype("bool")
 
 # update these to add new dtypes
 valid_dtypes = {
-    "1.25.1 and below": (
+    "1.25.2 and below": (
         ivy.int8,
         ivy.int16,
         ivy.int32,
@@ -69,7 +69,7 @@ valid_dtypes = {
     )
 }
 valid_numeric_dtypes = {
-    "1.25.1 and below": (
+    "1.25.2 and below": (
         ivy.int8,
         ivy.int16,
         ivy.int32,
@@ -86,7 +86,7 @@ valid_numeric_dtypes = {
     )
 }
 valid_int_dtypes = {
-    "1.25.1 and below": (
+    "1.25.2 and below": (
         ivy.int8,
         ivy.int16,
         ivy.int32,
@@ -97,11 +97,11 @@ valid_int_dtypes = {
         ivy.uint64,
     )
 }
-valid_float_dtypes = {"1.25.1 and below": (ivy.float16, ivy.float32, ivy.float64)}
+valid_float_dtypes = {"1.25.2 and below": (ivy.float16, ivy.float32, ivy.float64)}
 valid_uint_dtypes = {
-    "1.25.1 and below": (ivy.uint8, ivy.uint16, ivy.uint32, ivy.uint64)
+    "1.25.2 and below": (ivy.uint8, ivy.uint16, ivy.uint32, ivy.uint64)
 }
-valid_complex_dtypes = {"1.25.1 and below": (ivy.complex64, ivy.complex128)}
+valid_complex_dtypes = {"1.25.2 and below": (ivy.complex64, ivy.complex128)}
 
 # leave these untouched
 valid_dtypes = _dtype_from_version(valid_dtypes, backend_version)
@@ -113,12 +113,12 @@ valid_complex_dtypes = _dtype_from_version(valid_complex_dtypes, backend_version
 
 # invalid data types
 # update these to add new dtypes
-invalid_dtypes = {"1.25.1 and below": (ivy.bfloat16,)}
-invalid_numeric_dtypes = {"1.25.1 and below": (ivy.bfloat16,)}
-invalid_int_dtypes = {"1.25.1 and below": ()}
-invalid_float_dtypes = {"1.25.1 and below": (ivy.bfloat16,)}
-invalid_uint_dtypes = {"1.25.1 and below": ()}
-invalid_complex_dtypes = {"1.25.1 and below": ()}
+invalid_dtypes = {"1.25.2 and below": (ivy.bfloat16,)}
+invalid_numeric_dtypes = {"1.25.2 and below": (ivy.bfloat16,)}
+invalid_int_dtypes = {"1.25.2 and below": ()}
+invalid_float_dtypes = {"1.25.2 and below": (ivy.bfloat16,)}
+invalid_uint_dtypes = {"1.25.2 and below": ()}
+invalid_complex_dtypes = {"1.25.2 and below": ()}
 
 
 # leave these untouched

--- a/ivy/functional/backends/numpy/data_type.py
+++ b/ivy/functional/backends/numpy/data_type.py
@@ -133,7 +133,7 @@ def broadcast_arrays(*arrays: np.ndarray) -> List[np.ndarray]:
         raise ivy.utils.exceptions.IvyBroadcastShapeError(e)
 
 
-@with_unsupported_dtypes({"1.25.1 and below": ("complex",)}, backend_version)
+@with_unsupported_dtypes({"1.25.2 and below": ("complex",)}, backend_version)
 def broadcast_to(
     x: np.ndarray,
     /,
@@ -216,7 +216,7 @@ def as_ivy_dtype(
         )
 
 
-@with_unsupported_dtypes({"1.25.1 and below": ("bfloat16",)}, backend_version)
+@with_unsupported_dtypes({"1.25.2 and below": ("bfloat16",)}, backend_version)
 def as_native_dtype(dtype_in: Union[np.dtype, str, bool, int, float], /) -> np.dtype:
     if dtype_in is int:
         return ivy.default_int_dtype(as_native=True)

--- a/ivy/functional/backends/numpy/elementwise.py
+++ b/ivy/functional/backends/numpy/elementwise.py
@@ -83,7 +83,7 @@ atan.support_native_out = True
 
 
 @_scalar_output_to_0d_array
-@with_unsupported_dtypes({"1.25.1 and below": ("complex",)}, backend_version)
+@with_unsupported_dtypes({"1.25.2 and below": ("complex",)}, backend_version)
 def atan2(
     x1: np.ndarray, x2: np.ndarray, /, *, out: Optional[np.ndarray] = None
 ) -> np.ndarray:
@@ -103,7 +103,7 @@ atanh.support_native_out = True
 
 
 @_scalar_output_to_0d_array
-@with_unsupported_dtypes({"1.25.1 and below": ("complex",)}, backend_version)
+@with_unsupported_dtypes({"1.25.2 and below": ("complex",)}, backend_version)
 def bitwise_and(
     x1: Union[int, bool, np.ndarray],
     x2: Union[int, bool, np.ndarray],
@@ -119,7 +119,7 @@ bitwise_and.support_native_out = True
 
 
 @_scalar_output_to_0d_array
-@with_unsupported_dtypes({"1.25.1 and below": ("complex",)}, backend_version)
+@with_unsupported_dtypes({"1.25.2 and below": ("complex",)}, backend_version)
 def bitwise_invert(
     x: Union[int, bool, np.ndarray], /, *, out: Optional[np.ndarray] = None
 ) -> np.ndarray:
@@ -130,7 +130,7 @@ bitwise_invert.support_native_out = True
 
 
 @_scalar_output_to_0d_array
-@with_unsupported_dtypes({"1.25.1 and below": ("complex",)}, backend_version)
+@with_unsupported_dtypes({"1.25.2 and below": ("complex",)}, backend_version)
 def bitwise_left_shift(
     x1: Union[int, bool, np.ndarray],
     x2: Union[int, bool, np.ndarray],
@@ -146,7 +146,7 @@ bitwise_left_shift.support_native_out = True
 
 
 @_scalar_output_to_0d_array
-@with_unsupported_dtypes({"1.25.1 and below": ("complex",)}, backend_version)
+@with_unsupported_dtypes({"1.25.2 and below": ("complex",)}, backend_version)
 def bitwise_or(
     x1: Union[int, bool, np.ndarray],
     x2: Union[int, bool, np.ndarray],
@@ -162,7 +162,7 @@ bitwise_or.support_native_out = True
 
 
 @_scalar_output_to_0d_array
-@with_unsupported_dtypes({"1.25.1 and below": ("complex",)}, backend_version)
+@with_unsupported_dtypes({"1.25.2 and below": ("complex",)}, backend_version)
 def bitwise_right_shift(
     x1: Union[int, bool, np.ndarray],
     x2: Union[int, bool, np.ndarray],
@@ -178,7 +178,7 @@ bitwise_right_shift.support_native_out = True
 
 
 @_scalar_output_to_0d_array
-@with_unsupported_dtypes({"1.25.1 and below": ("complex",)}, backend_version)
+@with_unsupported_dtypes({"1.25.2 and below": ("complex",)}, backend_version)
 def bitwise_xor(
     x1: Union[int, bool, np.ndarray],
     x2: Union[int, bool, np.ndarray],
@@ -193,7 +193,7 @@ def bitwise_xor(
 bitwise_xor.support_native_out = True
 
 
-@with_unsupported_dtypes({"1.25.1 and below": ("complex",)}, backend_version)
+@with_unsupported_dtypes({"1.25.2 and below": ("complex",)}, backend_version)
 @_scalar_output_to_0d_array
 def ceil(x: np.ndarray, /, *, out: Optional[np.ndarray] = None) -> np.ndarray:
     if "int" in str(x.dtype):
@@ -216,7 +216,7 @@ def cos(x: np.ndarray, /, *, out: Optional[np.ndarray] = None) -> np.ndarray:
 cos.support_native_out = True
 
 
-@with_unsupported_dtypes({"1.25.1 and below": ("float16",)}, backend_version)
+@with_unsupported_dtypes({"1.25.2 and below": ("float16",)}, backend_version)
 @_scalar_output_to_0d_array
 def cosh(x: np.ndarray, /, *, out: Optional[np.ndarray] = None) -> np.ndarray:
     return np.cosh(x, out=out)
@@ -289,7 +289,7 @@ expm1.support_native_out = True
 
 
 @_scalar_output_to_0d_array
-@with_unsupported_dtypes({"1.25.1 and below": ("complex",)}, backend_version)
+@with_unsupported_dtypes({"1.25.2 and below": ("complex",)}, backend_version)
 def floor(x: np.ndarray, /, *, out: Optional[np.ndarray] = None) -> np.ndarray:
     if "int" in str(x.dtype):
         ret = np.copy(x)
@@ -304,7 +304,7 @@ floor.support_native_out = True
 
 
 @_scalar_output_to_0d_array
-@with_unsupported_dtypes({"1.25.1 and below": ("complex",)}, backend_version)
+@with_unsupported_dtypes({"1.25.2 and below": ("complex",)}, backend_version)
 def floor_divide(
     x1: Union[float, np.ndarray],
     x2: Union[float, np.ndarray],
@@ -486,7 +486,7 @@ log2.support_native_out = True
 
 
 @_scalar_output_to_0d_array
-@with_unsupported_dtypes({"1.25.1 and below": ("complex",)}, backend_version)
+@with_unsupported_dtypes({"1.25.2 and below": ("complex",)}, backend_version)
 def logaddexp(
     x1: np.ndarray, x2: np.ndarray, /, *, out: Optional[np.ndarray] = None
 ) -> np.ndarray:
@@ -618,7 +618,7 @@ pow.support_native_out = True
 
 
 @_scalar_output_to_0d_array
-@with_unsupported_dtypes({"1.25.1 and below": ("complex",)}, backend_version)
+@with_unsupported_dtypes({"1.25.2 and below": ("complex",)}, backend_version)
 def remainder(
     x1: Union[float, np.ndarray],
     x2: Union[float, np.ndarray],
@@ -858,7 +858,7 @@ reciprocal.support_native_out = True
 
 
 @_scalar_output_to_0d_array
-@with_unsupported_dtypes({"1.25.1 and below": ("complex",)}, backend_version)
+@with_unsupported_dtypes({"1.25.2 and below": ("complex",)}, backend_version)
 def deg2rad(x: np.ndarray, /, *, out: Optional[np.ndarray] = None) -> np.ndarray:
     return np.deg2rad(x, out=out)
 
@@ -867,7 +867,7 @@ deg2rad.support_native_out = True
 
 
 @_scalar_output_to_0d_array
-@with_unsupported_dtypes({"1.25.1 and below": ("complex",)}, backend_version)
+@with_unsupported_dtypes({"1.25.2 and below": ("complex",)}, backend_version)
 def rad2deg(x: np.ndarray, /, *, out: Optional[np.ndarray] = None) -> np.ndarray:
     return np.rad2deg(x, out=out)
 
@@ -884,7 +884,7 @@ isreal.support_native_out = False
 
 
 @_scalar_output_to_0d_array
-@with_unsupported_dtypes({"1.25.1 and below": ("complex",)}, backend_version)
+@with_unsupported_dtypes({"1.25.2 and below": ("complex",)}, backend_version)
 def fmod(
     x1: np.ndarray,
     x2: np.ndarray,

--- a/ivy/functional/backends/numpy/experimental/activations.py
+++ b/ivy/functional/backends/numpy/experimental/activations.py
@@ -50,7 +50,7 @@ def relu6(x: np.ndarray, /, *, out: Optional[np.ndarray] = None) -> np.ndarray:
 relu6.support_native_out = True
 
 
-@with_unsupported_dtypes({"1.25.1 and below": ("bool",)}, backend_version)
+@with_unsupported_dtypes({"1.25.2 and below": ("bool",)}, backend_version)
 @_scalar_output_to_0d_array
 def logsigmoid(input: np.ndarray, /, *, out: Optional[np.ndarray] = None) -> np.ndarray:
     return -(np.log1p(np.exp(-(input))))

--- a/ivy/functional/backends/numpy/experimental/elementwise.py
+++ b/ivy/functional/backends/numpy/experimental/elementwise.py
@@ -10,7 +10,7 @@ from . import backend_version
 
 
 @_scalar_output_to_0d_array
-@with_unsupported_dtypes({"1.25.1 and below": ("bfloat16",)}, backend_version)
+@with_unsupported_dtypes({"1.25.2 and below": ("bfloat16",)}, backend_version)
 def sinc(x: np.ndarray, /, *, out: Optional[np.ndarray] = None) -> np.ndarray:
     return np.sinc(x).astype(x.dtype)
 

--- a/ivy/functional/backends/numpy/experimental/general.py
+++ b/ivy/functional/backends/numpy/experimental/general.py
@@ -7,7 +7,7 @@ from . import backend_version
 from ivy import with_unsupported_dtypes
 
 
-@with_unsupported_dtypes({"1.25.1 and below": ("complex",)}, backend_version)
+@with_unsupported_dtypes({"1.25.2 and below": ("complex",)}, backend_version)
 def reduce(
     operand: np.ndarray,
     init_value: Union[int, float],

--- a/ivy/functional/backends/numpy/experimental/layers.py
+++ b/ivy/functional/backends/numpy/experimental/layers.py
@@ -643,7 +643,7 @@ def fft(
     return np.fft.fft(x, n, dim, norm).astype(out_dtype)
 
 
-@with_supported_dtypes({"1.25.1 and below": ("float32", "float64")}, backend_version)
+@with_supported_dtypes({"1.25.2 and below": ("float32", "float64")}, backend_version)
 def dct(
     x: np.ndarray,
     /,
@@ -905,7 +905,7 @@ def ifftn(
     return np.fft.ifftn(x, s, axes, norm).astype(x.dtype)
 
 
-@with_unsupported_dtypes({"1.25.1 and below": ("complex",)}, backend_version)
+@with_unsupported_dtypes({"1.25.2 and below": ("complex",)}, backend_version)
 def embedding(
     weights: np.ndarray,
     indices: np.ndarray,

--- a/ivy/functional/backends/numpy/experimental/linear_algebra.py
+++ b/ivy/functional/backends/numpy/experimental/linear_algebra.py
@@ -98,7 +98,7 @@ kron.support_native_out = False
 
 
 @with_supported_dtypes(
-    {"1.25.1 and below": ("float32", "float64", "complex64", "complex128")},
+    {"1.25.2 and below": ("float32", "float64", "complex64", "complex128")},
     backend_version,
 )
 def matrix_exp(

--- a/ivy/functional/backends/numpy/experimental/norms.py
+++ b/ivy/functional/backends/numpy/experimental/norms.py
@@ -4,7 +4,7 @@ from ivy.func_wrapper import with_unsupported_dtypes
 from . import backend_version
 
 
-@with_unsupported_dtypes({"1.25.1 and below": ("float16",)}, backend_version)
+@with_unsupported_dtypes({"1.25.2 and below": ("float16",)}, backend_version)
 def l1_normalize(
     x: np.ndarray,
     /,

--- a/ivy/functional/backends/numpy/experimental/searching.py
+++ b/ivy/functional/backends/numpy/experimental/searching.py
@@ -7,7 +7,7 @@ from ivy.func_wrapper import with_supported_dtypes
 from . import backend_version
 
 
-@with_supported_dtypes({"1.25.1 and below": ("int32", "int64")}, backend_version)
+@with_supported_dtypes({"1.25.2 and below": ("int32", "int64")}, backend_version)
 def unravel_index(
     indices: np.ndarray,
     shape: Tuple[int],

--- a/ivy/functional/backends/numpy/experimental/statistical.py
+++ b/ivy/functional/backends/numpy/experimental/statistical.py
@@ -8,7 +8,7 @@ from ..statistical import _infer_dtype
 
 
 @with_unsupported_dtypes(
-    {"1.25.1 and below": ("bfloat16",)},
+    {"1.25.2 and below": ("bfloat16",)},
     backend_version,
 )
 def histogram(
@@ -365,7 +365,7 @@ def __get_index(lst, indices=None, prefix=None):
     return indices
 
 
-@with_unsupported_dtypes({"1.25.1 and below": "bfloat16"}, backend_version)
+@with_unsupported_dtypes({"1.25.2 and below": "bfloat16"}, backend_version)
 def cummin(
     x: np.ndarray,
     /,

--- a/ivy/functional/backends/numpy/general.py
+++ b/ivy/functional/backends/numpy/general.py
@@ -435,7 +435,7 @@ def vmap(
     return _vmap
 
 
-@with_unsupported_dtypes({"1.25.1 and below": ("bfloat16",)}, backend_version)
+@with_unsupported_dtypes({"1.25.2 and below": ("bfloat16",)}, backend_version)
 def isin(
     elements: np.ndarray,
     test_elements: np.ndarray,

--- a/ivy/functional/backends/numpy/linear_algebra.py
+++ b/ivy/functional/backends/numpy/linear_algebra.py
@@ -19,7 +19,7 @@ from . import backend_version
 # -------------------#
 
 
-@with_unsupported_dtypes({"1.25.1 and below": ("float16", "complex")}, backend_version)
+@with_unsupported_dtypes({"1.25.2 and below": ("float16", "complex")}, backend_version)
 def cholesky(
     x: np.ndarray, /, *, upper: bool = False, out: Optional[np.ndarray] = None
 ) -> np.ndarray:
@@ -31,7 +31,7 @@ def cholesky(
     return ret
 
 
-@with_unsupported_dtypes({"1.25.1 and below": ("float16",)}, backend_version)
+@with_unsupported_dtypes({"1.25.2 and below": ("float16",)}, backend_version)
 def cross(
     x1: np.ndarray,
     x2: np.ndarray,
@@ -47,7 +47,7 @@ def cross(
 
 
 @_scalar_output_to_0d_array
-@with_unsupported_dtypes({"1.25.1 and below": ("float16",)}, backend_version)
+@with_unsupported_dtypes({"1.25.2 and below": ("float16",)}, backend_version)
 def det(x: np.ndarray, /, *, out: Optional[np.ndarray] = None) -> np.ndarray:
     return np.linalg.det(x)
 
@@ -64,7 +64,7 @@ def diagonal(
     return np.diagonal(x, offset=offset, axis1=axis1, axis2=axis2)
 
 
-@with_unsupported_dtypes({"1.25.1 and below": ("float16",)}, backend_version)
+@with_unsupported_dtypes({"1.25.2 and below": ("float16",)}, backend_version)
 def eigh(
     x: np.ndarray, /, *, UPLO: str = "L", out: Optional[np.ndarray] = None
 ) -> Tuple[np.ndarray]:
@@ -75,7 +75,7 @@ def eigh(
     return result_tuple(eigenvalues, eigenvectors)
 
 
-@with_unsupported_dtypes({"1.25.1 and below": ("float16",)}, backend_version)
+@with_unsupported_dtypes({"1.25.2 and below": ("float16",)}, backend_version)
 def eigvalsh(
     x: np.ndarray, /, *, UPLO: str = "L", out: Optional[np.ndarray] = None
 ) -> np.ndarray:
@@ -91,7 +91,7 @@ def inner(
 
 
 @with_unsupported_dtypes(
-    {"1.25.1 and below": ("bfloat16", "float16", "complex")},
+    {"1.25.2 and below": ("bfloat16", "float16", "complex")},
     backend_version,
 )
 def inv(
@@ -111,7 +111,7 @@ def inv(
     return np.linalg.inv(x)
 
 
-@with_unsupported_dtypes({"1.25.1 and below": ("float16", "bfloat16")}, backend_version)
+@with_unsupported_dtypes({"1.25.2 and below": ("float16", "bfloat16")}, backend_version)
 def matmul(
     x1: np.ndarray,
     x2: np.ndarray,
@@ -141,7 +141,7 @@ matmul.support_native_out = True
 
 
 @_scalar_output_to_0d_array
-@with_unsupported_dtypes({"1.25.1 and below": ("float16", "bfloat16")}, backend_version)
+@with_unsupported_dtypes({"1.25.2 and below": ("float16", "bfloat16")}, backend_version)
 def matrix_norm(
     x: np.ndarray,
     /,
@@ -163,7 +163,7 @@ def matrix_power(
 
 
 @with_unsupported_dtypes(
-    {"1.25.1 and below": ("float16", "bfloat16", "complex")},
+    {"1.25.2 and below": ("float16", "bfloat16", "complex")},
     backend_version,
 )
 @_scalar_output_to_0d_array
@@ -202,7 +202,7 @@ def matrix_transpose(
     return np.swapaxes(x, -1, -2)
 
 
-@with_unsupported_dtypes({"1.25.1 and below": ("float16",)}, backend_version)
+@with_unsupported_dtypes({"1.25.2 and below": ("float16",)}, backend_version)
 def outer(
     x1: np.ndarray,
     x2: np.ndarray,
@@ -217,7 +217,7 @@ def outer(
 outer.support_native_out = True
 
 
-@with_unsupported_dtypes({"1.25.1 and below": ("float16",)}, backend_version)
+@with_unsupported_dtypes({"1.25.2 and below": ("float16",)}, backend_version)
 def pinv(
     x: np.ndarray,
     /,
@@ -231,7 +231,7 @@ def pinv(
         return np.linalg.pinv(x, rtol)
 
 
-@with_unsupported_dtypes({"1.25.1 and below": ("float16",)}, backend_version)
+@with_unsupported_dtypes({"1.25.2 and below": ("float16",)}, backend_version)
 def qr(
     x: np.ndarray,
     /,
@@ -244,7 +244,7 @@ def qr(
     return res(q, r)
 
 
-@with_unsupported_dtypes({"1.25.1 and below": ("float16",)}, backend_version)
+@with_unsupported_dtypes({"1.25.2 and below": ("float16",)}, backend_version)
 def slogdet(
     x: np.ndarray,
     /,
@@ -259,7 +259,7 @@ def slogdet(
     return results(sign, logabsdet)
 
 
-@with_unsupported_dtypes({"1.25.1 and below": ("float16",)}, backend_version)
+@with_unsupported_dtypes({"1.25.2 and below": ("float16",)}, backend_version)
 def solve(
     x1: np.ndarray,
     x2: np.ndarray,
@@ -284,7 +284,7 @@ def solve(
     return ret
 
 
-@with_unsupported_dtypes({"1.25.1 and below": ("float16",)}, backend_version)
+@with_unsupported_dtypes({"1.25.2 and below": ("float16",)}, backend_version)
 def svd(
     x: np.ndarray, /, *, compute_uv: bool = True, full_matrices: bool = True
 ) -> Union[np.ndarray, Tuple[np.ndarray, ...]]:
@@ -298,7 +298,7 @@ def svd(
         return results(D)
 
 
-@with_unsupported_dtypes({"1.25.1 and below": ("float16",)}, backend_version)
+@with_unsupported_dtypes({"1.25.2 and below": ("float16",)}, backend_version)
 def svdvals(x: np.ndarray, /, *, out: Optional[np.ndarray] = None) -> np.ndarray:
     return np.linalg.svd(x, compute_uv=False)
 
@@ -327,7 +327,7 @@ def tensordot(
 
 
 @_scalar_output_to_0d_array
-@with_unsupported_dtypes({"1.25.1 and below": ("float16", "bfloat16")}, backend_version)
+@with_unsupported_dtypes({"1.25.2 and below": ("float16", "bfloat16")}, backend_version)
 def trace(
     x: np.ndarray,
     /,
@@ -355,7 +355,7 @@ def vecdot(
     return np.tensordot(x1, x2, axes=(axis, axis))
 
 
-@with_unsupported_dtypes({"1.25.1 and below": ("float16",)}, backend_version)
+@with_unsupported_dtypes({"1.25.2 and below": ("float16",)}, backend_version)
 def eig(x: np.ndarray, /, *, out: Optional[np.ndarray] = None) -> Tuple[np.ndarray]:
     result_tuple = NamedTuple(
         "eig", [("eigenvalues", np.ndarray), ("eigenvectors", np.ndarray)]
@@ -421,7 +421,7 @@ def vander(
 
 @with_unsupported_dtypes(
     {
-        "1.25.1 and below": (
+        "1.25.2 and below": (
             "complex",
             "unsigned",
         )

--- a/ivy/functional/backends/numpy/manipulation.py
+++ b/ivy/functional/backends/numpy/manipulation.py
@@ -209,7 +209,7 @@ def split(
     return np.split(x, num_or_size_splits, axis)
 
 
-@with_unsupported_dtypes({"1.25.1 and below": ("uint64",)}, backend_version)
+@with_unsupported_dtypes({"1.25.2 and below": ("uint64",)}, backend_version)
 def repeat(
     x: np.ndarray,
     /,

--- a/ivy/functional/backends/numpy/random.py
+++ b/ivy/functional/backends/numpy/random.py
@@ -51,7 +51,7 @@ def random_normal(
     return np.asarray(np.random.normal(mean, std, shape), dtype=dtype)
 
 
-@with_unsupported_dtypes({"1.25.1 and below": ("bfloat16",)}, backend_version)
+@with_unsupported_dtypes({"1.25.2 and below": ("bfloat16",)}, backend_version)
 def multinomial(
     population_size: int,
     num_samples: int,

--- a/ivy/functional/backends/numpy/sorting.py
+++ b/ivy/functional/backends/numpy/sorting.py
@@ -42,7 +42,7 @@ def sort(
 
 
 # msort
-@with_unsupported_dtypes({"1.25.1 and below": ("complex",)}, backend_version)
+@with_unsupported_dtypes({"1.25.2 and below": ("complex",)}, backend_version)
 def msort(
     a: Union[np.ndarray, list, tuple], /, *, out: Optional[np.ndarray] = None
 ) -> np.ndarray:

--- a/ivy/functional/backends/numpy/statistical.py
+++ b/ivy/functional/backends/numpy/statistical.py
@@ -170,7 +170,7 @@ var.support_native_out = True
 # ------#
 
 
-@with_unsupported_dtypes({"1.25.1 and below": "bfloat16"}, backend_version)
+@with_unsupported_dtypes({"1.25.2 and below": "bfloat16"}, backend_version)
 def cumprod(
     x: np.ndarray,
     /,


### PR DESCRIPTION
There is a new numpy minor release and it's causing all the numpy tests to fail.

I updated all the occurrences of the old `1.25.1` numpy version in the backend files with the new `1.25.2` version number