### PR TITLE
Fixed gcd function in the PyTorch frontend.

### DIFF
--- a/ivy/functional/frontends/torch/tensor.py
+++ b/ivy/functional/frontends/torch/tensor.py
@@ -1655,6 +1655,13 @@ class Tensor:
     def svd(self, some=True, compute_uv=True, *, out=None):
         return torch_frontend.svd(self, some=some, compute_uv=compute_uv, out=out)
 
+    @with_unsupported_dtypes(
+        {"2.0.1 and below": ("float16", "bfloat16", "float32", "float64", "complex")},
+        "torch",
+    )
+    def gcd(self, other, *, out=None):
+        return torch_frontend.gcd(self, other, out=out)
+
 
 class Size(tuple):
     def __new__(cls, iterable=()):
@@ -1671,11 +1678,3 @@ class Size(tuple):
 
     def __repr__(self):
         return f'ivy.frontends.torch.Size([{", ".join(str(d) for d in self)}])'
-
-
-@with_unsupported_dtypes(
-    {"2.0.1 and below": ("float16", "bfloat16", "float32", "float64", "complex")},
-    "torch",
-)
-def gcd(self, other, *, out=None):
-    return torch_frontend.gcd(self, other, out=out)


### PR DESCRIPTION
The function named gcd was mistakenly placed in an incorrect position, resulting in multiple errors during the testing of other functions. I have now relocated the gcd function to its appropriate position, eliminating those unwanted errors.