### PR TITLE
Fix flatten_frontend_to_np to use the right backend

### DIFF
--- a/ivy_tests/test_ivy/helpers/function_testing.py
+++ b/ivy_tests/test_ivy/helpers/function_testing.py
@@ -1861,7 +1861,9 @@ def flatten_frontend_to_np(*, backend: str, ret, frontend_array_fn=None):
     )
 
     with update_backend(backend) as ivy_backend:
-        return [ivy_backend.to_numpy(x.ivy_array) for x in ret_flat]
+        return [
+            ivy_backend.to_numpy(ivy_backend.array(x.ivy_array.data)) for x in ret_flat
+        ]
 
 
 def get_ret_and_flattened_np_array(

--- a/ivy_tests/test_ivy/helpers/function_testing.py
+++ b/ivy_tests/test_ivy/helpers/function_testing.py
@@ -1860,10 +1860,7 @@ def flatten_frontend_to_np(*, backend: str, ret, frontend_array_fn=None):
         ret=ret, backend=backend, frontend_array_fn=frontend_array_fn
     )
 
-    with update_backend(backend) as ivy_backend:
-        return [
-            ivy_backend.to_numpy(ivy_backend.array(x.ivy_array.data)) for x in ret_flat
-        ]
+    return [x.ivy_array.to_numpy() for x in ret_flat]
 
 
 def get_ret_and_flattened_np_array(


### PR DESCRIPTION
My test hangs when I call flatten_frontend_to_np. This code below also shows the problem.
```python
import ivy
import ivy.functional.frontends.torch as torch
import ivy_tests.test_ivy.helpers as helpers

ivy.set_backend("torch")

x=torch.tensor(1.)
y = helpers.flatten_frontend_to_np(ret=x, backend="torch")
```