### PR TITLE
fix(ivy): updated the as_native_dev implementation for torch to account for the availability of mps

### DIFF
--- a/ivy/functional/backends/torch/device.py
+++ b/ivy/functional/backends/torch/device.py
@@ -74,7 +74,7 @@ def as_native_dev(
 ) -> Optional[torch.device]:
     if not isinstance(device, str):
         return device
-    if device == "mps":
+    if torch.backends.mps.is_available():
         return torch.device(ivy.Device(device).replace("gpu", "mps"))
     return torch.device(ivy.Device(device).replace("gpu", "cuda"))
 


### PR DESCRIPTION
Earlier we were only attempting to replace `gpu` by `mps` if the `device=='mps'`