### PR TITLE
adds eval mode to stateful module

### DIFF
--- a/ivy/stateful/module.py
+++ b/ivy/stateful/module.py
@@ -817,6 +817,16 @@ class Module(ModuleHelpers, ModuleConverters, ModuleMeta):
         """Set the buffer at any place within the class."""
         self._set_buffers({var_name: value})
 
+    def eval(self, mode: bool = False):
+        # disables training mode for child modules
+        # if it exists
+        if hasattr(self, "training"):
+            self.training = mode
+        for module in self.v:
+            module = getattr(self, module, None)
+            if module:
+                module.eval(mode=mode)
+
     def __repr__(self):
         return object.__repr__(self)
 

--- a/ivy/stateful/norms.py
+++ b/ivy/stateful/norms.py
@@ -103,6 +103,7 @@ class BatchNorm2D(Module):
         device=None,
         v=None,
         dtype=None,
+        training=True,
     ):
         """
         Class for applying Layer Normalization over a mini-batch of inputs.
@@ -151,6 +152,7 @@ class BatchNorm2D(Module):
         self._bias_init = Zeros()
         self._running_mean_init = Zeros()
         self._running_var_init = Ones()
+        self.training = training
         Module.__init__(self, device=device, v=v, dtype=dtype)
 
     def _create_variables(self, device, dtype=None):
@@ -175,7 +177,7 @@ class BatchNorm2D(Module):
     def _forward(
         self,
         inputs,
-        training: bool = False,
+        training: bool = None,
     ):
         """
         Perform forward pass of the BatchNorm layer.
@@ -192,6 +194,8 @@ class BatchNorm2D(Module):
         ret
             The outputs following the batch normalization operation.
         """
+        orig_training = self.training
+        training = training if training is not None else self.training
         normalized, running_mean, running_var = ivy.batch_norm(
             inputs,
             self.v.running_mean,
@@ -207,4 +211,5 @@ class BatchNorm2D(Module):
             self.v.running_mean = running_mean
             self.v.running_var = running_var
 
+        self.training = orig_training
         return normalized


### PR DESCRIPTION
Adds a recursive eval function that iterates through modules to set the eval mode to the specified mode if `training` is an attribute of the said child modules or the module itself. Fixed BatchNoorm2D to maintain the internal state of training.