### PR TITLE
Refactor torch.Size class such that it keeps an ivy.Shape instance reference underneath

### DIFF
--- a/ivy/functional/frontends/torch/func_wrapper.py
+++ b/ivy/functional/frontends/torch/func_wrapper.py
@@ -239,7 +239,7 @@ def to_ivy_shape(fn: Callable) -> Callable:
     def to_ivy_shape_torch(*args, **kwargs):
         new_kwargs = {
             key: (
-                ivy.to_ivy_shape(tuple(value))
+                value.ivy_shape
                 if key in ["shape", "size"]
                 and isinstance(value, ivy.functional.frontends.torch.Size)
                 else value
@@ -251,7 +251,7 @@ def to_ivy_shape(fn: Callable) -> Callable:
         new_args = ivy.nested_map(
             args,
             lambda x: (
-                ivy.to_ivy_shape(tuple(x))
+                x.ivy_shape
                 if isinstance(x, ivy.functional.frontends.torch.Size)
                 else x
             ),

--- a/ivy/functional/frontends/torch/tensor.py
+++ b/ivy/functional/frontends/torch/tensor.py
@@ -1776,7 +1776,14 @@ class Size(tuple):
                 new_iterable.append(int(item))
             except Exception:
                 raise TypeError(f"Expected int, but got {type(item)} at index {i}")
-        return super().__new__(cls, new_iterable)
+        return super(Size, cls).__new__(cls, tuple(new_iterable))
+
+    def __init__(self, shape) -> None:
+        self._ivy_shape = ivy.shape(shape) if not isinstance(shape, ivy.Shape) else shape
 
     def __repr__(self):
         return f'ivy.frontends.torch.Size([{", ".join(str(d) for d in self)}])'
+
+    @property
+    def ivy_shape(self):
+        return self._ivy_shape

--- a/ivy/functional/ivy/general.py
+++ b/ivy/functional/ivy/general.py
@@ -1566,7 +1566,10 @@ def to_native_shape(
      ret
         the input in its native framework form
     """
-    if len(backend_stack) != 0 and isinstance(shape, ivy.NativeShape):
+    native_shape_type = (ivy.NativeShape,)
+    if ivy.current_backend_str() == "torch":
+        native_shape_type += (tuple,)
+    if len(backend_stack) != 0 and isinstance(shape, native_shape_type):
         return shape
     ivy.utils.assertions.check_isinstance(
         shape, (int, list, tuple, ivy.Array, ivy.NativeArray, ivy.Shape)


### PR DESCRIPTION
Refactor torch.Size class such that it keeps an ivy.Shape instance reference underneath to allow for correct transpilation path, modify the to_native_shape to check for tuple instances when the backend is set to torch since our proxy classes subclass tuple when tracking torch.Size in the compiler, modify the to_ivy_shape decorator to instead get ivy_shape attribute from frontend torch.Size instances rather than explicitly converting into an ivy.Shape instance