### PR TITLE
this fixes the unsupported-backend frontend(scipy) key error issue

### DIFF
--- a/ivy_tests/test_ivy/helpers/hypothesis_helpers/dtype_helpers.py
+++ b/ivy_tests/test_ivy/helpers/hypothesis_helpers/dtype_helpers.py
@@ -216,9 +216,6 @@ def get_dtypes(
 
     # If being called from a frontend test
 
-    # if test_globals.CURRENT_FRONTEND is not test_globals._Notsetval:
-    #     frontend_dtypes = retrieval_fn(test_globals.CURRENT_FRONTEND, kind, True)
-    #     valid_dtypes = valid_dtypes.intersection(frontend_dtypes)
 
     # Make sure we return dtypes that are compatible with ground truth backend
     ground_truth_is_set = (

--- a/ivy_tests/test_ivy/helpers/hypothesis_helpers/dtype_helpers.py
+++ b/ivy_tests/test_ivy/helpers/hypothesis_helpers/dtype_helpers.py
@@ -216,9 +216,9 @@ def get_dtypes(
 
     # If being called from a frontend test
 
-    if test_globals.CURRENT_FRONTEND is not test_globals._Notsetval:
-        frontend_dtypes = retrieval_fn(test_globals.CURRENT_FRONTEND, kind, True)
-        valid_dtypes = valid_dtypes.intersection(frontend_dtypes)
+    # if test_globals.CURRENT_FRONTEND is not test_globals._Notsetval:
+    #     frontend_dtypes = retrieval_fn(test_globals.CURRENT_FRONTEND, kind, True)
+    #     valid_dtypes = valid_dtypes.intersection(frontend_dtypes)
 
     # Make sure we return dtypes that are compatible with ground truth backend
     ground_truth_is_set = (


### PR DESCRIPTION
valid_dtypes.intersection(frontend_dtypes) is redundant. supported_device_dtypes already contains frontend supported dtypes, that is done in the _get_supported_devices_dtypes function