### PR TITLE
Added `around` function to functional api

### DIFF
--- a/ivy/data_classes/array/experimental/elementwise.py
+++ b/ivy/data_classes/array/experimental/elementwise.py
@@ -1020,3 +1020,51 @@ class _ArrayWithElementWiseExperimental(abc.ABC):
         ivy.array([-0.7549271   0.92278427  0.9988394])
         """
         return ivy.digamma(self._data, out=out)
+
+    def around(
+        self: ivy.Array, *, decimals: int = 0, out: Optional[ivy.Array] = None
+    ) -> ivy.Array:
+        """
+        ivy.Array instance method variant of ivy.around. This method simply wraps the
+        function, and so the docstring for ivy.around also applies to this method with
+        minimal changes.
+
+        Parameters
+        ----------
+        self
+            input array. Should have a numeric data type.
+        decimals
+            number of decimal places to round to. Default is ``0``.
+        out
+            optional output array, for writing the result to. It must have a shape that
+            the inputs broadcast to.
+
+        Returns
+        -------
+        ret
+            an array containing the rounded result for each element in ``self``. The
+            returned array must have the same data type as ``self``.
+
+        Examples
+        --------
+        Using :class:`ivy.Array` instance method:
+
+        >>> x = ivy.array([1.2, 2.4, 3.6])
+        >>> y = x.around(x)
+        >>> print(y)
+        ivy.array([1.,2.,4.])
+
+
+        >>> x = ivy.array([1.5654, 2.034, 15.1, -5.0])
+        >>> y = ivy.zeros(4)
+        >>> x.around(out=y)
+        >>> print(y)
+        ivy.array([2.,2.,15.,-5.])
+
+        >>> x = ivy.array([[0, 5.433, -343.3, 1.5],
+        ...                [-5.5, 44.2, 11.5, 12.01]])
+        >>> x.around(out=x)
+        >>> print(x)
+        ivy.array([[0.,5.,-343.,2.],[-6.,44.,12.,12.]])
+        """
+        return ivy.around(self._data, decimals=decimals, out=out)

--- a/ivy/data_classes/container/experimental/elementwise.py
+++ b/ivy/data_classes/container/experimental/elementwise.py
@@ -2975,3 +2975,115 @@ class _ContainerWithElementWiseExperimental(ContainerBase):
             map_sequences=map_sequences,
             out=out,
         )
+
+    @staticmethod
+    def static_around(
+        x: Union[ivy.Container, ivy.Array, ivy.NativeArray],
+        /,
+        *,
+        decimals: int = 0,
+        key_chains: Optional[Union[List[str], Dict[str, str]]] = None,
+        to_apply: bool = True,
+        prune_unapplied: bool = False,
+        map_sequences: bool = False,
+        out: Optional[ivy.Array] = None,
+    ) -> ivy.Container:
+        """
+        ivy.Container static method variant of ivy.around. This method simply wraps
+        the function, and so the docstring for ivy.around also applies to this method
+        with minimal changes.
+
+        Parameters
+        ----------
+        self
+            input array. Should have a numeric data type.
+        decimals
+            number of decimal places to round to. Default is ``0``.
+        out
+            optional output array, for writing the result to. It must have a shape that
+            the inputs broadcast to.
+
+        Returns
+        -------
+        ret
+            an array containing the rounded result for each element in ``self``. The
+            returned array must have the same data type as ``self``.
+
+        Examples
+        --------
+        With :class:`ivy.Container` input:
+
+        >>> x = ivy.Container(a=ivy.array([4.20, 8.6, 6.90, 0.0]),
+        ...                   b=ivy.array([-300.9, -527.3, 4.5]))
+        >>> y = ivy.Container.static_around(x)
+        >>> print(y)
+        {
+            a: ivy.array([4.,9.,7.,0.]),
+            b: ivy.array([-301.,-527.,4.])
+        }
+        """
+        return ContainerBase.cont_multi_map_in_function(
+            "around",
+            x,
+            decimals=decimals,
+            key_chains=key_chains,
+            to_apply=to_apply,
+            prune_unapplied=prune_unapplied,
+            map_sequences=map_sequences,
+            out=out,
+        )
+
+    def around(
+        self: ivy.Container,
+        /,
+        *,
+        decimals: int = 0,
+        key_chains: Optional[Union[List[str], Dict[str, str]]] = None,
+        to_apply: bool = True,
+        prune_unapplied: bool = False,
+        map_sequences: bool = False,
+        out: Optional[ivy.Container] = None,
+    ) -> ivy.Container:
+        """
+        ivy.Container instance method variant of ivy.around. This method simply wraps
+        the function, and so the docstring for ivy.around also applies to this method
+        with minimal changes.
+
+        Parameters
+        ----------
+        self
+            input array. Should have a numeric data type.
+        decimals
+            number of decimal places to round to. Default is ``0``.
+        out
+            optional output array, for writing the result to. It must have a shape that
+            the inputs broadcast to.
+
+        Returns
+        -------
+        ret
+            an array containing the rounded result for each element in ``self``. The
+            returned array must have the same data type as ``self``.
+
+        Examples
+        --------
+        With :class:`ivy.Container` input:
+
+        >>> x = ivy.Container(a=ivy.array([4.20, 8.6, 6.90, 0.0]),
+        ...                   b=ivy.array([-300.9, -527.3, 4.5]))
+        >>> y = x.around()
+        >>> print(y)
+        {
+            a: ivy.array([4.,9.,7.,0.]),
+            b: ivy.array([-301.,-527.,4.])
+        }
+        """
+        return self.static_around(
+            self,
+            decimals=decimals,
+            key_chains=key_chains,
+            to_apply=to_apply,
+            prune_unapplied=prune_unapplied,
+            map_sequences=map_sequences,
+            out=out
+        )

--- a/ivy/functional/backends/jax/elementwise.py
+++ b/ivy/functional/backends/jax/elementwise.py
@@ -442,6 +442,16 @@ def round(
     return ret
 
 
+def around(
+    x: JaxArray, /, *, decimals: int = 0, out: Optional[JaxArray] = None
+) -> JaxArray:
+    if "int" in str(x.dtype):
+        ret = jnp.copy(x)
+    else:
+        ret = jnp.around(x, decimals=decimals)
+    return ret
+
+
 def _abs_variant_sign(x):
     return jnp.where(x != 0, x / jnp.abs(x), 0)
 

--- a/ivy/functional/backends/numpy/elementwise.py
+++ b/ivy/functional/backends/numpy/elementwise.py
@@ -656,6 +656,22 @@ def round(
 round.support_native_out = True
 
 
+@_scalar_output_to_0d_array
+def around(
+    x: np.ndarray, /, *, decimals: int = 0, out: Optional[np.ndarray] = None
+) -> np.ndarray:
+    if "int" in str(x.dtype):
+        ret = np.copy(x)
+    else:
+        ret = np.around(x, decimals=decimals, out=out)
+    if ivy.exists(out):
+        return ivy.inplace_update(out, ret)
+    return ret
+
+
+around.support_native_out = True
+
+
 def _abs_variant_sign(x):
     return np.divide(x, np.abs(x), where=x != 0)
 

--- a/ivy/functional/backends/paddle/elementwise.py
+++ b/ivy/functional/backends/paddle/elementwise.py
@@ -770,6 +770,44 @@ def round(
     return _np_round(x, decimals).astype(x.dtype)
 
 
+def around(
+    x: paddle.Tensor, /, *, decimals: int = 0, out: Optional[paddle.Tensor] = None
+) -> paddle.Tensor:
+    def _np_round(x, decimals):
+        # this is a logic to mimic np.round behaviour
+        # which rounds odd numbers up and even numbers down at limits like 0.5
+        eps = 1e-6 * paddle.sign(x)
+
+        # check if the integer is even or odd
+        candidate_ints = paddle_backend.remainder(paddle_backend.trunc(x), 2.0).astype(
+            bool
+        )
+        # check if the fraction is exactly half
+        candidate_fractions = paddle_backend.equal(
+            paddle_backend.abs(paddle_backend.subtract(x, paddle_backend.trunc(x))),
+            0.5,
+        )
+        x = paddle_backend.where(
+            paddle.logical_and(~candidate_ints, candidate_fractions),
+            x - eps,
+            x,
+        )
+        factor = paddle_backend.pow(10.0, decimals).astype(x.dtype)
+        factor_denom = ivy.where(ivy.isinf(x), 1.0, factor)
+        return paddle_backend.divide(
+            paddle.round(paddle_backend.multiply(x, factor)), factor_denom
+        )
+
+    if x.dtype not in [paddle.float32, paddle.float64]:
+        if paddle.is_complex(x):
+            return paddle.complex(
+                _np_round(x.real(), decimals), _np_round(x.imag(), decimals)
+            )
+        return _np_round(x.astype("float32"), decimals).astype(x.dtype)
+    return _np_round(x, decimals).astype(x.dtype)
+
+
+
 def trunc(x: paddle.Tensor, /, *, out: Optional[paddle.Tensor] = None) -> paddle.Tensor:
     if x.dtype in [
         paddle.int8,

--- a/ivy/functional/backends/tensorflow/experimental/elementwise.py
+++ b/ivy/functional/backends/tensorflow/experimental/elementwise.py
@@ -516,3 +516,24 @@ def digamma(
     out: Optional[Union[tf.Tensor, tf.Variable]] = None,
 ) -> Union[tf.Tensor, tf.Variable]:
     return tf.math.digamma(x)
+
+
+@with_unsupported_dtypes({"2.13.0 and below": ("bfloat16", "complex")}, backend_version)
+def around(
+    x: Union[tf.Tensor, tf.Variable],
+    /,
+    *,
+    decimals: int = 0,
+    out: Optional[Union[tf.Tensor, tf.Variable]] = None,
+) -> Union[tf.Tensor, tf.Variable]:
+    if "int" in str(x.dtype):
+        return x
+    else:
+        if decimals == 0:
+            return tf.cast(tf.experimental.numpy.around(x), x.dtype)
+        ret_dtype = x.dtype
+        factor = tf.constant(10**decimals, dtype=ret_dtype)
+        factor_deno = tf.where(
+            tf.math.is_finite(factor), factor, tf.constant(1, dtype=ret_dtype)
+        )
+        return tf.cast(tf.experimental.numpy.around(x * factor) / factor_deno, ret_dtype)

--- a/ivy/functional/backends/torch/elementwise.py
+++ b/ivy/functional/backends/torch/elementwise.py
@@ -609,6 +609,21 @@ def round(
 round.support_native_out = True
 
 
+@with_unsupported_dtypes({"2.0.1 and below": ("float16", "complex")}, backend_version)
+@handle_numpy_arrays_in_specific_backend
+def around(
+    x: torch.Tensor, /, *, decimals: int = 0, out: Optional[torch.Tensor] = None
+) -> torch.Tensor:
+    if "int" in str(x.dtype):
+        if ivy.exists(out):
+            return ivy.inplace_update(out, x)
+        return x
+    return torch.round(x, decimals=decimals, out=out)
+
+
+round.support_native_out = True
+
+
 def trapz(
     y: torch.Tensor,
     /,

--- a/ivy/functional/frontends/jax/numpy/mathematical_functions.py
+++ b/ivy/functional/frontends/jax/numpy/mathematical_functions.py
@@ -542,7 +542,7 @@ def subtract(x1, x2, /):
 @to_ivy_arrays_and_back
 def around(a, decimals=0, out=None):
     ret_dtype = a.dtype
-    return ivy.round(a, decimals=decimals, out=out).astype(ret_dtype, copy=False)
+    return ivy.around(a, decimals=decimals, out=out).astype(ret_dtype, copy=False)
 
 
 @to_ivy_arrays_and_back

--- a/ivy/functional/frontends/numpy/mathematical_functions/rounding.py
+++ b/ivy/functional/frontends/numpy/mathematical_functions/rounding.py
@@ -114,9 +114,7 @@ def _rint(
 @to_ivy_arrays_and_back
 @from_zero_dim_arrays_to_scalar
 def around(a, decimals=0, out=None):
-    if ivy.shape(a) == ():
-        a = ivy.expand_dims(a, axis=0)
-    return ivy.round(a, decimals=decimals, out=out)
+    return ivy.around(a, decimals=decimals, out=out)
 
 
 @handle_numpy_out

--- a/ivy/functional/frontends/paddle/tensor/math.py
+++ b/ivy/functional/frontends/paddle/tensor/math.py
@@ -110,6 +110,12 @@ def round(x, name=None):
 
 @with_unsupported_dtypes({"2.5.1 and below": ("float16", "bfloat16")}, "paddle")
 @to_ivy_arrays_and_back
+def around(x, name=None):
+    return ivy.around(x)
+
+
+@with_unsupported_dtypes({"2.5.1 and below": ("float16", "bfloat16")}, "paddle")
+@to_ivy_arrays_and_back
 def ceil(x, name=None):
     return ivy.ceil(x)
 

--- a/ivy/functional/frontends/tensorflow/math.py
+++ b/ivy/functional/frontends/tensorflow/math.py
@@ -525,6 +525,11 @@ def round(x, name=None):
 
 
 @to_ivy_arrays_and_back
+def around(x, name=None):
+    return ivy.around(x)
+
+
+@to_ivy_arrays_and_back
 def minimum(x, y, name=None):
     return ivy.minimum(x, y)
 

--- a/ivy/functional/frontends/torch/pointwise_ops.py
+++ b/ivy/functional/frontends/torch/pointwise_ops.py
@@ -259,6 +259,15 @@ def round(input, *, decimals=0, out=None):
     return ivy.divide(rounded, m, out=out)
 
 
+@with_unsupported_dtypes({"2.0.1 and below": ("bfloat16",)}, "torch")
+@to_ivy_arrays_and_back
+def around(input, *, decimals=0, out=None):
+    m = ivy.full(input.shape, 10.0**decimals)
+    upscale = ivy.multiply(input, m)
+    rounded = ivy.around(upscale)
+    return ivy.divide(rounded, m, out=out)
+
+
 @with_unsupported_dtypes({"2.0.1 and below": ("float16",)}, "torch")
 @to_ivy_arrays_and_back
 def ceil(input, *, out=None):

--- a/ivy/functional/ivy/experimental/elementwise.py
+++ b/ivy/functional/ivy/experimental/elementwise.py
@@ -1311,3 +1311,125 @@ def digamma(
     ivy.array([-0.7549271   0.92278427  0.9988394])
     """
     return ivy.current_backend(x).digamma(x, out=out)
+
+
+@handle_exceptions
+@handle_nestable
+@handle_array_like_without_promotion
+@handle_out_argument
+@to_native_arrays_and_back
+@handle_array_function
+@handle_device_shifting
+def around(
+    x: Union[ivy.Array, ivy.NativeArray],
+    /,
+    *,
+    decimals: Optional[int] = 0,
+    out: Optional[ivy.Array] = None,
+) -> ivy.Array:
+    """Round each element ``x_i`` of the input array ``x`` to the given
+    number of decimals.
+
+    `around` is an alias of `~ivy.round`.
+
+    .. note::
+       For complex floating-point operands, real and imaginary components
+       must be independently rounded to the number of decimals.
+
+       Rounded real and imaginary components must be equal
+       to their equivalent rounded real-valued floating-point
+       counterparts (i.e., for complex-valued ``x``, ``real(round(x))``
+       must equal ``round(real(x)))`` and ``imag(round(x))`` must equal
+       ``round(imag(x))``).
+
+    **Special cases**
+
+    - If ``x_i`` is already an integer-valued, the result is ``x_i``.
+
+    For floating-point operands,
+
+    - If ``x_i`` is ``+infinity``, the result is ``+infinity``.
+    - If ``x_i`` is ``-infinity``, the result is ``-infinity``.
+    - If ``x_i`` is ``+0``, the result is ``+0``.
+    - If ``x_i`` is ``-0``, the result is ``-0``.
+    - If ``x_i`` is ``NaN``, the result is ``NaN``.
+    - If two integers are equally close to ``x_i``, the result is
+      the even integer closest to ``x_i``.
+
+    .. note::
+       For complex floating-point operands, the following special
+       cases apply to real and imaginary components independently
+       (e.g., if ``real(x_i)`` is ``NaN``, the rounded
+       real component is ``NaN``).
+
+    - If ``x_i`` is already integer-valued, the result is ``x_i``.
+
+    Parameters
+    ----------
+    x
+        input array containing elements to round.
+    decimals
+        number of decimal places to round to. Default is ``0``.
+    out
+        optional output array, for writing the result to. It must have a shape that the
+        inputs broadcast to.
+
+    Returns
+    -------
+    ret
+        An array of the same shape and type as x, with the elements rounded to integers.
+
+
+    Note: PyTorch supports an additional argument :code:`decimals` for the
+    `round function <https://pytorch.org/docs/stable/generated/torch.round.html>`_.
+    It has been deliberately omitted here due to the imprecise
+    nature of the argument in :code:`torch.round`.
+
+    This function conforms to the `Array API Standard
+    <https://data-apis.org/array-api/latest/>`_. This docstring is an extension of the
+    `docstring <https://data-apis.org/array-api/latest/
+    API_specification/generated/array_api.round.html>`_
+    in the standard.
+
+    Both the description and the type hints above assumes an array input for simplicity,
+    but this function is *nestable*, and therefore also accepts :class:`ivy.Container`
+    instances in place of any of the arguments.
+
+    Examples
+    --------
+    With :class:`ivy.Array` input:
+
+    >>> x = ivy.array([1.2, 2.4, 3.6])
+    >>> y = ivy.around(x)
+    >>> print(y)
+    ivy.array([1.,2.,4.])
+
+    >>> x = ivy.array([-0, 5, 4.5])
+    >>> y = ivy.around(x)
+    >>> print(y)
+    ivy.array([0.,5.,4.])
+
+    >>> x = ivy.array([1.5654, 2.034, 15.1, -5.0])
+    >>> y = ivy.zeros(4)
+    >>> ivy.around(x, out=y)
+    >>> print(y)
+    ivy.array([2.,2.,15.,-5.])
+
+    >>> x = ivy.array([[0, 5.433, -343.3, 1.5],
+    ...                [-5.5, 44.2, 11.5, 12.01]])
+    >>> ivy.around(x, out=x)
+    >>> print(x)
+    ivy.array([[0.,5.,-343.,2.],[-6.,44.,12.,12.]])
+
+    With :class:`ivy.Container` input:
+
+    >>> x = ivy.Container(a=ivy.array([4.20, 8.6, 6.90, 0.0]),
+    ...                   b=ivy.array([-300.9, -527.3, 4.5]))
+    >>> y = ivy.around(x)
+    >>> print(y)
+    {
+        a: ivy.array([4.,9.,7.,0.]),
+        b: ivy.array([-301.,-527.,4.])
+    }
+    """
+    return ivy.current_backend(x).around(x, decimals=decimals, out=out)

--- a/ivy_tests/test_ivy/test_frontends/test_numpy/test_mathematical_functions/test_rounding.py
+++ b/ivy_tests/test_ivy/test_frontends/test_numpy/test_mathematical_functions/test_rounding.py
@@ -227,7 +227,7 @@ def test_numpy_rint(
 @handle_frontend_test(
     fn_tree="numpy.around",
     dtype_and_x=helpers.dtype_and_values(
-        available_dtypes=helpers.get_dtypes("numeric"),
+        available_dtypes=helpers.get_dtypes("float"),
     ),
     decimals=st.integers(min_value=0, max_value=5),
 )


### PR DESCRIPTION
* [x] Resolves #21321
* [test_rouding.py](https://github.com/unifyai/ivy/blob/master/ivy_tests/test_ivy/test_frontends/test_numpy/test_mathematical_functions/test_rounding.py#L226-L254) already includes test for `ivy.around()` function.