### PR TITLE
Fixed the failing tests for the tensor.cosh_ function in PyTorch frontend.

### DIFF
--- a/ivy/functional/frontends/torch/tensor.py
+++ b/ivy/functional/frontends/torch/tensor.py
@@ -239,7 +239,7 @@ class Tensor:
     def cosh(self):
         return torch_frontend.cosh(self)
 
-    @with_unsupported_dtypes({"2.0.1 and below": ("float16",)}, "torch")
+    @with_unsupported_dtypes({"2.0.1 and below": ("float16", "bfloat16")}, "torch")
     def cosh_(self):
         self.ivy_array = self.cosh().ivy_array
         return self


### PR DESCRIPTION
closes https://github.com/unifyai/ivy/issues/20735

![image](https://github.com/unifyai/ivy/assets/59949692/fae52a87-36fc-4210-9003-76519206545e)
