### PR TITLE
Update2

### DIFF
--- a/ivy/functional/backends/paddle/experimental/manipulation.py
+++ b/ivy/functional/backends/paddle/experimental/manipulation.py
@@ -160,6 +160,26 @@ def hstack(
             return ivy.concat(arrays, axis=0)
 
 
+import paddle
+
+def moveaxis(
+    a: paddle.Tensor,
+    source: Union[int, Sequence[int]],
+    destination: Union[int, Sequence[int]],
+    /,
+    *,
+    copy: Optional[bool] = None,
+    out: Optional[paddle.Tensor] = None,
+) -> paddle.Tensor:
+    if isinstance(source, tuple):
+        source = list(source)
+    if isinstance(destination, tuple):
+        source = list(destination)
+    if a.dtype in [paddle.int8, paddle.int16, paddle.uint8]:
+        return paddle.moveaxis(a.cast("float32"), source, destination).cast(a.dtype)
+    return paddle.moveaxis(a, source, destination)
+
+
 @with_supported_device_and_dtypes(
     {
         "2.5.1 and above": {

--- a/ivy/functional/backends/paddle/experimental/manipulation.py
+++ b/ivy/functional/backends/paddle/experimental/manipulation.py
@@ -76,6 +76,32 @@ _i0B = [
 
 @with_unsupported_device_and_dtypes(
     {
+        "2.5.1 and above": {
+            "cpu": ("bfloat16", "uint8")
+        },
+    },
+    backend_version,
+)
+def moveaxis(
+    a: paddle.Tensor,
+    source: Union[int, Sequence[int]],
+    destination: Union[int, Sequence[int]],
+    /,
+    *,
+    copy: Optional[bool] = None,
+    out: Optional[paddle.Tensor] = None,
+) -> paddle.Tensor:
+    if isinstance(source, tuple):
+        source = list(source)
+    if isinstance(destination, tuple):
+        source = list(destination)
+    if a.dtype in [paddle.int8, paddle.int16, paddle.uint8]:
+        return paddle.moveaxis(a.cast("float32"), source, destination).cast(a.dtype)
+    return paddle.moveaxis(a, source, destination)
+
+
+@with_unsupported_device_and_dtypes(
+    {
         "2.5.1 and below": {
             "cpu": (
                 "int8",
@@ -140,32 +166,6 @@ def hstack(
             return ivy.concat(arrays, axis=1)
         else:
             return ivy.concat(arrays, axis=0)
-
-
-@with_unsupported_device_and_dtypes(
-    {
-        "2.5.1 and above": {
-            "cpu": ("bfloat16", "uint8")
-        },
-    },
-    backend_version,
-)
-def moveaxis(
-    a: paddle.Tensor,
-    source: Union[int, Sequence[int]],
-    destination: Union[int, Sequence[int]],
-    /,
-    *,
-    copy: Optional[bool] = None,
-    out: Optional[paddle.Tensor] = None,
-) -> paddle.Tensor:
-    if isinstance(source, tuple):
-        source = list(source)
-    if isinstance(destination, tuple):
-        source = list(destination)
-    if a.dtype in [paddle.int8, paddle.int16, paddle.uint8]:
-        return paddle.moveaxis(a.cast("float32"), source, destination).cast(a.dtype)
-    return paddle.moveaxis(a, source, destination)
 
 
 @with_supported_device_and_dtypes(

--- a/ivy/functional/backends/paddle/experimental/manipulation.py
+++ b/ivy/functional/backends/paddle/experimental/manipulation.py
@@ -74,24 +74,6 @@ _i0B = [
 ]
 
 
-def moveaxis(
-    a: paddle.Tensor,
-    source: Union[int, Sequence[int]],
-    destination: Union[int, Sequence[int]],
-    /,
-    *,
-    copy: Optional[bool] = None,
-    out: Optional[paddle.Tensor] = None,
-) -> paddle.Tensor:
-    if isinstance(source, tuple):
-        source = list(source)
-    if isinstance(destination, tuple):
-        source = list(destination)
-    if a.dtype in [paddle.int8, paddle.int16, paddle.uint8]:
-        return paddle.moveaxis(a.cast("float32"), source, destination).cast(a.dtype)
-    return paddle.moveaxis(a, source, destination)
-
-
 @with_unsupported_device_and_dtypes(
     {
         "2.5.1 and below": {
@@ -160,8 +142,14 @@ def hstack(
             return ivy.concat(arrays, axis=0)
 
 
-import paddle
-
+@with_unsupported_device_and_dtypes(
+    {
+        "2.5.1 and above": {
+            "cpu": ("bfloat16", "uint8")
+        },
+    },
+    backend_version,
+)
 def moveaxis(
     a: paddle.Tensor,
     source: Union[int, Sequence[int]],

--- a/ivy/functional/frontends/paddle/tensor/manipulation.py
+++ b/ivy/functional/frontends/paddle/tensor/manipulation.py
@@ -91,40 +91,6 @@ def reshape_(x, shape):
     ret = ivy.reshape(x, shape)
     ivy.inplace_update(x, ret)
     return x
-
-
-@with_supported_dtypes(
-    {
-        "2.5.1 and below": (
-            "float32",
-            "float64",
-            "int32",
-            "int64",
-        )
-    },
-    "paddle",
-)
-@to_ivy_arrays_and_back
-def moveaxis(x, source, destination):
-    if isinstance(source, list) and isinstance(destination, list):
-        if len(source) != len(destination):
-            raise ValueError("Source and destination lists must have the same length")
-        for src, dest in zip(source, destination):
-            x = moveaxis(x, src, dest)
-        return x
-    else:
-        if source == destination:
-            return x
-        if source < 0:
-            source = x.ndim + source
-        if destination < 0:
-            destination = x.ndim + destination
-        if source < 0 or source >= x.ndim or destination < 0 or destination >= x.ndim:
-            raise ValueError("Source or destination axis out of range")
-        order = list(range(x.ndim))
-        order.pop(source)
-        order.insert(destination, source)
-        return ivy.transpose(x, order)
     
 
 @with_supported_dtypes(
@@ -143,6 +109,21 @@ def moveaxis(x, source, destination):
 @to_ivy_arrays_and_back
 def roll(x, shifts, axis=None, name=None):
     return ivy.roll(x, shifts, axis=axis)
+
+@with_supported_dtypes(
+    {
+        "2.5.1 and below": (
+            "float32",
+            "float64",
+            "int32",
+            "int64",
+        )
+    },
+    "paddle",
+)
+@to_ivy_arrays_and_back
+def moveaxis(x, source, destination):
+    return ivy.moveaxis(x, source, destination)
 
 
 @with_supported_device_and_dtypes(

--- a/ivy/functional/frontends/paddle/tensor/manipulation.py
+++ b/ivy/functional/frontends/paddle/tensor/manipulation.py
@@ -122,7 +122,7 @@ def roll(x, shifts, axis=None, name=None):
     "paddle",
 )
 @to_ivy_arrays_and_back
-def moveaxis(x, source, destination):
+def moveaxis(x, source, destination, name=None)):
     return ivy.moveaxis(x, source, destination)
 
 

--- a/ivy/functional/frontends/paddle/tensor/manipulation.py
+++ b/ivy/functional/frontends/paddle/tensor/manipulation.py
@@ -105,37 +105,14 @@ def reshape_(x, shape):
     "paddle",
 )
 @to_ivy_arrays_and_back
-def moveaxis(
-    x: paddle.Tensor,
-    source: Union[int, List[int]],
-    destination: Union[int, List[int]],
-    /,
-    *,
-    out: Optional[paddle.Tensor] = None,
-) -> paddle.Tensor:
-    """
-    Move axes of an array to new positions.
-    Other axes remain in their original order.
-    Parameters
-    ----------
-    x : paddle.Tensor
-        The input tensor.
-    source : int
-        The original position of the axes to move. These must be unique.
-    destination : int
-        The destination position for each of the original axes. These must also be unique.
-    Returns
-    -------
-    result : paddle.Tensor
-        Array with moved axes. This array is a view of the input array.
-    """
-   if isinstance(source, list) and isinstance(destination, list):
+def moveaxis(x, source, destination):
+    if isinstance(source, list) and isinstance(destination, list):
         if len(source) != len(destination):
             raise ValueError("Source and destination lists must have the same length")
         for src, dest in zip(source, destination):
             x = moveaxis(x, src, dest)
         return x
-     else:
+    else:
         if source == destination:
             return x
         if source < 0:
@@ -147,7 +124,7 @@ def moveaxis(
         order = list(range(x.ndim))
         order.pop(source)
         order.insert(destination, source)
-        return paddle.transpose(x, order)
+        return ivy.transpose(x, order)
     
 
 @with_supported_dtypes(

--- a/ivy/functional/frontends/paddle/tensor/manipulation.py
+++ b/ivy/functional/frontends/paddle/tensor/manipulation.py
@@ -109,20 +109,27 @@ def reshape_(x, shape):
 @to_ivy_arrays_and_back
 def roll(x, shifts, axis=None, name=None):
     return ivy.roll(x, shifts, axis=axis)
+    
 
-@with_supported_dtypes(
+@with_supported_device_and_dtypes(
     {
-        "2.5.1 and below": (
-            "float32",
-            "float64",
-            "int32",
-            "int64",
-        )
+        "2.5.1 and below": {
+            "cpu": (
+                "bool",
+                "float16",
+                "float32",
+                "float64",
+                "int32",
+                "int64",
+                "complex64",
+                "complex128",
+            )
+        },
     },
     "paddle",
 )
 @to_ivy_arrays_and_back
-def moveaxis(x, source, destination, name=None)):
+def moveaxis(x, source, destination, name=None):
     return ivy.moveaxis(x, source, destination)
 
 

--- a/ivy/functional/frontends/paddle/tensor/manipulation.py
+++ b/ivy/functional/frontends/paddle/tensor/manipulation.py
@@ -95,6 +95,63 @@ def reshape_(x, shape):
 
 @with_supported_dtypes(
     {
+        "2.5.1 and below": (
+            "float32",
+            "float64",
+            "int32",
+            "int64",
+        )
+    },
+    "paddle",
+)
+@to_ivy_arrays_and_back
+def moveaxis(
+    x: paddle.Tensor,
+    source: Union[int, List[int]],
+    destination: Union[int, List[int]],
+    /,
+    *,
+    out: Optional[paddle.Tensor] = None,
+) -> paddle.Tensor:
+    """
+    Move axes of an array to new positions.
+    Other axes remain in their original order.
+    Parameters
+    ----------
+    x : paddle.Tensor
+        The input tensor.
+    source : int
+        The original position of the axes to move. These must be unique.
+    destination : int
+        The destination position for each of the original axes. These must also be unique.
+    Returns
+    -------
+    result : paddle.Tensor
+        Array with moved axes. This array is a view of the input array.
+    """
+   if isinstance(source, list) and isinstance(destination, list):
+        if len(source) != len(destination):
+            raise ValueError("Source and destination lists must have the same length")
+        for src, dest in zip(source, destination):
+            x = moveaxis(x, src, dest)
+        return x
+     else:
+        if source == destination:
+            return x
+        if source < 0:
+            source = x.ndim + source
+        if destination < 0:
+            destination = x.ndim + destination
+        if source < 0 or source >= x.ndim or destination < 0 or destination >= x.ndim:
+            raise ValueError("Source or destination axis out of range")
+        order = list(range(x.ndim))
+        order.pop(source)
+        order.insert(destination, source)
+        return paddle.transpose(x, order)
+    
+
+@with_supported_dtypes(
+    {
         "2.5.0 and below": (
             "float32",
             "float64",

--- a/ivy_tests/test_ivy/test_frontends/test_paddle/test_tensor/test_manipulation.py
+++ b/ivy_tests/test_ivy/test_frontends/test_paddle/test_tensor/test_manipulation.py
@@ -718,6 +718,56 @@ def test_paddle_take_along_axis(
     )
 
 
+# Helper for moveaxis
+@st.composite
+def _moveaxis_helper(draw):
+    input_dtype = draw(
+        helpers.dtype_and_values(
+            available_dtypes=helpers.get_dtypes("numeric"),
+            min_num_dims=2,
+            max_num_dims=5,
+        )
+    )
+    x = draw(
+        helpers.array_values(
+            dtype=input_dtype,
+            min_num_dims=2,
+            max_num_dims=5,
+        )
+    )
+    source = draw(st.integers(0, x.ndim - 1))
+    destination = draw(st.integers(0, x.ndim - 1))
+    return input_dtype, x, source, destination
+
+
+# moveaxis
+@handle_frontend_test(
+    fn_tree="paddle.moveaxis",
+    dtype_x_source_destination=_moveaxis_helper(),
+)
+def test_paddle_moveaxis(
+    *,
+    dtype_x_source_destination,
+    on_device,
+    fn_tree,
+    frontend,
+    test_flags,
+    backend_fw,
+):
+    input_dtype, x, source, destination = dtype_x_source_destination
+    helpers.test_frontend_function(
+        input_dtypes=input_dtype,
+        backend_to_test=backend_fw,
+        frontend=frontend,
+        test_flags=test_flags,
+        fn_tree=fn_tree,
+        on_device=on_device,
+        x=x[0],
+        source=source,
+        destination=destination,
+    )
+
+
 # rot90
 @handle_frontend_test(
     fn_tree="paddle.rot90",


### PR DESCRIPTION
Description
This PR adds the moveaxis function to the Paddle frontend in this repository. The moveaxis function is a utility function used to rearrange the axes of an array. It allows users to move specific axes to new positions while keeping the order of the other axes unchanged. This function is commonly used in tensor manipulation tasks and is available in other frontends like Numpy and Torch.

Summary of Changes
- Added the moveaxis function to the ivy/functional/backends/paddle/experimental/manipulation.py file.
- Implemented test cases for the moveaxis function in the ivy_tests/test_ivy/test_functional/test_experimental/test_core/test_manipulation.py file.

This PR enhances the functionality of the Paddle frontend by providing the moveaxis function, which allows for more flexible tensor manipulation operations.

Closes #19157

## Checklist 

- [x] Did you add a function?
- [x] Did you add the tests?
- [X] Did you follow the steps we provided?

