### PR TITLE
remove lambda and direct bindings for vmap

### DIFF
--- a/ivy/functional/backends/torch/general.py
+++ b/ivy/functional/backends/torch/general.py
@@ -516,7 +516,9 @@ def vmap(
     @ivy.output_to_native_arrays
     @ivy.inputs_to_native_arrays
     def _vmap(*args):
-        new_fun = lambda *args: ivy.to_native(func(*args))
+        def new_fun (*args):
+            return ivy.to_native(func(*args))
+		
         new_func = functorch.vmap(new_fun, in_axes, out_axes)
         return new_func(*args)
 


### PR DESCRIPTION
## PR description
removed lambda and direct bindings for vmap in torch backend and function instead defined using def

## Checklist 

- [ ] Step 1. reformatting general vmap function in torch backend

