### PR TITLE
#21429 - [Bug]: Typo in Numpy Frontend Tests for FFT #21429.

### DIFF
--- a/ivy_tests/test_ivy/test_frontends/test_numpy/test_fft/test_discrete_fourier_transform.py
+++ b/ivy_tests/test_ivy/test_frontends/test_numpy/test_fft/test_discrete_fourier_transform.py
@@ -16,7 +16,7 @@ from ivy_tests.test_ivy.test_functional.test_experimental.test_nn.test_layers im
     fn_tree="numpy.fft.ifft",
     dtype_and_x=x_and_ifft(),
 )
-def test_numpy_iftt(dtype_and_x, backend_fw, frontend, test_flags, fn_tree, on_device):
+def test_numpy_ifft(dtype_and_x, backend_fw, frontend, test_flags, fn_tree, on_device):
     input_dtype, x, dim, norm, n = dtype_and_x
     helpers.test_frontend_function(
         input_dtypes=input_dtype,
@@ -39,7 +39,7 @@ def test_numpy_iftt(dtype_and_x, backend_fw, frontend, test_flags, fn_tree, on_d
         available_dtypes=helpers.get_dtypes("float"), shape=(4,), array_api_dtypes=True
     ),
 )
-def test_numpy_ifttshift(
+def test_numpy_ifftshift(
     dtype_and_x, backend_fw, frontend, test_flags, fn_tree, on_device
 ):
     input_dtype, arr = dtype_and_x
@@ -92,7 +92,7 @@ def test_numpy_fft(
         available_dtypes=helpers.get_dtypes("float"), shape=(4,), array_api_dtypes=True
     ),
 )
-def test_numpy_fttshift(
+def test_numpy_fftshift(
     dtype_and_x, backend_fw, frontend, test_flags, fn_tree, on_device
 ):
     input_dtype, arr = dtype_and_x

--- a/ivy_tests/test_ivy/test_frontends/test_paddle/test_fft.py
+++ b/ivy_tests/test_ivy/test_frontends/test_paddle/test_fft.py
@@ -57,7 +57,7 @@ def test_paddle_fft(
         force_int_axis=True,
     ),
 )
-def test_paddle_fttshift(
+def test_paddle_fftshift(
     dtype_x_axis, frontend, test_flags, fn_tree, on_device, backend_fw
 ):
     input_dtype, x, axes = dtype_x_axis


### PR DESCRIPTION
This is my first time contributing and if there are any guidelines or important points while contributing or taking up tasks or issues, please let me know.

**Changes made in Line 19, 42 and 95 in the function names in test_discrete_fourier_transform.py** 
path: ivy_tests/test_ivy/test_frontends/test_numpy/test_fft/test_discrete_fourier_transform.py