### PR TITLE
add numpy.asscalar()

### DIFF
--- a/ivy/functional/frontends/numpy/manipulation_routines/changing_kind_of_array.py
+++ b/ivy/functional/frontends/numpy/manipulation_routines/changing_kind_of_array.py
@@ -5,3 +5,6 @@ import ivy
 
 def asmatrix(data, dtype=None):
     return np_frontend.matrix(ivy.array(data), dtype=dtype, copy=False)
+
+def asscalar(a):
+    return a.item()

--- a/ivy/functional/frontends/numpy/manipulation_routines/changing_kind_of_array.py
+++ b/ivy/functional/frontends/numpy/manipulation_routines/changing_kind_of_array.py
@@ -6,5 +6,6 @@ import ivy
 def asmatrix(data, dtype=None):
     return np_frontend.matrix(ivy.array(data), dtype=dtype, copy=False)
 
+
 def asscalar(a):
     return a.item()

--- a/ivy_tests/test_ivy/test_frontends/test_numpy/test_manipulation_routines/test_changing_kind_of_array.py
+++ b/ivy_tests/test_ivy/test_frontends/test_numpy/test_manipulation_routines/test_changing_kind_of_array.py
@@ -18,3 +18,14 @@ def test_numpy_asmatrix(arr, backend_fw):
         ret_gt = np.asmatrix(x[0])
         assert ret.shape == ret_gt.shape
         assert ivy_backend.all(ivy_backend.flatten(ret._data) == np.ravel(ret_gt))
+
+
+@handle_frontend_test(
+    fn_tree="numpy.asscalar",
+    arr=helpers.array_values(dtype=helpers.get_dtypes("numeric"), shape=1),
+)
+def test_numpy_asscalar(arr: np.ndarray, backend_fw):
+    with BackendHandler.update_backend(backend_fw) as ivy_backend:
+        ret_1 = arr.item()
+        ret_2 = np_frontend.asscalar(arr)
+        assert ret_1 == ret_2

--- a/ivy_tests/test_ivy/test_frontends/test_numpy/test_manipulation_routines/test_changing_kind_of_array.py
+++ b/ivy_tests/test_ivy/test_frontends/test_numpy/test_manipulation_routines/test_changing_kind_of_array.py
@@ -24,8 +24,7 @@ def test_numpy_asmatrix(arr, backend_fw):
     fn_tree="numpy.asscalar",
     arr=helpers.array_values(dtype=helpers.get_dtypes("numeric"), shape=1),
 )
-def test_numpy_asscalar(arr: np.ndarray, backend_fw):
-    with BackendHandler.update_backend(backend_fw) as ivy_backend:
-        ret_1 = arr.item()
-        ret_2 = np_frontend.asscalar(arr)
-        assert ret_1 == ret_2
+def test_numpy_asscalar(arr: np.ndarray):
+    ret_1 = arr.item()
+    ret_2 = np_frontend.asscalar(arr)
+    assert ret_1 == ret_2


### PR DESCRIPTION
# PR Description 
the numpy.asscalar function is deprecated and works exactly the same as calling the numpy.ndarray.item() method with no args. This is reflected in the way I wrote the test as well.

## Related Issue 

Close #22944


## Checklist 

- [x] Did you add a function?
- [x] Did you add the tests?
- [x] Did you follow the steps we provided?


