### PR TITLE
Add flag to enable `ivy.set_backend` in the testing pipeline.

### DIFF
--- a/ivy_tests/conftest.py
+++ b/ivy_tests/conftest.py
@@ -9,6 +9,10 @@ from hypothesis.database import (
     DirectoryBasedExampleDatabase,
 )
 from hypothesis.extra.redis import RedisExampleDatabase
+from ivy_tests.test_ivy.helpers.pipeline_helper import (
+    BackendHandler,
+    BackendHandlerMode,
+)
 
 
 hypothesis_cache = os.getcwd() + "/.hypothesis/examples/"
@@ -96,11 +100,21 @@ def pytest_addoption(parser):
             "this mode should be only used during development on the testing pipeline."
         ),
     )
+    parser.addoption(
+        "--set-backend",
+        action="store_true",
+        default=False,
+        help="Force the testing pipeline to use ivy.set_backend for backend setting",
+    )
 
 
 def pytest_configure(config):
     profile_settings = {}
     getopt = config.getoption
+
+    if getopt("--set-backend"):
+        BackendHandler._update_context(BackendHandlerMode.SetBackend)
+
     max_examples = getopt("--num-examples")
     deadline = getopt("--deadline")
     if (

--- a/ivy_tests/test_ivy/helpers/hypothesis_helpers/dtype_helpers.py
+++ b/ivy_tests/test_ivy/helpers/hypothesis_helpers/dtype_helpers.py
@@ -7,7 +7,7 @@ from typing import Optional
 
 # local
 import ivy
-from ..pipeline_helper import update_backend, get_frontend_config
+from ..pipeline_helper import BackendHandler, get_frontend_config
 from . import number_helpers as nh
 from . import array_helpers as ah
 from .. import globals as test_globals
@@ -369,7 +369,7 @@ def get_castable_dtype(draw, available_dtypes, dtype: str, x: Optional[list] = N
     ret
         A tuple of inputs and castable dtype.
     """
-    with update_backend(test_globals.CURRENT_BACKEND) as ivy_backend:
+    with BackendHandler.update_backend(test_globals.CURRENT_BACKEND) as ivy_backend:
         bound_dtype_bits = lambda d: (
             ivy_backend.dtype_bits(d) / 2
             if ivy_backend.is_complex_dtype(d)

--- a/ivy_tests/test_ivy/helpers/pipeline_helper.py
+++ b/ivy_tests/test_ivy/helpers/pipeline_helper.py
@@ -1,7 +1,12 @@
 # TODO rename file
+from enum import Enum
 import ivy
 import importlib
-from typing import Callable
+
+
+class BackendHandlerMode(Enum):
+    WithBackend = 0
+    SetBackend = 1
 
 
 class WithBackendContext:
@@ -15,8 +20,21 @@ class WithBackendContext:
         return
 
 
-# update_backend: Callable = ivy.utils.backend.ContextManager
-update_backend: Callable = WithBackendContext
+class BackendHandler:
+    _context = WithBackendContext
+
+    @classmethod
+    def _update_context(cls, mode: BackendHandlerMode):
+        if mode == BackendHandlerMode.WithBackend:
+            cls._context = WithBackendContext
+        elif mode == BackendHandlerMode.SetBackend:
+            cls._context = ivy.utils.backend.ContextManager
+        else:
+            raise ValueError(f"Unknown backend handler mode! {mode}")
+
+    @classmethod
+    def update_backend(cls, backend):
+        return cls._context(backend)
 
 
 def get_frontend_config(frontend: str):

--- a/ivy_tests/test_ivy/helpers/test_parameter_flags.py
+++ b/ivy_tests/test_ivy/helpers/test_parameter_flags.py
@@ -1,7 +1,7 @@
 import abc
 from hypothesis import strategies as st
 from . import globals as test_globals
-from .pipeline_helper import update_backend
+from .pipeline_helper import BackendHandler
 
 
 @st.composite
@@ -100,7 +100,7 @@ class FunctionTestFlags(TestFlags):
 
     def apply_flags(self, args_to_iterate, input_dtypes, offset, *, backend, on_device):
         ret = []
-        with update_backend(backend) as backend:
+        with BackendHandler.update_backend(backend) as backend:
             for i, entry in enumerate(args_to_iterate, start=offset):
                 x = backend.array(entry, dtype=input_dtypes[i], device=on_device)
                 if self.as_variable[i]:
@@ -178,7 +178,7 @@ class FrontendFunctionTestFlags(TestFlags):
 
     def apply_flags(self, args_to_iterate, input_dtypes, offset, *, backend, on_device):
         ret = []
-        with update_backend(backend) as backend:
+        with BackendHandler.update_backend(backend) as backend:
             for i, entry in enumerate(args_to_iterate, start=offset):
                 x = backend.array(entry, dtype=input_dtypes[i], device=on_device)
                 if self.as_variable[i]:
@@ -239,7 +239,7 @@ class InitMethodTestFlags(TestFlags):
 
     def apply_flags(self, args_to_iterate, input_dtypes, offset, *, backend, on_device):
         ret = []
-        with update_backend(backend) as backend:
+        with BackendHandler.update_backend(backend) as backend:
             for i, entry in enumerate(args_to_iterate, start=offset):
                 x = backend.array(entry, dtype=input_dtypes[i], device=on_device)
                 if self.as_variable[i]:
@@ -293,7 +293,7 @@ class MethodTestFlags(TestFlags):
 
     def apply_flags(self, args_to_iterate, input_dtypes, offset, *, backend, on_device):
         ret = []
-        with update_backend(backend) as backend:
+        with BackendHandler.update_backend(backend) as backend:
             for i, entry in enumerate(args_to_iterate, start=offset):
                 x = backend.array(entry, dtype=input_dtypes[i], device=on_device)
                 if self.as_variable[i]:
@@ -350,7 +350,7 @@ class FrontendMethodTestFlags(TestFlags):
 
     def apply_flags(self, args_to_iterate, input_dtypes, offset, *, backend, on_device):
         ret = []
-        with update_backend(backend) as backend:
+        with BackendHandler.update_backend(backend) as backend:
             for i, entry in enumerate(args_to_iterate, start=offset):
                 x = backend.array(entry, dtype=input_dtypes[i], device=on_device)
                 if self.as_variable[i]:

--- a/ivy_tests/test_ivy/helpers/testing_helpers.py
+++ b/ivy_tests/test_ivy/helpers/testing_helpers.py
@@ -13,7 +13,7 @@ from .hypothesis_helpers import number_helpers as nh
 from .globals import TestData
 from . import test_parameter_flags as pf
 from . import test_globals as t_globals
-from .pipeline_helper import update_backend
+from .pipeline_helper import BackendHandler
 from ivy_tests.test_ivy.helpers.test_parameter_flags import (
     BuiltInstanceStrategy,
     BuiltAsVariableStrategy,
@@ -111,7 +111,7 @@ def num_positional_args(draw, *, fn_name: str = None):
     num_keyword_only = 0
     total = 0
     fn = None
-    with update_backend(t_globals.CURRENT_BACKEND) as ivy_backend:
+    with BackendHandler.update_backend(t_globals.CURRENT_BACKEND) as ivy_backend:
         ivy_backend.utils.dynamic_import.import_module(fn_name.rpartition(".")[0])
         for i, fn_name_key in enumerate(fn_name.split(".")):
             if i == 0:
@@ -182,7 +182,7 @@ def _get_method_supported_devices_dtypes(
     """
     supported_device_dtypes = {}
     for backend_str in available_frameworks:
-        with update_backend(backend_str) as backend:
+        with BackendHandler.update_backend(backend_str) as backend:
             _fn = getattr(class_module.__dict__[class_name], method_name)
             devices_and_dtypes = backend.function_supported_devices_and_dtypes(_fn)
             organized_dtypes = {}
@@ -221,7 +221,7 @@ def _get_supported_devices_dtypes(fn_name: str, fn_module: str):
             fn_name = "_" + fn_name
 
     for backend_str in available_frameworks:
-        with update_backend(backend_str) as ivy_backend:
+        with BackendHandler.update_backend(backend_str) as ivy_backend:
             _tmp_mod = ivy_backend.utils.dynamic_import.import_module(fn_module)
             _fn = _tmp_mod.__dict__[fn_name]
             # for partial mixed functions we should pass the backend function

--- a/ivy_tests/test_ivy/test_frontends/test_jax/test_array.py
+++ b/ivy_tests/test_ivy/test_frontends/test_jax/test_array.py
@@ -4,7 +4,7 @@ import numpy as np
 
 # local
 import ivy_tests.test_ivy.helpers as helpers
-from ivy_tests.test_ivy.helpers import handle_frontend_method, update_backend
+from ivy_tests.test_ivy.helpers import handle_frontend_method, BackendHandler
 from ivy_tests.test_ivy.test_functional.test_core.test_statistical import (
     _get_castable_dtype,
 )
@@ -25,7 +25,7 @@ def test_jax_ivy_array(
     backend_fw,
 ):
     _, data = dtype_x
-    with update_backend(backend_fw) as ivy_backend:
+    with BackendHandler.update_backend(backend_fw) as ivy_backend:
         jax_frontend = ivy_backend.utils.dynamic_import.import_module(
             "ivy.functional.frontends.jax"
         )
@@ -50,7 +50,7 @@ def test_jax_array_dtype(
     backend_fw,
 ):
     dtype, data = dtype_x
-    with update_backend(backend_fw) as ivy_backend:
+    with BackendHandler.update_backend(backend_fw) as ivy_backend:
         jax_frontend = ivy_backend.utils.dynamic_import.import_module(
             "ivy.functional.frontends.jax"
         )
@@ -68,7 +68,7 @@ def test_jax_array_ndim(
     backend_fw,
 ):
     dtype, data = dtype_x
-    with update_backend(backend_fw) as ivy_backend:
+    with BackendHandler.update_backend(backend_fw) as ivy_backend:
         jax_frontend = ivy_backend.utils.dynamic_import.import_module(
             "ivy.functional.frontends.jax"
         )
@@ -87,7 +87,7 @@ def test_jax_array_shape(
     backend_fw,
 ):
     _, data, shape = dtype_x_shape
-    with update_backend(backend_fw) as ivy_backend:
+    with BackendHandler.update_backend(backend_fw) as ivy_backend:
         jax_frontend = ivy_backend.utils.dynamic_import.import_module(
             "ivy.functional.frontends.jax"
         )
@@ -114,7 +114,7 @@ def _transpose_helper(draw):
 
 @given(x_transpose=_transpose_helper())
 def test_jax_array_property_T(x_transpose, backend_fw):
-    with update_backend(backend_fw) as ivy_backend:
+    with BackendHandler.update_backend(backend_fw) as ivy_backend:
         x, xT = x_transpose
         jax_frontend = ivy_backend.utils.dynamic_import.import_module(
             "ivy.functional.frontends.jax"
@@ -145,7 +145,7 @@ def _at_helper(draw):
     x_y_index=_at_helper(),
 )
 def test_jax_array_at(x_y_index, backend_fw):
-    with update_backend(backend_fw) as ivy_backend:
+    with BackendHandler.update_backend(backend_fw) as ivy_backend:
         jax_frontend = ivy_backend.utils.dynamic_import.import_module(
             "ivy.functional.frontends.jax"
         )

--- a/ivy_tests/test_ivy/test_frontends/test_jax/test_general_functions.py
+++ b/ivy_tests/test_ivy/test_frontends/test_jax/test_general_functions.py
@@ -1,7 +1,7 @@
 # local
 import ivy
 import ivy_tests.test_ivy.helpers as helpers
-from ivy_tests.test_ivy.helpers import handle_frontend_test, update_backend
+from ivy_tests.test_ivy.helpers import handle_frontend_test, BackendHandler
 from ivy.functional.frontends.jax import vmap
 from hypothesis import strategies as st
 import jax
@@ -111,7 +111,7 @@ def test_jax_device_put(
     backend_fw,
     on_device,
 ):
-    with update_backend(backend_fw) as ivy_backend:
+    with BackendHandler.update_backend(backend_fw) as ivy_backend:
         dtype, x = dtype_and_x
         dtype = dtype[0]
         x = x[0]
@@ -146,7 +146,7 @@ def test_jax_device_get(
     backend_fw,
     on_device,
 ):
-    with update_backend(backend_fw) as ivy_backend:
+    with BackendHandler.update_backend(backend_fw) as ivy_backend:
         dtype, x = dtype_and_x
         dtype = dtype[0]
         x = x[0]

--- a/ivy_tests/test_ivy/test_frontends/test_jax/test_lax/test_linalg.py
+++ b/ivy_tests/test_ivy/test_frontends/test_jax/test_lax/test_linalg.py
@@ -6,7 +6,7 @@ from hypothesis import strategies as st
 # local
 import ivy_tests.test_ivy.helpers as helpers
 from ivy_tests.test_ivy.helpers import assert_all_close
-from ivy_tests.test_ivy.helpers import handle_frontend_test, update_backend
+from ivy_tests.test_ivy.helpers import handle_frontend_test, BackendHandler
 
 
 # svd
@@ -57,7 +57,7 @@ def test_jax_svd(
     )
 
     if compute_uv:
-        with update_backend(backend_fw) as ivy_backend:
+        with BackendHandler.update_backend(backend_fw) as ivy_backend:
             ret = [ivy_backend.to_numpy(x) for x in ret]
         frontend_ret = [np.asarray(x) for x in frontend_ret]
 
@@ -73,7 +73,7 @@ def test_jax_svd(
             ground_truth_backend=frontend,
         )
     else:
-        with update_backend(backend_fw) as ivy_backend:
+        with BackendHandler.update_backend(backend_fw) as ivy_backend:
             ret = ivy_backend.to_numpy(ret)
         assert_all_close(
             ret_np=ret,
@@ -179,7 +179,7 @@ def test_jax_eigh(
         lower=lower,
         symmetrize_input=symmetrize_input,
     )
-    with update_backend(backend_fw) as ivy_backend:
+    with BackendHandler.update_backend(backend_fw) as ivy_backend:
         ret = [ivy_backend.to_numpy(x) for x in ret]
     frontend_ret = [np.asarray(x) for x in frontend_ret]
 

--- a/ivy_tests/test_ivy/test_frontends/test_jax/test_lax/test_operators.py
+++ b/ivy_tests/test_ivy/test_frontends/test_jax/test_lax/test_operators.py
@@ -10,7 +10,7 @@ from jax.lax import ConvDimensionNumbers
 import ivy
 import ivy_tests.test_ivy.helpers as helpers
 import ivy_tests.test_ivy.helpers.globals as test_globals
-from ivy_tests.test_ivy.helpers import handle_frontend_test, update_backend
+from ivy_tests.test_ivy.helpers import handle_frontend_test, BackendHandler
 from ivy_tests.test_ivy.test_functional.test_experimental.test_nn.test_layers import (
     _reduce_window_helper,
 )
@@ -214,7 +214,7 @@ def test_jax_concat(
 @st.composite
 def _fill_value(draw):
     dtype = draw(helpers.get_dtypes("numeric", full=False, key="dtype"))[0]
-    with update_backend(test_globals.CURRENT_BACKEND) as ivy_backend:
+    with BackendHandler.update_backend(test_globals.CURRENT_BACKEND) as ivy_backend:
         if ivy_backend.is_uint_dtype(dtype):
             return draw(helpers.ints(min_value=0, max_value=5))
         elif ivy_backend.is_int_dtype(dtype):

--- a/ivy_tests/test_ivy/test_frontends/test_jax/test_numpy/test_indexing.py
+++ b/ivy_tests/test_ivy/test_frontends/test_jax/test_numpy/test_indexing.py
@@ -6,7 +6,7 @@ from jax.numpy import tril, triu, r_, c_
 
 # local
 import ivy_tests.test_ivy.helpers as helpers
-from ivy_tests.test_ivy.helpers import handle_frontend_test, update_backend
+from ivy_tests.test_ivy.helpers import handle_frontend_test, BackendHandler
 from ...test_numpy.test_indexing_routines.test_inserting_data_into_arrays import (
     _helper_r_,
     _helper_c_,
@@ -470,7 +470,7 @@ def test_jax_numpy_indices(
 def test_jax_numpy_r_(inputs, backend_fw):
     inputs, *_ = inputs
     ret_gt = r_.__getitem__(tuple(inputs))
-    with update_backend(backend_fw):
+    with BackendHandler.update_backend(backend_fw):
         ret = jnp_frontend.r_.__getitem__(tuple(inputs))
     assert np.allclose(ret.ivy_array, ret_gt)
 
@@ -478,6 +478,6 @@ def test_jax_numpy_r_(inputs, backend_fw):
 @handle_frontend_test(fn_tree="jax.numpy.add", inputs=_helper_c_())  # dummy fn_tree
 def test_jax_numpy_c_(inputs, backend_fw):
     ret_gt = c_.__getitem__(tuple(inputs))
-    with update_backend(backend_fw):
+    with BackendHandler.update_backend(backend_fw):
         ret = jnp_frontend.c_.__getitem__(tuple(inputs))
     assert np.allclose(ret.ivy_array, ret_gt)

--- a/ivy_tests/test_ivy/test_frontends/test_jax/test_numpy/test_linalg.py
+++ b/ivy_tests/test_ivy/test_frontends/test_jax/test_numpy/test_linalg.py
@@ -9,7 +9,7 @@ import ivy_tests.test_ivy.helpers as helpers
 from ivy_tests.test_ivy.helpers import (
     assert_all_close,
     handle_frontend_test,
-    update_backend,
+    BackendHandler,
 )
 from ivy_tests.test_ivy.test_functional.test_core.test_linalg import (
     _get_dtype_and_matrix,
@@ -68,7 +68,7 @@ def test_jax_svd(
     )
 
     if compute_uv:
-        with update_backend(backend_fw) as ivy_backend:
+        with BackendHandler.update_backend(backend_fw) as ivy_backend:
             ret = [ivy_backend.to_numpy(x) for x in ret]
         frontend_ret = [np.asarray(x) for x in frontend_ret]
 
@@ -84,7 +84,7 @@ def test_jax_svd(
             ground_truth_backend=frontend,
         )
     else:
-        with update_backend(backend_fw) as ivy_backend:
+        with BackendHandler.update_backend(backend_fw) as ivy_backend:
             ret = ivy_backend.to_numpy(ret)
         assert_all_close(
             ret_np=ret,
@@ -167,7 +167,7 @@ def test_jax_eig(
         a=x,
     )
 
-    with update_backend(backend_fw) as ivy_backend:
+    with BackendHandler.update_backend(backend_fw) as ivy_backend:
         ret = [ivy_backend.to_numpy(x).astype(np.float64) for x in ret]
     frontend_ret = [x.astype(np.float64) for x in frontend_ret]
 
@@ -229,7 +229,7 @@ def test_jax_eigh(
         UPLO=UPLO,
         symmetrize_input=symmetrize_input,
     )
-    with update_backend(backend_fw) as ivy_backend:
+    with BackendHandler.update_backend(backend_fw) as ivy_backend:
         ret = [ivy_backend.to_numpy(x) for x in ret]
     frontend_ret = [np.asarray(x) for x in frontend_ret]
 
@@ -366,7 +366,7 @@ def test_jax_qr(
         a=np.asarray(x[0], dtype[0]),
         mode=mode,
     )
-    with update_backend(backend_fw) as ivy_backend:
+    with BackendHandler.update_backend(backend_fw) as ivy_backend:
         ret = [ivy_backend.to_numpy(x).astype(np.float64) for x in ret]
     frontend_ret = [x.astype(np.float64) for x in frontend_ret]
 

--- a/ivy_tests/test_ivy/test_frontends/test_numpy/helpers.py
+++ b/ivy_tests/test_ivy/test_frontends/test_numpy/helpers.py
@@ -7,7 +7,7 @@ import ivy
 import ivy_tests.test_ivy.helpers as helpers
 import ivy.functional.frontends.numpy as np_frontend
 from ivy_tests.test_ivy.helpers.pipeline_helper import (
-    update_backend,
+    BackendHandler,
     get_frontend_config,
 )
 import ivy_tests.test_ivy.helpers.globals as test_globals
@@ -154,7 +154,7 @@ def _test_frontend_function_ignoring_uninitialized(*args, **kwargs):
 
 
 def _flatten_fw_return(ret, backend):
-    with update_backend(backend) as ivy_backend:
+    with BackendHandler.update_backend(backend) as ivy_backend:
         if not isinstance(ret, tuple):
             ret = (ret,)
         ret_idxs = ivy_backend.nested_argwhere(
@@ -179,7 +179,7 @@ def _flatten_fw_return(ret, backend):
 
 def _flatten_frontend_return(*, ret, backend):
     """Flattening the returned frontend value to a list of numpy arrays."""
-    with update_backend(backend) as ivy_backend:
+    with BackendHandler.update_backend(backend) as ivy_backend:
         if not isinstance(ret, tuple):
             if not ivy_backend.is_ivy_array(ret):
                 ret_np_flat = helpers.flatten_frontend_to_np(backend=backend, ret=ret)
@@ -224,7 +224,7 @@ def _get_safe_casting_dtype(draw, *, dtypes):
     for dtype in dtypes[1:]:
         if np_frontend.can_cast(target_dtype, dtype, casting="safe"):
             target_dtype = dtype
-    with update_backend(test_globals.CURRENT_BACKEND) as ivy_backend:
+    with BackendHandler.update_backend(test_globals.CURRENT_BACKEND) as ivy_backend:
         if ivy_backend.is_float_dtype(target_dtype):
             dtype = draw(st.sampled_from(["float64", None]))
         elif ivy_backend.is_uint_dtype(target_dtype):

--- a/ivy_tests/test_ivy/test_frontends/test_numpy/test_creation_routines/test_from_shape_or_value.py
+++ b/ivy_tests/test_ivy/test_frontends/test_numpy/test_creation_routines/test_from_shape_or_value.py
@@ -4,7 +4,7 @@ from hypothesis import strategies as st
 # local
 import ivy_tests.test_ivy.helpers as helpers
 import ivy_tests.test_ivy.helpers.globals as test_globals
-from ivy_tests.test_ivy.helpers import handle_frontend_test, update_backend
+from ivy_tests.test_ivy.helpers import handle_frontend_test, BackendHandler
 
 
 # empty
@@ -304,7 +304,7 @@ def test_numpy_zeros_like(
 def _input_fill_and_dtype(draw):
     dtype = draw(helpers.get_dtypes("float", full=False))
     dtype_and_input = draw(helpers.dtype_and_values(dtype=dtype))
-    with update_backend(test_globals.CURRENT_BACKEND) as ivy_backend:
+    with BackendHandler.update_backend(test_globals.CURRENT_BACKEND) as ivy_backend:
         if ivy_backend.is_uint_dtype(dtype[0]):
             fill_values = draw(st.integers(min_value=0, max_value=5))
         elif ivy_backend.is_int_dtype(dtype[0]):

--- a/ivy_tests/test_ivy/test_frontends/test_numpy/test_indexing_routines/test_inserting_data_into_arrays.py
+++ b/ivy_tests/test_ivy/test_frontends/test_numpy/test_indexing_routines/test_inserting_data_into_arrays.py
@@ -5,7 +5,7 @@ import numpy as np
 # local
 import ivy_tests.test_ivy.helpers as helpers
 import ivy_tests.test_ivy.test_frontends.test_numpy.helpers as np_frontend_helpers
-from ivy_tests.test_ivy.helpers import handle_frontend_test, update_backend
+from ivy_tests.test_ivy.helpers import handle_frontend_test, BackendHandler
 import ivy.functional.frontends.numpy as np_frontend
 
 
@@ -151,7 +151,7 @@ def test_numpy_fill_diagonal(
 def test_numpy_r_(inputs, backend_fw):
     inputs, elems_in_last_dim, dim = inputs
     ret_gt = np.r_.__getitem__(tuple(inputs))
-    with update_backend(backend_fw):
+    with BackendHandler.update_backend(backend_fw):
         ret = np_frontend.r_.__getitem__(tuple(inputs))
     if isinstance(inputs[0], str) and inputs[0] in ["r", "c"]:
         ret = ret._data
@@ -163,7 +163,7 @@ def test_numpy_r_(inputs, backend_fw):
 @handle_frontend_test(fn_tree="numpy.add", inputs=_helper_c_())  # dummy fn_tree
 def test_numpy_c_(inputs, backend_fw):
     ret_gt = np.c_.__getitem__(tuple(inputs))
-    with update_backend(backend_fw):
+    with BackendHandler.update_backend(backend_fw):
         ret = np_frontend.c_.__getitem__(tuple(inputs))
     if isinstance(inputs[0], str) and inputs[0] in ["r", "c"]:
         ret = ret._data

--- a/ivy_tests/test_ivy/test_frontends/test_numpy/test_linalg/test_decompositions.py
+++ b/ivy_tests/test_ivy/test_frontends/test_numpy/test_linalg/test_decompositions.py
@@ -5,7 +5,7 @@ from hypothesis import strategies as st
 
 # local
 import ivy_tests.test_ivy.helpers as helpers
-from ivy_tests.test_ivy.helpers import handle_frontend_test, update_backend
+from ivy_tests.test_ivy.helpers import handle_frontend_test, BackendHandler
 from ivy_tests.test_ivy.test_functional.test_core.test_linalg import (
     _get_dtype_and_matrix,
 )
@@ -120,7 +120,7 @@ def test_numpy_svd(
         full_matrices=full_matrices,
         compute_uv=compute_uv,
     )
-    with update_backend(backend_fw) as ivy_backend:
+    with BackendHandler.update_backend(backend_fw) as ivy_backend:
         for u, v in zip(ret, ret_gt):
             u = ivy_backend.to_numpy(ivy_backend.abs(u))
             v = ivy_backend.to_numpy(ivy_backend.abs(v))

--- a/ivy_tests/test_ivy/test_frontends/test_numpy/test_linalg/test_matrix_eigenvalues.py
+++ b/ivy_tests/test_ivy/test_frontends/test_numpy/test_linalg/test_matrix_eigenvalues.py
@@ -8,7 +8,7 @@ import ivy_tests.test_ivy.helpers as helpers
 from ivy_tests.test_ivy.helpers import (
     handle_frontend_test,
     assert_all_close,
-    update_backend,
+    BackendHandler,
 )
 from ivy_tests.test_ivy.test_functional.test_core.test_linalg import (
     _get_dtype_and_matrix,
@@ -86,7 +86,7 @@ def test_numpy_eig(
         a=x,
     )
 
-    with update_backend(backend_fw) as ivy_backend:
+    with BackendHandler.update_backend(backend_fw) as ivy_backend:
         ret = [ivy_backend.to_numpy(x).astype(np.float64) for x in ret]
         frontend_ret = [x.astype(np.float64) for x in frontend_ret]
 
@@ -145,7 +145,7 @@ def test_numpy_eigh(
         a=x,
         UPLO=UPLO,
     )
-    with update_backend(backend_fw) as ivy_backend:
+    with BackendHandler.update_backend(backend_fw) as ivy_backend:
         ret = [ivy_backend.to_numpy(x) for x in ret]
         frontend_ret = [np.asarray(x) for x in frontend_ret]
         L, Q = ret

--- a/ivy_tests/test_ivy/test_frontends/test_numpy/test_manipulation_routines/test_basic_operations.py
+++ b/ivy_tests/test_ivy/test_frontends/test_numpy/test_manipulation_routines/test_basic_operations.py
@@ -5,7 +5,7 @@ import numpy as np
 # local
 import ivy_tests.test_ivy.helpers as helpers
 import ivy_tests.test_ivy.test_frontends.test_numpy.helpers as np_frontend_helpers
-from ivy_tests.test_ivy.helpers import handle_frontend_test, update_backend
+from ivy_tests.test_ivy.helpers import handle_frontend_test, BackendHandler
 
 
 @st.composite
@@ -41,7 +41,7 @@ def test_numpy_copyto(
     if isinstance(where, list) or isinstance(where, tuple):
         where = where[0]
 
-    with update_backend(backend_fw) as ivy_backend:
+    with BackendHandler.update_backend(backend_fw) as ivy_backend:
         src_ivy = ivy_backend.functional.frontends.numpy.array(xs[0])
         dst_ivy = ivy_backend.functional.frontends.numpy.array(xs[1])
         ivy_backend.functional.frontends.numpy.copyto(

--- a/ivy_tests/test_ivy/test_frontends/test_numpy/test_manipulation_routines/test_changing_kind_of_array.py
+++ b/ivy_tests/test_ivy/test_frontends/test_numpy/test_manipulation_routines/test_changing_kind_of_array.py
@@ -4,7 +4,7 @@ import numpy as np
 # local
 import ivy.functional.frontends.numpy as np_frontend
 import ivy_tests.test_ivy.helpers as helpers
-from ivy_tests.test_ivy.helpers import handle_frontend_test, update_backend
+from ivy_tests.test_ivy.helpers import handle_frontend_test, BackendHandler
 
 
 @handle_frontend_test(
@@ -12,7 +12,7 @@ from ivy_tests.test_ivy.helpers import handle_frontend_test, update_backend
     arr=helpers.dtype_and_values(min_num_dims=2, max_num_dims=2),
 )
 def test_numpy_asmatrix(arr, backend_fw):
-    with update_backend(backend_fw) as ivy_backend:
+    with BackendHandler.update_backend(backend_fw) as ivy_backend:
         dtype, x = arr
         ret = np_frontend.asmatrix(x[0])
         ret_gt = np.asmatrix(x[0])

--- a/ivy_tests/test_ivy/test_frontends/test_numpy/test_ndarray/test_ndarray.py
+++ b/ivy_tests/test_ivy/test_frontends/test_numpy/test_ndarray/test_ndarray.py
@@ -9,7 +9,7 @@ import ivy_tests.test_ivy.helpers as helpers
 from ivy_tests.test_ivy.helpers import (
     handle_frontend_method,
     assert_all_close,
-    update_backend,
+    BackendHandler,
 )
 import ivy_tests.test_ivy.test_frontends.test_numpy.helpers as np_frontend_helpers
 from ivy_tests.test_ivy.test_functional.test_core.test_linalg import (
@@ -44,7 +44,7 @@ def test_numpy_ndarray_ivy_array(
     backend_fw,
 ):
     dtype, data, shape = dtype_x
-    with update_backend(backend_fw) as ivy_backend:
+    with BackendHandler.update_backend(backend_fw) as ivy_backend:
         x = ivy_backend.functional.frontends.numpy.ndarray(shape, dtype[0])
         x.ivy_array = data[0]
         ret = helpers.flatten_and_to_np(ret=x.ivy_array.data, backend=backend_fw)
@@ -65,7 +65,7 @@ def test_numpy_ndarray_ivy_array(
 )
 def test_numpy_ndarray_dtype(dtype_x, backend_fw, frontend):
     dtype, data, shape = dtype_x
-    with update_backend(backend_fw) as ivy_backend:
+    with BackendHandler.update_backend(backend_fw) as ivy_backend:
         x = ivy_backend.functional.frontends.numpy.ndarray(shape, dtype[0])
         x.ivy_array = data[0]
         ivy_backend.utils.assertions.check_equal(
@@ -84,7 +84,7 @@ def test_numpy_ndarray_shape(
     backend_fw,
 ):
     dtype, data, shape = dtype_x
-    with update_backend(backend_fw) as ivy_backend:
+    with BackendHandler.update_backend(backend_fw) as ivy_backend:
         x = ivy_backend.functional.frontends.numpy.ndarray(shape, dtype[0])
         x.ivy_array = data[0]
         ivy_backend.utils.assertions.check_equal(
@@ -100,7 +100,7 @@ def test_numpy_ndarray_shape(
 )
 def test_numpy_ndarray_property_ndim(dtype_x, backend_fw):
     dtype, data, shape = dtype_x
-    with update_backend(backend_fw) as ivy_backend:
+    with BackendHandler.update_backend(backend_fw) as ivy_backend:
         x = ivy_backend.functional.frontends.numpy.ndarray(shape, dtype[0])
         x.ivy_array = data[0]
         ivy_backend.utils.assertions.check_equal(x.ndim, data[0].ndim, as_array=False)
@@ -133,7 +133,7 @@ def test_numpy_T(
     frontend,
 ):
     dtype, data, shape = dtype_x
-    with update_backend(backend_fw) as ivy_backend:
+    with BackendHandler.update_backend(backend_fw) as ivy_backend:
         x = ivy_backend.functional.frontends.numpy.ndarray(shape, dtype[0])
         x.ivy_array = data[0]
         ret = helpers.flatten_and_to_np(ret=x.T.ivy_array, backend=backend_fw)
@@ -161,7 +161,7 @@ def test_numpy_T(
 def test_numpy_ndarray_flat(dtype_x, backend_fw):
     dtype, data, shape = dtype_x
 
-    with update_backend(backend_fw) as ivy_backend:
+    with BackendHandler.update_backend(backend_fw) as ivy_backend:
         x = ivy_backend.functional.frontends.numpy.ndarray(shape, dtype[0])
         x.ivy_array = data[0]
 
@@ -3085,7 +3085,7 @@ def test_numpy_ndarray_tobytes(
     backend_fw,
 ):
     dtype, data, shape = dtype_x
-    with update_backend(backend_fw) as ivy_backend:
+    with BackendHandler.update_backend(backend_fw) as ivy_backend:
         x = ivy_backend.functional.frontends.numpy.ndarray(shape, dtype[0])
         x.ivy_array = data[0]
         ivy_backend.utils.assertions.check_equal(

--- a/ivy_tests/test_ivy/test_frontends/test_paddle/test_tensor/test_creation.py
+++ b/ivy_tests/test_ivy/test_frontends/test_paddle/test_tensor/test_creation.py
@@ -4,7 +4,7 @@ from hypothesis import strategies as st
 # local
 import ivy_tests.test_ivy.helpers as helpers
 import ivy_tests.test_ivy.helpers.globals as test_globals
-from ivy_tests.test_ivy.helpers import handle_frontend_test, update_backend
+from ivy_tests.test_ivy.helpers import handle_frontend_test, BackendHandler
 
 
 # Helpers #
@@ -14,7 +14,7 @@ from ivy_tests.test_ivy.helpers import handle_frontend_test, update_backend
 @st.composite
 def _input_fill_and_dtype(draw):
     dtype = draw(helpers.get_dtypes("float", full=False))
-    with update_backend(test_globals.CURRENT_BACKEND) as ivy_backend:
+    with BackendHandler.update_backend(test_globals.CURRENT_BACKEND) as ivy_backend:
         dtype_and_input = draw(helpers.dtype_and_values(dtype=dtype))
         if ivy_backend.is_uint_dtype(dtype[0]):
             fill_values = draw(st.integers(min_value=0, max_value=5))

--- a/ivy_tests/test_ivy/test_frontends/test_tensorflow/test_func_wrapper.py
+++ b/ivy_tests/test_ivy/test_frontends/test_tensorflow/test_func_wrapper.py
@@ -4,7 +4,7 @@ from hypothesis import given, strategies as st
 # local
 import ivy
 import ivy_tests.test_ivy.helpers as helpers
-from ivy_tests.test_ivy.helpers import update_backend
+from ivy_tests.test_ivy.helpers import BackendHandler
 from ivy.functional.frontends.tensorflow.func_wrapper import (
     outputs_to_frontend_arrays,
     to_ivy_arrays_and_back,
@@ -29,7 +29,7 @@ def _fn(x=None, dtype=None):
 def test_tensorflow_inputs_to_ivy_arrays(dtype_and_x, backend_fw):
     x_dtype, x = dtype_and_x
 
-    with update_backend(backend_fw) as ivy_backend:
+    with BackendHandler.update_backend(backend_fw) as ivy_backend:
         _import_fn = ivy_backend.utils.dynamic_import.import_module
         _import_fn("ivy.functional.frontends.tensorflow.func_wrapper")
         _tensor_module = _import_fn("ivy.functional.frontends.tensorflow.tensor")

--- a/ivy_tests/test_ivy/test_frontends/test_tensorflow/test_raw_ops.py
+++ b/ivy_tests/test_ivy/test_frontends/test_tensorflow/test_raw_ops.py
@@ -13,7 +13,7 @@ import ivy_tests.test_ivy.helpers.globals as test_globals
 from ivy_tests.test_ivy.helpers import (
     handle_frontend_test,
     assert_all_close,
-    update_backend,
+    BackendHandler,
 )
 
 
@@ -484,7 +484,7 @@ def test_tensorflow_Div(  # NOQA
 @st.composite
 def _fill_value(draw):
     dtype = draw(_dtypes())[0]
-    with update_backend(test_globals.CURRENT_BACKEND) as ivy_backend:
+    with BackendHandler.update_backend(test_globals.CURRENT_BACKEND) as ivy_backend:
         if ivy_backend.is_uint_dtype(dtype):
             return draw(helpers.ints(min_value=0, max_value=5))
         elif ivy_backend.is_int_dtype(dtype):

--- a/ivy_tests/test_ivy/test_frontends/test_torch/test_creation_ops.py
+++ b/ivy_tests/test_ivy/test_frontends/test_torch/test_creation_ops.py
@@ -6,7 +6,7 @@ import numpy as np
 # local
 import ivy_tests.test_ivy.helpers as helpers
 import ivy_tests.test_ivy.helpers.globals as test_globals
-from ivy_tests.test_ivy.helpers import handle_frontend_test, update_backend
+from ivy_tests.test_ivy.helpers import handle_frontend_test, BackendHandler
 
 
 # Helper functions
@@ -16,7 +16,7 @@ from ivy_tests.test_ivy.helpers import handle_frontend_test, update_backend
 def _fill_value(draw):
     with_array = draw(st.sampled_from([True, False]))
     dtype = draw(st.shared(helpers.get_dtypes("numeric", full=False), key="dtype"))[0]
-    with update_backend(test_globals.CURRENT_BACKEND) as ivy_backend:
+    with BackendHandler.update_backend(test_globals.CURRENT_BACKEND) as ivy_backend:
         if ivy_backend.is_uint_dtype(dtype):
             ret = draw(helpers.ints(min_value=0, max_value=5))
         elif ivy_backend.is_int_dtype(dtype):

--- a/ivy_tests/test_ivy/test_functional/test_core/test_creation.py
+++ b/ivy_tests/test_ivy/test_functional/test_core/test_creation.py
@@ -6,7 +6,7 @@ import numpy as np
 
 # local
 import ivy_tests.test_ivy.helpers as helpers
-from ivy_tests.test_ivy.helpers import handle_test, update_backend
+from ivy_tests.test_ivy.helpers import handle_test, BackendHandler
 import ivy_tests.test_ivy.helpers.globals as test_globals
 from ivy_tests.test_ivy.test_functional.test_core.test_dtype import astype_helper
 
@@ -200,7 +200,7 @@ def _asarray_helper(draw):
             shared_dtype=True,
         )
     )
-    with update_backend(test_globals.CURRENT_BACKEND) as ivy_backend:
+    with BackendHandler.update_backend(test_globals.CURRENT_BACKEND) as ivy_backend:
         x_list = ivy_backend.nested_map(x, lambda x: x.tolist(), shallow=False)
         sh = draw(helpers.get_shape(min_num_dims=1))
         sh = ivy_backend.Shape(sh)
@@ -376,7 +376,7 @@ def test_from_dlpack(*, dtype_and_x, test_flags, backend_fw, fn_name, on_device)
 @st.composite
 def _fill_value(draw):
     dtype = draw(helpers.get_dtypes("numeric", full=False, key="dtype"))[0]
-    with update_backend(test_globals.CURRENT_BACKEND) as ivy_backend:
+    with BackendHandler.update_backend(test_globals.CURRENT_BACKEND) as ivy_backend:
         if ivy_backend.is_uint_dtype(dtype):
             return draw(helpers.ints(min_value=0, max_value=5))
         if ivy_backend.is_int_dtype(dtype):
@@ -656,7 +656,7 @@ def test_copy_array(
     if test_flags.as_variable[0]:
         assume("float" in dtype[0])
     # smoke test
-    with update_backend(backend_fw) as ivy_backend:
+    with BackendHandler.update_backend(backend_fw) as ivy_backend:
         x = test_flags.apply_flags(
             x, dtype, 0, backend=backend_fw, on_device=on_device
         )[0]

--- a/ivy_tests/test_ivy/test_functional/test_core/test_device.py
+++ b/ivy_tests/test_ivy/test_functional/test_core/test_device.py
@@ -28,7 +28,7 @@ except ImportError:
 import ivy
 import ivy_tests.test_ivy.helpers as helpers
 import ivy_tests.test_ivy.helpers.globals as test_globals
-from ivy_tests.test_ivy.helpers import handle_test, update_backend
+from ivy_tests.test_ivy.helpers import handle_test, BackendHandler
 
 
 # Helpers #
@@ -56,7 +56,7 @@ def _ram_array_and_clear_test(metric_fn, device, size=10000000):
 
 def _get_possible_devices():
     # Return all the possible usable devices
-    with update_backend(test_globals.CURRENT_BACKEND) as ivy_backend:
+    with BackendHandler.update_backend(test_globals.CURRENT_BACKEND) as ivy_backend:
         devices = ["cpu"]
         if ivy_backend.gpu_is_available():
             for i in range(ivy_backend.num_gpus()):
@@ -92,7 +92,7 @@ def test_dev(*, dtype_and_x, test_flags, backend_fw):
     dtype = dtype[0]
     x = x[0]
 
-    with update_backend(backend_fw) as ivy_backend:
+    with BackendHandler.update_backend(backend_fw) as ivy_backend:
         for device in _get_possible_devices():
             x = ivy_backend.array(x, device=device)
             if test_flags.as_variable and ivy_backend.is_float_dtype(dtype):
@@ -124,7 +124,7 @@ def test_as_ivy_dev(*, dtype_and_x, test_flags, backend_fw):
     dtype = dtype[0]
     x = x[0]
 
-    with update_backend(backend_fw) as ivy_backend:
+    with BackendHandler.update_backend(backend_fw) as ivy_backend:
         for device in _get_possible_devices():
             x = ivy_backend.array(x, device=device)
             if test_flags.as_variable and ivy_backend.is_float_dtype(dtype):
@@ -151,7 +151,7 @@ def test_as_native_dev(*, dtype_and_x, test_flags, on_device, backend_fw):
     dtype = dtype[0]
     x = x[0]
 
-    with update_backend(backend_fw) as ivy_backend:
+    with BackendHandler.update_backend(backend_fw) as ivy_backend:
         for device in _get_possible_devices():
             x = ivy_backend.asarray(x, device=on_device)
             if test_flags.as_variable:
@@ -176,7 +176,7 @@ def test_as_native_dev(*, dtype_and_x, test_flags, on_device, backend_fw):
 # default_device
 @handle_test(fn_tree="functional.ivy.default_device")
 def test_default_device(backend_fw):
-    with update_backend(backend_fw) as ivy_backend:
+    with BackendHandler.update_backend(backend_fw) as ivy_backend:
         # setting and unsetting
         orig_len = len(ivy_backend.default_device_stack)
         ivy_backend.set_default_device("cpu")
@@ -218,7 +218,7 @@ def test_to_device(
     dtype = dtype[0]
     x = x[0]
 
-    with update_backend(backend_fw) as ivy_backend:
+    with BackendHandler.update_backend(backend_fw) as ivy_backend:
         x = ivy_backend.asarray(x)
         if test_flags.as_variable and ivy_backend.is_float_dtype(dtype):
             x = ivy_backend.functional.ivy.gradients._variable(x)
@@ -284,7 +284,7 @@ def test_to_device(
 def test_handle_soft_device_variable(*, dtype_and_x, backend_fw):
     dtype, x = dtype_and_x
     dtype = dtype[0]
-    with update_backend(backend_fw) as ivy_backend:
+    with BackendHandler.update_backend(backend_fw) as ivy_backend:
         x = ivy_backend.to_device(x[0], "cpu")
 
         def fn(x, y):
@@ -328,7 +328,7 @@ def test_split_func_call(
     test_flags,
     backend_fw,
 ):
-    with update_backend(backend_fw) as ivy_backend:
+    with BackendHandler.update_backend(backend_fw) as ivy_backend:
         # inputs
         shape = tuple(array_shape)
         x1 = np.random.uniform(size=shape).astype(dtype[0])
@@ -385,7 +385,7 @@ def test_split_func_call_with_cont_input(
     on_device,
     backend_fw,
 ):
-    with update_backend(backend_fw) as ivy_backend:
+    with BackendHandler.update_backend(backend_fw) as ivy_backend:
         shape = tuple(array_shape)
         x1 = np.random.uniform(size=shape).astype(dtype[0])
         x2 = np.random.uniform(size=shape).astype(dtype[0])
@@ -441,7 +441,7 @@ def test_profiler(*, backend_fw):
 
     # log dir, each framework uses their own folder,
     # so we can run this test in parallel
-    with update_backend(backend_fw) as ivy_backend:
+    with BackendHandler.update_backend(backend_fw) as ivy_backend:
         this_dir = os.path.dirname(os.path.realpath(__file__))
         log_dir = os.path.join(this_dir, "../log")
         fw_log_dir = os.path.join(log_dir, backend_fw)
@@ -493,7 +493,7 @@ def test_num_ivy_arrays_on_dev(
     on_device,
     backend_fw,
 ):
-    with update_backend(backend_fw) as ivy_backend:
+    with BackendHandler.update_backend(backend_fw) as ivy_backend:
         arrays = [
             ivy_backend.array(np.random.uniform(size=2).tolist(), device=on_device)
             for _ in range(num)
@@ -513,7 +513,7 @@ def test_get_all_ivy_arrays_on_dev(
     on_device,
     backend_fw,
 ):
-    with update_backend(backend_fw) as ivy_backend:
+    with BackendHandler.update_backend(backend_fw) as ivy_backend:
         arrays = [ivy_backend.array(np.random.uniform(size=2)) for _ in range(num)]
         arr_ids_on_dev = [
             id(a) for a in ivy_backend.get_all_ivy_arrays_on_dev(on_device).values()
@@ -534,7 +534,7 @@ def test_print_all_ivy_arrays_on_dev(
     on_device,
     backend_fw,
 ):
-    with update_backend(backend_fw) as ivy_backend:
+    with BackendHandler.update_backend(backend_fw) as ivy_backend:
         arr = [ivy_backend.array(np.random.uniform(size=2)) for _ in range(num)]
 
         # Flush to avoid artifact
@@ -571,7 +571,7 @@ def test_print_all_ivy_arrays_on_dev(
 
 @handle_test(fn_tree="total_mem_on_dev")
 def test_total_mem_on_dev(backend_fw):
-    with update_backend(backend_fw) as ivy_backend:
+    with BackendHandler.update_backend(backend_fw) as ivy_backend:
         devices = _get_possible_devices()
         for device in devices:
             if "cpu" in device:
@@ -587,7 +587,7 @@ def test_total_mem_on_dev(backend_fw):
 
 @handle_test(fn_tree="used_mem_on_dev")
 def test_used_mem_on_dev(backend_fw):
-    with update_backend(backend_fw) as ivy_backend:
+    with BackendHandler.update_backend(backend_fw) as ivy_backend:
         devices = _get_possible_devices()
 
         # Check that there not all memory is used
@@ -605,7 +605,7 @@ def test_used_mem_on_dev(backend_fw):
 
 @handle_test(fn_tree="percent_used_mem_on_dev")
 def test_percent_used_mem_on_dev(backend_fw):
-    with update_backend(backend_fw) as ivy_backend:
+    with BackendHandler.update_backend(backend_fw) as ivy_backend:
         devices = _get_possible_devices()
 
         for device in devices:
@@ -624,7 +624,7 @@ def test_percent_used_mem_on_dev(backend_fw):
 
 @handle_test(fn_tree="gpu_is_available")
 def test_gpu_is_available(backend_fw):
-    with update_backend(backend_fw) as ivy_backend:
+    with BackendHandler.update_backend(backend_fw) as ivy_backend:
         # If gpu is available but cannot be initialised it will fail the test
         if ivy_backend.gpu_is_available():
             try:
@@ -635,7 +635,7 @@ def test_gpu_is_available(backend_fw):
 
 @handle_test(fn_tree="num_cpu_cores")
 def test_num_cpu_cores(backend_fw):
-    with update_backend(backend_fw) as ivy_backend:
+    with BackendHandler.update_backend(backend_fw) as ivy_backend:
         # using multiprocessing module too because ivy uses psutil as basis.
         p_cpu_cores = psutil.cpu_count()
         m_cpu_cores = multiprocessing.cpu_count()
@@ -645,12 +645,12 @@ def test_num_cpu_cores(backend_fw):
 
 
 def _composition_1(backend_fw):
-    with update_backend(backend_fw) as ivy_backend:
+    with BackendHandler.update_backend(backend_fw) as ivy_backend:
         return ivy_backend.relu().argmax()
 
 
 def _composition_2(backend_fw):
-    with update_backend(backend_fw) as ivy_backend:
+    with BackendHandler.update_backend(backend_fw) as ivy_backend:
         return ivy_backend.ceil() or ivy_backend.floor()
 
 
@@ -666,7 +666,7 @@ def test_function_supported_devices(
     expected,
     backend_fw,
 ):
-    with update_backend(backend_fw) as ivy_backend:
+    with BackendHandler.update_backend(backend_fw) as ivy_backend:
         res = ivy_backend.function_supported_devices(func)
         exp = set(expected)
 
@@ -685,7 +685,7 @@ def test_function_unsupported_devices(
     expected,
     backend_fw,
 ):
-    with update_backend(backend_fw) as ivy_backend:
+    with BackendHandler.update_backend(backend_fw) as ivy_backend:
         res = ivy_backend.function_unsupported_devices(func)
         exp = set(expected)
 
@@ -700,7 +700,7 @@ def get_gpu_mem_usage(backend, device="gpu:0"):
 
 @handle_test(fn_tree="clear_cached_mem_on_dev")
 def test_clear_cached_mem_on_dev(backend_fw):
-    with update_backend(backend_fw) as ivy_backend:
+    with BackendHandler.update_backend(backend_fw) as ivy_backend:
         devices = _get_possible_devices()
         for device in devices:
             # Testing on only GPU since clearing cache mem is relevant
@@ -724,7 +724,7 @@ def get_cpu_percent():
 
 @handle_test(fn_tree="dev_util")
 def test_dev_util(backend_fw):
-    with update_backend(backend_fw) as ivy_backend:
+    with BackendHandler.update_backend(backend_fw) as ivy_backend:
         devices = _get_possible_devices()
         for device in devices:
             # The internally called psutil.cpu_percent() has a unique behavior where it
@@ -745,7 +745,7 @@ def test_dev_util(backend_fw):
 
 @handle_test(fn_tree="tpu_is_available")
 def test_tpu_is_available(backend_fw):
-    with update_backend(backend_fw) as ivy_backend:
+    with BackendHandler.update_backend(backend_fw) as ivy_backend:
         import tensorflow as tf
 
         try:

--- a/ivy_tests/test_ivy/test_functional/test_core/test_dtype.py
+++ b/ivy_tests/test_ivy/test_functional/test_core/test_dtype.py
@@ -8,13 +8,13 @@ import typing
 # local
 import ivy
 import ivy_tests.test_ivy.helpers as helpers
-from ivy_tests.test_ivy.helpers import handle_test, update_backend
+from ivy_tests.test_ivy.helpers import handle_test, BackendHandler
 
 
 # dtype objects
 @handle_test(fn_tree="functional.ivy.exists")  # dummy fn_tree
 def test_dtype_instances(backend_fw):
-    with update_backend(backend_fw) as ivy_backend:
+    with BackendHandler.update_backend(backend_fw) as ivy_backend:
         assert ivy_backend.exists(ivy_backend.int8)
         assert ivy_backend.exists(ivy_backend.int16)
         assert ivy_backend.exists(ivy_backend.int32)
@@ -317,7 +317,7 @@ def test_is_hashable_dtype(
     input_dtype,
     backend_fw,
 ):
-    with update_backend(backend_fw) as ivy_backend:
+    with BackendHandler.update_backend(backend_fw) as ivy_backend:
         input_dtype = input_dtype[0]
         res = ivy_backend.is_hashable_dtype(input_dtype)
         assert res
@@ -333,7 +333,7 @@ def test_as_ivy_dtype(
     input_dtype,
     backend_fw,
 ):
-    with update_backend(backend_fw) as ivy_backend:
+    with BackendHandler.update_backend(backend_fw) as ivy_backend:
         input_dtype = input_dtype[0]
         res = ivy_backend.as_ivy_dtype(input_dtype)
         if isinstance(input_dtype, str):
@@ -356,7 +356,7 @@ def test_as_native_dtype(
     input_dtype,
     backend_fw,
 ):
-    with update_backend(backend_fw) as ivy_backend:
+    with BackendHandler.update_backend(backend_fw) as ivy_backend:
         input_dtype = input_dtype[0]
         res = ivy_backend.as_native_dtype(input_dtype)
         if isinstance(input_dtype, ivy_backend.NativeDtype):
@@ -379,7 +379,7 @@ def test_as_native_dtype(
 def test_closest_valid_dtype(
     *, input_dtype, test_flags, backend_fw, fn_name, on_device
 ):
-    with update_backend(backend_fw) as ivy_backend:
+    with BackendHandler.update_backend(backend_fw) as ivy_backend:
         input_dtype = input_dtype[0]
         res = ivy_backend.closest_valid_dtype(input_dtype)
         assert isinstance(input_dtype, ivy_backend.Dtype) or isinstance(
@@ -402,7 +402,7 @@ def test_default_dtype(
     as_native,
     backend_fw,
 ):
-    with update_backend(backend_fw) as ivy_backend:
+    with BackendHandler.update_backend(backend_fw) as ivy_backend:
         input_dtype = input_dtype[0]
         res = ivy_backend.default_dtype(dtype=input_dtype, as_native=as_native)
         assert (
@@ -653,7 +653,7 @@ def test_default_float_dtype(
     as_native,
     backend_fw,
 ):
-    with update_backend(backend_fw) as ivy_backend:
+    with BackendHandler.update_backend(backend_fw) as ivy_backend:
         float_dtype, x = dtype_x
         res = ivy_backend.default_float_dtype(
             input=input,
@@ -693,7 +693,7 @@ def test_default_int_dtype(
     backend_fw,
 ):
     int_dtype, x = dtype_x
-    with update_backend(backend_fw) as ivy_backend:
+    with BackendHandler.update_backend(backend_fw) as ivy_backend:
         res = ivy_backend.default_int_dtype(
             input=input,
             int_dtype=int_dtype[0],
@@ -730,7 +730,7 @@ def test_default_complex_dtype(
     backend_fw,
 ):
     complex_dtype, x = dtype_x
-    with update_backend(backend_fw) as ivy_backend:
+    with BackendHandler.update_backend(backend_fw) as ivy_backend:
         res = ivy_backend.default_complex_dtype(
             input=input,
             complex_dtype=complex_dtype[0],
@@ -820,7 +820,7 @@ _composition_2.test_unsupported_dtypes = {
     func=st.sampled_from([_composition_1, _composition_2]),
 )
 def test_function_supported_dtypes(*, func, backend_fw):
-    with update_backend(backend_fw) as ivy_backend:
+    with BackendHandler.update_backend(backend_fw) as ivy_backend:
         res = ivy_backend.function_supported_dtypes(func)
         exp = set(ivy_backend.all_dtypes).difference(
             set(func.test_unsupported_dtypes[backend_fw])
@@ -834,7 +834,7 @@ def test_function_supported_dtypes(*, func, backend_fw):
     func=st.sampled_from([_composition_2]),
 )
 def test_function_unsupported_dtypes(*, func, backend_fw):
-    with update_backend(backend_fw) as ivy_backend:
+    with BackendHandler.update_backend(backend_fw) as ivy_backend:
         res = ivy_backend.function_unsupported_dtypes(func)
         exp = func.test_unsupported_dtypes[backend_fw]
         assert set(tuple(exp)) == set(res)
@@ -861,7 +861,7 @@ def test_function_dtype_versioning(
     func_and_version,
     backend_fw,
 ):
-    with update_backend(backend_fw) as ivy_backend:
+    with BackendHandler.update_backend(backend_fw) as ivy_backend:
         for key in func_and_version:
             if key != backend_fw:
                 continue
@@ -905,7 +905,7 @@ def test_function_dtype_versioning_frontend(
     func_and_version,
     backend_fw,
 ):
-    with update_backend(backend_fw) as ivy_backend:
+    with BackendHandler.update_backend(backend_fw) as ivy_backend:
         _import_mod = ivy_backend.utils.dynamic_import
         for key in func_and_version:
             if key != backend_fw:
@@ -943,7 +943,7 @@ def test_invalid_dtype(
     dtype_in,
     backend_fw,
 ):
-    with update_backend(backend_fw) as ivy_backend:
+    with BackendHandler.update_backend(backend_fw) as ivy_backend:
         dtype_in = dtype_in[0]
         res = ivy_backend.invalid_dtype(dtype_in)
         invalid_dtypes = ivy_backend.invalid_dtypes
@@ -969,7 +969,7 @@ def test_unset_default_dtype(
     dtype,
     backend_fw,
 ):
-    with update_backend(backend_fw) as ivy_backend:
+    with BackendHandler.update_backend(backend_fw) as ivy_backend:
         dtype = dtype[0]
         stack_size_before = len(ivy_backend.default_dtype_stack)
         ivy_backend.set_default_dtype(dtype)
@@ -990,7 +990,7 @@ def test_unset_default_float_dtype(
     dtype,
     backend_fw,
 ):
-    with update_backend(backend_fw) as ivy_backend:
+    with BackendHandler.update_backend(backend_fw) as ivy_backend:
         dtype = dtype[0]
         stack_size_before = len(ivy_backend.default_float_dtype_stack)
         ivy_backend.set_default_float_dtype(dtype)
@@ -1011,7 +1011,7 @@ def test_unset_default_int_dtype(
     dtype,
     backend_fw,
 ):
-    with update_backend(backend_fw) as ivy_backend:
+    with BackendHandler.update_backend(backend_fw) as ivy_backend:
         dtype = dtype[0]
         stack_size_before = len(ivy_backend.default_int_dtype_stack)
         ivy_backend.set_default_int_dtype(dtype)
@@ -1032,7 +1032,7 @@ def test_unset_default_complex_dtype(
     dtype,
     backend_fw,
 ):
-    with update_backend(backend_fw) as ivy_backend:
+    with BackendHandler.update_backend(backend_fw) as ivy_backend:
         dtype = dtype[0]
         stack_size_before = len(ivy_backend.default_complex_dtype_stack)
         ivy_backend.set_default_complex_dtype(dtype)
@@ -1053,7 +1053,7 @@ def test_valid_dtype(
     dtype_in,
     backend_fw,
 ):
-    with update_backend(backend_fw) as ivy_backend:
+    with BackendHandler.update_backend(backend_fw) as ivy_backend:
         dtype_in = dtype_in[0]
         res = ivy_backend.valid_dtype(dtype_in)
         valid_dtypes = ivy_backend.valid_dtypes
@@ -1078,7 +1078,7 @@ def test_is_native_dtype(
     input_dtype,
     backend_fw,
 ):
-    with update_backend(backend_fw) as ivy_backend:
+    with BackendHandler.update_backend(backend_fw) as ivy_backend:
         input_dtype = input_dtype[0]
         if isinstance(input_dtype, str):
             assert ivy_backend.is_native_dtype(input_dtype) is False

--- a/ivy_tests/test_ivy/test_functional/test_core/test_elementwise.py
+++ b/ivy_tests/test_ivy/test_functional/test_core/test_elementwise.py
@@ -9,7 +9,7 @@ from hypothesis import assume, strategies as st
 import ivy
 import ivy_tests.test_ivy.helpers as helpers
 from ivy_tests.test_ivy.helpers import handle_test
-from ivy_tests.test_ivy.helpers.pipeline_helper import update_backend
+from ivy_tests.test_ivy.helpers.pipeline_helper import BackendHandler
 import ivy_tests.test_ivy.helpers.globals as test_globals
 
 _zero = np.asarray(0, dtype="uint8")
@@ -1187,7 +1187,7 @@ def pow_helper(draw, available_dtypes=None):
 
     def cast_filter(dtype1_x1_dtype2):
         dtype1, _, dtype2 = dtype1_x1_dtype2
-        with update_backend(test_globals.CURRENT_BACKEND) as ivy_backend:
+        with BackendHandler.update_backend(test_globals.CURRENT_BACKEND) as ivy_backend:
             if ivy_backend.can_cast(dtype1, dtype2):
                 return True
         return False
@@ -1197,7 +1197,7 @@ def pow_helper(draw, available_dtypes=None):
             cast_filter
         )
     )
-    with update_backend(test_globals.CURRENT_BACKEND) as ivy_backend:
+    with BackendHandler.update_backend(test_globals.CURRENT_BACKEND) as ivy_backend:
         if ivy_backend.is_int_dtype(dtype2):
             max_val = ivy_backend.iinfo(dtype2).max
         else:

--- a/ivy_tests/test_ivy/test_functional/test_core/test_general.py
+++ b/ivy_tests/test_ivy/test_functional/test_core/test_general.py
@@ -47,7 +47,7 @@ except ImportError:
     ivy.functional.backends.torch = SimpleNamespace()
 
 import ivy_tests.test_ivy.helpers as helpers
-from ivy_tests.test_ivy.helpers import handle_test, update_backend
+from ivy_tests.test_ivy.helpers import handle_test, BackendHandler
 from ivy_tests.test_ivy.helpers.assertions import assert_all_close
 from ivy_tests.test_ivy.test_functional.test_core.test_elementwise import pow_helper
 
@@ -817,7 +817,7 @@ def test_exists(x):
     ),
 )
 def test_default(x, default_val, test_flags, backend_fw):
-    with update_backend(backend_fw) as ivy_backend:
+    with BackendHandler.update_backend(backend_fw) as ivy_backend:
         with_callable = False
         if x is not None:
             if hasattr(x, "__call__"):
@@ -1185,7 +1185,7 @@ def test_container_types():
 
 
 def test_inplace_arrays_supported(backend_fw):
-    with update_backend(backend_fw) as ivy_backend:
+    with BackendHandler.update_backend(backend_fw) as ivy_backend:
         if backend_fw in ["numpy", "torch"]:
             assert ivy_backend.inplace_arrays_supported()
         elif backend_fw in ["jax", "tensorflow", "paddle"]:
@@ -1195,7 +1195,7 @@ def test_inplace_arrays_supported(backend_fw):
 
 
 def test_inplace_variables_supported(backend_fw):
-    with update_backend(backend_fw) as ivy_backend:
+    with BackendHandler.update_backend(backend_fw) as ivy_backend:
         if backend_fw in ["numpy", "torch", "tensorflow"]:
             assert ivy_backend.inplace_variables_supported()
         elif backend_fw in ["jax", "paddle"]:
@@ -1217,7 +1217,7 @@ def test_inplace_variables_supported(backend_fw):
 def test_inplace_update(
     x_val_and_dtypes, keep_x_dtype, test_flags, on_device, backend_fw
 ):
-    with update_backend(backend_fw) as ivy_backend:
+    with BackendHandler.update_backend(backend_fw) as ivy_backend:
         dtype = x_val_and_dtypes[0][0]
         if dtype in ivy_backend.function_unsupported_dtypes(ivy_backend.inplace_update):
             return
@@ -1259,7 +1259,7 @@ def test_inplace_decrement(x_val_and_dtypes, test_flags, on_device, backend_fw):
     dtype = x_val_and_dtypes[0][0]
     x, val = x_val_and_dtypes[1]
     x, val = x.tolist(), val.tolist()
-    with update_backend(backend_fw) as ivy_backend:
+    with BackendHandler.update_backend(backend_fw) as ivy_backend:
         x = ivy_backend.array(x, dtype=dtype, device=on_device)
         val = ivy_backend.array(val, dtype=dtype, device=on_device)
         new_val = x - val
@@ -1290,7 +1290,7 @@ def test_inplace_decrement(x_val_and_dtypes, test_flags, on_device, backend_fw):
 )
 def test_inplace_increment(x_val_and_dtypes, test_flags, on_device, backend_fw):
     dtype = x_val_and_dtypes[0][0]
-    with update_backend(backend_fw) as ivy_backend:
+    with BackendHandler.update_backend(backend_fw) as ivy_backend:
         if dtype in ivy_backend.function_unsupported_dtypes(
             ivy_backend.inplace_increment
         ):
@@ -1653,7 +1653,7 @@ _composition_2.test_unsupported_devices_and_dtypes = {
     [_composition_1, _composition_2],
 )
 def test_function_supported_device_and_dtype(func, backend_fw):
-    with update_backend(backend_fw) as ivy_backend:
+    with BackendHandler.update_backend(backend_fw) as ivy_backend:
         res = ivy_backend.function_supported_devices_and_dtypes(func, recurse=True)
         exp = {"cpu": func.test_unsupported_devices_and_dtypes.copy()["cpu"]}
         for dev in exp:
@@ -1674,7 +1674,7 @@ def test_function_supported_device_and_dtype(func, backend_fw):
     [_composition_1, _composition_2],
 )
 def test_function_unsupported_devices(func, backend_fw):
-    with update_backend(backend_fw) as ivy_backend:
+    with BackendHandler.update_backend(backend_fw) as ivy_backend:
         res = ivy_backend.function_unsupported_devices_and_dtypes(func)
         exp = func.test_unsupported_devices_and_dtypes.copy()
         for dev in exp:
@@ -1916,7 +1916,7 @@ def _fn3(x, y):
     in_axes_as_cont=st.booleans(),
 )
 def test_vmap(func, dtype_and_arrays_and_axes, in_axes_as_cont, backend_fw):
-    with update_backend(backend_fw) as ivy_backend:
+    with BackendHandler.update_backend(backend_fw) as ivy_backend:
         dtype, generated_arrays, in_axes = dtype_and_arrays_and_axes
         arrays = [ivy_backend.native_array(array) for array in generated_arrays]
         assume(
@@ -1939,7 +1939,7 @@ def test_vmap(func, dtype_and_arrays_and_axes, in_axes_as_cont, backend_fw):
         except Exception:
             fw_res = None
 
-    with update_backend("jax") as gt_backend:
+    with BackendHandler.update_backend("jax") as gt_backend:
         arrays = [gt_backend.native_array(array) for array in generated_arrays]
         if in_axes_as_cont:
             jax_vmapped_func = gt_backend.vmap(func, in_axes=in_axes, out_axes=0)

--- a/ivy_tests/test_ivy/test_functional/test_core/test_gradients.py
+++ b/ivy_tests/test_ivy/test_functional/test_core/test_gradients.py
@@ -8,7 +8,7 @@ import numpy as np
 # local
 import ivy
 import ivy_tests.test_ivy.helpers as helpers
-from ivy_tests.test_ivy.helpers import handle_test, update_backend
+from ivy_tests.test_ivy.helpers import handle_test, BackendHandler
 
 
 @st.composite
@@ -115,7 +115,7 @@ def test_execute_with_gradients(
     assume(not backend_fw == "numpy")
 
     def func(xs):
-        with update_backend(backend_fw) as ivy_backend:
+        with BackendHandler.update_backend(backend_fw) as ivy_backend:
             if isinstance(xs, ivy_backend.Container):
                 array_idxs = ivy_backend.nested_argwhere(xs, ivy_backend.is_array)
                 array_vals = ivy_backend.multi_index_nest(xs, array_idxs)
@@ -154,7 +154,7 @@ def test_execute_with_gradients(
 def test_value_and_grad(x, dtype, func, backend_fw):
     if backend_fw == "numpy":
         return
-    with update_backend(backend_fw) as ivy_backend:
+    with BackendHandler.update_backend(backend_fw) as ivy_backend:
         var = ivy_backend.ivy.functional.ivy.gradients._variable(
             ivy_backend.array(x, dtype=dtype)
         )
@@ -164,7 +164,7 @@ def test_value_and_grad(x, dtype, func, backend_fw):
             ret=value, backend=backend_fw
         ), helpers.flatten_and_to_np(ret=grad, backend=backend_fw)
 
-    with update_backend("tensorflow") as gt_backend:
+    with BackendHandler.update_backend("tensorflow") as gt_backend:
         var = gt_backend.ivy.functional.ivy.gradients._variable(
             gt_backend.array(x, dtype=dtype)
         )
@@ -192,7 +192,7 @@ def test_jac(x, dtype, func_str, backend_fw):
     if backend_fw == "numpy":
         pytest.skip()
 
-    with update_backend(backend_fw) as ivy_backend:
+    with BackendHandler.update_backend(backend_fw) as ivy_backend:
         f = ivy_backend.__dict__[func_str]
         func = lambda x: ivy_backend.mean(f(x))
         _variable_fn = ivy_backend.ivy.functional.ivy.gradients._variable
@@ -202,7 +202,7 @@ def test_jac(x, dtype, func_str, backend_fw):
         jacobian_np = helpers.flatten_and_to_np(ret=jacobian, backend=backend_fw)
         assert jacobian_np != []
 
-    with update_backend("tensorflow") as gt_backend:
+    with BackendHandler.update_backend("tensorflow") as gt_backend:
         f = gt_backend.__dict__[func_str]
         func = lambda x: gt_backend.mean(f(x))
         _variable_fn = gt_backend.ivy.functional.ivy.gradients._variable
@@ -219,7 +219,7 @@ def test_jac(x, dtype, func_str, backend_fw):
     # Test nested input
     func = lambda xs: (2 * xs[1]["x2"], xs[0])
 
-    with update_backend(backend_fw) as ivy_backend:
+    with BackendHandler.update_backend(backend_fw) as ivy_backend:
         _variable_fn = ivy_backend.ivy.functional.ivy.gradients._variable
         var1 = _variable_fn(ivy_backend.array(x[0], dtype=dtype))
         var2 = _variable_fn(ivy_backend.array(x[1], dtype=dtype))
@@ -228,7 +228,7 @@ def test_jac(x, dtype, func_str, backend_fw):
         jacobian = fn(var)
         jacobian_np = helpers.flatten_and_to_np(ret=jacobian, backend=backend_fw)
 
-    with update_backend("tensorflow") as gt_backend:
+    with BackendHandler.update_backend("tensorflow") as gt_backend:
         _variable_fn = gt_backend.ivy.functional.ivy.gradients._variable
         var1 = _variable_fn(gt_backend.array(x[0], dtype=dtype))
         var2 = _variable_fn(gt_backend.array(x[1], dtype=dtype))
@@ -244,7 +244,7 @@ def test_jac(x, dtype, func_str, backend_fw):
         assert np.allclose(jacobian, jacobian_from_gt)
 
     # Test func with non 0-dim output
-    with update_backend(backend_fw) as ivy_backend:
+    with BackendHandler.update_backend(backend_fw) as ivy_backend:
         func = ivy_backend.__dict__[func_str]
         _variable_fn = ivy_backend.ivy.functional.ivy.gradients._variable
         var = _variable_fn(ivy_backend.array(x, dtype=dtype))
@@ -252,7 +252,7 @@ def test_jac(x, dtype, func_str, backend_fw):
         jacobian = fn(var)
         jacobian_np = helpers.flatten_and_to_np(ret=jacobian, backend=backend_fw)
 
-    with update_backend("tensorflow") as gt_backend:
+    with BackendHandler.update_backend("tensorflow") as gt_backend:
         func = gt_backend.__dict__[func_str]
         _variable_fn = gt_backend.ivy.functional.ivy.gradients._variable
         var = _variable_fn(gt_backend.array(x, dtype=dtype))
@@ -282,7 +282,7 @@ def test_grad(x, dtype, func, backend_fw, nth):
     ):
         return
 
-    with update_backend(backend_fw) as ivy_backend:
+    with BackendHandler.update_backend(backend_fw) as ivy_backend:
         _variable_fn = ivy_backend.ivy.functional.ivy.gradients._variable
         var = _variable_fn(ivy_backend.array(x, dtype=dtype))
         fn = ivy_backend.grad(func)
@@ -292,7 +292,7 @@ def test_grad(x, dtype, func, backend_fw, nth):
         grad = fn(var)
         grad_np = helpers.flatten_and_to_np(ret=grad, backend=backend_fw)
 
-    with update_backend("tensorflow") as gt_backend:
+    with BackendHandler.update_backend("tensorflow") as gt_backend:
         _variable_fn = gt_backend.ivy.functional.ivy.gradients._variable
         var = _variable_fn(ivy.array(x, dtype=dtype))
         fn = gt_backend.grad(func)

--- a/ivy_tests/test_ivy/test_functional/test_core/test_linalg.py
+++ b/ivy_tests/test_ivy/test_functional/test_core/test_linalg.py
@@ -7,7 +7,7 @@ from hypothesis import assume, strategies as st
 
 # local
 import ivy_tests.test_ivy.helpers as helpers
-from ivy_tests.test_ivy.helpers import handle_test, update_backend
+from ivy_tests.test_ivy.helpers import handle_test, BackendHandler
 from ivy_tests.test_ivy.helpers.hypothesis_helpers.general_helpers import (
     matrix_is_stable,
 )
@@ -762,12 +762,12 @@ def test_vector_norm(
 
     # Specific value test to handle cases when ord is one of {inf, -inf}
 
-    with update_backend(backend_fw) as ivy_backend:
+    with BackendHandler.update_backend(backend_fw) as ivy_backend:
         arr = ivy_backend.array([[1.0, 2.0, 3.0], [-1.0, 2.0, 4.0]])
         arr_normed_inf = ivy_backend.vector_norm(arr, axis=0, ord=float("inf"))
         arr_normed_min_inf = ivy_backend.vector_norm(arr, axis=0, ord=float("-inf"))
 
-    with update_backend(test_flags.ground_truth_backend) as gt_backend:
+    with BackendHandler.update_backend(test_flags.ground_truth_backend) as gt_backend:
         gt_arr_normed_inf = gt_backend.array([1.0, 2.0, 4.0])
         gt_arr_normed_min_inf = gt_backend.array([1.0, 2.0, 3.0])
 
@@ -913,7 +913,7 @@ def test_svd(*, dtype_x, uv, fm, test_flags, backend_fw, fn_name, on_device):
             Vh_gt = ret_from_gt_flat_np[2 * len(ret_from_gt_flat_np) // 3 + i]
         S_gt = np.expand_dims(S_gt, -2) if m > n else np.expand_dims(S_gt, -1)
 
-        with update_backend("numpy") as ivy_backend:
+        with BackendHandler.update_backend("numpy") as ivy_backend:
             S_mat = (
                 S
                 * ivy_backend.eye(

--- a/ivy_tests/test_ivy/test_functional/test_core/test_meta.py
+++ b/ivy_tests/test_ivy/test_functional/test_core/test_meta.py
@@ -8,7 +8,7 @@ from hypothesis import strategies as st
 # local
 import ivy_tests.test_ivy.helpers as helpers
 from ivy_tests.test_ivy.helpers import handle_test
-from ivy_tests.test_ivy.helpers.pipeline_helper import update_backend
+from ivy_tests.test_ivy.helpers.pipeline_helper import BackendHandler
 
 
 # ToDo: replace dict checks for verifying costs with analytic calculations
@@ -45,7 +45,7 @@ def test_fomaml_step_unique_vars(
     if backend_fw == "numpy":
         return
 
-    with update_backend(backend_fw) as ivy_backend:
+    with BackendHandler.update_backend(backend_fw) as ivy_backend:
         # config
         inner_learning_rate = 1e-2
         variable_fn = ivy_backend.functional.ivy._variable
@@ -211,7 +211,7 @@ def test_fomaml_step_shared_vars(
     if backend_fw == "numpy":
         return
 
-    with update_backend(backend_fw) as ivy_backend:
+    with BackendHandler.update_backend(backend_fw) as ivy_backend:
         # config
         inner_learning_rate = 1e-2
         variable_fn = ivy_backend.functional.ivy._variable
@@ -395,7 +395,7 @@ def test_fomaml_step_overlapping_vars(
     if backend_fw == "numpy":
         pytest.skip()
 
-    with update_backend(backend_fw) as ivy_backend:
+    with BackendHandler.update_backend(backend_fw) as ivy_backend:
         # config
         inner_learning_rate = 1e-2
         variable_fn = ivy_backend.functional.ivy._variable
@@ -561,7 +561,7 @@ def test_reptile_step(
         # nested classes,
         pytest.skip()
 
-    with update_backend(backend_fw) as ivy_backend:
+    with BackendHandler.update_backend(backend_fw) as ivy_backend:
         # config
         inner_learning_rate = 1e-2
         variable_fn = ivy_backend.functional.ivy._variable
@@ -696,7 +696,7 @@ def test_maml_step_unique_vars(
         # nested classes
         pytest.skip()
 
-    with update_backend(backend_fw) as ivy_backend:
+    with BackendHandler.update_backend(backend_fw) as ivy_backend:
         # config
         inner_learning_rate = 1e-2
         variable_fn = ivy_backend.functional.ivy._variable
@@ -864,7 +864,7 @@ def test_maml_step_shared_vars(
         # nested classes
         pytest.skip()
 
-    with update_backend(backend_fw) as ivy_backend:
+    with BackendHandler.update_backend(backend_fw) as ivy_backend:
         # config
         inner_learning_rate = 1e-2
         variable_fn = ivy_backend.functional.ivy._variable
@@ -1093,7 +1093,7 @@ def test_maml_step_overlapping_vars(
         # nested classes
         pytest.skip()
 
-    with update_backend(backend_fw) as ivy_backend:
+    with BackendHandler.update_backend(backend_fw) as ivy_backend:
         # config
         inner_learning_rate = 1e-2
         variable_fn = ivy_backend.functional.ivy._variable

--- a/ivy_tests/test_ivy/test_functional/test_core/test_random.py
+++ b/ivy_tests/test_ivy/test_functional/test_core/test_random.py
@@ -6,7 +6,7 @@ from hypothesis import strategies as st
 # local
 import ivy
 import ivy_tests.test_ivy.helpers as helpers
-from ivy_tests.test_ivy.helpers import handle_test, update_backend
+from ivy_tests.test_ivy.helpers import handle_test, BackendHandler
 
 
 # random_uniform
@@ -277,7 +277,7 @@ def test_randint(*, dtype_low_high, seed, test_flags, backend_fw, fn_name, on_de
 )
 def test_seed(seed_val, backend_fw):
     # smoke test
-    with update_backend(backend_fw) as ivy_backend:
+    with BackendHandler.update_backend(backend_fw) as ivy_backend:
         ivy_backend.seed(seed_value=seed_val)
 
 

--- a/ivy_tests/test_ivy/test_functional/test_experimental/test_core/test_gradients.py
+++ b/ivy_tests/test_ivy/test_functional/test_experimental/test_core/test_gradients.py
@@ -4,7 +4,7 @@ import numpy as np
 
 # local
 import ivy_tests.test_ivy.helpers as helpers
-from ivy_tests.test_ivy.helpers.pipeline_helper import update_backend
+from ivy_tests.test_ivy.helpers.pipeline_helper import BackendHandler
 
 
 # bind_custom_gradient_function
@@ -22,7 +22,7 @@ def test_bind_custom_gradient_function(
 ):
     if backend_fw == "numpy":
         return
-    with update_backend(backend_fw) as ivy_backend:
+    with BackendHandler.update_backend(backend_fw) as ivy_backend:
         inter_func_ = lambda x: ivy_backend.__dict__[inter_func_str](x)
         x = ivy_backend.array(x_, dtype=dtype)
         inter_func = ivy_backend.bind_custom_gradient_function(
@@ -33,7 +33,7 @@ def test_bind_custom_gradient_function(
         ret_np = helpers.flatten_and_to_np(backend=backend_fw, ret=ret)
         grad_np = helpers.flatten_and_to_np(backend=backend_fw, ret=grad)
 
-    with update_backend("tensorflow") as gt_backend:
+    with BackendHandler.update_backend("tensorflow") as gt_backend:
         x = gt_backend.array(x_, dtype=dtype)
         inter_func_ = lambda x: gt_backend.__dict__[inter_func_str](x)
         inter_func = gt_backend.bind_custom_gradient_function(

--- a/ivy_tests/test_ivy/test_functional/test_experimental/test_core/test_linalg.py
+++ b/ivy_tests/test_ivy/test_functional/test_experimental/test_core/test_linalg.py
@@ -7,7 +7,7 @@ import itertools
 
 # local
 import ivy_tests.test_ivy.helpers as helpers
-from ivy_tests.test_ivy.helpers import handle_test, update_backend
+from ivy_tests.test_ivy.helpers import handle_test, BackendHandler
 import ivy
 
 
@@ -1138,7 +1138,7 @@ def test_truncated_svd(*, data, test_flags, backend_fw, fn_name, on_device):
             Vh_gt = ret_from_gt_flat_np[2 * len(ret_from_gt_flat_np) // 3 + i]
         S_gt = np.expand_dims(S_gt, -2) if m > n else np.expand_dims(S_gt, -1)
 
-        with update_backend("numpy") as ivy_backend:
+        with BackendHandler.update_backend("numpy") as ivy_backend:
             S_mat = (
                 S
                 * ivy_backend.eye(
@@ -1249,7 +1249,7 @@ def test_initialize_tucker(*, data, test_flags, backend_fw, fn_name, on_device):
         ret=ret_from_gt_np[1], backend=test_flags.ground_truth_backend
     )
 
-    with update_backend(backend_fw) as ivy_backend:
+    with BackendHandler.update_backend(backend_fw) as ivy_backend:
         n_elem = int(ivy_backend.prod(rank[: len(modes)])) * int(
             ivy_backend.prod(x.shape[len(modes) :])
         )
@@ -1339,7 +1339,7 @@ def test_partial_tucker(*, data, test_flags, backend_fw, fn_name, on_device):
         ret=ret_from_gt_np[1], backend=test_flags.ground_truth_backend
     )
 
-    with update_backend(backend_fw) as ivy_backend:
+    with BackendHandler.update_backend(backend_fw) as ivy_backend:
         n_elem = int(ivy_backend.prod(rank[: len(modes)])) * int(
             ivy_backend.prod(x.shape[len(modes) :])
         )

--- a/ivy_tests/test_ivy/test_functional/test_experimental/test_core/test_random.py
+++ b/ivy_tests/test_ivy/test_functional/test_experimental/test_core/test_random.py
@@ -3,7 +3,7 @@ from hypothesis import strategies as st, assume
 
 # local
 import ivy_tests.test_ivy.helpers as helpers
-from ivy_tests.test_ivy.helpers import handle_test, update_backend
+from ivy_tests.test_ivy.helpers import handle_test, BackendHandler
 
 
 # Helpers #
@@ -48,7 +48,7 @@ def test_dirichlet(
         )
 
     ret, ret_gt = call()
-    with update_backend(backend_fw) as ivy_backend:
+    with BackendHandler.update_backend(backend_fw) as ivy_backend:
         if seed:
             ret1, ret_gt1 = call()
             assert ivy_backend.any(ret == ret1)
@@ -108,7 +108,7 @@ def test_beta(
     ret_gt = helpers.flatten_and_to_np(
         ret=ret_gt, backend=test_flags.ground_truth_backend
     )
-    with update_backend(backend_fw) as ivy_backend:
+    with BackendHandler.update_backend(backend_fw) as ivy_backend:
         for u, v in zip(ret, ret_gt):
             assert ivy_backend.all(u >= 0) and ivy_backend.all(u <= 1)
             assert ivy_backend.all(v >= 0) and ivy_backend.all(v <= 1)
@@ -151,7 +151,7 @@ def test_gamma(
     ret_gt = helpers.flatten_and_to_np(
         ret=ret_gt, backend=test_flags.ground_truth_backend
     )
-    with update_backend(backend_fw) as ivy_backend:
+    with BackendHandler.update_backend(backend_fw) as ivy_backend:
         for u, v in zip(ret, ret_gt):
             assert ivy_backend.all(u >= 0)
             assert ivy_backend.all(v >= 0)
@@ -204,7 +204,7 @@ def test_poisson(
     ret, ret_gt = call()
     if seed:
         ret1, ret_gt1 = call()
-        with update_backend(backend_fw) as ivy_backend:
+        with BackendHandler.update_backend(backend_fw) as ivy_backend:
             assert ivy_backend.any(ret == ret1)
     ret = helpers.flatten_and_to_np(ret=ret, backend=backend_fw)
     ret_gt = helpers.flatten_and_to_np(

--- a/ivy_tests/test_ivy/test_misc/test_array.py
+++ b/ivy_tests/test_ivy/test_misc/test_array.py
@@ -5,7 +5,7 @@ import numpy as np
 # local
 import ivy
 import ivy_tests.test_ivy.helpers as helpers
-from ivy_tests.test_ivy.helpers import handle_method, handle_test, update_backend
+from ivy_tests.test_ivy.helpers import handle_method, handle_test, BackendHandler
 from ivy_tests.test_ivy.test_functional.test_core.test_elementwise import (
     not_too_close_to_zero,
     pow_helper,
@@ -71,7 +71,7 @@ def test_array_property_data(
     test_flags,
 ):
     _, data = dtype_x
-    with update_backend(backend_fw) as ivy_backend:
+    with BackendHandler.update_backend(backend_fw) as ivy_backend:
         data = ivy_backend.native_array(data[0])
         x = ivy_backend.Array(data)
         ret = helpers.flatten_and_to_np(ret=x.data, backend=backend_fw)
@@ -93,7 +93,7 @@ def test_array_property_dtype(
     backend_fw,
 ):
     _, data = dtype_x
-    with update_backend(backend_fw) as ivy_backend:
+    with BackendHandler.update_backend(backend_fw) as ivy_backend:
         data = ivy_backend.native_array(data[0])
         x = ivy_backend.Array(data)
         ivy_backend.utils.assertions.check_equal(
@@ -110,7 +110,7 @@ def test_array_property_device(
     backend_fw,
 ):
     _, data = dtype_x
-    with update_backend(backend_fw) as ivy_backend:
+    with BackendHandler.update_backend(backend_fw) as ivy_backend:
         data = ivy_backend.native_array(data[0])
         x = ivy_backend.Array(data)
         ivy_backend.utils.assertions.check_equal(
@@ -130,7 +130,7 @@ def test_array_property_ndim(
     backend_fw,
 ):
     _, data, input_shape = dtype_x
-    with update_backend(backend_fw) as ivy_backend:
+    with BackendHandler.update_backend(backend_fw) as ivy_backend:
         data = ivy_backend.native_array(data[0])
         x = ivy_backend.Array(data)
         ivy_backend.utils.assertions.check_equal(
@@ -150,7 +150,7 @@ def test_array_property_shape(
     backend_fw,
 ):
     _, data, input_shape = dtype_x
-    with update_backend(backend_fw) as ivy_backend:
+    with BackendHandler.update_backend(backend_fw) as ivy_backend:
         data = ivy_backend.native_array(data[0])
         x = ivy_backend.Array(data)
         ivy_backend.utils.assertions.check_equal(
@@ -171,7 +171,7 @@ def test_array_property_size(
     backend_fw,
 ):
     _, data, input_shape = dtype_x
-    with update_backend(backend_fw) as ivy_backend:
+    with BackendHandler.update_backend(backend_fw) as ivy_backend:
         data = ivy_backend.native_array(data[0])
         x = ivy_backend.Array(data)
         size_gt = 1
@@ -191,7 +191,7 @@ def test_array_property_itemsize(
     backend_fw,
 ):
     dtype, data = dtype_x
-    with update_backend(backend_fw) as ivy_backend:
+    with BackendHandler.update_backend(backend_fw) as ivy_backend:
         data = ivy_backend.native_array(data[0])
         x = ivy_backend.Array(data)
         ivy_backend.utils.assertions.check_equal(
@@ -207,7 +207,7 @@ def test_array_property_itemsize(
 )
 def test_array_property_strides(dtype_x, backend_fw):
     dtype, data = dtype_x
-    with update_backend(backend_fw) as ivy_backend:
+    with BackendHandler.update_backend(backend_fw) as ivy_backend:
         data = ivy_backend.native_array(data[0])
         x = ivy_backend.Array(data)
         ivy_backend.utils.assertions.check_equal(
@@ -228,7 +228,7 @@ def test_array_property_mT(
     test_flags,
 ):
     _, data = dtype_x
-    with update_backend(backend_fw) as ivy_backend:
+    with BackendHandler.update_backend(backend_fw) as ivy_backend:
         data = ivy_backend.native_array(data[0])
         x = ivy_backend.Array(data)
         ret = helpers.flatten_and_to_np(ret=x.mT, backend=backend_fw)
@@ -257,7 +257,7 @@ def test_array_property_T(
     test_flags,
 ):
     _, data = dtype_x
-    with update_backend(backend_fw) as ivy_backend:
+    with BackendHandler.update_backend(backend_fw) as ivy_backend:
         data = ivy_backend.native_array(data[0])
         x = ivy_backend.Array(data)
         ret = helpers.flatten_and_to_np(ret=x.T, backend=backend_fw)
@@ -282,7 +282,7 @@ def test_array_property_real(
     test_flags,
 ):
     _, data = dtype_x
-    with update_backend(backend_fw) as ivy_backend:
+    with BackendHandler.update_backend(backend_fw) as ivy_backend:
         data = ivy_backend.native_array(data[0])
         x = ivy_backend.Array(data)
         ret = helpers.flatten_and_to_np(ret=x.real, backend=backend_fw)
@@ -305,7 +305,7 @@ def test_array_property_imag(
     test_flags,
 ):
     _, data = dtype_x
-    with update_backend(backend_fw) as ivy_backend:
+    with BackendHandler.update_backend(backend_fw) as ivy_backend:
         data = ivy_backend.native_array(data[0])
         x = ivy_backend.Array(data)
         ret = helpers.flatten_and_to_np(ret=x.imag, backend=backend_fw)

--- a/ivy_tests/test_ivy/test_misc/test_shape.py
+++ b/ivy_tests/test_ivy/test_misc/test_shape.py
@@ -2,7 +2,7 @@ from hypothesis import assume, strategies as st
 import numpy as np
 
 import ivy_tests.test_ivy.helpers as helpers
-from ivy_tests.test_ivy.helpers import handle_method, update_backend
+from ivy_tests.test_ivy.helpers import handle_method, BackendHandler
 from ivy_tests.test_ivy.test_functional.test_core.test_elementwise import (
     not_too_close_to_zero,
     pow_helper,
@@ -94,7 +94,7 @@ def test_shape__pow__(
     assume(not ("bfloat16" in input_dtype))
 
     # Make sure x2 isn't a float when x1 is integer
-    with update_backend(backend_fw) as ivy_backend:
+    with BackendHandler.update_backend(backend_fw) as ivy_backend:
         assume(
             not (
                 ivy_backend.is_int_dtype(


### PR DESCRIPTION
- Added BackendHandler class to allow for dynamic setting of ContextManager
- Added flag `--set-backend` to force the testing pipeline to use `ivy.set_backend` for backend setting
- Fixed invalid reference issues due to the addition of BackendHandler