### PR TITLE
Fix: Use the right function in eigvals in JAX Frontend

### DIFF
--- a/ivy/functional/frontends/jax/numpy/linalg.py
+++ b/ivy/functional/frontends/jax/numpy/linalg.py
@@ -40,7 +40,7 @@ def eigh(a, UPLO="L", symmetrize_input=True):
 
 @to_ivy_arrays_and_back
 def eigvals(a):
-    return ivy.eigh(a)
+    return ivy.eigvals(a)
 
 
 @to_ivy_arrays_and_back

--- a/ivy_tests/test_ivy/test_frontends/test_jax/test_numpy/test_linalg.py
+++ b/ivy_tests/test_ivy/test_frontends/test_jax/test_numpy/test_linalg.py
@@ -396,7 +396,6 @@ def test_jax_qr(
         and np.linalg.cond(x[1][0]) < 1 / sys.float_info.epsilon
         and np.linalg.det(np.asarray(x[1][0])) != 0
     ),
-    test_with_out=st.just(False),
 )
 def test_jax_eigvals(
     *,
@@ -407,21 +406,35 @@ def test_jax_eigvals(
     test_flags,
     backend_fw,
 ):
-    dtype, x = dtype_and_x
-    x = np.array(x[0], dtype=dtype[0])
+    dtypes, x = dtype_and_x
+    x = np.array(x[0], dtype=dtypes[0])
     # make symmetric positive-definite beforehand
     x = np.matmul(x.T, x) + np.identity(x.shape[0]) * 1e-3
 
     ret, frontend_ret = helpers.test_frontend_function(
-        input_dtypes=dtype,
-        frontend=frontend,
+        input_dtypes=dtypes,
         backend_to_test=backend_fw,
+        frontend=frontend,
         test_flags=test_flags,
         fn_tree=fn_tree,
         on_device=on_device,
         test_values=False,
         a=x,
     )
+
+    with BackendHandler.update_backend(backend_fw) as ivy_backend:
+        # Calculate the magnitude of the complex numbers then sort them for testing
+        ret = np.sort(np.abs(ivy_backend.to_numpy(ret))).astype(np.float64)
+        frontend_ret = np.sort(np.abs(frontend_ret)).astype(np.float64)
+
+        assert_all_close(
+            ret_np=ret,
+            ret_from_gt_np=frontend_ret,
+            backend=backend_fw,
+            ground_truth_backend=frontend,
+            atol=1e-2,
+            rtol=1e-2,
+        )
 
 
 # cholesky


### PR DESCRIPTION
The `eigvals` function in [ivy/functional/frontends/jax/numpy/linalg.py](https://github.com/unifyai/ivy/compare/main...abdllahdev:fix/jax.numpy.linalg.eigvals?expand=1#diff-4e9d5ec55b3112ae12f59f6a33c6157d51020ba720f35934cfd9cfbb86624cab) is not using the right function instead it's using `eigh`