### PR TITLE
Fixed the failing tests for the fliplr method in PyTorch frontend.

### DIFF
--- a/ivy/functional/frontends/torch/tensor.py
+++ b/ivy/functional/frontends/torch/tensor.py
@@ -911,6 +911,7 @@ class Tensor:
     def flip(self, dims):
         return torch_frontend.flip(self, dims)
 
+    @with_unsupported_dtypes({"2.0.1 and below": ("bfloat16",)}, "torch")
     def fliplr(self):
         return torch_frontend.fliplr(self)
 


### PR DESCRIPTION
closes https://github.com/unifyai/ivy/issues/20775

![image](https://github.com/unifyai/ivy/assets/59949692/d6c73849-a73f-4803-b1b0-647c93bf1935)
