### PR TITLE
Implements the missing vorbis window for the tf.signal frontend

### DIFF
--- a/ivy/functional/frontends/tensorflow/signal.py
+++ b/ivy/functional/frontends/tensorflow/signal.py
@@ -26,6 +26,9 @@ def vorbis_window(window_length, dtype=ivy.float32, name=None):
     return ivy.vorbis_window(window_length, dtype=dtype, out=None)
 
 
+vorbis_window.supported_dtypes = ("float32", "float64", "float16", "bfloat16")
+
+
 # idct
 @to_ivy_arrays_and_back
 def idct(input, type=2, n=None, axis=-1, norm=None, name=None):

--- a/ivy/functional/frontends/tensorflow/signal.py
+++ b/ivy/functional/frontends/tensorflow/signal.py
@@ -13,6 +13,15 @@ def kaiser_window(window_length, beta=12.0, dtype=ivy.float32, name=None):
 
 kaiser_window.supported_dtypes = ("float32", "float64", "float16", "bfloat16")
 
+# dct
+@to_ivy_arrays_and_back
+def dct(input, type=2, n=None, axis=-1, norm=None, name=None):
+    return ivy.dct(input, type=type, n=n, axis=axis, norm=norm)
+
+#vorbis_window
+@to_ivy_arrays_and_back
+def vorbis_window(window_length,dtype=ivy.float32,name=None):
+    return ivy.vorbis_window(window_length,dtype=dtype,out=None)
 
 # idct
 @to_ivy_arrays_and_back

--- a/ivy/functional/frontends/tensorflow/signal.py
+++ b/ivy/functional/frontends/tensorflow/signal.py
@@ -13,15 +13,18 @@ def kaiser_window(window_length, beta=12.0, dtype=ivy.float32, name=None):
 
 kaiser_window.supported_dtypes = ("float32", "float64", "float16", "bfloat16")
 
+
 # dct
 @to_ivy_arrays_and_back
 def dct(input, type=2, n=None, axis=-1, norm=None, name=None):
     return ivy.dct(input, type=type, n=n, axis=axis, norm=norm)
 
-#vorbis_window
+
+# vorbis_window
 @to_ivy_arrays_and_back
-def vorbis_window(window_length,dtype=ivy.float32,name=None):
-    return ivy.vorbis_window(window_length,dtype=dtype,out=None)
+def vorbis_window(window_length, dtype=ivy.float32, name=None):
+    return ivy.vorbis_window(window_length, dtype=dtype, out=None)
+
 
 # idct
 @to_ivy_arrays_and_back

--- a/ivy_tests/test_ivy/test_frontends/test_tensorflow/test_signal.py
+++ b/ivy_tests/test_ivy/test_frontends/test_tensorflow/test_signal.py
@@ -10,18 +10,10 @@ from ivy_tests.test_ivy.helpers import handle_frontend_test
 @handle_frontend_test(
     fn_tree="tensorflow.signal.kaiser_window",
     dtype_and_window_length=helpers.dtype_and_values(
-        available_dtypes=["int32"],
-        min_dim_size=0,
-        max_dim_size=0,
-        max_value=100,
-        min_value=0,
+        available_dtypes=helpers.get_dtypes("integer")
     ),
     dtype_and_beta=helpers.dtype_and_values(
-        available_dtypes=helpers.get_dtypes("numeric"),
-        min_dim_size=0,
-        max_dim_size=0,
-        max_value=80,
-        min_value=10,
+        available_dtypes=helpers.get_dtypes("numeric")
     ),
     dtype=helpers.get_dtypes("numeric"),
     test_with_out=st.just(False),
@@ -46,9 +38,9 @@ def test_tensorflow_kaiser_window(
         test_flags=test_flags,
         fn_tree=fn_tree,
         on_device=on_device,
-        window_length=window_length[0],
-        beta=beta[0],
-        dtype=dtype[0],
+        window_length=window_length,
+        beta=beta,
+        dtype=dtype,
     )
 
 
@@ -103,29 +95,7 @@ def test_tensorflow_idct(
         norm=norm,
         atol=1e-01,
     )
-
-
-# @st.composite
-# def valid_idct(draw):
-#     dtype, x = draw(
-#         helpers.dtype_and_values(
-#             available_dtypes=["float32", "float64"],
-#             max_value=65280,
-#             min_value=-65280,
-#             min_num_dims=1,
-#             min_dim_size=2,
-#             shared_dtype=True,
-#         )
-#     )
-#     n = None
-#     axis = -1
-#     norm = draw(st.sampled_from([None, "ortho"]))
-#     type = draw(helpers.ints(min_value=1, max_value=4))
-#     if norm == "ortho" and type == 1:
-#         norm = None
-#     return dtype, x, type, n, axis, norm
-
-
+    
 # dct
 @handle_frontend_test(
     fn_tree="tensorflow.signal.dct",

--- a/ivy_tests/test_ivy/test_frontends/test_tensorflow/test_signal.py
+++ b/ivy_tests/test_ivy/test_frontends/test_tensorflow/test_signal.py
@@ -95,7 +95,8 @@ def test_tensorflow_idct(
         norm=norm,
         atol=1e-01,
     )
-    
+
+
 # dct
 @handle_frontend_test(
     fn_tree="tensorflow.signal.dct",

--- a/ivy_tests/test_ivy/test_frontends/test_tensorflow/test_signal.py
+++ b/ivy_tests/test_ivy/test_frontends/test_tensorflow/test_signal.py
@@ -125,21 +125,22 @@ def test_tensorflow_idct(
 #         norm = None
 #     return dtype, x, type, n, axis, norm
 
+
 # dct
 @handle_frontend_test(
     fn_tree="tensorflow.signal.dct",
-    dtype_and_x = helpers.dtype_and_values(
-            available_dtypes=["float32", "float64"],
-            max_value=65280,
-            min_value=-65280,
-            min_num_dims=1,
-            min_dim_size=2,
-            shared_dtype=True,
-        ),
-    n=helpers.ints(min_value=1,max_value=3),
-    norm =st.sampled_from([None, "ortho"]),
-    type = helpers.ints(min_value=1, max_value=4),
-    #dtype_x_and_args=valid_idct(),
+    dtype_and_x=helpers.dtype_and_values(
+        available_dtypes=["float32", "float64"],
+        max_value=65280,
+        min_value=-65280,
+        min_num_dims=1,
+        min_dim_size=2,
+        shared_dtype=True,
+    ),
+    n=helpers.ints(min_value=1, max_value=3),
+    norm=st.sampled_from([None, "ortho"]),
+    type=helpers.ints(min_value=1, max_value=4),
+    # dtype_x_and_args=valid_idct(),
     test_with_out=st.just(False),
 )
 def test_tensorflow_dct(
@@ -154,10 +155,13 @@ def test_tensorflow_dct(
     backend_fw,
     on_device,
 ):
-    input_dtype, x,= dtype_and_x
+    (
+        input_dtype,
+        x,
+    ) = dtype_and_x
     if norm == "ortho" and type == 1:
         norm = None
-    axis=-1
+    axis = -1
     helpers.test_frontend_function(
         input_dtypes=input_dtype,
         backend_to_test=backend_fw,
@@ -170,8 +174,9 @@ def test_tensorflow_dct(
         n=n,
         axis=axis,
         norm=norm,
-        #atol=1e-01,
+        # atol=1e-01,
     )
+
 
 # vorbis_window
 @handle_frontend_test(
@@ -182,11 +187,11 @@ def test_tensorflow_dct(
         min_value=1,
         max_value=10,
     ),
-    #dtype=helpers.get_dtypes("float", full=False),
+    # dtype=helpers.get_dtypes("float", full=False),
     test_with_out=st.just(False),
 )
 def test_tensorflow_vorbis_window(
-    *, dtype_and_x,  test_flags, backend_fw, fn_tree, on_device,frontend #,dtype
+    *, dtype_and_x, test_flags, backend_fw, fn_tree, on_device, frontend  # ,dtype
 ):
     input_dtype, x = dtype_and_x
     helpers.test_frontend_function(
@@ -198,5 +203,5 @@ def test_tensorflow_vorbis_window(
         on_device=on_device,
         atol=1e-02,
         window_length=int(x[0]),
-       #dtype=dtype[0],
+        # dtype=dtype[0],
     )

--- a/ivy_tests/test_ivy/test_frontends/test_tensorflow/test_signal.py
+++ b/ivy_tests/test_ivy/test_frontends/test_tensorflow/test_signal.py
@@ -10,10 +10,18 @@ from ivy_tests.test_ivy.helpers import handle_frontend_test
 @handle_frontend_test(
     fn_tree="tensorflow.signal.kaiser_window",
     dtype_and_window_length=helpers.dtype_and_values(
-        available_dtypes=helpers.get_dtypes("integer")
+        available_dtypes=["int32"],
+        min_dim_size=0,
+        max_dim_size=0,
+        max_value=100,
+        min_value=0,
     ),
     dtype_and_beta=helpers.dtype_and_values(
-        available_dtypes=helpers.get_dtypes("numeric")
+        available_dtypes=helpers.get_dtypes("numeric"),
+        min_dim_size=0,
+        max_dim_size=0,
+        max_value=80,
+        min_value=10,
     ),
     dtype=helpers.get_dtypes("numeric"),
     test_with_out=st.just(False),
@@ -38,9 +46,9 @@ def test_tensorflow_kaiser_window(
         test_flags=test_flags,
         fn_tree=fn_tree,
         on_device=on_device,
-        window_length=window_length,
-        beta=beta,
-        dtype=dtype,
+        window_length=window_length[0],
+        beta=beta[0],
+        dtype=dtype[0],
     )
 
 
@@ -94,4 +102,101 @@ def test_tensorflow_idct(
         axis=axis,
         norm=norm,
         atol=1e-01,
+    )
+
+
+# @st.composite
+# def valid_idct(draw):
+#     dtype, x = draw(
+#         helpers.dtype_and_values(
+#             available_dtypes=["float32", "float64"],
+#             max_value=65280,
+#             min_value=-65280,
+#             min_num_dims=1,
+#             min_dim_size=2,
+#             shared_dtype=True,
+#         )
+#     )
+#     n = None
+#     axis = -1
+#     norm = draw(st.sampled_from([None, "ortho"]))
+#     type = draw(helpers.ints(min_value=1, max_value=4))
+#     if norm == "ortho" and type == 1:
+#         norm = None
+#     return dtype, x, type, n, axis, norm
+
+# dct
+@handle_frontend_test(
+    fn_tree="tensorflow.signal.dct",
+    dtype_and_x = helpers.dtype_and_values(
+            available_dtypes=["float32", "float64"],
+            max_value=65280,
+            min_value=-65280,
+            min_num_dims=1,
+            min_dim_size=2,
+            shared_dtype=True,
+        ),
+    n=helpers.ints(min_value=1,max_value=3),
+    norm =st.sampled_from([None, "ortho"]),
+    type = helpers.ints(min_value=1, max_value=4),
+    #dtype_x_and_args=valid_idct(),
+    test_with_out=st.just(False),
+)
+def test_tensorflow_dct(
+    *,
+    dtype_and_x,
+    n,
+    norm,
+    type,
+    frontend,
+    test_flags,
+    fn_tree,
+    backend_fw,
+    on_device,
+):
+    input_dtype, x,= dtype_and_x
+    if norm == "ortho" and type == 1:
+        norm = None
+    axis=-1
+    helpers.test_frontend_function(
+        input_dtypes=input_dtype,
+        backend_to_test=backend_fw,
+        frontend=frontend,
+        test_flags=test_flags,
+        fn_tree=fn_tree,
+        on_device=on_device,
+        input=x[0],
+        type=type,
+        n=n,
+        axis=axis,
+        norm=norm,
+        #atol=1e-01,
+    )
+
+# vorbis_window
+@handle_frontend_test(
+    fn_tree="tensorflow.signal.vorbis_window",
+    dtype_and_x=helpers.dtype_and_values(
+        available_dtypes=helpers.get_dtypes("integer"),
+        max_num_dims=0,
+        min_value=1,
+        max_value=10,
+    ),
+    #dtype=helpers.get_dtypes("float", full=False),
+    test_with_out=st.just(False),
+)
+def test_tensorflow_vorbis_window(
+    *, dtype_and_x,  test_flags, backend_fw, fn_tree, on_device,frontend #,dtype
+):
+    input_dtype, x = dtype_and_x
+    helpers.test_frontend_function(
+        input_dtypes=input_dtype,
+        backend_to_test=backend_fw,
+        frontend=frontend,
+        test_flags=test_flags,
+        fn_tree=fn_tree,
+        on_device=on_device,
+        atol=1e-02,
+        window_length=int(x[0]),
+       #dtype=dtype[0],
     )

--- a/ivy_tests/test_ivy/test_frontends/test_tensorflow/test_signal.py
+++ b/ivy_tests/test_ivy/test_frontends/test_tensorflow/test_signal.py
@@ -153,7 +153,7 @@ def test_tensorflow_dct(
 @handle_frontend_test(
     fn_tree="tensorflow.signal.vorbis_window",
     dtype_and_x=helpers.dtype_and_values(
-        available_dtypes=helpers.get_dtypes("integer"),
+        available_dtypes=helpers.get_dtypes("valid"),
         max_num_dims=0,
         min_value=1,
         max_value=10,


### PR DESCRIPTION
There is an issue while testing for dtype that I would like to get help on, the test passes without it but passing dtype causes this error
![image](https://github.com/unifyai/ivy/assets/41777835/4863cb56-c09a-4398-b35d-9c6452c270df)
If aided on how to fix this, the test will be complete

Close #21437