### PR TITLE
Fixed the failing tests for the tensor.sign and tensor.sign_ methods in PyTorch frontend.

### DIFF
--- a/ivy/functional/frontends/torch/tensor.py
+++ b/ivy/functional/frontends/torch/tensor.py
@@ -1397,7 +1397,7 @@ class Tensor:
         self.ivy_array = self.addcmul(tensor1, tensor2, value=value).ivy_array
         return self
 
-    sign_decorator_dtypes = ("float16", "complex", "bool")
+    sign_decorator_dtypes = ("float16", "bfloat16", "complex", "bool")
 
     @with_unsupported_dtypes({"2.0.1 and below": sign_decorator_dtypes}, "torch")
     def sign(self):


### PR DESCRIPTION
closes https://github.com/unifyai/ivy/issues/20741

Tests for tensor.sign method:
![image](https://github.com/unifyai/ivy/assets/59949692/ef6a6d6a-53c2-4e9e-b52f-fb8d8b71efcf)

Tests for tensor.sign_ method:
![image](https://github.com/unifyai/ivy/assets/59949692/16203cd5-6fb4-4cf1-bbc5-1137d41d1aae)

