### PR TITLE
Update 3

### DIFF
--- a/ivy/functional/frontends/paddle/tensor/manipulation.py
+++ b/ivy/functional/frontends/paddle/tensor/manipulation.py
@@ -166,6 +166,22 @@ def take_along_axis(arr, indices, axis):
     return ivy.take_along_axis(arr, indices, axis)
 
 
+@with_supported_dtypes(
+    {
+        "2.5.1 and below": (
+            "float32",
+            "float64",
+            "int32",
+            "int64",
+        )
+    },
+    "paddle",
+)
+@to_ivy_arrays_and_back
+def moveaxis(x, source, destination):
+    return ivy.moveaxis(x, source, destination)
+
+
 @with_supported_device_and_dtypes(
     {
         "2.5.1 and above": {

--- a/ivy_tests/test_ivy/test_frontends/test_paddle/test_tensor/test_manipulation.py
+++ b/ivy_tests/test_ivy/test_frontends/test_paddle/test_tensor/test_manipulation.py
@@ -718,6 +718,56 @@ def test_paddle_take_along_axis(
     )
 
 
+# Helper for moveaxis
+@st.composite
+def _moveaxis_helper(draw):
+    input_dtype = draw(
+        helpers.dtype_and_values(
+            available_dtypes=helpers.get_dtypes("numeric"),
+            min_num_dims=2,
+            max_num_dims=5,
+        )
+    )
+    x = draw(
+        helpers.array_values(
+            dtype=input_dtype,
+            min_num_dims=2,
+            max_num_dims=5,
+        )
+    )
+    source = draw(st.integers(0, x.ndim - 1))
+    destination = draw(st.integers(0, x.ndim - 1))
+    return input_dtype, x, source, destination
+
+
+# moveaxis
+@handle_frontend_test(
+    fn_tree="paddle.moveaxis",
+    dtype_x_source_destination=_moveaxis_helper(),
+)
+def test_paddle_moveaxis(
+    *,
+    dtype_x_source_destination,
+    on_device,
+    fn_tree,
+    frontend,
+    test_flags,
+    backend_fw,
+):
+    input_dtype, x, source, destination = dtype_x_source_destination
+    helpers.test_frontend_function(
+        input_dtypes=input_dtype,
+        backend_to_test=backend_fw,
+        frontend=frontend,
+        test_flags=test_flags,
+        fn_tree=fn_tree,
+        on_device=on_device,
+        x=x[0],
+        source=source,
+        destination=destination,
+    )
+
+
 # rot90
 @handle_frontend_test(
     fn_tree="paddle.rot90",


### PR DESCRIPTION
Description
This PR adds the moveaxis function to the Paddle frontend in this repository. The moveaxis function is a utility function used to rearrange the axes of an array. It allows users to move specific axes to new positions while keeping the order of the other axes unchanged. This function is commonly used in tensor manipulation tasks and is available in other frontends like Numpy and Torch.

Summary of Changes
- Added the moveaxis function to the ivy/functional/backends/paddle/experimental/manipulation.py file.
- Implemented test cases for the moveaxis function in the ivy_tests/test_ivy/test_functional/test_experimental/test_core/test_manipulation.py file.

This PR enhances the functionality of the Paddle frontend by providing the moveaxis function, which allows for more flexible tensor manipulation operations.

Closes #19157

## Checklist 

- [x] Did you add a function?
- [x] Did you add the tests?
- [X] Did you follow the steps we provided?