### PR TITLE
fix: replaces 3.1416 with ivy.pi in frontends.torch.pointwise_ops.deg2rad

### DIFF
--- a/ivy/functional/frontends/torch/pointwise_ops.py
+++ b/ivy/functional/frontends/torch/pointwise_ops.py
@@ -326,7 +326,7 @@ def flipud(input):
 
 @to_ivy_arrays_and_back
 def deg2rad(input, *, out=None):
-    return ivy.array(input * 3.1416 / 180, out=out)
+    return ivy.array(input * ivy.pi / 180, out=out)
 
 
 arcsinh = asinh


### PR DESCRIPTION
A tiny fix which replaces `3.1416` (you could argue it is a magic number) with `ivy.pi` in `frontends.torch.pointwise_ops.deg2rad`