### PR TITLE
Add requirements needed for test_compilation

### DIFF
--- a/docker/multiversion_testing_requirements.txt
+++ b/docker/multiversion_testing_requirements.txt
@@ -21,3 +21,5 @@ packaging
 nvidia-ml-py<=11.495.46 # mod_name=pynvml
 paddle-bfloat
 jsonpickle
+dill
+scikit-image


### PR DESCRIPTION
Bug report:

1. I started a codespace for the graph-compiler repository. This creates a default env called multienv. 
2. This env doesn't have two packages that are needed, namely `dill` and `scikit-image`. 
3. This causes pytest to be unable to register the tests.

When I manually ran 
```
pip install dill
pip install scikit-image
```
The pytest discovery worked and all tests were runnable.

The default env is installed via the dockerfile at `docker/Dockerfile` which uses `multiversion_testing_requirements.txt` for requirements.  Therefore, I thought this would be the right place to add them.