### PR TITLE
Added abs function to JAX frontend

### DIFF
--- a/ivy/functional/frontends/jax/numpy/mathematical_functions.py
+++ b/ivy/functional/frontends/jax/numpy/mathematical_functions.py
@@ -11,6 +11,7 @@ from ivy.functional.frontends.numpy.manipulation_routines import trim_zeros
 def abs(x, /):
     return ivy.abs(x)
 
+
 @to_ivy_arrays_and_back
 def absolute(x, /):
     return ivy.abs(x)

--- a/ivy/functional/frontends/jax/numpy/mathematical_functions.py
+++ b/ivy/functional/frontends/jax/numpy/mathematical_functions.py
@@ -7,6 +7,7 @@ from ivy.func_wrapper import with_unsupported_dtypes
 from ivy.functional.frontends.jax.numpy import promote_types_of_jax_inputs
 from ivy.functional.frontends.numpy.manipulation_routines import trim_zeros
 
+
 @to_ivy_arrays_and_back
 def abs(x, /):
     return ivy.abs(x)

--- a/ivy/functional/frontends/jax/numpy/mathematical_functions.py
+++ b/ivy/functional/frontends/jax/numpy/mathematical_functions.py
@@ -7,6 +7,9 @@ from ivy.func_wrapper import with_unsupported_dtypes
 from ivy.functional.frontends.jax.numpy import promote_types_of_jax_inputs
 from ivy.functional.frontends.numpy.manipulation_routines import trim_zeros
 
+@to_ivy_arrays_and_back
+def abs(x, /):
+    return ivy.abs(x)
 
 @to_ivy_arrays_and_back
 def absolute(x, /):

--- a/ivy_tests/test_ivy/test_frontends/test_jax/test_numpy/test_mathematical_functions.py
+++ b/ivy_tests/test_ivy/test_frontends/test_jax/test_numpy/test_mathematical_functions.py
@@ -74,7 +74,6 @@ def test_jax_sign(
 # abs
 @handle_frontend_test(
     fn_tree="jax.numpy.abs",
-    aliases=["jax.numpy.absolute"],
     dtype_and_x=helpers.dtype_and_values(
         available_dtypes=helpers.get_dtypes("signed_integer"),
     ),
@@ -104,7 +103,6 @@ def test_jax_abs(
 # absolute
 @handle_frontend_test(
     fn_tree="jax.numpy.absolute",
-    aliases=["jax.numpy.abs"],
     dtype_and_x=helpers.dtype_and_values(
         available_dtypes=helpers.get_dtypes("signed_integer"),
     ),

--- a/ivy_tests/test_ivy/test_frontends/test_jax/test_numpy/test_mathematical_functions.py
+++ b/ivy_tests/test_ivy/test_frontends/test_jax/test_numpy/test_mathematical_functions.py
@@ -71,6 +71,36 @@ def test_jax_sign(
     )
 
 
+# abs
+@handle_frontend_test(
+    fn_tree="jax.numpy.abs",
+    aliases=["jax.numpy.absolute"],
+    dtype_and_x=helpers.dtype_and_values(
+        available_dtypes=helpers.get_dtypes("signed_integer"),
+    ),
+    test_with_out=st.just(False),
+)
+def test_jax_abs(
+    *,
+    dtype_and_x,
+    on_device,
+    fn_tree,
+    frontend,
+    backend_fw,
+    test_flags,
+):
+    input_dtype, x = dtype_and_x
+    helpers.test_frontend_function(
+        input_dtypes=input_dtype,
+        frontend=frontend,
+        backend_to_test=backend_fw,
+        test_flags=test_flags,
+        fn_tree=fn_tree,
+        on_device=on_device,
+        x=x[0],
+    )
+
+
 # absolute
 @handle_frontend_test(
     fn_tree="jax.numpy.absolute",


### PR DESCRIPTION
<!-- 
This template will help you to have a meaningful PR, please follow it and do not leave it blank.
-->

# PR Description 
Added the jax.numpy.abs function to the JAX frontend for Ivy.
<!-- 
If there is no related issue, please add a short description about your PR.
-->

## Related Issue 

<!-- 
Please use this format to link other issues with their numbers: Close #123 
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Close #22639

## Checklist 

- [] Did you add a function? Yes
- [] Did you add the tests? Yes
- [] Did you follow the steps we provided? Yes

### Socials: 

<!-- 
If you have Twitter, please provide it here otherwise just ignore this.
-->
