### PR TITLE
Fixed typos in deep dive docs

### DIFF
--- a/docs/overview/deep_dive/arrays.rst
+++ b/docs/overview/deep_dive/arrays.rst
@@ -136,7 +136,7 @@ There are different ways to do so. One way is to use a global dict :code:`HANDLE
     	def __ivy_array_function__(self, func, types, args, kwargs):
     		if func not in HANDLED_FUNCTIONS:
     			return NotImplemented
-    		if not all((t, (MyArray, ivy.Array, ivy.NativeArray)) for t in types):
+    		if not all(issubclass(t, (MyArray, ivy.Array, ivy.NativeArray)) for t in types):
     			return NotImplemented
     		return HANDLED_FUNCTIONS[func](*args, **kwargs)		
 

--- a/docs/overview/deep_dive/building_the_docs_pipline.rst
+++ b/docs/overview/deep_dive/building_the_docs_pipline.rst
@@ -175,7 +175,7 @@ This is a partial `Sphinx configuration file`_. Which is being imported in the
 `conf.py <https://github.com/unifyai/doc-builder/blob/main/docs/conf.py#L150>`_,
 it's used to customize options that are specific to the project being documented.
 While importing common configuration such as the theme, the extensions, etc in the 
-original ``conf.py``
+original ``conf.py``.
 
 This is a part of ``partial_conf.py``:
 
@@ -343,7 +343,7 @@ This will remove any function that has ``__qualname__`` attribute equal to
 ``ivy_data``
 ~~~~~~~~~~~~
 
-This is a custom documenter for ``autodoc`` that document Ivy data attributes that live
+This is a custom documenter for ``autodoc`` that documents Ivy data attributes that live
 in ``ivy.functional.ivy``, it will replace the module to ``ivy.`` instead of 
 ``ivy.functional.ivy.<submodule>``.
 

--- a/docs/overview/deep_dive/data_types.rst
+++ b/docs/overview/deep_dive/data_types.rst
@@ -523,9 +523,9 @@ There are currently four modes that accomplish this.
 
 :code:`upcast_data_types` mode casts the unsupported dtype encountered to the next highest supported dtype in the same
 dtype group, i.e, if the unsupported dtype encountered is :code:`uint8` , then this mode will try to upcast it to the next available supported :code:`uint` dtype. If no
-higher `uint` dtype is avaiable, then there won't be any upcasting performed. You can set this mode by calling :code:`ivy.upcast_data_types()` with an optional :code:`val` keyword argument that defaults to :code:`True`.
+higher `uint` dtype is available, then there won't be any upcasting performed. You can set this mode by calling :code:`ivy.upcast_data_types()` with an optional :code:`val` keyword argument that defaults to :code:`True`.
 
-Similarly, :code:`downcast_data_dtypes` tries to downcast to the next lower supported dtype in the same dtype group. No casting is performed is no lower dtype is found in the same group.
+Similarly, :code:`downcast_data_dtypes` tries to downcast to the next lower supported dtype in the same dtype group. No casting is performed if no lower dtype is found in the same group.
 It can also be set by calling :code:`ivy.downcast_data_types()` with the optional :code:`val` keyword that defaults to boolean value :code:`True`.
 
 :code:`crosscast_data_types` is for cases when a function doesn't support :code:`int` dtypes, but supports :code:`float` and vice-versa. In such cases,

--- a/docs/overview/deep_dive/exception_handling.rst
+++ b/docs/overview/deep_dive/exception_handling.rst
@@ -320,8 +320,7 @@ exception messages only.
 
     IvyIndexError: jax: all: axis 2 is out of bounds for array of dimension 1
 
-
-@handle_exceptions Decorator
+:code:`@handle_exceptions` Decorator
 ----------------------------
 
 To ensure that all backend exceptions are caught properly, a decorator is used to handle functions in the :code:`try/except` block.
@@ -509,18 +508,18 @@ Let's look at an example!
 
     # in ivy/utils/assertions.py
     def check_less(x1, x2, allow_equal=False, message=""):
-    # less_equal
-    if allow_equal and ivy.any(x1 > x2):
-        raise ivy.exceptions.IvyException(
-            "{} must be lesser than or equal to {}".format(x1, x2)
-            if message == ""
-            else message
-        )
-    # less
-    elif not allow_equal and ivy.any(x1 >= x2):
-        raise ivy.exceptions.IvyException(
-            "{} must be lesser than {}".format(x1, x2) if message == "" else message
-        )
+      # less_equal
+      if allow_equal and ivy.any(x1 > x2):
+          raise ivy.exceptions.IvyException(
+              "{} must be lesser than or equal to {}".format(x1, x2)
+              if message == ""
+              else message
+          )
+      # less
+      elif not allow_equal and ivy.any(x1 >= x2):
+          raise ivy.exceptions.IvyException(
+              "{} must be lesser than {}".format(x1, x2) if message == "" else message
+          )
 
 **ivy.set_split_factor**
 

--- a/docs/overview/deep_dive/function_arguments.rst
+++ b/docs/overview/deep_dive/function_arguments.rst
@@ -183,7 +183,7 @@ Numbers in Operator Functions
 All operator functions (which have a corresponding such as :code:`+`, :code:`-`, :code:`*`, :code:`/`) must also be fully compatible with numbers (float or :code:`int`) passed into any of the array inputs, even in the absence of any arrays.
 For example, :code:`ivy.add(1, 2)`, :code:`ivy.add(1.5, 2)` and :code:`ivy.add(1.5, ivy.array([2]))` should all run without error.
 Therefore, the type hints for :func:`ivy.add` include float as one of the types in the :code:`Union` for the array inputs, and also as one of the types in the :code:`Union` for the output.
-`PEP 484 Type Hints <https://peps.python.org/pep-0484/#the-numeric-tower>`_ state that "when an argument is annotated as having type float, an argument of type int is acceptable".
+`PEP 484 Type Hints <https://peps.python.org/pep-0484/#the-numeric-tower>`_ states that "when an argument is annotated as having type float, an argument of type int is acceptable".
 Therefore, we only include float in the type hints.
 
 Integer Sequences

--- a/docs/overview/deep_dive/gradients.rst
+++ b/docs/overview/deep_dive/gradients.rst
@@ -149,16 +149,17 @@ Gradient APIs of frameworks
 General Structure of Backend-specific implementations
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Here's a high-level description of the steps followed backend-specific implementation of :func:`ivy.execute_with_gradients`
-1. Get Duplicate Index Chains : indices of arrays that share the same :code:`id`
-2. Convert integer arrays to floats : only for ease of use. it's *not* recommended to pass integer arrays to gradient functions
-3. Get relevant inputs : based on the :code:`xs_grad_idxs`, we collect the relevant inputs for gradient computation
-4. Enable gradient support : we implicitly make use of framework-specific APIs to enable gradients in arrays. Ivy doesn't need to have an explicit variable class as the gradient API is fully functional
-5. Compute Results : we do the forward pass by passing the input as it is to the function
-6. Get relevant outputs : based on the :code:`ret_grad_idxs`, we collect the relevant outputs for gradient computation
-7. Compute gradients : we make use of the framework-specific APIs to compute the gradients for the relevant outputs with respect to the relevant inputs
-8. Handle duplicates : we explicitly handle duplicate instances using the index chains captured above as different frameworks treat duplicates differently
-9. Post process and detach : finally, all computed gradients are updated to deal with :code:`NaN` and :code:`inf` and the input arrays are detached (i.e. gradient propagation is stopped)
+Here's a high-level description of the steps followed backend-specific implementation of :func:`ivy.execute_with_gradients`:
+
+#. 1. Get Duplicate Index Chains : indices of arrays that share the same :code:`id`
+#. 2. Convert integer arrays to floats : only for ease of use. it's *not* recommended to pass integer arrays to gradient functions
+#. 3. Get relevant inputs : based on the :code:`xs_grad_idxs`, we collect the relevant inputs for gradient computation
+#. 4. Enable gradient support : we implicitly make use of framework-specific APIs to enable gradients in arrays. Ivy doesn't need to have an explicit variable class as the gradient API is fully functional
+#. 5. Compute Results : we do the forward pass by passing the input as it is to the function
+#. 6. Get relevant outputs : based on the :code:`ret_grad_idxs`, we collect the relevant outputs for gradient computation
+#. 7. Compute gradients : we make use of the framework-specific APIs to compute the gradients for the relevant outputs with respect to the relevant inputs
+#. 8. Handle duplicates : we explicitly handle duplicate instances using the index chains captured above as different frameworks treat duplicates differently
+#. 9. Post process and detach : finally, all computed gradients are updated to deal with :code:`NaN` and :code:`inf` and the input arrays are detached (i.e. gradient propagation is stopped)
 
 Framework-specific Considerations
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/overview/deep_dive/gradients.rst
+++ b/docs/overview/deep_dive/gradients.rst
@@ -151,15 +151,15 @@ General Structure of Backend-specific implementations
 
 Here's a high-level description of the steps followed backend-specific implementation of :func:`ivy.execute_with_gradients`:
 
-#. 1. Get Duplicate Index Chains : indices of arrays that share the same :code:`id`
-#. 2. Convert integer arrays to floats : only for ease of use. it's *not* recommended to pass integer arrays to gradient functions
-#. 3. Get relevant inputs : based on the :code:`xs_grad_idxs`, we collect the relevant inputs for gradient computation
-#. 4. Enable gradient support : we implicitly make use of framework-specific APIs to enable gradients in arrays. Ivy doesn't need to have an explicit variable class as the gradient API is fully functional
-#. 5. Compute Results : we do the forward pass by passing the input as it is to the function
-#. 6. Get relevant outputs : based on the :code:`ret_grad_idxs`, we collect the relevant outputs for gradient computation
-#. 7. Compute gradients : we make use of the framework-specific APIs to compute the gradients for the relevant outputs with respect to the relevant inputs
-#. 8. Handle duplicates : we explicitly handle duplicate instances using the index chains captured above as different frameworks treat duplicates differently
-#. 9. Post process and detach : finally, all computed gradients are updated to deal with :code:`NaN` and :code:`inf` and the input arrays are detached (i.e. gradient propagation is stopped)
+#. Get Duplicate Index Chains : indices of arrays that share the same :code:`id`
+#. Convert integer arrays to floats : only for ease of use. it's *not* recommended to pass integer arrays to gradient functions
+#. Get relevant inputs : based on the :code:`xs_grad_idxs`, we collect the relevant inputs for gradient computation
+#. Enable gradient support : we implicitly make use of framework-specific APIs to enable gradients in arrays. Ivy doesn't need to have an explicit variable class as the gradient API is fully functional
+#. Compute Results : we do the forward pass by passing the input as it is to the function
+#. Get relevant outputs : based on the :code:`ret_grad_idxs`, we collect the relevant outputs for gradient computation
+#. Compute gradients : we make use of the framework-specific APIs to compute the gradients for the relevant outputs with respect to the relevant inputs
+#. Handle duplicates : we explicitly handle duplicate instances using the index chains captured above as different frameworks treat duplicates differently
+#. Post process and detach : finally, all computed gradients are updated to deal with :code:`NaN` and :code:`inf` and the input arrays are detached (i.e. gradient propagation is stopped)
 
 Framework-specific Considerations
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/overview/deep_dive/inplace_updates.rst
+++ b/docs/overview/deep_dive/inplace_updates.rst
@@ -451,7 +451,7 @@ When :code:`copy` is not specified explicitly, then an inplace update is perform
 Setting :code:`copy=False` is equivalent to passing :code:`out=input_array`.
 If only one of :code:`copy` or :code:`out` is specified, then this specified argument is given priority.
 If both are specified, then priority is given to the more general :code:`out` argument.
-As with the :code:`out` argument, the :code:`copy` argument is also handled `by the wrapper <insert_link>`_.
+As with the :code:`out` argument, the :code:`copy` argument is also handled `by the wrapper <https://unify.ai/docs/ivy/overview/deep_dive/function_wrapping.html#function-wrapping>`_.
 
 
 Views

--- a/docs/overview/deep_dive/ivy_frontends_tests.rst
+++ b/docs/overview/deep_dive/ivy_frontends_tests.rst
@@ -559,7 +559,7 @@ an assertion, the examples given below will make it clearer.
 Alias functions
 ^^^^^^^^^^^^^^^
 Let's take a quick walkthrough on testing the function alias as we know that such functions have the same behavior as original functions.
-Taking an example of :func:`torch_frontend.greater` has an alias function :func:`torch_frontend.gt` which we need to make sure that it is working same as the targeted framework function :func:`torch.greater` and :func:`torch.gt`.
+For example :func:`torch_frontend.greater` has an alias function :func:`torch_frontend.gt` which we need to make sure that it is working the same as the targeted framework function :func:`torch.greater` and :func:`torch.gt`.
 
 Code example for alias function:
 

--- a/docs/overview/deep_dive/ivy_tests.rst
+++ b/docs/overview/deep_dive/ivy_tests.rst
@@ -187,7 +187,7 @@ Suppose you need to generate a 1-D array or a scaler value, which also generate 
 
 we can then later use this strategy in any of our tests.
 
-Writing Hypothesis Test
+Writing Hypothesis Tests
 ^^^^^^^^^^^^^^^^^^^^^^^
 
 Writing Hypothesis tests are intuitive and simple, as an example, we've implemented our own :code:`add` function, which takes in 2 parameters :code:`x` and :code:`y`.
@@ -225,17 +225,17 @@ In order to run a test, a lot of pre-processing must be done, e.g. import the fu
     3.  :code:`with_out` flag
 2.  Generate :code:`num_positional_args`
 
-The flags that the decorators would generate, may be more or less depending on the function, **Ivy Functional API** requires :code:`gradient_test` flag, some test functions like :code:`test_gpu_is_available` does not requrie any of these flags, and therefore the decorator will not generate any of these.
+The flags that the decorators would generate, may be more or less depending on the function, **Ivy Functional API** requires :code:`gradient_test` flag, some test functions like :code:`test_gpu_is_available` does not require any of these flags, and therefore the decorator will not generate any of these.
 
 3.  Generate test specific parameters, :code:`fn_name`, :code:`fn_tree`, :code:`method_tree`.
 4.  Check for the function's supported data types and devices.
 5.  Implicitly wraps the test function using Hypothesis :code:`@given` decorator, this allows us to write less code, more readable, and easy to update and maintain.
 
-This is not an exhaustive list of what the :code:`handle_test` decorators actually do, they may do more or less in the future, to summaraize, the test decorators does some of **Pretest-processing** part in the testing pipeline.
+This is not an exhaustive list of what the :code:`handle_test` decorators actually do, they may do more or less in the future, to summarize, the test decorators do some of the **Pretest-processing** part in the testing pipeline.
 
 - Why do we have multiple handle test decorators?
 
-Having multiple test decorator is mainly for efficiency, `handle_test` could do what `handle_frontend_test` does, it just handles the parameters slighlty different, and this can be inferred at run time, but we choose to seperate the decorator for general different usages, currently we have 4 seperate decorators
+Having multiple test decorator is mainly for efficiency, `handle_test` could do what `handle_frontend_test` does, it just handles the parameters slightly different, and this can be inferred at run time, but we choose to separate the decorator for general different usages, currently we have 4 separate decorators
 
 1.  :code:`handle_test`
 2.  :code:`handle_method`
@@ -246,7 +246,7 @@ One of the few differences between the 4 decorators that they generate different
 
 - Integration
 
-Our test decorators actually transforms to :code:`@given` decorators at PyTets collecting time, therefore this allows us to use other **Hypothesis** decorators like, :code:`@reproduce_failure`, :code:`@settings`, :code:`@seed`.
+Our test decorators actually transforms to :code:`@given` decorators at PyTest collecting time, therefore this allows us to use other **Hypothesis** decorators like, :code:`@reproduce_failure`, :code:`@settings`, :code:`@seed`.
 
 Writing Ivy Tests
 ^^^^^^^^^^^^^^^^^
@@ -303,7 +303,7 @@ The generated data is returned as a tuple.
 
 One thing to note here is the :code:`test_flags` variable in the test function. This is basically an object which is initialized internally, which captures all the flags mentioned above for the test during collection time. These flags are then available for the helper function at test time.
 
-The test flags can also be generated explicitely like this -:
+The test flags can also be generated explicitly like this -:
 
 .. code-block:: python
     @handle_test(
@@ -354,7 +354,7 @@ The test then runs on the newly created arrays with specified data types.
 Why do we need helper functions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-It is usually the case that any ivy function should run seamlessly on ‘all the possible varieties, as well as the edge cases’ encountered by the following parameters -:
+It is usually the case that any ivy function should run seamlessly on `all the possible varieties, as well as the edge cases` encountered by the following parameters -:
 
 * All possible data types - **composite**
 * Boolean array types if the function expects one - **composite**
@@ -622,7 +622,7 @@ be used for the given input. For example, when :code:`function_supported_dtypes`
 
     {'compositional': ('float32', 'int8', 'uint8', 'float64', 'int16', 'int32', 'int64'), 'primary': ('bool', 'float32', 'int8', 'uint8', 'float64', 'int64', 'int16', 'int32')}
 
-As can be seen from the above output that the data-types supported will depend on the implementation used for the given input. It's because of this reason that we need a slighlty
+As can be seen from the above output that the data-types supported will depend on the implementation used for the given input. It's because of this reason that we need a slightly
 different pipeline for testing partial mixed functions. Basically, while writing the strategies for the tests of these functions, we need to first determine which implementation 
 will be used and then based on that generate the data to test the function. Here's a example from the test of :code:`ivy.linear` function:
 

--- a/docs/overview/deep_dive/ivy_tests.rst
+++ b/docs/overview/deep_dive/ivy_tests.rst
@@ -354,7 +354,7 @@ The test then runs on the newly created arrays with specified data types.
 Why do we need helper functions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-It is usually the case that any ivy function should run seamlessly on `all the possible varieties, as well as the edge cases` encountered by the following parameters -:
+It is usually the case that any ivy function should run seamlessly on ‘all the possible varieties, as well as the edge cases’ encountered by the following parameters -:
 
 * All possible data types - **composite**
 * Boolean array types if the function expects one - **composite**


### PR DESCRIPTION
I also added the missing function name (`issubclass`) in the arrays code example, otherwise the check is a bit odd in my opinion. 