### PR TITLE
docstring formatting on ivy/functional/ivy/searching.py

### DIFF
--- a/ivy/functional/ivy/searching.py
+++ b/ivy/functional/ivy/searching.py
@@ -177,7 +177,7 @@ def argmin(
         An optional output_dtype from: int32, int64. Defaults to int64.
     select_last_index
         If this is set to True, the index corresponding to the
-        last occurrence of the maximum value will be returned
+        last occurrence of the maximum value will be returned.
     out
         if axis is None, a zero-dimensional array containing the index of the first
         occurrence of the minimum value; otherwise, a non-zero-dimensional array

--- a/ivy/functional/ivy/searching.py
+++ b/ivy/functional/ivy/searching.py
@@ -50,7 +50,7 @@ def argmax(
         input array. Should have a numeric data type.
     axis
         axis along which to search. If None, the function must return the index of the
-        maximum value of the flattened array. Deafult: ``None``.
+        maximum value of the flattened array. Default = None.
     keepdims
         If this is set to True, the axes which are reduced are left in the result as
         dimensions with size one. With this option, the result will broadcast correctly
@@ -117,6 +117,16 @@ def argmax(
     >>> y = ivy.argmax(x, axis=1, keepdims=True, out=z)
     >>> print(z)
     ivy.array([[0],[2],[2]])
+
+    With :class:`ivy.Container` input:
+
+    >>> x = ivy.Container(a=ivy.array([0., -1., 2.]), b=ivy.array([3., 4., 5.]))
+    >>> y = ivy.argmax(x)
+    >>> print(y)
+    {
+        a: ivy.array(2),
+        b: ivy.array(2)
+    }
     """
     return current_backend(x).argmax(
         x,
@@ -164,7 +174,10 @@ def argmin(
         input array (see Broadcasting). Otherwise, if False, the reduced axes
         (dimensions) must not be included in the result. Default = False.
     dtype
-            An optional output_dtype from: int32, int64. Defaults to int64.
+        An optional output_dtype from: int32, int64. Defaults to int64.
+    select_last_index
+        If this is set to True, the index corresponding to the
+        last occurrence of the maximum value will be returned
     out
         if axis is None, a zero-dimensional array containing the index of the first
         occurrence of the minimum value; otherwise, a non-zero-dimensional array


### PR DESCRIPTION
# PR Description 

docstring formatting -> ivy/functional/ivy/searching.py
- fixed "default" typo on argmax function
- added test for argmax function
- added parameter description in docstring for argmin function

## Related Issue 

Reformat searching
argmax

<!-- 
Please use this format to link other issues with their numbers: Close #123 
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Close #22808 

## Checklist 

- [ ] Did you add a function?
- [x] Did you add the tests?
- [x] Did you follow the steps we provided?

### Socials: 

<!-- 
If you have Twitter, please provide it here otherwise just ignore this.
-->
