### PR TITLE
refactor(ivy): removed additional framework dependencies due to `pad`

### DIFF
--- a/ivy/functional/backends/paddle/experimental/manipulation.py
+++ b/ivy/functional/backends/paddle/experimental/manipulation.py
@@ -19,7 +19,10 @@ import paddle
 import ivy
 import ivy.functional.backends.paddle as paddle_backend
 from ivy.func_wrapper import with_supported_device_and_dtypes
-from ...tensorflow.experimental.manipulation import _to_tf_padding
+from ivy.functional.ivy.experimental.manipulation import (
+    _check_paddle_pad,
+    _to_paddle_padding,
+)
 
 # Code from cephes for i0
 
@@ -148,42 +151,13 @@ def pad(
     )
 
 
-pad.partial_mixed_handler = lambda *args, mode="constant", constant_values=0, reflect_type="even", **kwargs: _check_paddle_pad(
-    mode, reflect_type, args[1], args[0].shape, constant_values, 3
-)
-
-
-def _check_paddle_pad(
-    mode, reflect_type, pad_width, input_shape, constant_values, ndim_limit
-):
-    pad_width = _to_tf_padding(pad_width, len(input_shape))
-    return isinstance(constant_values, Number) and (
-        mode == "constant"
-        or (
-            (
-                (
-                    mode == "reflect"
-                    and reflect_type == "even"
-                    and all(
-                        pad_width[i][0] < s and pad_width[i][1] < s
-                        for i, s in enumerate(input_shape)
-                    )
-                )
-                or mode in ["edge", "wrap"]
-            )
-            and len(input_shape) <= ndim_limit
+pad.partial_mixed_handler = (
+    lambda *args, mode="constant", constant_values=0, reflect_type="even", **kwargs: (
+        _check_paddle_pad(
+            mode, reflect_type, args[1], args[0].shape, constant_values, 3
         )
     )
-
-
-def _to_paddle_padding(pad_width, ndim):
-    if isinstance(pad_width, Number):
-        pad_width = [pad_width] * (2 * ndim)
-    else:
-        if len(pad_width) == 2 and isinstance(pad_width[0], Number) and ndim != 1:
-            pad_width = pad_width * ndim
-        pad_width = [item for sublist in pad_width for item in sublist[::-1]][::-1]
-    return pad_width
+)
 
 
 @with_unsupported_device_and_dtypes(

--- a/ivy/functional/backends/tensorflow/experimental/manipulation.py
+++ b/ivy/functional/backends/tensorflow/experimental/manipulation.py
@@ -18,6 +18,7 @@ import tensorflow as tf
 from ivy.func_wrapper import with_unsupported_dtypes
 from .. import backend_version
 import ivy
+from ivy.functional.ivy.experimental.manipulation import _to_tf_padding
 
 
 def moveaxis(
@@ -294,8 +295,10 @@ def pad(
     )
 
 
-pad.partial_mixed_handler = lambda *args, mode="constant", constant_values=0, reflect_type="even", **kwargs: _check_tf_pad(
-    args[0].shape, args[1], mode, constant_values, reflect_type
+pad.partial_mixed_handler = (
+    lambda *args, mode="constant", constant_values=0, reflect_type="even", **kwargs: (
+        _check_tf_pad(args[0].shape, args[1], mode, constant_values, reflect_type)
+    )
 )
 
 
@@ -323,14 +326,6 @@ def _check_tf_pad(input_shape, pad_width, mode, constant_values, reflect_type):
             )
         )
     )
-
-
-def _to_tf_padding(pad_width, ndim):
-    if isinstance(pad_width, Number):
-        pad_width = [[pad_width] * 2] * ndim
-    elif len(pad_width) == 2 and isinstance(pad_width[0], Number):
-        pad_width = pad_width * ndim
-    return pad_width
 
 
 def expand(

--- a/ivy/functional/backends/torch/experimental/manipulation.py
+++ b/ivy/functional/backends/torch/experimental/manipulation.py
@@ -18,8 +18,11 @@ import torch
 from ivy.func_wrapper import with_unsupported_dtypes, with_supported_dtypes
 from .. import backend_version
 import ivy
-from ...paddle.experimental.manipulation import _check_paddle_pad, _to_paddle_padding
-from ...tensorflow.experimental.manipulation import _to_tf_padding
+from ivy.functional.ivy.experimental.manipulation import (
+    _to_tf_padding,
+    _check_paddle_pad,
+    _to_paddle_padding,
+)
 
 
 def moveaxis(
@@ -110,8 +113,10 @@ def pad(
         ).squeeze(0)
 
 
-pad.partial_mixed_handler = lambda *args, mode="constant", constant_values=0, reflect_type="even", **kwargs: _check_torch_pad(
-    mode, reflect_type, args[1], args[0].shape, constant_values
+pad.partial_mixed_handler = (
+    lambda *args, mode="constant", constant_values=0, reflect_type="even", **kwargs: (
+        _check_torch_pad(mode, reflect_type, args[1], args[0].shape, constant_values)
+    )
 )
 
 


### PR DESCRIPTION
Removed paddle and tensorflow dependency for using the torch backend by moving the helpers to the ivy file