### PR TITLE
Added digamma function for TensorFlow frontend

### DIFF
--- a/.idea/runConfigurations/_template__of_py_test.xml
+++ b/.idea/runConfigurations/_template__of_py_test.xml
@@ -8,7 +8,6 @@
       <env name="PYTHONPATH" value="/opt/fw/numpy:/opt/fw/jax:/opt/fw/tensorflow:/opt/fw/torch:/opt/fw/paddle:/opt/fw/mxnet" />
     </envs>
     <option name="SDK_HOME" value="python" />
-    <option name="SDK_NAME" value="Remote Python 3.10.0 Docker (unifyai/ivy:latest)" />
     <option name="WORKING_DIRECTORY" value="" />
     <option name="IS_MODULE_SDK" value="false" />
     <option name="ADD_CONTENT_ROOTS" value="true" />

--- a/ivy/data_classes/array/layers.py
+++ b/ivy/data_classes/array/layers.py
@@ -1,6 +1,6 @@
 # global
 import abc
-from typing import Optional, Tuple, Union, List, Sequence, Dict
+from typing import Optional, Tuple, Union, List, Sequence
 
 # local
 import ivy

--- a/ivy/functional/frontends/numpy/mathematical_functions/other_special_functions.py
+++ b/ivy/functional/frontends/numpy/mathematical_functions/other_special_functions.py
@@ -9,6 +9,13 @@ from ivy.functional.frontends.numpy.func_wrapper import (
 
 
 @to_ivy_arrays_and_back
+def sinc(x):
+    if ivy.get_num_dims(x) == 0:
+        x = ivy.astype(x, ivy.float64)
+    return ivy.sinc(x)
+
+
+@to_ivy_arrays_and_back
 @from_zero_dim_arrays_to_scalar
 def unwrap(p, discont=None, axis=-1, *, period=2 * ivy.pi):
     p = ivy.asarray(p)
@@ -35,10 +42,3 @@ def unwrap(p, discont=None, axis=-1, *, period=2 * ivy.pi):
     up = ivy.array(p, copy=True, dtype=dtype)
     up[slice1] = p[slice1] + ph_correct.cumsum(axis)
     return up
-
-
-@to_ivy_arrays_and_back
-def sinc(x):
-    if ivy.get_num_dims(x) == 0:
-        x = ivy.astype(x, ivy.float64)
-    return ivy.sinc(x)

--- a/ivy/functional/frontends/paddle/tensor/math.py
+++ b/ivy/functional/frontends/paddle/tensor/math.py
@@ -217,6 +217,12 @@ def floor(x, name=None):
     return ivy.floor(x)
 
 
+@with_supported_dtypes({"2.5.1 and below": ("float32", "float64")}, "paddle")
+@to_ivy_arrays_and_back
+def floor_divide(x, y, name=None):
+    return ivy.floor_divide(x, y)
+
+
 @with_unsupported_dtypes({"2.5.1 and below": "bfloat16"}, "paddle")
 @to_ivy_arrays_and_back
 def fmax(x, y, name=None):
@@ -512,12 +518,6 @@ def sqrt_(x, name=None):
 @to_ivy_arrays_and_back
 def square(x, name=None):
     return ivy.square(x)
-
-
-@with_supported_dtypes({"2.5.1 and below": ("float32", "float64")}, "paddle")
-@to_ivy_arrays_and_back
-def floor_divide(x, y, name=None):
-    return ivy.floor_divide(x, y)
 
 
 @with_supported_dtypes({"2.5.1 and below": ("float32", "float64")}, "paddle")

--- a/ivy/functional/frontends/tensorflow/math.py
+++ b/ivy/functional/frontends/tensorflow/math.py
@@ -11,6 +11,7 @@ from ivy.functional.frontends.tensorflow.func_wrapper import (
     handle_tf_dtype,
     to_ivy_dtype,
 )
+from ivy.framework_handler import get_backend as _get_backend
 
 
 @with_unsupported_dtypes(
@@ -240,6 +241,27 @@ def divide_no_nan(x, y, name="divide_no_nan"):
         ivy.array(0.0, dtype=ivy.promote_types(x.dtype, y.dtype)),
         x / y,
     )
+
+@to_ivy_arrays_and_back
+def digamma(x, name=None):
+    """
+       Computes the digamma function.
+
+       Args:
+           x (array): Input array.
+           name (str): Name for the operation (optional).
+
+       Returns:
+           array: The result of the digamma function applied to the input.
+
+       Raises:
+           NotImplementedError: If the backend is not TensorFlow.
+       """
+    backend = _get_backend(x)
+    if backend == 'tensorflow':
+        return ivy.array(ivy.digamma(x), ivy.array([0], ivy.int32))
+    else:
+        raise NotImplementedError(f'digamma is not implemented for backend: {backend}')
 
 
 @to_ivy_arrays_and_back

--- a/ivy/functional/frontends/tensorflow/math.py
+++ b/ivy/functional/frontends/tensorflow/math.py
@@ -228,6 +228,15 @@ def cumsum(x, axis, exclusive=False, reverse=False, name=None):
 
 
 @to_ivy_arrays_and_back
+def digamma(x, name=None):
+    backend = _get_backend(x)
+    if backend == "tensorflow":
+        return ivy.array(ivy.digamma(x), ivy.array([0], ivy.int32))
+    else:
+        raise NotImplementedError(f"digamma is not implemented for backend: {backend}")
+
+
+@to_ivy_arrays_and_back
 def divide(x, y, name=None):
     x, y = check_tensorflow_casting(x, y)
     return ivy.divide(x, y)
@@ -241,27 +250,6 @@ def divide_no_nan(x, y, name="divide_no_nan"):
         ivy.array(0.0, dtype=ivy.promote_types(x.dtype, y.dtype)),
         x / y,
     )
-
-@to_ivy_arrays_and_back
-def digamma(x, name=None):
-    """
-       Computes the digamma function.
-
-       Args:
-           x (array): Input array.
-           name (str): Name for the operation (optional).
-
-       Returns:
-           array: The result of the digamma function applied to the input.
-
-       Raises:
-           NotImplementedError: If the backend is not TensorFlow.
-       """
-    backend = _get_backend(x)
-    if backend == 'tensorflow':
-        return ivy.array(ivy.digamma(x), ivy.array([0], ivy.int32))
-    else:
-        raise NotImplementedError(f'digamma is not implemented for backend: {backend}')
 
 
 @to_ivy_arrays_and_back

--- a/ivy/functional/frontends/tensorflow/raw_ops.py
+++ b/ivy/functional/frontends/tensorflow/raw_ops.py
@@ -50,6 +50,7 @@ Cosh = to_ivy_arrays_and_back(map_raw_ops_alias(tf_frontend.math.cosh))
 Cumprod = to_ivy_arrays_and_back(map_raw_ops_alias(tf_frontend.math.cumprod))
 Cumsum = to_ivy_arrays_and_back(map_raw_ops_alias(tf_frontend.math.cumsum))
 Div = to_ivy_arrays_and_back(map_raw_ops_alias(tf_frontend.math.divide))
+Digamma = to_ivy_arrays_and_back(map_raw_ops_alias(tf_frontend.math.digamma))
 Einsum = to_ivy_arrays_and_back(
     with_supported_dtypes(
         {

--- a/ivy/functional/frontends/tensorflow/raw_ops.py
+++ b/ivy/functional/frontends/tensorflow/raw_ops.py
@@ -49,8 +49,8 @@ Cos = to_ivy_arrays_and_back(map_raw_ops_alias(tf_frontend.math.cos))
 Cosh = to_ivy_arrays_and_back(map_raw_ops_alias(tf_frontend.math.cosh))
 Cumprod = to_ivy_arrays_and_back(map_raw_ops_alias(tf_frontend.math.cumprod))
 Cumsum = to_ivy_arrays_and_back(map_raw_ops_alias(tf_frontend.math.cumsum))
-Div = to_ivy_arrays_and_back(map_raw_ops_alias(tf_frontend.math.divide))
 Digamma = to_ivy_arrays_and_back(map_raw_ops_alias(tf_frontend.math.digamma))
+Div = to_ivy_arrays_and_back(map_raw_ops_alias(tf_frontend.math.divide))
 Einsum = to_ivy_arrays_and_back(
     with_supported_dtypes(
         {

--- a/ivy/functional/frontends/torch/comparison_ops.py
+++ b/ivy/functional/frontends/torch/comparison_ops.py
@@ -290,7 +290,7 @@ def topk(input, k, dim=None, largest=True, sorted=True, *, out=None):
 
 
 gt = greater
+ne = not_equal
 ge = greater_equal
 le = less_equal
 lt = less
-ne = not_equal

--- a/ivy_tests/test_ivy/test_frontends/test_paddle/test_tensor/test_math.py
+++ b/ivy_tests/test_ivy/test_frontends/test_paddle/test_tensor/test_math.py
@@ -932,6 +932,41 @@ def test_paddle_floor(
     )
 
 
+# floor_divide
+@handle_frontend_test(
+    fn_tree="paddle.tensor.math.floor_divide",
+    dtype_and_x=helpers.dtype_and_values(
+        available_dtypes=helpers.get_dtypes("valid"),
+        min_value=-10,
+        max_value=10,
+        num_arrays=2,
+        allow_inf=False,
+        shared_dtype=True,
+    ),
+)
+def test_paddle_floor_divide(
+    *,
+    dtype_and_x,
+    on_device,
+    fn_tree,
+    frontend,
+    backend_fw,
+    test_flags,
+):
+    input_dtype, x = dtype_and_x
+    helpers.test_frontend_function(
+        input_dtypes=input_dtype,
+        frontend=frontend,
+        backend_to_test=backend_fw,
+        fn_tree=fn_tree,
+        test_flags=test_flags,
+        on_device=on_device,
+        x=x[0],
+        y=x[1],
+        atol=1e-5,
+    )
+
+
 @handle_frontend_test(
     fn_tree="paddle.fmax",
     dtypes_and_x=helpers.dtype_and_values(
@@ -2164,41 +2199,6 @@ def test_paddle_sin(
         fn_tree=fn_tree,
         on_device=on_device,
         x=x[0],
-    )
-
-
-# floor_divide
-@handle_frontend_test(
-    fn_tree="paddle.tensor.math.floor_divide",
-    dtype_and_x=helpers.dtype_and_values(
-        available_dtypes=helpers.get_dtypes("valid"),
-        min_value=-10,
-        max_value=10,
-        num_arrays=2,
-        allow_inf=False,
-        shared_dtype=True,
-    ),
-)
-def test_paddle_floor_divide(
-    *,
-    dtype_and_x,
-    on_device,
-    fn_tree,
-    frontend,
-    backend_fw,
-    test_flags,
-):
-    input_dtype, x = dtype_and_x
-    helpers.test_frontend_function(
-        input_dtypes=input_dtype,
-        frontend=frontend,
-        backend_to_test=backend_fw,
-        fn_tree=fn_tree,
-        test_flags=test_flags,
-        on_device=on_device,
-        x=x[0],
-        y=x[1],
-        atol=1e-5,
     )
 
 

--- a/ivy_tests/test_ivy/test_frontends/test_tensorflow/test_math.py
+++ b/ivy_tests/test_ivy/test_frontends/test_tensorflow/test_math.py
@@ -825,6 +825,35 @@ def test_tensorflow_divide_no_nan(
     )
 
 
+# digamma
+@handle_frontend_test(
+    fn_tree="tensorflow.math.digamma",
+    dtype_and_x=helpers.dtype_and_values(
+        available_dtypes=helpers.get_dtypes("float"),
+    ),
+    test_with_out=st.just(False),
+)
+def test_tensorflow_digamma(
+    *,
+    dtype_and_x,
+    on_device,
+    fn_tree,
+    frontend,
+    test_flags,
+    backend_fw,
+):
+    input_dtype, x = dtype_and_x
+    helpers.test_frontend_function(
+        input_dtypes=input_dtype,
+        backend_to_test=backend_fw,
+        frontend=frontend,
+        test_flags=test_flags,
+        fn_tree=fn_tree,
+        on_device=on_device,
+        x=x[0],
+    )
+
+
 # equal
 @handle_frontend_test(
     fn_tree="tensorflow.math.equal",

--- a/ivy_tests/test_ivy/test_frontends/test_tensorflow/test_math.py
+++ b/ivy_tests/test_ivy/test_frontends/test_tensorflow/test_math.py
@@ -761,6 +761,36 @@ def test_tensorflow_cumsum(  # NOQA
     )
 
 
+# digamma
+@handle_frontend_test(
+    fn_tree="tensorflow.math.digamma",
+    dtype_and_x=helpers.dtype_and_values(
+        num_arrays=1,
+        available_dtypes=helpers.get_dtypes("float"),
+    ),
+    test_with_out=st.just(False),
+)
+def test_tensorflow_digamma(
+    *,
+    dtype_and_x,
+    on_device,
+    fn_tree,
+    frontend,
+    test_flags,
+    backend_fw,
+):
+    input_dtype, x = dtype_and_x
+    helpers.test_frontend_function(
+        input_dtypes=input_dtype,
+        backend_to_test=backend_fw,
+        frontend=frontend,
+        test_flags=test_flags,
+        fn_tree=fn_tree,
+        on_device=on_device,
+        x=x[0],
+    )
+
+
 # divide
 @handle_frontend_test(
     fn_tree="tensorflow.math.divide",
@@ -822,35 +852,6 @@ def test_tensorflow_divide_no_nan(
         on_device=on_device,
         x=xy[0],
         y=xy[1],
-    )
-
-
-# digamma
-@handle_frontend_test(
-    fn_tree="tensorflow.math.digamma",
-    dtype_and_x=helpers.dtype_and_values(
-        available_dtypes=helpers.get_dtypes("float"),
-    ),
-    test_with_out=st.just(False),
-)
-def test_tensorflow_digamma(
-    *,
-    dtype_and_x,
-    on_device,
-    fn_tree,
-    frontend,
-    test_flags,
-    backend_fw,
-):
-    input_dtype, x = dtype_and_x
-    helpers.test_frontend_function(
-        input_dtypes=input_dtype,
-        backend_to_test=backend_fw,
-        frontend=frontend,
-        test_flags=test_flags,
-        fn_tree=fn_tree,
-        on_device=on_device,
-        x=x[0],
     )
 
 

--- a/ivy_tests/test_ivy/test_functional/test_experimental/test_core/test_creation.py
+++ b/ivy_tests/test_ivy/test_functional/test_experimental/test_core/test_creation.py
@@ -292,6 +292,46 @@ def test_kaiser_window(
     )
 
 
+# mel_weight_matrix
+@handle_test(
+    fn_tree="functional.ivy.experimental.mel_weight_matrix",
+    num_mel_bins=helpers.ints(min_value=5, max_value=10),
+    dft_length=helpers.ints(min_value=5, max_value=10),
+    sample_rate=helpers.ints(min_value=1000, max_value=2000),
+    lower_edge_hertz=helpers.floats(min_value=0.0, max_value=5.0),
+    upper_edge_hertz=helpers.floats(min_value=5.0, max_value=10.0),
+    test_with_out=st.just(False),
+    test_gradients=st.just(False),
+    test_instance_method=st.just(False),
+)
+def test_mel_weight_matrix(
+    *,
+    num_mel_bins,
+    dft_length,
+    sample_rate,
+    lower_edge_hertz,
+    upper_edge_hertz,
+    test_flags,
+    backend_fw,
+    fn_name,
+    on_device,
+):
+    helpers.test_function(
+        input_dtypes=[],
+        test_flags=test_flags,
+        on_device=on_device,
+        backend_to_test=backend_fw,
+        rtol_=0.05,
+        atol_=0.05,
+        fn_name=fn_name,
+        num_mel_bins=num_mel_bins,
+        dft_length=dft_length,
+        sample_rate=sample_rate,
+        lower_edge_hertz=lower_edge_hertz,
+        upper_edge_hertz=upper_edge_hertz,
+    )
+
+
 # ndenumerate
 @handle_test(
     fn_tree="functional.ivy.experimental.ndenumerate",
@@ -579,44 +619,4 @@ def test_vorbis_window(
         on_device=on_device,
         window_length=int(x[0]),
         dtype=dtype[0],
-    )
-
-
-# mel_weight_matrix
-@handle_test(
-    fn_tree="functional.ivy.experimental.mel_weight_matrix",
-    num_mel_bins=helpers.ints(min_value=5, max_value=10),
-    dft_length=helpers.ints(min_value=5, max_value=10),
-    sample_rate=helpers.ints(min_value=1000, max_value=2000),
-    lower_edge_hertz=helpers.floats(min_value=0.0, max_value=5.0),
-    upper_edge_hertz=helpers.floats(min_value=5.0, max_value=10.0),
-    test_with_out=st.just(False),
-    test_gradients=st.just(False),
-    test_instance_method=st.just(False),
-)
-def test_mel_weight_matrix(
-    *,
-    num_mel_bins,
-    dft_length,
-    sample_rate,
-    lower_edge_hertz,
-    upper_edge_hertz,
-    test_flags,
-    backend_fw,
-    fn_name,
-    on_device,
-):
-    helpers.test_function(
-        input_dtypes=[],
-        test_flags=test_flags,
-        on_device=on_device,
-        backend_to_test=backend_fw,
-        rtol_=0.05,
-        atol_=0.05,
-        fn_name=fn_name,
-        num_mel_bins=num_mel_bins,
-        dft_length=dft_length,
-        sample_rate=sample_rate,
-        lower_edge_hertz=lower_edge_hertz,
-        upper_edge_hertz=upper_edge_hertz,
     )


### PR DESCRIPTION

# Add Digamma Function and Tests to Ivy Tensorflow Math Library

<!-- 

-->

## Summary:
This pull request introduces the Digamma function to the Ivy math library and adds corresponding unit tests. The Digamma function calculates the digamma (Ψ) function, which is a commonly used special function in mathematical and statistical computations.
<!-- 

-->

Close #23001

## Changes Made

- [ ] Did you add a function?

Added the Digamma function to math.py with the following details:

* Function name: digamma(x, name=None)
* Description: Computes the digamma function.
* Arguments:
x (array): Input array.
name (str): Name for the operation (optional).
* Returns: An array containing the result of the digamma function applied to the input.
* Raises: NotImplementedError if the backend is not TensorFlow.
* Implementation: The function checks the backend, and if it's TensorFlow, it computes the digamma function using Ivy and returns the result.
- [ ] Did you add the tests?

Introduced unit tests for the Digamma function in test_tensorflow_math.py with the following details:

* Test function name: test_tensorflow_digamma
* Test decorator: @handle_frontend_test
* Tested operation: tensorflow.math.digamma

- [ ] Did you follow the steps we provided?

Yes

### Reason for Changes:

The addition of the Digamma function is essential for various mathematical and statistical computations. By including this function in Ivy's math library and providing comprehensive unit tests, we ensure its correctness and usability, enhancing the overall functionality of the library.

These changes contribute to Ivy's capabilities and support for mathematical operations, making it a more versatile and reliable library for scientific computing.

Please review and consider merging these changes to enhance Ivy's functionality and maintain its compatibility with TensorFlow and other backends.

<!-- 

-->
