### PR TITLE
Fixed the failing tests for the unsqueeze method in PyTorch frontend.

### DIFF
--- a/ivy/functional/frontends/torch/tensor.py
+++ b/ivy/functional/frontends/torch/tensor.py
@@ -651,6 +651,7 @@ class Tensor:
         self.ivy_array = self.detach().ivy_array
         return self
 
+    @with_unsupported_dtypes({"2.0.1 and below": ("bfloat16", "uint16")}, "torch")
     @numpy_to_torch_style_args
     def unsqueeze(self, dim):
         return torch_frontend.unsqueeze(self, dim)


### PR DESCRIPTION
closes https://github.com/unifyai/ivy/issues/20738

![image](https://github.com/unifyai/ivy/assets/59949692/c5849b52-c2a9-4a2c-8db7-a775b2bc3f0a)
