### PR TITLE
fix(jax-backend): set `symmetrize_input=False` in `jax.eigh` for consistency

### DIFF
--- a/ivy/functional/backends/jax/linear_algebra.py
+++ b/ivy/functional/backends/jax/linear_algebra.py
@@ -113,7 +113,7 @@ def eigh(
     result_tuple = NamedTuple(
         "eigh", [("eigenvalues", JaxArray), ("eigenvectors", JaxArray)]
     )
-    eigenvalues, eigenvectors = jnp.linalg.eigh(x, UPLO=UPLO)
+    eigenvalues, eigenvectors = jnp.linalg.eigh(x, UPLO=UPLO, symmetrize_input=False)
     return result_tuple(eigenvalues, eigenvectors)
 
 


### PR DESCRIPTION
Set the `symmetrize_input` argument to `False` in `jax.eigh` to ensure consistent behavior with other backends. The default behavior in `jax` was leading to different eigenvalues than other frameworks.



## Related Issue 

Close #23098




