### PR TITLE
fix: skip tensorflow.zeros tests for Paddle backend with ndim >= 10

### DIFF
--- a/ivy_tests/test_ivy/test_frontends/test_tensorflow/test_general_functions.py
+++ b/ivy_tests/test_ivy/test_frontends/test_tensorflow/test_general_functions.py
@@ -2,7 +2,6 @@
 from hypothesis import strategies as st, assume
 import numpy as np
 from tensorflow import errors as tf_errors
-import ivy
 
 # local
 import ivy_tests.test_ivy.helpers as helpers
@@ -2382,9 +2381,9 @@ def test_tensorflow_while_loop(
     input=helpers.get_shape(
         allow_none=False,
         min_num_dims=0,
-        max_num_dims=10,
+        max_num_dims=9,
         min_dim_size=0,
-        max_dim_size=10,
+        max_dim_size=9,
     ),
     dtype=helpers.get_dtypes("valid", full=False),
 )
@@ -2398,9 +2397,6 @@ def test_tensorflow_zeros(
     fn_tree,
     on_device,
 ):
-    if ivy.current_backend_str() == "paddle":
-        # Paddle only supports ndim from 0 to 9
-        assume(input.shape[0] < 10)
     helpers.test_frontend_function(
         shape=input,
         input_dtypes=dtype,

--- a/ivy_tests/test_ivy/test_frontends/test_tensorflow/test_general_functions.py
+++ b/ivy_tests/test_ivy/test_frontends/test_tensorflow/test_general_functions.py
@@ -2,6 +2,7 @@
 from hypothesis import strategies as st, assume
 import numpy as np
 from tensorflow import errors as tf_errors
+import ivy
 
 # local
 import ivy_tests.test_ivy.helpers as helpers
@@ -2397,6 +2398,9 @@ def test_tensorflow_zeros(
     fn_tree,
     on_device,
 ):
+    if ivy.current_backend_str() == "paddle":
+        # Paddle only supports ndim from 0 to 9
+        assume(input.shape[0] < 10)
     helpers.test_frontend_function(
         shape=input,
         input_dtypes=dtype,
@@ -2412,7 +2416,7 @@ def test_tensorflow_zeros(
 @handle_frontend_test(
     fn_tree="tensorflow.zeros_like",
     dtype_and_x=helpers.dtype_and_values(
-        available_dtypes=helpers.get_dtypes("numeric")
+        available_dtypes=helpers.get_dtypes("numeric"),
     ),
     dtype=helpers.get_dtypes("numeric", full=False),
     test_with_out=st.just(False),


### PR DESCRIPTION
# PR Description: 
Added a condition to skip tests in "test_tensorflow_zeros" when using the Paddle backend and the dimension is 10 or more.

This is a temporary measure until the Paddle backend supports dimensions greater than 9.

## Related Issue: 

Close #23155

