### PR TITLE
Fix: add missing import in JAX Frontend

### DIFF
--- a/ivy/functional/frontends/jax/numpy/linalg.py
+++ b/ivy/functional/frontends/jax/numpy/linalg.py
@@ -2,7 +2,7 @@
 import ivy
 from ivy.functional.frontends.jax import Array
 from ivy.functional.frontends.jax.func_wrapper import to_ivy_arrays_and_back
-from ivy.func_wrapper import with_unsupported_dtypes
+from ivy.func_wrapper import with_unsupported_dtypes, with_supported_dtypes
 from ivy.functional.frontends.jax.numpy import promote_types_of_jax_inputs
 
 


### PR DESCRIPTION
The `@with_supported_dtypes` decorator is used in this file without import