### PR TITLE
Fixed the failing tests for the tensor.arctanh_ method in PyTorch frontend.

### DIFF
--- a/ivy/functional/frontends/torch/tensor.py
+++ b/ivy/functional/frontends/torch/tensor.py
@@ -352,7 +352,7 @@ class Tensor:
     def arctanh(self):
         return torch_frontend.arctanh(self)
 
-    @with_unsupported_dtypes({"2.0.1 and below": ("float16",)}, "torch")
+    @with_unsupported_dtypes({"2.0.1 and below": ("float16", "bfloat16")}, "torch")
     def arctanh_(self):
         self.ivy_array = self.arctanh().ivy_array
         return self


### PR DESCRIPTION
closes https://github.com/unifyai/ivy/issues/20696

![image](https://github.com/unifyai/ivy/assets/59949692/f357485b-4bcc-4e53-9b5a-5c7c07fcd6ae)
