### PR TITLE
(fix): added copy=false to astype in batch_norm to reduce overhead of node expansions by one node

### DIFF
--- a/ivy/functional/ivy/experimental/norms.py
+++ b/ivy/functional/ivy/experimental/norms.py
@@ -196,7 +196,7 @@ def batch_norm(
     if scale is not None:
         inv = inv * scale
     xnormalized = x * inv.astype(x.dtype, copy=False) + ivy.astype(
-        offset - mean * inv if offset is not None else -mean * inv, x.dtype
+        offset - mean * inv if offset is not None else -mean * inv, x.dtype, copy=False
     )
 
     if data_format == "NCS":


### PR DESCRIPTION
# PR Description 

a fix to reduce overhead when transpiling modules that use batch_norm, by adding copy=False to astype in order to remove any cloning
## Checklist 

- [ x] Did you add a function?
- [ ] Did you add the tests?
- [x ] Did you follow the steps we provided?
