### PR TITLE
Fixed the failing tests for the acos method in PyTorch frontend.

### DIFF
--- a/ivy/functional/frontends/torch/tensor.py
+++ b/ivy/functional/frontends/torch/tensor.py
@@ -584,7 +584,7 @@ class Tensor:
         self.ivy_array = self.arctan2(other).ivy_array
         return self
 
-    @with_unsupported_dtypes({"2.0.1 and below": ("float16",)}, "torch")
+    @with_unsupported_dtypes({"2.0.1 and below": ("float16", "bfloat16")}, "torch")
     def acos(self):
         return torch_frontend.acos(self)
 


### PR DESCRIPTION
closes https://github.com/unifyai/ivy/issues/20773

![image](https://github.com/unifyai/ivy/assets/59949692/afae6b18-506f-4633-8a9c-9dd16be89b6c)
