### PR TITLE
Refactor exists

### DIFF
--- a/ivy/data_classes/array/general.py
+++ b/ivy/data_classes/array/general.py
@@ -988,7 +988,7 @@ class _ArrayWithGeneral(abc.ABC):
         """
         return ivy.value_is_nan(self, include_infs=include_infs)
 
-    def exists(self: ivy.Array) -> bool:
+    def exists(self: ivy.Array, /) -> bool:
         """
         ivy.Array instance method variant of ivy.exists. This method simply wraps the
         function, and so the docstring for ivy.exists also applies to this method with
@@ -1002,7 +1002,7 @@ class _ArrayWithGeneral(abc.ABC):
         Returns
         -------
         ret
-            True if x is not None, else False.
+            True if input is not None, else False.
 
         Examples
         --------

--- a/ivy/data_classes/container/general.py
+++ b/ivy/data_classes/container/general.py
@@ -4242,3 +4242,57 @@ class _ContainerWithGeneral(ContainerBase):
             A tuple containing the strides.
         """
         return self.static_strides(self)
+
+    @staticmethod
+    def static_exists(x: ivy.Container, /) -> ivy.Container:
+        """
+        ivy.Container instance method variant of ivy.exists. This method simply wraps
+        the function, and so the docstring for ivy.exists also applies to this method
+        with minimal changes.
+
+        Parameters
+        ----------
+        x
+            input container.
+
+        Returns
+        -------
+        ret
+            True if x is not None, else False.
+
+        Examples
+        --------
+        >>> x = ivy.Container(a=[1,2,3,4], b=[])
+        >>> y = x.exists()
+        >>> print(y)
+        { a: True, b: True }
+
+        >>> x = ivy.Container(a=None, b=[1,2])
+        >>> y = x.exists()
+        >>> print(y)
+        { a: False, b: True }
+
+        >>> x = ivy.Container(a={"d": 1, "c": 3}, b=None)
+        >>> y = x.exists()
+        >>> print(y)
+        { a: { c: True, d: True }, b: False }
+        """
+        return ContainerBase.cont_multi_map_in_function("exists", x)
+
+    def exists(self: ivy.Container, /) -> ivy.Container:
+        """
+        ivy.Container instance method variant of ivy.exists. This method simply wraps
+        the function, and so the docstring for ivy.exists also applies to this method
+        with minimal changes.
+
+        Parameters
+        ----------
+        x
+            input container.
+
+        Returns
+        -------
+        ret
+            True if x is not None, else False.
+        """
+        return self.static_exists(self)

--- a/ivy/data_classes/container/general.py
+++ b/ivy/data_classes/container/general.py
@@ -4287,7 +4287,7 @@ class _ContainerWithGeneral(ContainerBase):
 
         Parameters
         ----------
-        x
+        self
             input container.
 
         Returns

--- a/ivy/data_classes/container/general.py
+++ b/ivy/data_classes/container/general.py
@@ -4244,7 +4244,15 @@ class _ContainerWithGeneral(ContainerBase):
         return self.static_strides(self)
 
     @staticmethod
-    def static_exists(x: ivy.Container, /) -> ivy.Container:
+    def _static_exists(
+        x: ivy.Container,
+        /,
+        *,
+        key_chains: Optional[Union[List[str], Dict[str, str], ivy.Container]] = None,
+        to_apply: Union[bool, ivy.Container] = True,
+        prune_unapplied: Union[bool, ivy.Container] = False,
+        map_sequences: Union[bool, ivy.Container] = False,
+    ) -> ivy.Container:
         """
         ivy.Container instance method variant of ivy.exists. This method simply wraps
         the function, and so the docstring for ivy.exists also applies to this method
@@ -4253,12 +4261,86 @@ class _ContainerWithGeneral(ContainerBase):
         Parameters
         ----------
         x
-            input container.
+            The input container.
+        key_chains
+            The key-chains to apply or not apply the method to. Default is ``None``.
+        to_apply
+            If True, the method will be applied to key_chains, otherwise key_chains
+            will be skipped. Default is ``True``.
+        prune_unapplied
+            Whether to prune key_chains for which the function was not applied.
+            Default is ``False``.
+        map_sequences
+            Whether to also map method to sequences (lists, tuples).
+            Default is ``False``.
 
         Returns
         -------
         ret
-            True if x is not None, else False.
+            A boolean container detaling if any of the leaf nodes are None.
+            True if not None, False if None.
+
+        Examples
+        --------
+        >>> x = ivy.Container(a=ivy.array([0,4,5]), b=ivy.array([2,2,0]))
+        >>> y = x._static_exists(x)
+        >>> print(y)
+        { a: True, b: True }
+
+        >>> x = ivy.Container(a=[1,2], b=None)
+        >>> y = x._static_exists(x)
+        >>> print(y)
+        { a: True, b: False }
+
+        >>> x = ivy.Container(a={"d": 1, "c": 3}, b={"d": 20, "c": None})
+        >>> y = x._static_exists(x)
+        >>> print(y)
+        { a: { c: True, d: True }, b: { c: False, d: True } }
+        """
+        return ContainerBase.cont_multi_map_in_function(
+            "exists",
+            x,
+            key_chains=key_chains,
+            to_apply=to_apply,
+            prune_unapplied=prune_unapplied,
+            map_sequences=map_sequences,
+        )
+
+    def exists(
+        self: ivy.Container,
+        /,
+        *,
+        key_chains: Optional[Union[List[str], Dict[str, str], ivy.Container]] = None,
+        to_apply: Union[bool, ivy.Container] = True,
+        prune_unapplied: Union[bool, ivy.Container] = False,
+        map_sequences: Union[bool, ivy.Container] = False,
+    ) -> ivy.Container:
+        """
+        ivy.Container instance method variant of ivy.exists. This method simply wraps
+        the function, and so the docstring for ivy.exists also applies to this method
+        with minimal changes.
+
+        Parameters
+        ----------
+        self
+            The input container.
+        key_chains
+            The key-chains to apply or not apply the method to. Default is ``None``.
+        to_apply
+            If True, the method will be applied to key_chains, otherwise key_chains
+            will be skipped. Default is ``True``.
+        prune_unapplied
+            Whether to prune key_chains for which the function was not applied.
+            Default is ``False``.
+        map_sequences
+            Whether to also map method to sequences (lists, tuples).
+            Default is ``False``.
+
+        Returns
+        -------
+        ret
+            A boolean container detaling if any of the leaf nodes are None.
+            True if not None, False if None.
 
         Examples
         --------
@@ -4277,22 +4359,10 @@ class _ContainerWithGeneral(ContainerBase):
         >>> print(y)
         { a: { c: True, d: True }, b: False }
         """
-        return ContainerBase.cont_multi_map_in_function("exists", x)
-
-    def exists(self: ivy.Container, /) -> ivy.Container:
-        """
-        ivy.Container instance method variant of ivy.exists. This method simply wraps
-        the function, and so the docstring for ivy.exists also applies to this method
-        with minimal changes.
-
-        Parameters
-        ----------
-        self
-            input container.
-
-        Returns
-        -------
-        ret
-            True if x is not None, else False.
-        """
-        return self.static_exists(self)
+        return self._static_exists(
+            self,
+            key_chains=key_chains,
+            to_apply=to_apply,
+            prune_unapplied=prune_unapplied,
+            map_sequences=map_sequences,
+        )

--- a/ivy/functional/ivy/general.py
+++ b/ivy/functional/ivy/general.py
@@ -1353,7 +1353,7 @@ def has_nans(
 
 
 @handle_exceptions
-def exists(x: Any) -> bool:
+def exists(x: Any, /) -> bool:
     """
     Check as to whether the input is None or not.
 


### PR DESCRIPTION
# PR Description 

The docstrings, examples, hint types, and arguments for exists were mostly correct. I turned the passed in parameter to be positional only, as per the recommendations from the Ivy documentation.

I also implemented an ivy.Container instance method for exists that returns an ivy.Container detailing if any of the leaves are None.

## Related Issue 
This should resolve issue #22937 for reformatting exists.

## Checklist 

- [x] Did you add a function?
- [x] Did you add the tests? - I added docstrings tests
- [x] Did you follow the steps we provided?

## Checklist provided by docs

- [x] Remove all lambda and direct bindings for the backend functions (in ivy.functional.backends), with each function instead defined using def.
- [x] Implement the following if they don’t exist but should do: ivy.Array instance method, ivy.Container instance method, ivy.Array special method, ivy.Array reverse special method, ivy.Container special method, ivy.Container reverse special method.
- [x] Make sure that the aforementioned methods are added into the correct category-specific parent class, such as ivy.ArrayWithElementwise, ivy.ContainerWithManipulation etc.
- [x] Correct all of the Function Arguments and the type hints for every function and its relevant methods, including those you did not implement yourself.
- [x] Add the correct Docstrings to every function and its relevant methods, including those you did not implement yourself.
- [x] Add thorough Docstring Examples for every function and its relevant methods and ensure they pass the docstring tests.
