### PR TITLE
Added numpy.mean function to JAX frontend

### DIFF
--- a/ivy/functional/frontends/jax/numpy/mathematical_functions.py
+++ b/ivy/functional/frontends/jax/numpy/mathematical_functions.py
@@ -378,6 +378,12 @@ def minimum(x1, x2, /):
 
 
 @to_ivy_arrays_and_back
+def mean(x, axis=None, keepdims=False, out=None, /):
+    x = promote_types_of_jax_inputs(x)
+    return ivy.mean(x, axis=axis, keepdims=keepdims, out=out)
+
+
+@to_ivy_arrays_and_back
 @with_unsupported_dtypes({"0.4.14 and below": ("complex",)}, "jax")
 def mod(x1, x2, /):
     x1, x2 = promote_types_of_jax_inputs(x1, x2)

--- a/ivy_tests/test_ivy/test_frontends/test_jax/test_numpy/test_mathematical_functions.py
+++ b/ivy_tests/test_ivy/test_frontends/test_jax/test_numpy/test_mathematical_functions.py
@@ -686,6 +686,42 @@ def test_jax_dot(
     )
 
 
+# mean
+@handle_frontend_test(
+    fn_tree="jax.numpy.mean",
+    dtype_and_x=helpers.dtype_and_values(
+        available_dtypes=helpers.get_dtypes("numeric"),
+        num_arrays=1,
+        large_abs_safety_factor=2,
+        small_abs_safety_factor=2,
+        safety_factor_scale="log",
+    ),
+    test_with_out=st.just(True),
+)
+def test_jax_mean(
+    *,
+    dtype_and_x,
+    on_device,
+    fn_tree,
+    frontend,
+    backend_fw,
+    test_flags,
+):
+    input_dtype, x = dtype_and_x
+    helpers.test_frontend_function(
+        input_dtypes=input_dtype,
+        frontend=frontend,
+        backend_to_test=backend_fw,
+        test_flags=test_flags,
+        fn_tree=fn_tree,
+        on_device=on_device,
+        x=x[0],
+        axis=x[1],
+        keepdims=x[2],
+        out=x[3]
+    )
+
+
 # mod
 @handle_frontend_test(
     fn_tree="jax.numpy.mod",


### PR DESCRIPTION
<!-- 
This template will help you to have a meaningful PR, please follow it and do not leave it blank.
-->

# PR Description 
Added the jax.numpy.mean function to the JAX frontend API.
<!-- 
If there is no related issue, please add a short description about your PR.
-->

## Related Issue 

<!-- 
Please use this format to link other issues with their numbers: Close #123 
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Close #22642

## Checklist 

- [ ] Did you add a function? Yes
- [ ] Did you add the tests? Yes
- [ ] Did you follow the steps we provided? Yes

### Socials: 

<!-- 
If you have Twitter, please provide it here otherwise just ignore this.
-->
