### PR TITLE
Added updated digamma function for TensorFlow frontend

### DIFF
--- a/.idea/runConfigurations/_template__of_py_test.xml
+++ b/.idea/runConfigurations/_template__of_py_test.xml
@@ -8,6 +8,7 @@
       <env name="PYTHONPATH" value="/opt/fw/numpy:/opt/fw/jax:/opt/fw/tensorflow:/opt/fw/torch:/opt/fw/paddle:/opt/fw/mxnet" />
     </envs>
     <option name="SDK_HOME" value="python" />
+    <option name="SDK_NAME" value="Remote Python 3.10.0 Docker (unifyai/ivy:latest)" />
     <option name="WORKING_DIRECTORY" value="" />
     <option name="IS_MODULE_SDK" value="false" />
     <option name="ADD_CONTENT_ROOTS" value="true" />

--- a/.idea/runConfigurations/_template__of_py_test.xml
+++ b/.idea/runConfigurations/_template__of_py_test.xml
@@ -8,7 +8,6 @@
       <env name="PYTHONPATH" value="/opt/fw/numpy:/opt/fw/jax:/opt/fw/tensorflow:/opt/fw/torch:/opt/fw/paddle:/opt/fw/mxnet" />
     </envs>
     <option name="SDK_HOME" value="python" />
-    <option name="SDK_NAME" value="Remote Python 3.10.0 Docker (unifyai/ivy:latest)" />
     <option name="WORKING_DIRECTORY" value="" />
     <option name="IS_MODULE_SDK" value="false" />
     <option name="ADD_CONTENT_ROOTS" value="true" />

--- a/ivy/functional/frontends/tensorflow/math.py
+++ b/ivy/functional/frontends/tensorflow/math.py
@@ -228,6 +228,11 @@ def cumsum(x, axis, exclusive=False, reverse=False, name=None):
 
 
 @to_ivy_arrays_and_back
+def digamma(x, name=None):
+    return ivy.digamma(x)
+
+
+@to_ivy_arrays_and_back
 def divide(x, y, name=None):
     x, y = check_tensorflow_casting(x, y)
     return ivy.divide(x, y)
@@ -241,14 +246,6 @@ def divide_no_nan(x, y, name="divide_no_nan"):
         ivy.array(0.0, dtype=ivy.promote_types(x.dtype, y.dtype)),
         x / y,
     )
-
-
-@to_ivy_arrays_and_back
-def digamma(x, name=None):
-    dtype = ivy.dtype(x)
-    if dtype in ["complex64", "complex128"]:
-        return ivy.digamma(ivy.real(x)) + 1j * ivy.digamma(ivy.imag(x))
-    return ivy.digamma(x)
 
 
 @to_ivy_arrays_and_back

--- a/ivy/functional/frontends/tensorflow/math.py
+++ b/ivy/functional/frontends/tensorflow/math.py
@@ -245,24 +245,10 @@ def divide_no_nan(x, y, name="divide_no_nan"):
 
 @to_ivy_arrays_and_back
 def digamma(x, name=None):
-    """
-       Computes the digamma function.
-
-       Args:
-           x (array): Input array.
-           name (str): Name for the operation (optional).
-
-       Returns:
-           array: The result of the digamma function applied to the input.
-
-       Raises:
-           NotImplementedError: If the backend is not TensorFlow.
-       """
-    backend = _get_backend(x)
-    if backend == 'tensorflow':
-        return ivy.array(ivy.digamma(x), ivy.array([0], ivy.int32))
-    else:
-        raise NotImplementedError(f'digamma is not implemented for backend: {backend}')
+    dtype = ivy.dtype(x)
+    if dtype in ["complex64", "complex128"]:
+        return ivy.digamma(ivy.real(x)) + 1j * ivy.digamma(ivy.imag(x))
+    return ivy.digamma(x)
 
 
 @to_ivy_arrays_and_back

--- a/ivy/functional/frontends/tensorflow/math.py
+++ b/ivy/functional/frontends/tensorflow/math.py
@@ -11,6 +11,7 @@ from ivy.functional.frontends.tensorflow.func_wrapper import (
     handle_tf_dtype,
     to_ivy_dtype,
 )
+from ivy.framework_handler import get_backend as _get_backend
 
 
 @with_unsupported_dtypes(
@@ -240,6 +241,28 @@ def divide_no_nan(x, y, name="divide_no_nan"):
         ivy.array(0.0, dtype=ivy.promote_types(x.dtype, y.dtype)),
         x / y,
     )
+
+
+@to_ivy_arrays_and_back
+def digamma(x, name=None):
+    """
+       Computes the digamma function.
+
+       Args:
+           x (array): Input array.
+           name (str): Name for the operation (optional).
+
+       Returns:
+           array: The result of the digamma function applied to the input.
+
+       Raises:
+           NotImplementedError: If the backend is not TensorFlow.
+       """
+    backend = _get_backend(x)
+    if backend == 'tensorflow':
+        return ivy.array(ivy.digamma(x), ivy.array([0], ivy.int32))
+    else:
+        raise NotImplementedError(f'digamma is not implemented for backend: {backend}')
 
 
 @to_ivy_arrays_and_back

--- a/ivy/functional/frontends/tensorflow/math.py
+++ b/ivy/functional/frontends/tensorflow/math.py
@@ -11,7 +11,6 @@ from ivy.functional.frontends.tensorflow.func_wrapper import (
     handle_tf_dtype,
     to_ivy_dtype,
 )
-from ivy.framework_handler import get_backend as _get_backend
 
 
 @with_unsupported_dtypes(

--- a/ivy/functional/frontends/tensorflow/raw_ops.py
+++ b/ivy/functional/frontends/tensorflow/raw_ops.py
@@ -50,6 +50,7 @@ Cosh = to_ivy_arrays_and_back(map_raw_ops_alias(tf_frontend.math.cosh))
 Cumprod = to_ivy_arrays_and_back(map_raw_ops_alias(tf_frontend.math.cumprod))
 Cumsum = to_ivy_arrays_and_back(map_raw_ops_alias(tf_frontend.math.cumsum))
 Div = to_ivy_arrays_and_back(map_raw_ops_alias(tf_frontend.math.divide))
+Digamma = to_ivy_arrays_and_back(map_raw_ops_alias(tf_frontend.math.digamma))
 Einsum = to_ivy_arrays_and_back(
     with_supported_dtypes(
         {

--- a/ivy/functional/frontends/tensorflow/raw_ops.py
+++ b/ivy/functional/frontends/tensorflow/raw_ops.py
@@ -49,8 +49,8 @@ Cos = to_ivy_arrays_and_back(map_raw_ops_alias(tf_frontend.math.cos))
 Cosh = to_ivy_arrays_and_back(map_raw_ops_alias(tf_frontend.math.cosh))
 Cumprod = to_ivy_arrays_and_back(map_raw_ops_alias(tf_frontend.math.cumprod))
 Cumsum = to_ivy_arrays_and_back(map_raw_ops_alias(tf_frontend.math.cumsum))
-Div = to_ivy_arrays_and_back(map_raw_ops_alias(tf_frontend.math.divide))
 Digamma = to_ivy_arrays_and_back(map_raw_ops_alias(tf_frontend.math.digamma))
+Div = to_ivy_arrays_and_back(map_raw_ops_alias(tf_frontend.math.divide))
 Einsum = to_ivy_arrays_and_back(
     with_supported_dtypes(
         {

--- a/ivy_tests/test_ivy/test_frontends/test_tensorflow/test_math.py
+++ b/ivy_tests/test_ivy/test_frontends/test_tensorflow/test_math.py
@@ -825,6 +825,36 @@ def test_tensorflow_divide_no_nan(
     )
 
 
+# digamma
+@handle_frontend_test(
+    fn_tree="tensorflow.math.digamma",
+    dtype_and_x=helpers.dtype_and_values(
+        num_arrays=1,
+        available_dtypes=helpers.get_dtypes("float"),
+    ),
+    test_with_out=st.just(False),
+)
+def test_tensorflow_digamma(
+    *,
+    dtype_and_x,
+    on_device,
+    fn_tree,
+    frontend,
+    test_flags,
+    backend_fw,
+):
+    input_dtype, x = dtype_and_x
+    helpers.test_frontend_function(
+        input_dtypes=input_dtype,
+        backend_to_test=backend_fw,
+        frontend=frontend,
+        test_flags=test_flags,
+        fn_tree=fn_tree,
+        on_device=on_device,
+        x=x[0],
+    )
+
+
 # equal
 @handle_frontend_test(
     fn_tree="tensorflow.math.equal",
@@ -854,35 +884,6 @@ def test_tensorflow_equal(
         on_device=on_device,
         x=x[0],
         y=x[1],
-    )
-
-# digamma
-@handle_frontend_test(
-    fn_tree="tensorflow.math.digamma",
-    dtype_and_x=helpers.dtype_and_values(
-        num_arrays=1,
-        available_dtypes=helpers.get_dtypes("float"),
-    ),
-    test_with_out=st.just(False),
-)
-def test_tensorflow_digamma(
-    *,
-    dtype_and_x,
-    on_device,
-    fn_tree,
-    frontend,
-    test_flags,
-    backend_fw,
-):
-    input_dtype, x = dtype_and_x
-    helpers.test_frontend_function(
-        input_dtypes=input_dtype,
-        backend_to_test=backend_fw,
-        frontend=frontend,
-        test_flags=test_flags,
-        fn_tree=fn_tree,
-        on_device=on_device,
-        x=x[0],
     )
 
 

--- a/ivy_tests/test_ivy/test_frontends/test_tensorflow/test_math.py
+++ b/ivy_tests/test_ivy/test_frontends/test_tensorflow/test_math.py
@@ -766,6 +766,7 @@ def test_tensorflow_cumsum(  # NOQA
     fn_tree="tensorflow.math.digamma",
     dtype_and_x=helpers.dtype_and_values(
         available_dtypes=helpers.get_dtypes("float"),
+        num_arrays=1,
     ),
     test_with_out=st.just(False),
 )

--- a/ivy_tests/test_ivy/test_frontends/test_tensorflow/test_math.py
+++ b/ivy_tests/test_ivy/test_frontends/test_tensorflow/test_math.py
@@ -825,36 +825,6 @@ def test_tensorflow_divide_no_nan(
     )
 
 
-# digamma
-@handle_frontend_test(
-    fn_tree="tensorflow.math.digamma",
-    dtype_and_x=helpers.dtype_and_values(
-        num_arrays=1,
-        available_dtypes=helpers.get_dtypes("float"),
-    ),
-    test_with_out=st.just(False),
-)
-def test_tensorflow_digamma(
-    *,
-    dtype_and_x,
-    on_device,
-    fn_tree,
-    frontend,
-    test_flags,
-    backend_fw,
-):
-    input_dtype, x = dtype_and_x
-    helpers.test_frontend_function(
-        input_dtypes=input_dtype,
-        backend_to_test=backend_fw,
-        frontend=frontend,
-        test_flags=test_flags,
-        fn_tree=fn_tree,
-        on_device=on_device,
-        x=x[0],
-    )
-
-
 # equal
 @handle_frontend_test(
     fn_tree="tensorflow.math.equal",
@@ -884,6 +854,35 @@ def test_tensorflow_equal(
         on_device=on_device,
         x=x[0],
         y=x[1],
+    )
+
+# digamma
+@handle_frontend_test(
+    fn_tree="tensorflow.math.digamma",
+    dtype_and_x=helpers.dtype_and_values(
+        num_arrays=1,
+        available_dtypes=helpers.get_dtypes("float"),
+    ),
+    test_with_out=st.just(False),
+)
+def test_tensorflow_digamma(
+    *,
+    dtype_and_x,
+    on_device,
+    fn_tree,
+    frontend,
+    test_flags,
+    backend_fw,
+):
+    input_dtype, x = dtype_and_x
+    helpers.test_frontend_function(
+        input_dtypes=input_dtype,
+        backend_to_test=backend_fw,
+        frontend=frontend,
+        test_flags=test_flags,
+        fn_tree=fn_tree,
+        on_device=on_device,
+        x=x[0],
     )
 
 

--- a/ivy_tests/test_ivy/test_frontends/test_tensorflow/test_math.py
+++ b/ivy_tests/test_ivy/test_frontends/test_tensorflow/test_math.py
@@ -761,6 +761,35 @@ def test_tensorflow_cumsum(  # NOQA
     )
 
 
+# digamma
+@handle_frontend_test(
+    fn_tree="tensorflow.math.digamma",
+    dtype_and_x=helpers.dtype_and_values(
+        available_dtypes=helpers.get_dtypes("float"),
+    ),
+    test_with_out=st.just(False),
+)
+def test_tensorflow_digamma(
+    *,
+    dtype_and_x,
+    on_device,
+    fn_tree,
+    frontend,
+    test_flags,
+    backend_fw,
+):
+    input_dtype, x = dtype_and_x
+    helpers.test_frontend_function(
+        input_dtypes=input_dtype,
+        backend_to_test=backend_fw,
+        frontend=frontend,
+        test_flags=test_flags,
+        fn_tree=fn_tree,
+        on_device=on_device,
+        x=x[0],
+    )
+
+
 # divide
 @handle_frontend_test(
     fn_tree="tensorflow.math.divide",
@@ -822,36 +851,6 @@ def test_tensorflow_divide_no_nan(
         on_device=on_device,
         x=xy[0],
         y=xy[1],
-    )
-
-
-# digamma
-@handle_frontend_test(
-    fn_tree="tensorflow.math.digamma",
-    dtype_and_x=helpers.dtype_and_values(
-        num_arrays=1,
-        available_dtypes=helpers.get_dtypes("float"),
-    ),
-    test_with_out=st.just(False),
-)
-def test_tensorflow_digamma(
-    *,
-    dtype_and_x,
-    on_device,
-    fn_tree,
-    frontend,
-    test_flags,
-    backend_fw,
-):
-    input_dtype, x = dtype_and_x
-    helpers.test_frontend_function(
-        input_dtypes=input_dtype,
-        backend_to_test=backend_fw,
-        frontend=frontend,
-        test_flags=test_flags,
-        fn_tree=fn_tree,
-        on_device=on_device,
-        x=x[0],
     )
 
 

--- a/ivy_tests/test_ivy/test_frontends/test_tensorflow/test_math.py
+++ b/ivy_tests/test_ivy/test_frontends/test_tensorflow/test_math.py
@@ -825,6 +825,36 @@ def test_tensorflow_divide_no_nan(
     )
 
 
+# digamma
+@handle_frontend_test(
+    fn_tree="tensorflow.math.digamma",
+    dtype_and_x=helpers.dtype_and_values(
+        num_arrays=1,
+        available_dtypes=helpers.get_dtypes("float"),
+    ),
+    test_with_out=st.just(False),
+)
+def test_tensorflow_digamma(
+    *,
+    dtype_and_x,
+    on_device,
+    fn_tree,
+    frontend,
+    test_flags,
+    backend_fw,
+):
+    input_dtype, x = dtype_and_x
+    helpers.test_frontend_function(
+        input_dtypes=input_dtype,
+        backend_to_test=backend_fw,
+        frontend=frontend,
+        test_flags=test_flags,
+        fn_tree=fn_tree,
+        on_device=on_device,
+        x=x[0],
+    )
+
+
 # equal
 @handle_frontend_test(
     fn_tree="tensorflow.math.equal",


### PR DESCRIPTION
# Add Digamma Function and Tests to Ivy TensorFlow frontend Math Library

<!-- 

-->

## Summary:
This pull request introduces the Digamma function to the Ivy math library and adds corresponding unit tests. The Digamma function calculates the digamma (Ψ) function, which is a commonly used special function in mathematical and statistical computations.
<!-- 

-->

Close #23001

## Changes Made

- [x] Did you add a function?

Added the Digamma function to math.py with the following details:

* Added a new function 'digamma(x)' to the 'math.py' module. This function computes the digamma function for input 'x'.

- [x] Did you add the tests?

* Added a test suite for the Digamma function in the 'test_tensorflow_math.py' module. The tests cover various data types and input values to ensure the correctness of the Digamma function in the TensorFlow frontend.

- [x] Did you follow the steps we provided?

Yes

### Reason for Changes:

The addition of the Digamma function is essential for various mathematical and statistical computations.

These changes contribute to Ivy's capabilities and support for mathematical operations, making it a more versatile and reliable library for scientific computing.

Please review and consider merging these changes to enhance Ivy's functionality and maintain its compatibility with TensorFlow and other backends.

<!-- 

-->
