### PR TITLE
Fixed add_ method in the Paddle frontend

### DIFF
--- a/ivy/functional/frontends/paddle/tensor/tensor.py
+++ b/ivy/functional/frontends/paddle/tensor/tensor.py
@@ -226,6 +226,7 @@ class Tensor:
     def tanh(self, name=None):
         return paddle_frontend.Tensor(ivy.tanh(self._ivy_array))
 
+    @with_supported_dtypes({"2.5.1 and below": ("float32", "float64")}, "paddle")
     def add_(self, y, name=None):
         self.ivy_array = paddle_frontend.Tensor(
             ivy.add(self._ivy_array, _to_ivy_array(y))

--- a/ivy/functional/frontends/paddle/tensor/tensor.py
+++ b/ivy/functional/frontends/paddle/tensor/tensor.py
@@ -226,9 +226,11 @@ class Tensor:
     def tanh(self, name=None):
         return paddle_frontend.Tensor(ivy.tanh(self._ivy_array))
 
-    @with_supported_dtypes({"2.5.1 and below": ("float32", "float64")}, "paddle")
-    def add_(self, name=None):
-        return paddle_frontend.Tensor(ivy.add(self._ivy_array))
+    def add_(self, y, name=None):
+        self.ivy_array = paddle_frontend.Tensor(
+            ivy.add(self._ivy_array, _to_ivy_array(y))
+        ).ivy_array
+        return self
 
     @with_supported_dtypes(
         {"2.5.1 and below": ("float16", "float32", "float64", "int32", "int64")},

--- a/ivy_tests/test_ivy/test_frontends/test_paddle/test_tensor/test_tensor.py
+++ b/ivy_tests/test_ivy/test_frontends/test_paddle/test_tensor/test_tensor.py
@@ -969,7 +969,7 @@ def test_paddle_tensor_tanh(
     init_tree="paddle.to_tensor",
     method_name="add_",
     dtype_and_x=helpers.dtype_and_values(
-        available_dtypes=helpers.get_dtypes("float"),
+        available_dtypes=helpers.get_dtypes("float"), num_arrays=2, shared_dtype=True
     ),
 )
 def test_paddle_tensor_add_(
@@ -989,7 +989,7 @@ def test_paddle_tensor_add_(
             "data": x[0],
         },
         method_input_dtypes=input_dtype,
-        method_all_as_kwargs_np={},
+        method_all_as_kwargs_np={"y": x[1]},
         frontend_method_data=frontend_method_data,
         init_flags=init_flags,
         method_flags=method_flags,

--- a/ivy_tests/test_ivy/test_frontends/test_paddle/test_tensor/test_tensor.py
+++ b/ivy_tests/test_ivy/test_frontends/test_paddle/test_tensor/test_tensor.py
@@ -969,7 +969,7 @@ def test_paddle_tensor_tanh(
     init_tree="paddle.to_tensor",
     method_name="add_",
     dtype_and_x=helpers.dtype_and_values(
-        available_dtypes=helpers.get_dtypes("float"), num_arrays=2, shared_dtype=True
+        available_dtypes=helpers.get_dtypes("valid"), num_arrays=2, shared_dtype=True
     ),
 )
 def test_paddle_tensor_add_(


### PR DESCRIPTION
I've rectified the issue with the `add_` method, which previously was not performing the desired in-place modifications on the input array correctly. This adjustment guarantees that the `add_` method now functions as intended, directly altering the input array in place.

![image](https://github.com/unifyai/ivy/assets/59949692/e8e208e1-2a7c-4670-931e-6385213d43b1)
