### PR TITLE
fix dtype and device defaulting for torch new_zeros

### DIFF
--- a/ivy/functional/frontends/torch/tensor.py
+++ b/ivy/functional/frontends/torch/tensor.py
@@ -461,8 +461,19 @@ class Tensor:
         return torch_frontend.erf(self, out=out)
 
     def new_zeros(
-        self, size, *, dtype=None, device=None, requires_grad=False, layout=None
+        self,
+        size,
+        *,
+        dtype=None,
+        device=None,
+        requires_grad=False,
+        layout=None,
+        pin_memory=False,
     ):
+        if dtype is None:
+            dtype = self.dtype
+        if device is None:
+            device = self.device
         if isinstance(size[0], tuple):
             return torch_frontend.zeros(
                 size=size[0], dtype=dtype, device=device, requires_grad=requires_grad


### PR DESCRIPTION
Fix dtype/device defaulting for torch.Tensor.new_zeros frontend, so that if dtype/device is not specified in the args it will default to using the dtype/device of the current tensor - matching the functionality defined in the docs here https://pytorch.org/docs/stable/generated/torch.Tensor.new_zeros.html "By default, the returned Tensor has the same torch.dtype and torch.device as this tensor". Also add missing `pin_memory` kwarg.