### PR TITLE
Remove redundant statement in `backends.numpy.experimental.statistical.cov`

### DIFF
--- a/ivy/functional/backends/numpy/experimental/statistical.py
+++ b/ivy/functional/backends/numpy/experimental/statistical.py
@@ -376,9 +376,6 @@ def cov(
     aweights: Optional[np.ndarray] = None,
     dtype: Optional[np.dtype] = None,
 ) -> np.ndarray:
-    if fweights is not None:
-        fweights = fweights.astype(np.int64)
-
     return np.cov(
         m=x1,
         y=x2,


### PR DESCRIPTION
NumPy already handles the conversion of "fweights" input frequency weights vector into python "float" [see](https://github.com/numpy/numpy/blob/3b99af4b075af9fb44a869d3b4726f368fe77524/numpy/lib/function_base.py#L2703-L2704). While the backend function adds a statement to convert "fweights" input frequency vector into "np.int64" which will have no effect once the numpy function is called.