### PR TITLE
Added paddle frontend for binary cross entropy

### DIFF
--- a/ivy_tests/test_ivy/test_frontends/test_paddle/test_nn/test_functional/test_loss.py
+++ b/ivy_tests/test_ivy/test_frontends/test_paddle/test_nn/test_functional/test_loss.py
@@ -40,6 +40,59 @@ def _cos_embd_loss_helper(draw):
 # ------------ #
 
 
+# binary_cross_entropy
+@handle_frontend_test(
+    fn_tree="paddle.nn.functional.binary_cross_entropy",
+    dtype_and_vals=helpers.dtype_and_values(
+        available_dtypes=helpers.get_dtypes("float"),
+        num_arrays=3,
+        shared_dtype=True,
+        min_value=1.0013580322265625e-05,
+        max_value=1.0,
+        large_abs_safety_factor=2,
+        small_abs_safety_factor=2,
+        safety_factor_scale="linear",
+        allow_inf=False,
+        exclude_min=True,
+        exclude_max=True,
+        min_num_dims=1,
+        max_num_dims=1,
+        min_dim_size=2,
+        shape=(5,),
+    ),
+    reduction=st.sampled_from(["mean", "none", "sum"]),
+)
+def test_paddle_binary_cross_entropy(
+    *,
+    dtype_and_vals,
+    reduction,
+    on_device,
+    fn_tree,
+    frontend,
+    test_flags,
+    backend_fw,
+):
+    input_dtype, x = dtype_and_vals
+    pred_dtype, pred = input_dtype[0], x[0]
+    true_dtype, true = input_dtype[1], x[1]
+    weight_dtype, weight = input_dtype[2], x[2]
+
+    helpers.test_frontend_function(
+        input_dtypes=[pred_dtype, true_dtype, weight_dtype],
+        backend_to_test=backend_fw,
+        frontend=frontend,
+        test_flags=test_flags,
+        fn_tree=fn_tree,
+        on_device=on_device,
+        input=pred,
+        label=true,
+        weight=weight,
+        reduction=reduction,
+        rtol=1e-02,
+        atol=1e-02,
+    )
+
+
 @handle_frontend_test(
     fn_tree="paddle.nn.functional.binary_cross_entropy_with_logits",
     dtype_and_x=helpers.dtype_and_values(


### PR DESCRIPTION
<!-- 
This template will help you to have a meaningful PR, please follow it and do not leave it blank.
-->

# PR Description 

<!-- 
If there is no related issue, please add a short description about your PR.
-->

## Related Issue 

<!-- 
Please use this format to link other issues with their numbers: Close #123 
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Close #22215

## Checklist 

- [ ] Added a function "binary_cross_entropy"
- [ ] Added test function "test_paddle_binary_cross_entropy"
- [ ] Followed all steps provided

The tests encountered an issue "Frontend function returned non-frontend arrays: ivy.array([float, float])".  I think this happens because the ground-truth function returns a paddle.Tensor object while this function returns an ivy.frontends.paddle.Tensor object. In converting the ivy array to a paddle tensor I used ivy.functional.frontends.paddle.to_tensor() which does not return the same data type as paddle.to_tensor().


### Socials: 

<!-- 
If you have Twitter, please provide it here otherwise just ignore this.
-->
