### PR TITLE
Implemented precision_score function in _classification.py

### DIFF
--- a/ivy/functional/frontends/sklearn/metrics/_classification.py
+++ b/ivy/functional/frontends/sklearn/metrics/_classification.py
@@ -17,3 +17,28 @@ def accuracy_score(y_true, y_pred, *, normalize=True, sample_weight=None):
         ret = ret / y_true.shape[0]
         ret = ret.astype("float64")
     return ret
+
+
+@to_ivy_arrays_and_back
+def precision_score(y_true, y_pred, *, average="binary", sample_weight=None):
+    # TODO: implement sample_weight
+    y_type = type_of_target(y_true)
+    if y_type.startswith("multilabel"):
+        true_positives = ivy.count_nonzero(
+            ivy.equal(y_true, y_pred).astype("int64"), axis=0
+        )
+        all_positives = ivy.count_nonzero(y_pred, axis=0)
+    else:
+        true_positives = ivy.count_nonzero(
+            ivy.equal(y_true, y_pred).astype("int64"), axis =1
+        )
+        all_positives = ivy.count_nonzero(y_pred)
+    if average == "binary":
+        precision = true_positives / all_positives
+    elif average == "micro":
+        precision = ivy.sum(true_positives) / ivy.sum(all_positives)
+    elif average == "macro":
+        precision = ivy.mean(true_positives / all_positives)
+    else:
+        raise ValueError("Invalid value for 'average'.")
+    return precision


### PR DESCRIPTION
The precision_score function calculates the precision score for classification tasks, which is a measure of the accuracy of positive predictions. 

The precision_score function takes as input the true labels y_true and predicted labels y_pred. It also allows for optional parameters such as normalize for controlling whether the result should be normalized and sample_weight for handling sample weights.

The function first determines the type of target variable, checking if it is a multilabel classification problem. If it is, it computes the difference between y_true and y_pred and counts the number of non-zero elements along the specified axis, corresponding to the number of different labels predicted. It then checks if this count is equal to zero for each sample and converts the result to an integer.

For binary or multiclass classification problems, the code simply compares y_true and y_pred for equality, again converting the result to integers.

The function sums up the integer values, which represent the number of correct positive predictions, and optionally normalizes the result by dividing it by the total number of samples. The final result is cast as a float if normalization is enabled.


<!-- 
This template will help you to have a meaningful PR, please follow it and do not leave it blank.
-->

# PR Description 

<!-- 
If there is no related issue, please add a short description about your PR.
-->

## Related Issue 

<!-- 
Please use this format to link other issues with their numbers: Close #123 
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Close #

## Checklist 

- [ ] Did you add a function?
- [ ] Did you add the tests?
- [ ] Did you follow the steps we provided?

### Socials: 

<!-- 
If you have Twitter, please provide it here otherwise just ignore this.
-->
