### PR TITLE
Added rot90 frontend function and test for paddle tensor manipulation

### DIFF
--- a/ivy/functional/backends/paddle/experimental/manipulation.py
+++ b/ivy/functional/backends/paddle/experimental/manipulation.py
@@ -162,6 +162,12 @@ def hstack(
             return ivy.concat(arrays, axis=0)
 
 
+with_supported_device_and_dtypes(
+    {"2.5.1 and below": {"cpu": ("bool", "int32", "int64", "float32", "float64")}},
+    backend_version,
+)
+
+
 def rot90(
     m: paddle.Tensor,
     /,

--- a/ivy/functional/backends/paddle/experimental/manipulation.py
+++ b/ivy/functional/backends/paddle/experimental/manipulation.py
@@ -162,12 +162,21 @@ def hstack(
             return ivy.concat(arrays, axis=0)
 
 
-with_supported_device_and_dtypes(
-    {"2.5.1 and below": {"cpu": ("bool", "int32", "int64", "float32", "float64")}},
+@with_supported_device_and_dtypes(
+    {
+        "2.5.1 and above": {
+            "cpu": (
+                "bool",
+                "int32",
+                "int64",
+                "float32",
+                "float64",
+            ),
+            "gpu": ("float16",),
+        },
+    },
     backend_version,
 )
-
-
 def rot90(
     m: paddle.Tensor,
     /,

--- a/ivy/functional/frontends/paddle/tensor/manipulation.py
+++ b/ivy/functional/frontends/paddle/tensor/manipulation.py
@@ -148,3 +148,20 @@ def roll(x, shifts, axis=None, name=None):
 @to_ivy_arrays_and_back
 def take_along_axis(arr, indices, axis):
     return ivy.take_along_axis(arr, indices, axis)
+
+
+@with_supported_dtypes(
+    {
+        "2.5.1 and below": (
+            "bool",
+            "int32",
+            "int64",
+            "float32",
+            "float64",
+        )
+    },
+    "paddle",
+)
+@to_ivy_arrays_and_back
+def rot90(x, k=1, axes=(0, 1), name=None):
+    return ivy.rot90(x, k=k, axes=axes)

--- a/ivy/functional/frontends/paddle/tensor/manipulation.py
+++ b/ivy/functional/frontends/paddle/tensor/manipulation.py
@@ -6,6 +6,7 @@ from ivy.functional.frontends.paddle.func_wrapper import (
 from ivy.func_wrapper import (
     with_unsupported_dtypes,
     with_supported_dtypes,
+    with_supported_device_and_dtypes,
 )
 
 
@@ -150,15 +151,18 @@ def take_along_axis(arr, indices, axis):
     return ivy.take_along_axis(arr, indices, axis)
 
 
-@with_supported_dtypes(
+@with_supported_device_and_dtypes(
     {
-        "2.5.1 and below": (
-            "bool",
-            "int32",
-            "int64",
-            "float32",
-            "float64",
-        )
+        "2.5.1 and above": {
+            "cpu": (
+                "bool",
+                "int32",
+                "int64",
+                "float32",
+                "float64",
+            ),
+            "gpu": ("float16",),
+        },
     },
     "paddle",
 )

--- a/ivy_tests/test_ivy/test_frontends/test_paddle/test_tensor/test_manipulation.py
+++ b/ivy_tests/test_ivy/test_frontends/test_paddle/test_tensor/test_manipulation.py
@@ -5,6 +5,9 @@ import math
 # local
 import ivy_tests.test_ivy.helpers as helpers
 from ivy_tests.test_ivy.helpers import handle_frontend_test
+from ivy_tests.test_ivy.test_functional.test_experimental.test_core.test_manipulation import (  # noqa
+    _get_dtype_values_k_axes_for_rot90,
+)
 
 
 # Helpers #
@@ -636,4 +639,39 @@ def test_paddle_take_along_axis(
         arr=value,
         indices=indices,
         axis=axis,
+    )
+
+
+# rot90
+@handle_frontend_test(
+    fn_tree="paddle.rot90",
+    dtype_m_k_axes=_get_dtype_values_k_axes_for_rot90(
+        available_dtypes=helpers.get_dtypes("numeric"),
+        min_num_dims=1,
+        max_num_dims=5,
+        min_dim_size=1,
+        max_dim_size=10,
+    ),
+    test_with_out=st.just(False),
+)
+def test_paddle_rot90(
+    *,
+    dtype_m_k_axes,
+    on_device,
+    fn_tree,
+    frontend,
+    backend_fw,
+    test_flags,
+):
+    input_dtype, m, k, axes = dtype_m_k_axes
+    helpers.test_frontend_function(
+        input_dtypes=input_dtype,
+        backend_to_test=backend_fw,
+        frontend=frontend,
+        test_flags=test_flags,
+        fn_tree=fn_tree,
+        on_device=on_device,
+        x=m,
+        k=k,
+        axes=tuple(axes),
     )

--- a/ivy_tests/test_ivy/test_frontends/test_paddle/test_tensor/test_manipulation.py
+++ b/ivy_tests/test_ivy/test_frontends/test_paddle/test_tensor/test_manipulation.py
@@ -646,13 +646,12 @@ def test_paddle_take_along_axis(
 @handle_frontend_test(
     fn_tree="paddle.rot90",
     dtype_m_k_axes=_get_dtype_values_k_axes_for_rot90(
-        available_dtypes=helpers.get_dtypes("numeric"),
+        available_dtypes=helpers.get_dtypes(kind="valid"),
         min_num_dims=1,
         max_num_dims=5,
         min_dim_size=1,
         max_dim_size=10,
     ),
-    test_with_out=st.just(False),
 )
 def test_paddle_rot90(
     *,


### PR DESCRIPTION
Issue #21630 

* Added frontend function for rot90 for paddle 
* Added frontend test for rot90 for paddle 

Test Summary: 
`pytest ivy_tests/test_ivy/test_frontends/test_paddle/test_tensor/test_manipulation.py::test_paddle_rot90`

<details close>
<summary>TEST RESULTS</summary>
<br>
<img width="979" alt="Screenshot 2023-08-11 at 11 47 48 AM" src="https://github.com/unifyai/ivy/assets/84662239/4d2ae3f1-9175-4deb-a4c1-fa0f4ca947de">
</details>