### PR TITLE
Added ivy.Array support to jax native compile

### DIFF
--- a/ivy/functional/backends/jax/__init__.py
+++ b/ivy/functional/backends/jax/__init__.py
@@ -23,6 +23,19 @@ register_pytree_node(
 )
 
 
+# make ivy.Array compatible with jax pytree traversal
+def _array_flatten(tree):
+    return ((tree.data,), None)
+
+
+def _array_unflatten(aux_data, children):
+    if type(*children) == object:
+        return children
+    return ivy.Array(*children)
+
+
+register_pytree_node(ivy.Array, _array_flatten, _array_unflatten)
+
 # noinspection PyUnresolvedReferences
 if not ivy.is_local():
     _module_in_memory = sys.modules[__name__]


### PR DESCRIPTION
Works with jit,lax.map,vmap and jvp.
It fails for [jax.vjp]([https://jax.readthedocs.io/en/latest/_autosummary/jax.vjp.html#jax.vjp).