### PR TITLE
Fixed erf_ method in the PyTorch frontend.

### DIFF
--- a/ivy/functional/frontends/torch/tensor.py
+++ b/ivy/functional/frontends/torch/tensor.py
@@ -486,7 +486,7 @@ class Tensor:
     def not_equal(self, other, *, out=None):
         return torch_frontend.not_equal(self, other, out=out)
 
-    ne = not_equal
+    # ne = not_equal
 
     def equal(self, other):
         return torch_frontend.equal(self, other)
@@ -495,9 +495,10 @@ class Tensor:
     def erf(self, *, out=None):
         return torch_frontend.erf(self, out=out)
 
-    @with_unsupported_dtypes({"2.0.1 and below": ("float16", "complex")}, "torch")
+    @with_supported_dtypes({"2.0.1 and below": ("float32", "float64")}, "torch")
     def erf_(self, *, out=None):
-        self.ivy_array = torch_frontend.erf(self, out=out).ivy_array
+        self.ivy_array = self.erf(out=out).ivy_array
+        return self
 
     def new_zeros(
         self,

--- a/ivy/functional/frontends/torch/tensor.py
+++ b/ivy/functional/frontends/torch/tensor.py
@@ -486,7 +486,7 @@ class Tensor:
     def not_equal(self, other, *, out=None):
         return torch_frontend.not_equal(self, other, out=out)
 
-    # ne = not_equal
+    ne = not_equal
 
     def equal(self, other):
         return torch_frontend.equal(self, other)

--- a/ivy/functional/frontends/torch/tensor.py
+++ b/ivy/functional/frontends/torch/tensor.py
@@ -495,7 +495,7 @@ class Tensor:
     def erf(self, *, out=None):
         return torch_frontend.erf(self, out=out)
 
-    @with_supported_dtypes({"2.0.1 and below": ("float32", "float64")}, "torch")
+    @with_supported_dtypes({"2.0.1 and below": ("float32", "float64", "bfloat16")}, "torch")
     def erf_(self, *, out=None):
         self.ivy_array = self.erf(out=out).ivy_array
         return self

--- a/ivy/functional/frontends/torch/tensor.py
+++ b/ivy/functional/frontends/torch/tensor.py
@@ -495,7 +495,9 @@ class Tensor:
     def erf(self, *, out=None):
         return torch_frontend.erf(self, out=out)
 
-    @with_supported_dtypes({"2.0.1 and below": ("float32", "float64", "bfloat16")}, "torch")
+    @with_supported_dtypes(
+        {"2.0.1 and below": ("float32", "float64", "bfloat16")}, "torch"
+    )
     def erf_(self, *, out=None):
         self.ivy_array = self.erf(out=out).ivy_array
         return self

--- a/ivy_tests/test_ivy/test_frontends/test_torch/test_tensor.py
+++ b/ivy_tests/test_ivy/test_frontends/test_torch/test_tensor.py
@@ -1344,7 +1344,7 @@ def test_torch_tensor_cos_(
         init_input_dtypes=input_dtype,
         backend_to_test=backend_fw,
         init_all_as_kwargs_np={
-            "data": list(x[0]) if type(x[0]) == int else x[0],
+            "data": list(x[0]) if isinstance(x[0], int) else x[0],
         },
         method_input_dtypes=input_dtype,
         method_all_as_kwargs_np={},
@@ -10471,7 +10471,7 @@ def test_torch_tensor_erf(
     init_tree="torch.tensor",
     method_name="erf_",
     dtype_and_x=helpers.dtype_and_values(
-        available_dtypes=helpers.get_dtypes("float"),
+        available_dtypes=helpers.get_dtypes("valid"),
     ),
 )
 def test_torch_tensor_erf_(

--- a/ivy_tests/test_ivy/test_frontends/test_torch/test_tensor.py
+++ b/ivy_tests/test_ivy/test_frontends/test_torch/test_tensor.py
@@ -1344,7 +1344,7 @@ def test_torch_tensor_cos_(
         init_input_dtypes=input_dtype,
         backend_to_test=backend_fw,
         init_all_as_kwargs_np={
-            "data": list(x[0]) if isinstance(x[0], int) else x[0],
+            "data": list(x[0]) if type(x[0]) == int else x[0],
         },
         method_input_dtypes=input_dtype,
         method_all_as_kwargs_np={},


### PR DESCRIPTION
This method was intended to execute an in-place operation on the `erf` method, but it lacked a return value.

![image](https://github.com/unifyai/ivy/assets/59949692/39987955-5eee-4252-b619-cd038fae1b16)
