### PR TITLE
Added tanh_ function in paddle tensor frontend

### DIFF
--- a/ivy/functional/frontends/paddle/tensor/math.py
+++ b/ivy/functional/frontends/paddle/tensor/math.py
@@ -479,3 +479,9 @@ def amax(x, axis=None, keepdims=False):
         if i < 0 or i >= x.ndim:
             raise ValueError("axis {} is out of range [-{}:{}]".format(i, 0, x.ndim))
     return ivy.max(x, axis=axis, keepdims=keepdims)
+
+
+@with_supported_dtypes({"2.5.1 and below": ("float32", "float64")}, "paddle")
+@to_ivy_arrays_and_back
+def tanh_(x, name=None):
+    return ivy.tanh(ivy.inplace_update(x, ivy.tanh(x)))

--- a/ivy_tests/test_ivy/test_frontends/test_paddle/test_tensor/test_math.py
+++ b/ivy_tests/test_ivy/test_frontends/test_paddle/test_tensor/test_math.py
@@ -2048,3 +2048,33 @@ def test_paddle_amax(
         on_device=on_device,
         x=x[0],
     )
+
+
+# tanh_
+
+
+@handle_frontend_test(
+    fn_tree="paddle.tensor.math.tanh_",
+    dtype_and_x=helpers.dtype_and_values(
+        available_dtypes=helpers.get_dtypes("float"),
+    ),
+)
+def test_paddle_tanh_(
+    *,
+    dtype_and_x,
+    on_device,
+    backend_fw,
+    fn_tree,
+    frontend,
+    test_flags,
+):
+    input_dtype, x = dtype_and_x
+    helpers.test_frontend_function(
+        input_dtypes=input_dtype,
+        backend_to_test=backend_fw,
+        frontend=frontend,
+        test_flags=test_flags,
+        fn_tree=fn_tree,
+        on_device=on_device,
+        x=x[0],
+    )


### PR DESCRIPTION
Issue: #22082 

* Added frontend function for tanh_ for paddle tensor
* Added frontend test for tanh_ for paddle tensor
* Test Summary: 
       `pytest ivy_tests/test_ivy/test_frontends/test_paddle/test_tensor/test_math.py::test_paddle_tanh_`
<details close>
<summary>Test Results</summary>
<br>
<img width="1392" alt="Screenshot 2023-08-17 at 6 52 55 PM" src="https://github.com/unifyai/ivy/assets/84662239/7190eddd-84fe-4674-9172-7b676df5fd42">
</details>  
