### PR TITLE
Added moveaxis function

### DIFF
--- a/ivy/functional/frontends/paddle/tensor/manipulation.py
+++ b/ivy/functional/frontends/paddle/tensor/manipulation.py
@@ -151,6 +151,22 @@ def take_along_axis(arr, indices, axis):
     return ivy.take_along_axis(arr, indices, axis)
 
 
+@with_supported_dtypes(
+    {
+        "2.5.1 and below": (
+            "float32",
+            "float64",
+            "int32",
+            "int64",
+        )
+    },
+    "paddle",
+)
+@to_ivy_arrays_and_back
+def moveaxis(x, source, destination):
+    return ivy.moveaxis(x, source, destination)
+
+
 @with_supported_device_and_dtypes(
     {
         "2.5.1 and above": {

--- a/ivy_tests/test_ivy/test_frontends/test_paddle/test_tensor/test_manipulation.py
+++ b/ivy_tests/test_ivy/test_frontends/test_paddle/test_tensor/test_manipulation.py
@@ -642,6 +642,50 @@ def test_paddle_take_along_axis(
     )
 
 
+# moveaxis
+@st.composite
+def _moveaxis_helper(draw):
+    dtype, x, shape = draw(
+        helpers.dtype_and_values(
+            available_dtypes=helpers.get_dtypes("valid"),
+            min_num_dims=2,
+            max_num_dims=4,
+            ret_shape=True,
+        )
+    )
+    source = draw(st.sampled_from(list(range(len(shape)))))
+    destination = draw(st.sampled_from(list(range(len(shape)))))
+    while source == destination:
+        destination = draw(st.sampled_from(list(range(len(shape)))))
+    return dtype, x, source, destination
+
+@handle_frontend_test(
+    fn_tree="paddle.moveaxis",
+    dtype_x_source_destination=_moveaxis_helper(),
+)
+def test_paddle_moveaxis(
+    *,
+    dtype_x_source_destination,
+    on_device,
+    fn_tree,
+    frontend,
+    test_flags,
+    backend_fw,
+):
+    input_dtype, x, source, destination = dtype_x_source_destination
+    helpers.test_frontend_function(
+        input_dtypes=input_dtype,
+        backend_to_test=backend_fw,
+        frontend=frontend,
+        test_flags=test_flags,
+        fn_tree=fn_tree,
+        on_device=on_device,
+        x=x[0],
+        source=source,
+        destination=destination,
+    )
+
+
 # rot90
 @handle_frontend_test(
     fn_tree="paddle.rot90",


### PR DESCRIPTION
close #19157

This commit introduces the moveaxis function to the paddle.tensor.manipulation module in the Paddle frontend of the Ivy library. The function has been tested for basic use-cases and aligns with the expected behavior of similar functions in other libraries.