### PR TITLE
Add dropout function for MindSpore Frontend

### DIFF
--- a/ivy/functional/frontends/mindspore/ops/function/nn_func.py
+++ b/ivy/functional/frontends/mindspore/ops/function/nn_func.py
@@ -22,6 +22,25 @@ from ivy.functional.frontends.paddle.func_wrapper import to_ivy_arrays_and_back
     "mindspore",
 )
 @to_ivy_arrays_and_back
+def dropout(input, p=0.5, training=True, seed=None):
+    return ivy.dropout(input, p, training=training, seed=seed)
+
+
+@with_supported_dtypes(
+    {
+        "2.0.0 and below": (
+            "int8",
+            "int16",
+            "int32",
+            "int64",
+            "float16",
+            "float32",
+            "float64",
+        )
+    },
+    "mindspore",
+)
+@to_ivy_arrays_and_back
 def dropout2d(input, p=0.5, training=True):
     return ivy.dropout2d(input, p, training=training, data_format="NCHW")
 

--- a/ivy_tests/test_ivy/test_frontends/test_mindspore/test_ops/test_function/test_mindspore_nn_func.py
+++ b/ivy_tests/test_ivy/test_frontends/test_mindspore/test_ops/test_function/test_mindspore_nn_func.py
@@ -8,6 +8,40 @@
 # import ivy_tests.test_ivy.helpers as helpers
 # from ivy_tests.test_ivy.helpers import handle_frontend_test
 #
+# 
+# #dropout
+# @handle_frontend_test(
+#     fn_tree="mindspore.ops.dropout",
+#     d_type_and_x=helpers.dtype_and_values(),
+#     p=helpers.floats(min_value=0.0, max_value=1.0),
+#     training=st.booleans(),
+#     seed=helpers.ints(min_value=0, max_value=100)
+# )
+# def test_mindspore_dropout(
+#     *,
+#     d_type_and_x,
+#     p,
+#     training,
+#     seed,
+#     on_device,
+#     fn_tree,
+#     frontend,
+#     test_flags,
+# ):
+#     dtype, x = d_type_and_x
+#     ret, frontend_ret = helpers.test_frontend_function(
+#         input_dtypes=dtype,
+#         frontend=frontend,
+#         test_flags=test_flags,
+#         fn_tree=fn_tree,
+#         on_device=on_device,
+#         input=x[0],
+#         p=p,
+#         training=training,
+#         seed=seed,
+#     )
+#
+#
 # #dropout2d
 # @handle_frontend_test(
 #     fn_tree="mindspore.ops.function.nn_func.dropout2d",


### PR DESCRIPTION
close #21361 

As with other MindSpore Frontend Functions, I have kept the test commented as the MindSpore Backend has not added yet. I have tested the Logic manually and it works fine. 