### PR TITLE
Fixed the failing tests for the tensor.arcsin method in PyTorch frontend.

### DIFF
--- a/ivy/functional/frontends/torch/tensor.py
+++ b/ivy/functional/frontends/torch/tensor.py
@@ -248,7 +248,7 @@ class Tensor:
     def arcsinh(self):
         return torch_frontend.arcsinh(self)
 
-    @with_unsupported_dtypes({"2.0.1 and below": ("float16",)}, "torch")
+    @with_unsupported_dtypes({"2.0.1 and below": ("float16", "bfloat16")}, "torch")
     def arcsin(self):
         return torch_frontend.arcsin(self)
 


### PR DESCRIPTION
closes https://github.com/unifyai/ivy/issues/20695

![image](https://github.com/unifyai/ivy/assets/59949692/74352412-9171-40ed-991c-420431cd5f30)
