### PR TITLE
feat(frontend): Add torch.complex, torch.polar and its tests

### DIFF
--- a/ivy/functional/frontends/torch/creation_ops.py
+++ b/ivy/functional/frontends/torch/creation_ops.py
@@ -256,6 +256,7 @@ def ones_like_v_0p4p0_and_above(
 
 
 @with_supported_dtypes({"2.0.1 and below": ("float32", "float64")}, "torch")
+@to_ivy_arrays_and_back
 def polar(
     abs,
     angle,

--- a/ivy/functional/frontends/torch/creation_ops.py
+++ b/ivy/functional/frontends/torch/creation_ops.py
@@ -4,7 +4,11 @@ from ivy.functional.frontends.torch.func_wrapper import (
     to_ivy_arrays_and_back,
     to_ivy_shape,
 )
-from ivy.func_wrapper import with_unsupported_dtypes
+from ivy.func_wrapper import (
+    with_unsupported_dtypes,
+    with_supported_dtypes,
+    handle_out_argument,
+)
 import ivy.functional.frontends.torch as torch_frontend
 
 
@@ -308,3 +312,32 @@ def zeros_like(
 ):
     ret = ivy.zeros_like(input, dtype=dtype, device=device)
     return ret
+
+
+@with_supported_dtypes({"2.0.1 and below": ("float32", "float64")}, "torch")
+@to_ivy_arrays_and_back
+@handle_out_argument
+def complex(
+    real,
+    imag,
+    *,
+    out=None,
+):
+    assert real.dtype == imag.dtype, ValueError(
+        f"Expected real and imag to have the same dtype, "
+        " but got real.dtype = {real.dtype} and imag.dtype = {imag.dtype}."
+    )
+
+    complex_dtype = ivy.complex64 if real.dtype != ivy.float64 else ivy.complex128
+    complex_array = real + imag * 1j
+    return complex_array.astype(complex_dtype)
+
+
+@with_supported_dtypes({"2.0.1 and below": ("float32", "float64")}, "torch")
+def polar(
+    abs,
+    angle,
+    *,
+    out=None,
+):
+    return complex(abs * angle.cos(), abs * angle.sin(), out=out)

--- a/ivy/functional/frontends/torch/creation_ops.py
+++ b/ivy/functional/frontends/torch/creation_ops.py
@@ -7,7 +7,6 @@ from ivy.functional.frontends.torch.func_wrapper import (
 from ivy.func_wrapper import (
     with_unsupported_dtypes,
     with_supported_dtypes,
-    handle_out_argument,
 )
 import ivy.functional.frontends.torch as torch_frontend
 
@@ -73,6 +72,24 @@ def asarray(
     copy=None,
 ):
     return ivy.asarray(obj, copy=copy, dtype=dtype, device=device)
+
+
+@with_supported_dtypes({"2.0.1 and below": ("float32", "float64")}, "torch")
+@to_ivy_arrays_and_back
+def complex(
+    real,
+    imag,
+    *,
+    out=None,
+):
+    assert real.dtype == imag.dtype, ValueError(
+        "Expected real and imag to have the same dtype, "
+        f" but got real.dtype = {real.dtype} and imag.dtype = {imag.dtype}."
+    )
+
+    complex_dtype = ivy.complex64 if real.dtype != ivy.float64 else ivy.complex128
+    complex_array = real + imag * 1j
+    return complex_array.astype(complex_dtype, out=out)
 
 
 @to_ivy_arrays_and_back
@@ -238,6 +255,16 @@ def ones_like_v_0p4p0_and_above(
     return ret
 
 
+@with_supported_dtypes({"2.0.1 and below": ("float32", "float64")}, "torch")
+def polar(
+    abs,
+    angle,
+    *,
+    out=None,
+):
+    return complex(abs * angle.cos(), abs * angle.sin(), out=out)
+
+
 @to_ivy_arrays_and_back
 @with_unsupported_dtypes({"2.0.1 and below": ("float16",)}, "torch")
 def range(
@@ -312,32 +339,3 @@ def zeros_like(
 ):
     ret = ivy.zeros_like(input, dtype=dtype, device=device)
     return ret
-
-
-@with_supported_dtypes({"2.0.1 and below": ("float32", "float64")}, "torch")
-@to_ivy_arrays_and_back
-@handle_out_argument
-def complex(
-    real,
-    imag,
-    *,
-    out=None,
-):
-    assert real.dtype == imag.dtype, ValueError(
-        f"Expected real and imag to have the same dtype, "
-        " but got real.dtype = {real.dtype} and imag.dtype = {imag.dtype}."
-    )
-
-    complex_dtype = ivy.complex64 if real.dtype != ivy.float64 else ivy.complex128
-    complex_array = real + imag * 1j
-    return complex_array.astype(complex_dtype)
-
-
-@with_supported_dtypes({"2.0.1 and below": ("float32", "float64")}, "torch")
-def polar(
-    abs,
-    angle,
-    *,
-    out=None,
-):
-    return complex(abs * angle.cos(), abs * angle.sin(), out=out)

--- a/ivy_tests/test_ivy/test_frontends/test_torch/test_creation_ops.py
+++ b/ivy_tests/test_ivy/test_frontends/test_torch/test_creation_ops.py
@@ -830,3 +830,57 @@ def test_torch_zeros_like(
         dtype=dtype[0],
         device=on_device,
     )
+
+
+# complex
+@handle_frontend_test(
+    fn_tree="torch.complex",
+    dtype_and_x=helpers.dtype_and_values(available_dtypes=helpers.get_dtypes("float")),
+)
+def test_complex(
+    *,
+    dtype_and_x,
+    on_device,
+    fn_tree,
+    frontend,
+    test_flags,
+    backend_fw,
+):
+    input_dtype, input = dtype_and_x
+    helpers.test_frontend_function(
+        input_dtypes=input_dtype,
+        backend_to_test=backend_fw,
+        frontend=frontend,
+        test_flags=test_flags,
+        fn_tree=fn_tree,
+        on_device=on_device,
+        real=input[0],
+        imag=input[0],
+    )
+
+
+# polar
+@handle_frontend_test(
+    fn_tree="torch.polar",
+    dtype_and_x=helpers.dtype_and_values(available_dtypes=helpers.get_dtypes("float")),
+)
+def test_polar(
+    *,
+    dtype_and_x,
+    on_device,
+    fn_tree,
+    frontend,
+    test_flags,
+    backend_fw,
+):
+    input_dtype, input = dtype_and_x
+    helpers.test_frontend_function(
+        input_dtypes=input_dtype,
+        backend_to_test=backend_fw,
+        frontend=frontend,
+        test_flags=test_flags,
+        fn_tree=fn_tree,
+        on_device=on_device,
+        abs=input[0],
+        angle=input[0],
+    )

--- a/ivy_tests/test_ivy/test_frontends/test_torch/test_creation_ops.py
+++ b/ivy_tests/test_ivy/test_frontends/test_torch/test_creation_ops.py
@@ -181,6 +181,7 @@ def test_complex(
 @handle_frontend_test(
     fn_tree="torch.polar",
     dtype_and_x=helpers.dtype_and_values(available_dtypes=helpers.get_dtypes("float")),
+    test_with_out=st.just(False),
 )
 def test_polar(
     *,

--- a/ivy_tests/test_ivy/test_frontends/test_torch/test_creation_ops.py
+++ b/ivy_tests/test_ivy/test_frontends/test_torch/test_creation_ops.py
@@ -150,6 +150,60 @@ def _start_stop_step(draw):
 # ------------ #
 
 
+# complex
+@handle_frontend_test(
+    fn_tree="torch.complex",
+    dtype_and_x=helpers.dtype_and_values(available_dtypes=helpers.get_dtypes("float")),
+)
+def test_complex(
+    *,
+    dtype_and_x,
+    on_device,
+    fn_tree,
+    frontend,
+    test_flags,
+    backend_fw,
+):
+    input_dtype, input = dtype_and_x
+    helpers.test_frontend_function(
+        input_dtypes=input_dtype,
+        backend_to_test=backend_fw,
+        frontend=frontend,
+        test_flags=test_flags,
+        fn_tree=fn_tree,
+        on_device=on_device,
+        real=input[0],
+        imag=input[0],
+    )
+
+
+# polar
+@handle_frontend_test(
+    fn_tree="torch.polar",
+    dtype_and_x=helpers.dtype_and_values(available_dtypes=helpers.get_dtypes("float")),
+)
+def test_polar(
+    *,
+    dtype_and_x,
+    on_device,
+    fn_tree,
+    frontend,
+    test_flags,
+    backend_fw,
+):
+    input_dtype, input = dtype_and_x
+    helpers.test_frontend_function(
+        input_dtypes=input_dtype,
+        backend_to_test=backend_fw,
+        frontend=frontend,
+        test_flags=test_flags,
+        fn_tree=fn_tree,
+        on_device=on_device,
+        abs=input[0],
+        angle=input[0],
+    )
+
+
 # arange
 @handle_frontend_test(
     fn_tree="torch.arange",
@@ -829,58 +883,4 @@ def test_torch_zeros_like(
         input=input[0],
         dtype=dtype[0],
         device=on_device,
-    )
-
-
-# complex
-@handle_frontend_test(
-    fn_tree="torch.complex",
-    dtype_and_x=helpers.dtype_and_values(available_dtypes=helpers.get_dtypes("float")),
-)
-def test_complex(
-    *,
-    dtype_and_x,
-    on_device,
-    fn_tree,
-    frontend,
-    test_flags,
-    backend_fw,
-):
-    input_dtype, input = dtype_and_x
-    helpers.test_frontend_function(
-        input_dtypes=input_dtype,
-        backend_to_test=backend_fw,
-        frontend=frontend,
-        test_flags=test_flags,
-        fn_tree=fn_tree,
-        on_device=on_device,
-        real=input[0],
-        imag=input[0],
-    )
-
-
-# polar
-@handle_frontend_test(
-    fn_tree="torch.polar",
-    dtype_and_x=helpers.dtype_and_values(available_dtypes=helpers.get_dtypes("float")),
-)
-def test_polar(
-    *,
-    dtype_and_x,
-    on_device,
-    fn_tree,
-    frontend,
-    test_flags,
-    backend_fw,
-):
-    input_dtype, input = dtype_and_x
-    helpers.test_frontend_function(
-        input_dtypes=input_dtype,
-        backend_to_test=backend_fw,
-        frontend=frontend,
-        test_flags=test_flags,
-        fn_tree=fn_tree,
-        on_device=on_device,
-        abs=input[0],
-        angle=input[0],
     )


### PR DESCRIPTION
# PR Description 

Adds `torch.polar` and `torch.complex` to the torch frontend (see `creation_ops` issue #8), alongside its tests.
Ended up implementing `torch.complex` since it made more sense to be able to use it for `torch.polar`.

I've made some comments on the PR to make some of my decisions more clear, you can probably see them while going through the code or in the PR feed below.

## Related Issue 

Closes #22752 and #22978

## Checklist 

- [X] Did you add a function?
- [X] Did you add the tests?
- [X] Did you follow the steps we provided?

