### PR TITLE
add `multi_dot` for padddle backend 

### DIFF
--- a/ivy/functional/backends/paddle/experimental/linear_algebra.py
+++ b/ivy/functional/backends/paddle/experimental/linear_algebra.py
@@ -4,7 +4,10 @@ from typing import Optional, Tuple, Union, Any
 
 # local
 from ivy.functional.ivy.experimental.linear_algebra import _check_valid_dimension_size
-from ivy.func_wrapper import with_unsupported_device_and_dtypes
+from ivy.func_wrapper import (
+    with_unsupported_device_and_dtypes,
+    with_supported_device_and_dtypes,
+)
 from ivy.utils.exceptions import IvyNotImplementedException
 from .. import backend_version
 
@@ -117,3 +120,28 @@ def dot(
 
 
 dot.support_native_out = True
+
+
+@with_supported_device_and_dtypes(
+    {
+        "2.5.1 and below": {
+            "cpu": (
+                "float32",
+                "float64",
+            ),
+            "gpu": (
+                "float16",
+                "float32",
+                "float64",
+            ),
+        }
+    },
+    backend_version,
+)
+def multi_dot(
+    x: paddle.Tensor,
+    /,
+    *,
+    out: Optional[paddle.Tensor] = None,
+) -> paddle.Tensor:
+    return paddle.linalg.multi_dot(x)

--- a/ivy/functional/backends/torch/experimental/linear_algebra.py
+++ b/ivy/functional/backends/torch/experimental/linear_algebra.py
@@ -155,6 +155,7 @@ def adjoint(
     return torch.adjoint(x).resolve_conj()
 
 
+@with_unsupported_dtypes({"2.0.1 and below": ("float16",)}, backend_version)
 def multi_dot(
     x: Sequence[torch.Tensor],
     /,

--- a/ivy_tests/test_ivy/test_functional/test_experimental/test_core/test_linalg.py
+++ b/ivy_tests/test_ivy/test_functional/test_experimental/test_core/test_linalg.py
@@ -483,11 +483,12 @@ def _generate_multi_dot_dtype_and_arrays(draw):
     dtype_x=_generate_multi_dot_dtype_and_arrays(),
     test_gradients=st.just(False),
 )
-def test_multi_dot(dtype_x, test_flags, backend_fw, fn_name):
+def test_multi_dot(dtype_x, test_flags, backend_fw, fn_name, on_device):
     dtype, x = dtype_x
     helpers.test_function(
         input_dtypes=dtype,
         test_flags=test_flags,
+        on_device=on_device,
         backend_to_test=backend_fw,
         fn_name=fn_name,
         test_values=True,


### PR DESCRIPTION
Close #21119 

- Added missing function [multi_dot](https://www.paddlepaddle.org.cn/documentation/docs/en/api/paddle/linalg/multi_dot_en.html) for paddle backend.
- Fixed torch backend failing due to float16 kernel not implemented for multi_dot
- added missing `on_device`  argument at `test_multi_dot`

Also, I tried to `git checkout` array_api changes but for some reason they are not getting checked out. Thus, if the changes made to array_api are not welcomed then please guide me on how to remove them or checkout them .