### PR TITLE
Fixed git errors

### DIFF
--- a/ivy/functional/frontends/torch/tensor.py
+++ b/ivy/functional/frontends/torch/tensor.py
@@ -486,8 +486,6 @@ class Tensor:
     def not_equal(self, other, *, out=None):
         return torch_frontend.not_equal(self, other, out=out)
 
-    ne = not_equal
-
     def equal(self, other):
         return torch_frontend.equal(self, other)
 

--- a/ivy_tests/test_ivy/test_frontends/test_torch/test_tensor.py
+++ b/ivy_tests/test_ivy/test_frontends/test_torch/test_tensor.py
@@ -289,16 +289,6 @@ def _get_dtype_and_multiplicative_matrices(draw):
 
 
 @st.composite
-def _get_dtype_and_multiplicative_matrices(draw):
-    return draw(
-        st.one_of(
-            _get_dtype_input_and_matrices(),
-            _get_dtype_and_3dbatch_matrices(),
-        )
-    )
-
-
-@st.composite
 def _get_dtype_input_and_vectors(draw, with_input=False, same_size=False):
     dim_size1 = draw(helpers.ints(min_value=2, max_value=5))
     dim_size2 = dim_size1 if same_size else draw(helpers.ints(min_value=2, max_value=5))
@@ -5269,7 +5259,7 @@ def test_torch_tensor_cos_(
         init_input_dtypes=input_dtype,
         backend_to_test=backend_fw,
         init_all_as_kwargs_np={
-            "data": list(x[0]) if type(x[0]) == int else x[0],
+            "data": list(x[0]) if isinstance(x[0], int) else x[0],
         },
         method_input_dtypes=input_dtype,
         method_all_as_kwargs_np={},


### PR DESCRIPTION
Corrected the errors encountered while attempting to commit the code:

```
ivy/functional/frontends/torch/tensor.py:954:5: F811 redefinition of unused 'ne' from line 511
ivy_tests/test_ivy/test_frontends/test_torch/test_tensor.py:292:1: F811 redefinition of unused '_get_dtype_and_multiplicative_matrices' from line 282
ivy_tests/test_ivy/test_frontends/test_torch/test_tensor.py:1347:35: E721 do not compare types, for exact checks use `is` / `is not`, for instance checks use `isinstance()`
```