### PR TITLE
Added zero_ method to the PyTorch frontend.

### DIFF
--- a/ivy/functional/frontends/torch/tensor.py
+++ b/ivy/functional/frontends/torch/tensor.py
@@ -1340,6 +1340,11 @@ class Tensor:
         self.ivy_array = self.log10().ivy_array
         return self
 
+    @with_unsupported_dtypes({"2.0.1 and below": ("bfloat16", "uint16")}, "torch")
+    def zero_(self):
+        self.ivy_array = torch_frontend.zeros_like(self).ivy_array
+        return self
+
     def short(self, memory_format=None):
         self.ivy_array = ivy.astype(self.ivy_array, ivy.int16, copy=False)
         return self

--- a/ivy_tests/test_ivy/test_frontends/test_torch/test_tensor.py
+++ b/ivy_tests/test_ivy/test_frontends/test_torch/test_tensor.py
@@ -8637,6 +8637,42 @@ def test_torch_instance_log10_(
     )
 
 
+# zero_ tests
+@handle_frontend_method(
+    class_tree=CLASS_TREE,
+    init_tree="torch.tensor",
+    method_name="zero_",
+    dtype_and_x=helpers.dtype_and_values(
+        available_dtypes=helpers.get_dtypes("float"),
+        allow_inf=False,
+    ),
+)
+def test_torch_instance_zero_(
+    dtype_and_x,
+    frontend_method_data,
+    init_flags,
+    method_flags,
+    frontend,
+    on_device,
+    backend_fw,
+):
+    input_dtype, x = dtype_and_x
+    helpers.test_frontend_method(
+        init_input_dtypes=input_dtype,
+        backend_to_test=backend_fw,
+        init_all_as_kwargs_np={
+            "data": x[0],
+        },
+        method_input_dtypes=input_dtype,
+        method_all_as_kwargs_np={},
+        frontend_method_data=frontend_method_data,
+        init_flags=init_flags,
+        method_flags=method_flags,
+        frontend=frontend,
+        on_device=on_device,
+    )
+
+
 # short
 @handle_frontend_method(
     class_tree=CLASS_TREE,


### PR DESCRIPTION
closes https://github.com/unifyai/ivy/issues/21222

This pull request introduces the zero_ method to the PyTorch frontend. Additionally, it includes comprehensive test cases to ensure the correctness and functionality of the method. This enhancement aims to provide users with an efficient and convenient way to zero out the elements of a PyTorch tensor in place. The implementation adheres to the Ivy library's code standards and guidelines.