### PR TITLE
BUG: Torch backend was failing  test I resolved it

### DIFF
--- a/ivy/functional/frontends/torch/miscellaneous_ops.py
+++ b/ivy/functional/frontends/torch/miscellaneous_ops.py
@@ -330,7 +330,7 @@ def einsum(equation, *operands):
 
 
 @to_ivy_arrays_and_back
-@with_unsupported_dtypes({"2.0.1 and below": ("float16",)}, "torch")
+@with_unsupported_dtypes({"2.0.1 and below": ("float16", "bfloat16")}, "torch")
 def cross(input, other, dim=None, *, out=None):
     if dim is None:
         dim = -1


### PR DESCRIPTION
Cross function's test method was failing in Torch beck-end because `bflaot16`  was not suppered by torch so I resolve it.
PS: I did not create Issue for that . 