### PR TITLE
Modified floor_ method in the Paddle frontend

### DIFF
--- a/ivy/functional/frontends/paddle/tensor/tensor.py
+++ b/ivy/functional/frontends/paddle/tensor/tensor.py
@@ -180,6 +180,11 @@ class Tensor:
     @with_unsupported_dtypes({"2.5.1 and below": ("float16", "bfloat16")}, "paddle")
     def floor(self, name=None):
         return paddle_frontend.Tensor(ivy.floor(self._ivy_array))
+    
+    @with_unsupported_dtypes({"2.5.1 and below": ("float16", "bfloat16")}, "paddle")
+    def floor_(self):
+        self.ivy_array = self.floor().ivy_array
+        return self
 
     @with_supported_dtypes(
         {"2.5.1 and below": ("float32", "float64", "int32", "int64")}, "paddle"
@@ -200,10 +205,6 @@ class Tensor:
         else:
             ret = ivy.clip(self._ivy_array, min, max)
         return paddle_frontend.Tensor(ret)
-
-    @with_unsupported_dtypes({"2.5.1 and below": ("float16", "bfloat16")}, "paddle")
-    def floor_(self):
-        return paddle_frontend.Tensor(ivy.floor(self._ivy_array))
 
     @with_supported_dtypes({"2.5.1 and below": ("float32", "float64")}, "paddle")
     def tanh(self, name=None):


### PR DESCRIPTION
I've fixed the `floor_` method, which previously wasn't correctly performing the desired in-place modifications on the input array. This modification now ensures that the `floor_` method works as intended, directly modifying the input array inplace.

![image](https://github.com/unifyai/ivy/assets/86601825/3db0a114-0466-478b-b5d6-f47655a0fbcd)
