### PR TITLE
Fixed the failing tests for the tensor.arctan_ method in PyTorch frontend.

### DIFF
--- a/ivy/functional/frontends/torch/tensor.py
+++ b/ivy/functional/frontends/torch/tensor.py
@@ -570,7 +570,7 @@ class Tensor:
     def arctan(self):
         return torch_frontend.atan(self)
 
-    @with_unsupported_dtypes({"2.0.1 and below": ("float16",)}, "torch")
+    @with_unsupported_dtypes({"2.0.1 and below": ("float16", "bfloat16")}, "torch")
     def arctan_(self):
         self.ivy_array = self.arctan().ivy_array
         return self


### PR DESCRIPTION
closes https://github.com/unifyai/ivy/issues/20666

![image](https://github.com/unifyai/ivy/assets/59949692/7b0ca578-4c57-416c-8349-27f3d1c82a79)
