### PR TITLE
fix ivy.expand with negative shape indices

### DIFF
--- a/ivy/functional/backends/numpy/experimental/manipulation.py
+++ b/ivy/functional/backends/numpy/experimental/manipulation.py
@@ -405,7 +405,7 @@ def expand(
     shape = list(shape)
     for i, dim in enumerate(shape):
         if dim < 0:
-            shape[i] = x.shape[i]
+            shape[i] = int(np.prod(x.shape) / np.prod([s for s in shape if s > 0]))
     return np.broadcast_to(x, tuple(shape))
 
 

--- a/ivy/functional/backends/tensorflow/experimental/manipulation.py
+++ b/ivy/functional/backends/tensorflow/experimental/manipulation.py
@@ -264,7 +264,7 @@ def expand(
     shape = list(shape)
     for i, dim in enumerate(shape):
         if dim < 0:
-            shape[i] = x.shape[i]
+            shape[i] = x.shape.num_elements() / tf.reduce_prod([s for s in shape if s > 0])
     return tf.broadcast_to(x, shape)
 
 


### PR DESCRIPTION
Fix ivy.expand for tensorflow and numpy backends where negative indices are included within the shape (meaning the size of the dimension needs to be inferred). Fixes this minimal example:

```
ivy.set_backend('tensorflow')
x = ivy.random_normal(shape=(4))
args = (x, (1, -1))

print(ivy.expand(*args), ivy.expand(*args).shape)
```