### PR TITLE
Fixed the failing tests for the acos_ method in PyTorch frontend.

### DIFF
--- a/ivy/functional/frontends/torch/tensor.py
+++ b/ivy/functional/frontends/torch/tensor.py
@@ -588,7 +588,7 @@ class Tensor:
     def acos(self):
         return torch_frontend.acos(self)
 
-    @with_unsupported_dtypes({"2.0.1 and below": ("float16",)}, "torch")
+    @with_unsupported_dtypes({"2.0.1 and below": ("float16", "bfloat16")}, "torch")
     def acos_(self):
         self.ivy_array = self.acos().ivy_array
         return self


### PR DESCRIPTION
closes https://github.com/unifyai/ivy/issues/20625

![image](https://github.com/unifyai/ivy/assets/59949692/a6d22ae0-dd1c-4aec-ac68-7c1f343c31a6)

