### PR TITLE
docs: set `autosectionlabel_prefix_document` to `True`

### DIFF
--- a/docs/overview/contributing.rst
+++ b/docs/overview/contributing.rst
@@ -15,28 +15,28 @@ We want our ML unification journey to be as inclusive as possible, this is all o
 The contributor guide is split into the sections below, it's best to go from start to finish, but you can also dive in at any stage! We're excited for you to get involved!  🦾
 
 
-| (a) `Setting Up <https://unify.ai/docs/ivy/overview/contributing/setting_up.html>`_
+| (a) `Setting Up <contributing/setting_up.rst>`_
 | Building the right environment 🏛️
 |
-| (b) :ref:`The Basics`
+| (b) `The Basics <contributing/the_basics.rst>`_
 | Managing your fork 🇾, creating issues ⭕, and creating pull-requests ⬆️
 |
-| (c) :ref:`Building the Docs`
+| (c) `Building the Docs <contributing/building_the_docs.rst>`_
 | How to build the documentation locally 🏗️
 |
-| (d) :ref:`Deep Dive`
+| (d) `Deep Dive <deep_dive.rst>`_
 | Take a deep dive into the codebase 🤿
 |
-| (e) :ref:`Open Tasks`
+| (e) `Open Tasks <contributing/open_tasks.rst>`_
 | See where you can help us out! 🙋
 |
-| (f) :ref:`Applied Libraries`
+| (f) `Applied Libraries <contributing/applied_libraries.rst>`_
 | Getting started with our applied libraries! 📚
 | 
-| (g) :ref:`Helpful Resources`
+| (g) `Helpful Resources <contributing/helpful_resources.rst>`_
 | Resources you would find useful when learning Ivy 📖
 | 
-| (g) :ref:`Error Handling`
+| (g) `Error Handling <contributing/error_handling.rst>`_
 | Common errors you will be facing contributing to Ivy ❌
 
 .. toctree::

--- a/docs/overview/contributing/applied_libraries.rst
+++ b/docs/overview/contributing/applied_libraries.rst
@@ -139,4 +139,4 @@ Example - Ivy Robot
 
 These examples should hopefully give you a good understanding of what is required when developing the Ivy applied libraries.
 
-If you have any questions, please feel free to reach out on `discord`_ in the `pycharm channel`_, `docker channel`_, `pre-commit channel`_, `pip packages channel`_ or `other channel`_, depending on the question!
+If you have any questions, please feel free to reach out on `discord`_ in the `pycharm channel`_, `docker channel`_, `pre-commit channel`_ or `pip packages channel`_, depending on the question!

--- a/docs/overview/contributing/building_the_docs.rst
+++ b/docs/overview/contributing/building_the_docs.rst
@@ -2,7 +2,8 @@ Building the Docs
 =================
 
 This document describes how to build the Ivy docs. If you want to know more about how
-our custom building pipeline work, check our :ref:`Building the Docs Pipeline` deep dive
+our custom building pipeline work, check our `Building the Docs Pipeline 
+<../deep_dive/building_the_docs_pipline.rst>`_ deep dive
 
 Building the Docs using Docker
 ------------------------------

--- a/docs/overview/contributing/open_tasks.rst
+++ b/docs/overview/contributing/open_tasks.rst
@@ -7,6 +7,7 @@ Open Tasks
 .. _`issue description`: https://github.com/unifyai/ivy/issues/1526
 .. _`reference API`: https://numpy.org/doc/stable/reference/routines.linalg.html
 .. _`imports`: https://github.com/unifyai/ivy/blob/38dbb607334cb32eb513630c4496ad0024f80e1c/ivy/functional/frontends/numpy/__init__.py#L27
+.. _`Deep Dive`: ../deep_dive.rst
 
 Here, we explain all tasks which are currently open for contributions from the community!
 
@@ -32,7 +33,7 @@ Function Formatting
 
 Currently, we have many ToDo list issues `open <https://github.com/unifyai/ivy/issues?q=is%3Aopen+is%3Aissue+label%3A%22Function+Reformatting%22+label%3AToDo>`_ for a general function formatting task, which is explained below.
 
-Each function in each submodule should be updated to follow the implementation instructions given in the :ref:`Deep Dive` section.
+Each function in each submodule should be updated to follow the implementation instructions given in the `Deep Dive`_ section.
 The updates should be applied for the:
 
 #. ivy API
@@ -44,25 +45,25 @@ The updates should be applied for the:
 #. container operators
 #. container reverse operators
 
-The :ref:`Deep Dive` is an **essential** resource for learning how each of these functions/methods should be implemented.
-Before starting any contribution task, you should go through the :ref:`Deep Dive`, and familiarize yourself with the content.
+The `Deep Dive`_ is an **essential** resource for learning how each of these functions/methods should be implemented.
+Before starting any contribution task, you should go through the `Deep Dive`_, and familiarize yourself with the content.
 
 At the time of writing, many of the functions are not implemented as they should be.
-You will need to make changes to the current implementations, but you do not need to address *all* sections of the :ref:`Deep Dive` in detail.
+You will need to make changes to the current implementations, but you do not need to address *all* sections of the `Deep Dive`_ in detail.
 Specifically, you **do not** need to address the following:
 
 #. Implement the hypothesis testing for the function
 #. Get the tests passing for your function, if they are failing before you start
 
-However, everything else covered in the :ref:`Deep Dive` must be addressed.
+However, everything else covered in the `Deep Dive`_ must be addressed.
 Some common important tasks are:
 
 #. Remove all :code:`lambda` and direct bindings for the backend functions (in :code:`ivy.functional.backends`), with each function instead defined using :code:`def`.
 #. Implement the following if they don't exist but should do: :class:`ivy.Array` instance method, :class:`ivy.Container` instance method, :class:`ivy.Array` special method, :class:`ivy.Array` reverse special method, :class:`ivy.Container` special method, :class:`ivy.Container` reverse special method.
 #. Make sure that the aforementioned methods are added into the correct category-specific parent class, such as :class:`ivy.ArrayWithElementwise`, :class:`ivy.ContainerWithManipulation` etc.
-#. Correct all of the :ref:`Function Arguments` and the type hints for every function **and** its *relevant methods*, including those you did not implement yourself.
-#. Add the correct :ref:`Docstrings` to every function **and** its *relevant methods*, including those you did not implement yourself.
-#. Add thorough :ref:`Docstring Examples` for every function **and** its *relevant methods* and ensure they pass the docstring tests.
+#. Correct all of the `Function Arguments <../deep_dive/function_arguments.rst>`_ and the type hints for every function **and** its *relevant methods*, including those you did not implement yourself.
+#. Add the correct `Docstrings <../deep_dive/docstrings.rst>`_ to every function **and** its *relevant methods*, including those you did not implement yourself.
+#. Add thorough `Docstring Examples <../deep_dive/docstring_examples.rst>`_ for every function **and** its *relevant methods* and ensure they pass the docstring tests.
 
 Formatting checklist
 ~~~~~~~~~~~~~~~~~~~~
@@ -106,15 +107,15 @@ The PR assignee will then see this comment and address your issues.
 Frontend APIs
 -------------
 
-For this task, the goal will be to implement functions for each of the frontend functional APIs (see :ref:`Ivy as a Transpiler`), with frontend APIs implemented for: :code:`JAX`, :code:`NumPy`, :code:`TensorFlow` :code:`PyTorch`, :code:`Paddle`, :code:`Scipy`, :code:`MXNet` and :code:`MindSpore`.
+For this task, the goal will be to implement functions for each of the frontend functional APIs (see `Ivy as a Transpiler <../design/ivy_as_a_transpiler.rst>`_), with frontend APIs implemented for: :code:`JAX`, :code:`NumPy`, :code:`TensorFlow` :code:`PyTorch`, :code:`Paddle`, :code:`Scipy`, :code:`MXNet` and :code:`MindSpore`.
 
 Currently, we have many ToDo list issues `open <https://github.com/unifyai/ivy/issues?q=is%3Aopen+is%3Aissue+label%3AToDo+label%3A%22JAX+Frontend%22%2C%22TensorFlow+Frontend%22%2C%22PyTorch+Frontend%22%2C%22NumPy+Frontend%22+-label%3A%22Test+Sweep%22>`_ for this task.
 
 The general workflow for this task is:
 
-#. Find the correct location for the function by following the :ref:`Where to place a frontend function` subsection below
-#. Implement the function by following the :ref:`Ivy Frontends` guide
-#. Write tests for your function by following the :ref:`Ivy Frontend Tests` guide
+#. Find the correct location for the function by following the :ref:`overview/contributing/open_tasks:Where to place a frontend function` subsection below
+#. Implement the function by following the `Ivy Frontends <../deep_dive/ivy_frontends.rst>`_ guide
+#. Write tests for your function by following the `Ivy Frontend Tests <../deep_dive/ivy_frontends_tests.rst>`_ guide
 #. Verify that the tests for your function are passing
 
 If you feel as though there is an ivy function :code:`ivy.<func_name>` clearly missing, which would make your frontend function much simpler to implement, then you should first do the following:
@@ -128,7 +129,7 @@ At some point, a member of our team will assess whether it should be added, and 
 
 After this, you then have two options for how to proceed:
 
-#. Try to implement the function as a composition of currently present ivy functions, as explained in the "Temporary Compositions" sub-section of the :ref:`Ivy Frontends` guide, and add the :code:`#ToDo` comment in the implementation as explained.
+#. Try to implement the function as a composition of currently present ivy functions, as explained in the "Temporary Compositions" sub-section of the `Ivy Frontends <../deep_dive/ivy_frontends.rst>`_ guide, and add the :code:`#ToDo` comment in the implementation as explained.
    Once the PR is merged, your sub-task issue will then be closed as normal.
 #. Alternatively, if you do not want to try and implement the frontend function compositionally, or if this is not feasible, then you can simply choose another frontend function to work on.
    You could also choose to work on another open task entirely at this point if you wanted to.
@@ -217,7 +218,7 @@ However, you can still use the checklist as a reference in cases where you do un
 
 **Notes**:
 
-1. More details on how to update the checklist items can be found in the :ref:`Formatting checklist` part of our docs.
+1. More details on how to update the checklist items can be found in the :ref:`overview/contributing/open_tasks:Formatting checklist` part of our docs.
 2. Do not edit the checklist text, only the emoji symbols.
 3. Please refrain from using the checkboxes next to checklist items.
 
@@ -234,10 +235,10 @@ There is only one central ToDo list `issue <https://github.com/unifyai/ivy/issue
 A general workflow for these tasks would be:
 
 #. Analyze the function type, we have a very detailed section for it in the deep dive `Function Types Guide <https://unify.ai/docs/ivy/overview/deep_dive/function_types.html>`_
-#. Every function will have a different file structure according to the function type, refer to :ref:`Where to place a backend function` subsection below.
+#. Every function will have a different file structure according to the function type, refer to :ref:`overview/contributing/open_tasks:Where to place a backend function` subsection below.
 #. Implement the container instance method in :mod:`ivy/container/experimental/[relevant_submodule].py` and the array instance method 
    in :mod:`ivy/array/experimental/[relevant_submodule].py`
-#. Write tests for the function using the :ref:`Ivy Tests` guide, and make sure they are passing.
+#. Write tests for the function using the `Ivy Tests <../deep_dive/ivy_tests.rst>`_ guide, and make sure they are passing.
 
 A few points to keep in mind while doing this:
 
@@ -249,13 +250,13 @@ If you’re stuck on a function which requires complex compositions, feel free t
 Extending the Ivy API
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-We primarily invite contributors to work on the tasks listed as :ref:`Open Tasks`, as these are on our current roadmap. As a result of this, we prompt everyone interested in contributing to our Experimental API to do so under the `Ivy Experimental API Open Task`_.
+We primarily invite contributors to work on the tasks listed as :ref:`overview/contributing/open_tasks:Open Tasks`, as these are on our current roadmap. As a result of this, we prompt everyone interested in contributing to our Experimental API to do so under the :ref:`Ivy Experimental API Open Task <overview/contributing/open_tasks:Ivy Experimental API>`.
 
 However, if you would like to extend Ivy's functionality with a new function, you are invited to open an issue using the *Missing Function Suggestion* template as described in `Creating an Issue on Ivy’s GitHub using a Template <https://unify.ai/docs/ivy/overview/contributing/open_tasks.html#creating-an-issue-on-ivy-s-github-using-a-template>`_.
 
 In this template form, you'll be asked to fill in the reason you think we should implement the suggested function, as well as the links to any native implementations of the suggested function.
 
-We will review your issue as soon as possible and let you know if it's been accepted or not. In case we deem that the suggested function fits our roadmap, we will add it as a subtask to the `Ivy Experimental API Open Task`_.
+We will review your issue as soon as possible and let you know if it's been accepted or not. In case we deem that the suggested function fits our roadmap, we will add it as a subtask to the `Ivy Experimental API Open Task <overview/contributing/open_tasks:Ivy Experimental API>`_.
 
 Where to place a backend function
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/overview/contributing/open_tasks.rst
+++ b/docs/overview/contributing/open_tasks.rst
@@ -14,7 +14,7 @@ Here, we explain all tasks which are currently open for contributions from the c
 This section of the docs will be updated frequently, whereby new tasks will be added and completed tasks will be removed.
 The tasks outlined here are generally broad high-level tasks, each of which is made up of many individual sub-tasks, distributed across task-specific `ToDo List Issues <https://github.com/unifyai/ivy/issues?q=is%3Aopen+is%3Aissue+label%3AToDo>`_.
 
-Please read about `ToDo List Issues <https://unify.ai/docs/ivy/overview/contributing/the_basics.html#todo-list-issues>`_ in detail before continuing.
+Please read about :ref:`overview/contributing/the_basics:ToDo List Issues` in detail before continuing.
 All tasks should be selected and allocated as described in the ToDo List Issues section.
 We make no mention of task selection and allocation in the explanations below, which instead focus on the steps to complete only once a sub-task has been allocated to you.
 
@@ -234,7 +234,7 @@ There is only one central ToDo list `issue <https://github.com/unifyai/ivy/issue
 
 A general workflow for these tasks would be:
 
-#. Analyze the function type, we have a very detailed section for it in the deep dive `Function Types Guide <https://unify.ai/docs/ivy/overview/deep_dive/function_types.html>`_
+#. Analyze the function type, we have a very detailed section for it in the deep dive `Function Types Guide <../deep_dive/function_types.rst>`_
 #. Every function will have a different file structure according to the function type, refer to :ref:`overview/contributing/open_tasks:Where to place a backend function` subsection below.
 #. Implement the container instance method in :mod:`ivy/container/experimental/[relevant_submodule].py` and the array instance method 
    in :mod:`ivy/array/experimental/[relevant_submodule].py`
@@ -252,7 +252,7 @@ Extending the Ivy API
 
 We primarily invite contributors to work on the tasks listed as :ref:`overview/contributing/open_tasks:Open Tasks`, as these are on our current roadmap. As a result of this, we prompt everyone interested in contributing to our Experimental API to do so under the :ref:`Ivy Experimental API Open Task <overview/contributing/open_tasks:Ivy Experimental API>`.
 
-However, if you would like to extend Ivy's functionality with a new function, you are invited to open an issue using the *Missing Function Suggestion* template as described in `Creating an Issue on Ivy’s GitHub using a Template <https://unify.ai/docs/ivy/overview/contributing/open_tasks.html#creating-an-issue-on-ivy-s-github-using-a-template>`_.
+However, if you would like to extend Ivy's functionality with a new function, you are invited to open an issue using the *Missing Function Suggestion* template as described in :ref:`overview/contributing/open_tasks:Creating an Issue on Ivy's GitHub using a Template`.
 
 In this template form, you'll be asked to fill in the reason you think we should implement the suggested function, as well as the links to any native implementations of the suggested function.
 
@@ -268,15 +268,15 @@ There are multiple types of backend functions as discussed above, we will go thr
 **Primary Functions**
 
 Implement the function in :mod:`ivy/functional/ivy/experimental/[relevant_submodule].py` simply deferring to their backend-specific implementation
-(where ivy.current_backend(x).function_name() is called), refer to the `Ivy API Guide <https://unify.ai/docs/ivy/overview/deep_dive/navigating_the_code.html#ivy-api>`_
+(where ivy.current_backend(x).function_name() is called), refer to the :ref:`Ivy API Guide <overview/deep_dive/navigating_the_code:Ivy API>`
 to get a clearer picture of how this must be done. Then, implement the functions in each of the backend files :mod:`ivy/functional/backends/backend_name/experimental/[relevant_submodule].py`,
-you can refer to the `Backend API Guide <https://unify.ai/docs/ivy/overview/deep_dive/navigating_the_code.html#backend-api>`_ for this.
+you can refer to the :ref:`Backend API Guide <overview/deep_dive/navigating_the_code:Backend API>` for this.
 
 **Compositional Functions**
 
 Implement the function in :mod:`ivy/functional/ivy/experimental/[relevant_submodule].py`, we will not use the primary function approach in this
 case, the implementation will be a composition of functions from Ivy's functional API. You can refer to
-`Compositional Functions Guide <https://unify.ai/docs/ivy/overview/deep_dive/function_types.html#compositional-functions>`_ for a better understanding of this.
+:ref:`overview/deep_dive/function_types:Compositional Functions` for a better understanding of this.
 You don't need to add any implementation in any other file in this case.
 
 **Mixed Functions**
@@ -288,8 +288,8 @@ will be a composition of functions from Ivy's functional API. After you are done
 
 **Other Function Types**
 
-`Standalone Functions <https://unify.ai/docs/ivy/overview/deep_dive/function_types.html#standalone-functions>`_, `Nestable Functions <https://unify.ai/docs/ivy/overview/deep_dive/function_types.html#nestable-functions>`_ and
-`Convenience Functions <https://unify.ai/docs/ivy/overview/deep_dive/function_types.html#convenience-functions>`_ are the ones which you will rarely come across
+:ref:`overview/deep_dive/function_types:Standalone Functions`, :ref:`overview/deep_dive/function_types:Nestable Functions` and
+:ref:`overview/deep_dive/function_types:Convenience Functions` are the ones which you will rarely come across
 while implementing a function from the ToDo List but they are an essential part of the Ivy API.
 
 

--- a/docs/overview/contributing/setting_up.rst
+++ b/docs/overview/contributing/setting_up.rst
@@ -638,7 +638,7 @@ the steps explained below will help you in setting up a less resource-intensive 
 
       pip install git+https://github.com/unifyai/ivy.git
 
-#. If you want to set up a local repository, you can do so by following `this guide <https://unify.ai/docs/ivy/overview/contributing/setting_up.html#forking-and-cloning-the-repo>`_ 
+#. If you want to set up a local repository, you can do so by following :ref:`this guide <overview/contributing/setting_up:Forking and cloning the repo>`
    as explained above and install the required development dependencies by running:
 
    .. code-block:: none

--- a/docs/overview/contributing/the_basics.rst
+++ b/docs/overview/contributing/the_basics.rst
@@ -10,7 +10,6 @@ The Basics
 .. _`commit frequency channel`: https://discord.com/channels/799879767196958751/982728822317256712
 .. _`PyCharm blog`: https://www.jetbrains.com/help/pycharm/finding-and-replacing-text-in-file.html
 .. _`Debugging`: https://www.jetbrains.com/help/pycharm/debugging-code.html
-.. _`Ivy Experimental API Open Task`: https://unify.ai/docs/ivy/overview/contributing/open_tasks.html#ivy-experimental-api
 
 Getting Help
 ------------
@@ -54,7 +53,7 @@ We make extensive use of `ToDo list issues <https://github.com/unifyai/ivy/issue
 
 We have a clear process for contributors to engage with such ToDo lists:
 
-a. Find a task to work on which (i) is not marked as completed with a tick (ii) does not have an issue created and (iii) is not mentioned in the comments. Currently, there are three open tasks: `function reformatting <https://unify.ai/docs/ivy/overview/contributing/open_tasks.html#function-formatting>`_, `frontend APIs <https://unify.ai/docs/ivy/overview/contributing/open_tasks.html#frontend-apis>`_ and `ivy experimental API <https://unify.ai/docs/ivy/overview/contributing/open_tasks.html#ivy-experimental-api>`_.
+a. Find a task to work on which (i) is not marked as completed with a tick (ii) does not have an issue created and (iii) is not mentioned in the comments. Currently, there are three open tasks: :ref:`overview/contributing/open_tasks:Function Formatting`, :ref:`overview/contributing/open_tasks:Frontend APIs` and :ref:`overview/contributing/open_tasks:Ivy Experimental API`.
 
 b. Create a new issue with the title being just the name of the sub-task you would like to work on.
 

--- a/docs/overview/deep_dive.rst
+++ b/docs/overview/deep_dive.rst
@@ -4,7 +4,7 @@ Deep Dive
 .. _`issues`: https://github.com/unifyai/ivy/issues
 .. _`pull-requests`: https://github.com/unifyai/ivy/pulls
 
-For general users of the framework, who are mainly concerned with learning how to *use* Ivy, then the :ref:`Design` section is the best place to start 🙂
+For general users of the framework, who are mainly concerned with learning how to *use* Ivy, then the `Design <design.rst>`_ section is the best place to start 🙂
 
 This *deep dive* section is more targeted at people who would like to dive deeper into how Ivy actually works under the hood 🔧
 
@@ -13,74 +13,76 @@ Going through the sections outlined below will get you right into the weeds of t
 It's best to go through the sub-sections from start to finish, but you can also dive in at any stage!
 We're excited for you to get involved! 🦾
 
-| (a) :ref:`Navigating the Code` 🧭
+| (a) `Navigating the Code <deep_dive/navigating_the_code.rst>`_ 🧭
 | A quick tour through the codebase
 |
-| (b) :ref:`Function Types` 🧮
+| (b) `Function Types <deep_dive/function_types.rst>`_ 🧮
 | Primary, compositional, mixed, and nestable functions
 |
-| (c) :ref:`Superset Behaviour` ⊃
+| (c) `Superset Behaviour <deep_dive/superset_behaviour.rst>`_ ⊃
 | Ivy goes for the superset when unifying the backend functions
 |
-| (d) :ref:`Backend Setting` ⚙
+| (d) `Backend Setting <deep_dive/backend_setting.rst>`_ ⚙
 | How the backend is set, and what this means for each function type️
 |
-| (e) :ref:`Arrays` 🔢
+| (e) `Arrays <deep_dive/arrays.rst>`_ 🔢
 | Different types of arrays, and how they're handled
 |
-| (f) :ref:`Containers` 🗂
+| (f) `Containers <deep_dive/containers.rst>`_ 🗂
 | What the :class:`ivy.Container` does
 |
-| (g) :ref:`Data Types` 💾
+| (g) `Data Types <deep_dive/data_types.rst>`_ 💾
 | How functions infer the correct data type
 |
-| (h) :ref:`Devices` 📱
+| (h) `Devices <deep_dive/devices.rst>`_ 📱
 | How functions infer the correct device
 |
-| (i) :ref:`Inplace Updates` 🎯
+| (i) `Inplace Updates <deep_dive/inplace_updates.rst>`_ 🎯
 | How the :code:`out` argument is used to specify the output target
 |
-| (j) :ref:`Function Wrapping` 🎁
+| (j) `Function Wrapping <deep_dive/function_wrapping.rst>`_ 🎁
 | How functions are dynamically wrapped at runtime
 |
-| (k) :ref:`Formatting` 📋
+| (k) `Formatting <deep_dive/formatting.rst>`_ 📋
 | How the code is automatically formatted
 |
-| (l) :ref:`Function Arguments` 📑
+| (l) `Function Arguments <deep_dive/function_arguments.rst>`_ 📑
 | How to add the correct function arguments
 |
-| (m) :ref:`Docstrings` 📄
+| (m) `Docstrings <deep_dive/docstrings.rst>`_ 📄
 | How to properly write docstrings
 |
-| (n) :ref:`Docstring Examples` 💯
+| (n) `Docstring Examples <deep_dive/docstring_examples.rst>`_ 💯
 | How to add useful examples to the docstrings
 |
-| (o) :ref:`Array API Tests` 🤝
+| (o) `Array API Tests <deep_dive/array_api_tests.rst>`_ 🤝
 | How we're borrowing the test suite from the Array API Standard
 |
-| (p) :ref:`Ivy Tests` 🧪
+| (p) `Ivy Tests <deep_dive/ivy_tests.rst>`_ 🧪
 | How to add new tests for each Ivy function
 |
-| (q) :ref:`Ivy Frontends` ➡
+| (q) `Ivy Frontends <deep_dive/ivy_frontends.rst>`_ ➡
 | How to implement frontend functions
 |
-| (r) :ref:`Ivy Frontend Tests` 🧪
+| (r) `Ivy Frontend Tests <deep_dive/ivy_frontends_tests.rst>`_ 🧪
 | How to add new tests for each frontend function
 |
-| (s) :ref:`Exception Handling` ⚠
+| (s) `Exception Handling <deep_dive/exception_handling.rst>`_ ⚠
 | How to handle exceptions and assertions in a function
 |
-| (t) :ref:`Continuous Integration` 🔁
+| (t) `Continuous Integration <deep_dive/continuous_integration.rst>`_ 🔁
 | Ivy Tests running on the Repository
 |
-| (u) :ref:`Gradients` 🔁
+| (u) `Gradients <deep_dive/gradients.rst>`_ 🔁
 | Everything about our Gradients API
 |
-| (v) :ref:`Operating Modes` 🧮
+| (v) `Operating Modes <deep_dive/operating_modes.rst>`_ 🧮
 | Everything about modes Ivy can operate in, along with their purposes
 |
-| (w) :ref:`Building the Docs Pipeline` 📚
+| (w) `Building the Docs Pipeline <deep_dive/building_the_docs_pipeline.rst>`_ 📚
 | How are we building our docs
+
+
 .. toctree::
    :hidden:
    :maxdepth: -1
@@ -108,4 +110,4 @@ We're excited for you to get involved! 🦾
    deep_dive/continuous_integration.rst
    deep_dive/gradients.rst
    deep_dive/operating_modes.rst
-   deep_dive/building_the_docs_pipline.rst
+   deep_dive/building_the_docs_pipeline.rst

--- a/docs/overview/deep_dive/array_api_tests.rst
+++ b/docs/overview/deep_dive/array_api_tests.rst
@@ -12,12 +12,10 @@ Array API Tests
 .. _`array-api test repository`: https://github.com/data-apis/array-api/tree/main
 .. _`issue`: https://github.com/numpy/numpy/issues/21213
 .. _`ivy_tests/array_api_testing/test_array_api/array_api_tests/test_special_cases.py`: https://github.com/data-apis/array-api-tests/blob/ddd3b7a278cd0c0b68c0e4666b2c9f4e67b7b284/array_api_tests/test_special_cases.py
-.. _`here`: https://unify.ai/docs/ivy/overview/contributing/the_basics.html#running-tests-locally
 .. _`git website`: https://www.git-scm.com/book/en/v2/Git-Tools-Submodules
 .. _`hypothesis`: https://hypothesis.readthedocs.io/en/latest/
-.. _`ivy tests`: https://unify.ai/docs/ivy/overview/deep_dive/ivy_tests.html
-.. _`final section`: https://unify.ai/docs/ivy/overview/deep_dive/ivy_tests.html#re-running-failed-ivy-tests
-.. _`CI Pipeline`: https://unify.ai/docs/ivy/overview/deep_dive/continuous_integration.html
+.. _`ivy tests`: ivy_tests.rst
+.. _`CI Pipeline`: continuous_integration.html
 
 In conjunction with our own ivy unit tests, we import the array-api `test suite`_.
 These tests check that all ivy backend libraries behave according to the `Array API Standard`_ which was established in May 2020 by a group of maintainers.
@@ -99,7 +97,7 @@ Using the IDE
 You can also run a specific test or test file by using your IDE.
 To make this work, you should set the backend explicitly in the `_array_module.py` file as explained in the previous subsection.
 After that, you can run the API test files as you typically would with other tests.
-See `here`_  for instructions on how to run tests in ivy more generally.
+See :ref:`here <overview/contributing/the_basics:Running Tests Locally>`  for instructions on how to run tests in ivy more generally.
 
 *NB*: make sure to not add any changes to the array-api files to your commit.
 
@@ -107,7 +105,7 @@ Regenerating Test Failures
 --------------------------
 Array-API tests are written using `hypothesis`_ to perform property-based testing, just like the `ivy tests`_.
 However, unlike the ivy tests, the Array-API tests make liberal use of :code:`data.draw` in the main body of the test function instead of generating the data in the :code:`@given` decorator that wraps it.
-This means that failed tests cannot be re-run with the :code:`@example` decorator, as explained in the `final section`_ of the ivy tests deep dive.
+This means that failed tests cannot be re-run with the :code:`@example` decorator, as explained in the :ref:`final section <overview/deep_dive/ivy_tests:Re-Running Failed Ivy Tests>` of the ivy tests deep dive.
 Fortunately, it is possible to regenerate test failures using a unique decorator that appears in the final line of the falsifying example in the error stack trace:
 
 .. code-block:: none

--- a/docs/overview/deep_dive/arrays.rst
+++ b/docs/overview/deep_dive/arrays.rst
@@ -85,7 +85,7 @@ Therefore, most functions in Ivy must adopt the following pipeline:
 #. call the backend-specific function, passing in these :class:`ivy.NativeArray` instances
 #. convert all of the :class:`ivy.NativeArray` instances which are returned from the backend function back into :class:`ivy.Array` instances, and return
 
-Given the repeating nature of these steps, this is all entirely handled in the `inputs_to_native_arrays`_ and `outputs_to_ivy_arrays`_ wrappers, as explained in the :ref:`Function Wrapping` section.
+Given the repeating nature of these steps, this is all entirely handled in the `inputs_to_native_arrays`_ and `outputs_to_ivy_arrays`_ wrappers, as explained in the `Function Wrapping <function_wrapping.rst>`_ section.
 
 All Ivy functions *also* accept :class:`ivy.NativeArray` instances in the input.
 This is for a couple of reasons.
@@ -93,11 +93,11 @@ Firstly, :class:`ivy.Array` instances must be converted to :class:`ivy.NativeArr
 Secondly, this makes it easier to combine backend-specific code with Ivy code, without needing to explicitly wrap any arrays before calling sections of Ivy code.
 
 Therefore, all input arrays to Ivy functions have type :code:`Union[ivy.Array, ivy.NativeArray]`, whereas the output arrays have type :class:`ivy.Array`.
-This is further explained in the :ref:`Function Arguments` section.
+This is further explained in the `Function Arguments <function_arguments.rst>`_ section.
 
 However, :class:`ivy.NativeArray` instances are not permitted for the :code:`out` argument, which is used in most functions.
 This is because the :code:`out` argument dictates the array to which the result should be written, and so it effectively serves the same purpose as the function return.
-This is further explained in the :ref:`Inplace Updates` section.
+This is further explained in the `Inplace Updates <inplace_updates.rst>`_ section.
 
 As a final point, extra attention is required for *compositional* functions, as these do not directly defer to a backend implementation.
 If the first line of code in a compositional function performs operations on the input array, then this will call the special methods on an :class:`ivy.NativeArray` and not on an :class:`ivy.Array`.

--- a/docs/overview/deep_dive/backend_setting.rst
+++ b/docs/overview/deep_dive/backend_setting.rst
@@ -23,7 +23,7 @@ When calling `this function`_ for setting the backend, the following steps are p
 #. loop through the original :code:`ivy_original_dict` (which has all functions, including compositional), and (a) add the primary function from the backend if it exists, (b) else add the compositional function from :code:`ivy_original_dict`.
 #. `wrap the functions`_ where necessary, extending them with shared repeated functionality and `writing the function`_ to :attr:`ivy.__dict__`.
    Wrapping is used in order to avoid excessive code duplication in every backend function implementation.
-   This is explained in more detail in the next section: :ref:`Function Wrapping`.
+   This is explained in more detail in the next section: `Function Wrapping <function_wrapping.rst>`_.
 
 It's helpful to look at an example:
 

--- a/docs/overview/deep_dive/building_the_docs_pipeline.rst
+++ b/docs/overview/deep_dive/building_the_docs_pipeline.rst
@@ -84,7 +84,7 @@ To build the docs through docker you use this command:
 
     docker run -v /path/to/project:/project unifyai/doc-builder
 
-You can also add options described in the :ref:`The convenience script` section.
+You can also add options described in the :ref:`overview/deep_dive/building_the_docs_pipeline:The convenience script` section.
 
 .. code-block:: bash
     
@@ -167,7 +167,7 @@ The last directive is ``autosummary``, which is used to automatically generate a
 of contents for a module, as well as the documentation itself automatically by
 discovering the docstrings of the module. This is a custom directive, built on the original
 `autosummary`_
-extension. We will explain in detail how did we change it, in :ref:`Custom Extensions`.
+extension. We will explain in detail how did we change it, in :ref:`overview/deep_dive/building_the_docs_pipeline:Custom Extensions`.
 
 ``partial_conf.py``
 ~~~~~~~~~~~~~~~~~~~
@@ -194,7 +194,7 @@ Here we are overriding the ``ivy_toctree_caption_map`` configuration, which is u
 customize the title of the table of contents for each module. 
 ``ivy_toctree_caption_map`` is one of the configuration options we have in our
 ``custom_autosummary`` extension, which will be covered extensively in 
-:ref:`Custom Extensions`.
+:ref:`overview/deep_dive/building_the_docs_pipeline:Custom Extensions`.
 
 ``prebuild.sh``
 ~~~~~~~~~~~~~~~

--- a/docs/overview/deep_dive/containers.rst
+++ b/docs/overview/deep_dive/containers.rst
@@ -185,7 +185,7 @@ As for the special methods which are `implemented`_ in the main :class:`ivy.Cont
 
 As a result, the operator functions will make use of the special methods of the lefthand passed input objects if available, otherwise it will make use of the reverse special method of the righthand operand.
 For instance, if the lefthand operand at any given leaf of the container in an :class:`ivy.Array`, then the operator function will make calls to the special methods of this array object.
-As explained in the :ref:`Arrays` section of the Deep Dive, these special methods will in turn call the corresponding functions from the ivy functional API.
+As explained in the `Arrays <arrays.rst>`_ section of the Deep Dive, these special methods will in turn call the corresponding functions from the ivy functional API.
  
 Examples include `__add__`_, `__sub__`_, `__mul__`_ and `__truediv__`_ which will make calls to :func:`ivy.add`, :func:`ivy.subtract`, :func:`ivy.multiply` and :func:`ivy.divide` respectively if the lefthand operand is an :class:`ivy.Array` object.
 Otherwise, these special methods will be called on whatever objects are at the leaves of the container, such as int, float, :class:`ivy.NativeArray` etc.
@@ -193,10 +193,10 @@ Otherwise, these special methods will be called on whatever objects are at the l
 Nestable Functions
 ------------------
 
-As introduced in the :ref:`Function Types` section, most functions in Ivy are *nestable*, which means that they can accept :class:`ivy.Container` instances in place of **any** of the arguments.
+As introduced in the `Function Types <function_types.rst>`_ section, most functions in Ivy are *nestable*, which means that they can accept :class:`ivy.Container` instances in place of **any** of the arguments.
 
 Here, we expand on this explanation.
-Please check out the explanation in the :ref:`Function Types` section first.
+Please check out the explanation in the `Function Types <function_types.rst>`_ section first.
 
 **Explicitly Nestable Functions**
 

--- a/docs/overview/deep_dive/continuous_integration.rst
+++ b/docs/overview/deep_dive/continuous_integration.rst
@@ -289,7 +289,7 @@ Array API Tests
 ---------------
 The `array-api-intelligent-tests.yml (Push) <https://github.com/unifyai/ivy/blob/main/.github/workflows/array-api-intelligent-tests.yml>`_ and the `array-api-intelligent-tests-pr.yml (Pull Request) <https://github.com/unifyai/ivy/blob/main/.github/workflows/array-api-intelligent-tests-pr.yml>`_ workflows run the Array API Tests. Similar to Ivy Tests, The Array API tests are also determined intelligently and only relevant tests are triggered on each commit.
 
-More details about the Array API Tests are available `here <https://unify.ai/docs/ivy/overview/deep_dive/array_api_tests.html>`_.
+More details about the Array API Tests are available `here <array_api_tests.rst>`_.
 
 Periodic Testing
 ----------------

--- a/docs/overview/deep_dive/data_types.rst
+++ b/docs/overview/deep_dive/data_types.rst
@@ -80,7 +80,7 @@ Data Type Module
 The `data_type.py`_ module provides a variety of functions for working with data types.
 A few examples include :func:`ivy.astype` which copies an array to a specified data type, :func:`ivy.broadcast_to` which broadcasts an array to a specified shape, and :func:`ivy.result_type` which returns the dtype that results from applying the type promotion rules to the arguments.
 
-Many functions in the :mod:`data_type.py` module are *convenience* functions, which means that they do not directly modify arrays, as explained in the :ref:`Function Types` section.
+Many functions in the :mod:`data_type.py` module are *convenience* functions, which means that they do not directly modify arrays, as explained in the `Function Types <function_types.rst>`_ section.
 
 For example, the following are all convenience functions:
 `ivy.can_cast`_, which determines if one data type can be cast to another data type according to type-promotion rules, `ivy.dtype <https://github.com/unifyai/ivy/blob/8482eb3fcadd0721f339a1a55c3f3b9f5c86d8ba/ivy/functional/ivy/data_type.py#L1096>`__, which gets the data type for the input array, `ivy.set_default_dtype`_, which sets the global default data dtype, and `ivy.default_dtype`_, which returns the correct data type to use.
@@ -221,7 +221,7 @@ The non-creation functions which do support it are generally functions that invo
 
 The ``dtype`` argument is handled in the `infer_dtype`_ wrapper, for all functions which have the decorator :code:`@infer_dtype`.
 This function calls `ivy.default_dtype`_ in order to determine the correct data type.
-As discussed in the :ref:`Function Wrapping` section, this is applied to all applicable functions dynamically during `backend setting`_.
+As discussed in the `Function Wrapping <function_wrapping.rst>`_ section, this is applied to all applicable functions dynamically during `backend setting`_.
 
 Overall, `ivy.default_dtype`_ infers the data type as follows:
 

--- a/docs/overview/deep_dive/devices.rst
+++ b/docs/overview/deep_dive/devices.rst
@@ -33,7 +33,7 @@ The devices currently supported by Ivy are as follows:
 * gpu:idx
 * tpu:idx
 
-In a similar manner to the :class:`ivy.Dtype` and :class:`ivy.NativeDtype` classes (see :ref:`Data Types`), there is both an `ivy.Device`_ class and an :class:`ivy.NativeDevice` class, with :class:`ivy.NativeDevice` initially set as an `empty class`_.
+In a similar manner to the :class:`ivy.Dtype` and :class:`ivy.NativeDtype` classes (see `Data Types <data_types.rst>`_), there is both an `ivy.Device`_ class and an :class:`ivy.NativeDevice` class, with :class:`ivy.NativeDevice` initially set as an `empty class`_.
 The :class:`ivy.Device` class derives from :code:`str`, and has simple logic in the constructor to verify that the string formatting is correct.
 When a backend is set, the :class:`ivy.NativeDevice` is replaced with the backend-specific `device class`_.
 
@@ -43,7 +43,7 @@ Device Module
 The `device.py`_ module provides a variety of functions for working with devices.
 A few examples include :func:`ivy.get_all_ivy_arrays_on_dev` which gets all arrays which are currently alive on the specified device, :func:`ivy.dev` which gets the device for input array, and :func:`ivy.num_gpus` which determines the number of available GPUs for use with the backend framework.
 
-Many functions in the :mod:`device.py` module are *convenience* functions, which means that they do not directly modify arrays, as explained in the :ref:`Function Types` section.
+Many functions in the :mod:`device.py` module are *convenience* functions, which means that they do not directly modify arrays, as explained in the `Function Types <function_types.rst>`_ section.
 
 For example, the following are all convenience functions: `ivy.total_mem_on_dev`_, which gets the total amount of memory for a given device, `ivy.dev_util`_, which gets the current utilization (%) for a given device, `ivy.num_cpu_cores`_, which determines the number of cores available in the CPU, and `ivy.default_device`_, which returns the correct device to use.
 
@@ -64,7 +64,7 @@ In cases where the input arrays are located on different devices, an error will 
 
 The :code:`device` argument is handled in `infer_device`_ for all functions which have the :code:`@infer_device` decorator, similar to how :code:`dtype` is handled.
 This function calls `ivy.default_device`_ in order to determine the correct device.
-As discussed in the :ref:`Function Wrapping` section, this is applied to all applicable functions dynamically during `backend setting`_.
+As discussed in the `Function Wrapping <function_wrapping.rst>`_ section, this is applied to all applicable functions dynamically during `backend setting`_.
 
 Overall, `ivy.default_device`_ infers the device as follows:
 
@@ -77,7 +77,7 @@ Overall, `ivy.default_device`_ infers the device as follows:
 For the majority of functions which defer to `infer_device`_ for handling the device, these steps will have been followed and the :code:`device` argument will be populated with the correct value before the backend-specific implementation is even entered into.
 Therefore, whereas the :code:`device` argument is listed as optional in the ivy API at :mod:`ivy/functional/ivy/category_name.py`, the argument is listed as required in the backend-specific implementations at :mod:`ivy/functional/backends/backend_name/category_name.py`.
 
-This is exactly the same as with the :code:`dtype` argument, as explained in the :ref:`Data Types` section.
+This is exactly the same as with the :code:`dtype` argument, as explained in the `Data Types <data_types.rst>`_ section.
 
 Let's take a look at the function :func:`ivy.zeros` as an example.
 

--- a/docs/overview/deep_dive/formatting.rst
+++ b/docs/overview/deep_dive/formatting.rst
@@ -19,7 +19,7 @@ Lint Checks
 
 In addition to `black`_ and `flake8`_, Ivy uses other linters to help automate the formatting process, especially for
 issues `flake8`_ detects but doesn't fix automatically. In addition to that, we validate docstring as part of our
-linting process. You can learn more about our docstring formatting in the :ref:`Docstrings` section.
+linting process. You can learn more about our docstring formatting in the `Docstrings <docstrings.rst>`_ section.
 
 We use the following linters:
 

--- a/docs/overview/deep_dive/formatting.rst
+++ b/docs/overview/deep_dive/formatting.rst
@@ -3,7 +3,6 @@ Formatting
 
 .. _`flake8`: https://flake8.pycqa.org/en/latest/index.html
 .. _`black`: https://black.readthedocs.io/en/stable/index.html
-.. _`pre-commit guide`: https://unify.ai/docs/ivy/overview/contributing/setting_up.html#pre-commit
 .. _`formatting channel`: https://discord.com/channels/799879767196958751/1028266706436624456
 .. _`discord`: https://discord.gg/sXyFF8tDtm
 

--- a/docs/overview/deep_dive/function_arguments.rst
+++ b/docs/overview/deep_dive/function_arguments.rst
@@ -10,7 +10,7 @@ Function Arguments
 
 Here, we explain how the function arguments differ between the placeholder implementation at :mod:`ivy/functional/ivy/category_name.py`, and the backend-specific implementation at :mod:`ivy/functional/backends/backend_name/category_name.py`.
 
-Many of these points are already addressed in the previous sections: :ref:`Arrays`, :ref:`Data Types`, :ref:`Devices` and :ref:`Inplace Updates`.
+Many of these points are already addressed in the previous sections: `Arrays <arrays.rst>`_, `Data Types <data_types.rst>`_, `Devices <devices.rst>`_ and `Inplace Updates <inplace_updates.rst>`_.
 However, we thought it would be convenient to revisit all of these considerations in a single section, dedicated to function arguments.
 
 As for type-hints, all functions in the Ivy API at :mod:`ivy/functional/ivy/category_name.py` should have full and thorough type-hints.
@@ -161,13 +161,13 @@ For example, calling any of (:code:`+`, :code:`-`, :code:`*`, :code:`/` etc.) on
 
 :class:`ivy.NativeArray` instances are also not permitted for the :code:`out` argument, which is used in many functions.
 This is because the :code:`out` argument dictates the array to which the result should be written, and so it effectively serves the same purpose as the function return when no :code:`out` argument is specified.
-This is all explained in more detail in the :ref:`Arrays` section.
+This is all explained in more detail in the `Arrays <arrays.rst>`_ section.
 
 out Argument
 ------------
 
 The :code:`out` argument should always be provided as a keyword-only argument, and it should be added to all functions in the Ivy API and backend API which support inplace updates, with a default value of :code:`None` in all cases.
-The :code:`out` argument is explained in more detail in the :ref:`Inplace Updates` section.
+The :code:`out` argument is explained in more detail in the `Inplace Updates <inplace_updates.rst>`_ section.
 
 dtype and device arguments
 --------------------------
@@ -175,7 +175,7 @@ dtype and device arguments
 In the Ivy API at :mod:`ivy/functional/ivy/category_name.py`, the :code:`dtype` and :code:`device` arguments should both always be provided as keyword-only arguments, with a default value of :code:`None`.
 In contrast, these arguments should both be added as required arguments in the backend implementation at :mod:`ivy/functional/backends/backend_name/category_name.py`.
 In a nutshell, by the time the backend implementation is entered, the correct :code:`dtype` and :code:`device` to use have both already been correctly handled by code which is wrapped around the backend implementation.
-This is further explained in the :ref:`Data Types` and :ref:`Devices` sections respectively.
+This is further explained in the `Data Types <data_types.rst>`_ and `Devices <devices.rst>`_ sections respectively.
 
 Numbers in Operator Functions
 -----------------------------

--- a/docs/overview/deep_dive/function_types.rst
+++ b/docs/overview/deep_dive/function_types.rst
@@ -81,8 +81,8 @@ The backend-specific implementation of :func:`ivy.tan`  for PyTorch in :mod:`ivy
         x = _cast_for_unary_op(x)
         return torch.tan(x, out=out)
 
-The reason that the Ivy implementation has type hint :code:`Union[ivy.Array, ivy.NativeArray]` but PyTorch implementation has :class:`torch.Tensor` is explained in the :ref:`Arrays` section.
-Likewise, the reason that the :code:`out` argument in the Ivy implementation has array type hint :class:`ivy.Array` whereas :code:`x` has :code:`Union[ivy.Array, ivy.NativeArray]` is also explained in the :ref:`Arrays` section.
+The reason that the Ivy implementation has type hint :code:`Union[ivy.Array, ivy.NativeArray]` but PyTorch implementation has :class:`torch.Tensor` is explained in the `Arrays <arrays.rst>`_ section.
+Likewise, the reason that the :code:`out` argument in the Ivy implementation has array type hint :class:`ivy.Array` whereas :code:`x` has :code:`Union[ivy.Array, ivy.NativeArray]` is also explained in the `Arrays <arrays.rst>`_ section.
 
 Compositional Functions
 -----------------------
@@ -135,7 +135,7 @@ One example of this is :code:`ivy.linear` for which the torch native function :c
 to be a 2 dimensional tensor while as ivy also allows the :code:`weight` argument to be 3 dimensional. While achieving the objective of having superset
 behaviour across the backends, the native functionality of frameworks should be made use of as much as possible. Even if a framework-specific function
 doesn't provide complete superset behaviour, we should still make use of the partial behaviour that it provides and then add more logic for the
-remaining part. This is explained in detail in the :ref:`Maximizing Usage of Native Functionality` section. Ivy allows this partial support with the help of the `partial_mixed_handler`_
+remaining part. This is explained in detail in the :ref:`overview/deep_dive/superset_behaviour:Maximizing Usage of Native Functionality` section. Ivy allows this partial support with the help of the `partial_mixed_handler`_
 attribute which should be added to the backend implementation with a boolean function that specifies some condition on the inputs to switch between the compositional
 and primary implementations. For example, the :code:`torch` backend implementation of :code:`linear`` looks like:
 
@@ -159,7 +159,7 @@ the :code:`handle_partial_mixed_function` decorator first evaluates the boolean 
 is `True` and the compositional implementation otherwise.
 
 
-For further information on decorators, please refer to the :ref:`Function Wrapping` section.
+For further information on decorators, please refer to the `Function Wrapping <function_wrapping.rst>`_ section.
 
 For all mixed functions, we must add the :code:`mixed_backend_wrappers` attribute to the compositional implementation of mixed functions to specify which additional wrappers need to be applied to the primary implementation and which ones from the compositional implementation should be skipped.
 We do this by creating a dictionary of two keys, :code:`to_add` and :code:`to_skip`, each containing the tuple of wrappers to be added or skipped respectively. In general, :code:`handle_out_argument`, :code:`inputs_to_native_arrays` and :code:`outputs_to_ivy_arrays`
@@ -215,9 +215,9 @@ This *nestable* property of Ivy functions means that the same function can be us
 
 This added support for handling :class:`ivy.Container` instances is all handled automatically when `_wrap_function`_ is applied to every function in the :code:`ivy` module during `backend setting`_.
 This will add the `handle_nestable`_ wrapping to the function if it has the :code:`@handle_nestable` decorator.
-This function wrapping process is covered in a bit more detail in the :ref:`Function Wrapping` section.
+This function wrapping process is covered in a bit more detail in the `Function Wrapping <function_wrapping.rst>`_ section.
 
-Nestable functions are explained in more detail in the :ref:`Containers` section.
+Nestable functions are explained in more detail in the `Containers <containers.rst>` section.
 
 Convenience Functions
 ---------------------

--- a/docs/overview/deep_dive/function_wrapping.rst
+++ b/docs/overview/deep_dive/function_wrapping.rst
@@ -29,6 +29,11 @@ Function Wrapping
 .. _`ivy.linear`: https://github.com/unifyai/ivy/blob/5658401b266352d3bf72c95e4af6ae9233115722/ivy/functional/ivy/layers.py#L81
 .. _`handle_exceptions`: https://github.com/unifyai/ivy/blob/5658401b266352d3bf72c95e4af6ae9233115722/ivy/utils/exceptions.py#L189
 .. _`example`: https://github.com/unifyai/ivy/blob/5658401b266352d3bf72c95e4af6ae9233115722/ivy/functional/backends/torch/layers.py#L30
+.. _`Arrays`: arrays.rst
+.. _`Inplace Updates`: inplace_updates.rst
+.. _`Data Types`: data_types.rst
+.. _`Devices`: devices.rst
+.. _`Backend Setting`: backend_setting.rst
 
 When a backend framework is set by calling :code:`ivy.set_backend(backend_name)`, then all Ivy functions are `wrapped`_.
 This is achieved by calling `_wrap_function`_, which will apply the appropriate wrapping to the given function, based on what decorators it has.
@@ -37,7 +42,7 @@ For example, `abs`_ has the decorators :code:`@to_native_arrays_and_back` and :c
 The new function returned by :code:`_wrap_function` is a replacement of the original function with extra code added to support requirements common to many functions in the API.
 This is the main purpose of the wrapping, to avoid code duplication which would exist if we added identical logic in every single function independently.
 
-Depending on the function being wrapped, the new function might handle :ref:`Arrays`, :ref:`Inplace Updates`, :ref:`Data Types` and/or :ref:`Devices`.
+Depending on the function being wrapped, the new function might handle `Arrays`_, `Inplace Updates`_, `Data Types`_ and/or `Devices`_.
 
 Our test decorators actually transforms to :code:`@given` decorators at Pytest collecting time, therefore this allows us to use other **Hypothesis** decorators like, :code:`@reproduce_failure`, :code:`@settings`, :code:`@seed`.
 
@@ -74,11 +79,11 @@ This recommended order is followed to ensure that tests are efficient and accura
 Conversion Wrappers
 ^^^^^^^^^^^^^^^^^^^
 
-#.  `inputs_to_native_arrays`_ : This wrapping function converts all :class:`ivy.Array` instances in the arguments to their :class:`ivy.NativeArray` counterparts, based on the :ref:`Backend Setting` before calling the function.
-#.  `inputs_to_ivy_arrays`_ : This wrapping function converts all :class:`ivy.NativeArray` instances in the arguments to their :class:`ivy.Array` counterparts, based on the :ref:`Backend Setting` before calling the function.
-#.  `outputs_to_ivy_arrays`_ : This wrapping function converts all :class:`ivy.NativeArray` instances in the outputs to their :class:`ivy.Array` counterparts, based on the :ref:`Backend Setting` before calling the function.
+#.  `inputs_to_native_arrays`_ : This wrapping function converts all :class:`ivy.Array` instances in the arguments to their :class:`ivy.NativeArray` counterparts, based on the `Backend Setting`_ before calling the function.
+#.  `inputs_to_ivy_arrays`_ : This wrapping function converts all :class:`ivy.NativeArray` instances in the arguments to their :class:`ivy.Array` counterparts, based on the `Backend Setting`_ before calling the function.
+#.  `outputs_to_ivy_arrays`_ : This wrapping function converts all :class:`ivy.NativeArray` instances in the outputs to their :class:`ivy.Array` counterparts, based on the `Backend Setting`_ before calling the function.
 #.  `to_native_arrays_and_back`_ : This wrapping function converts all :class:`ivy.Array` instances in the arguments to their :class:`ivy.NativeArray` counterparts, calls the function with those arguments and then converts the :class:`ivy.NativeArray` instances in the output back to :class:`ivy.Array`.
-    This wrapping function is heavily used because it enables achieving the objective of ensuring that every ivy function could accept an :class:`ivy.Array` and return an :class:`ivy.Array`, making it independent of the :ref:`Backend Setting`.
+    This wrapping function is heavily used because it enables achieving the objective of ensuring that every ivy function could accept an :class:`ivy.Array` and return an :class:`ivy.Array`, making it independent of the `Backend Setting`_.
 
 Inference Wrappers
 ^^^^^^^^^^^^^^^^^^
@@ -95,7 +100,7 @@ Out Argument Support
 #.  `handle_out_argument`_ : This wrapping function is used in nearly all ivy functions.
     It enables appropriate handling of the :code:`out` argument of functions.
     In cases where the backend framework natively supports the :code:`out` argument for a function, we prefer to use it as it's a more efficient implementation of the :code:`out` argument for that particular backend framework.
-    But in cases when it isn't supported, we support it anyway with :ref:`Inplace Updates`.
+    But in cases when it isn't supported, we support it anyway with `Inplace Updates`_.
 
 Nestable Support
 ^^^^^^^^^^^^^^^^
@@ -105,7 +110,7 @@ Nestable Support
 Partial Mixed Function Support
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-#. `handle_partial_mixed_function`_: This wrapping function enables switching between compositional and primary implementations of :ref:`Mixed Functions` based on some condition on the arguments of the function.
+#. `handle_partial_mixed_function`_: This wrapping function enables switching between compositional and primary implementations of :ref:`overview/deep_dive/function_types:Mixed Functions` based on some condition on the arguments of the function.
 #.  The condition is specified through a lambda function which when evaluates to `True` the primary implementation is run and otherwise the compositional implementation is executed.
 #.  For backends that have a primary implementation of a mixed function, the reference to the compositional implementation is `stored as an attribute`_ inside the backend function during backend setting. To make use of this decorator, one must
 #.  add the :code:`partial_mixed_handler` attribute containing the lambda function to the backend implementation. Here's an `example`_ from the torch backend implementation of linear.
@@ -113,29 +118,29 @@ Partial Mixed Function Support
 Shape Conversion
 ^^^^^^^^^^^^^^^^
 
-#.  `inputs_to_native_shapes`_ : This wrapping function converts all :class:`ivy.Shape` instances in the arguments to their :class:`ivy.NativeShape` counterparts, based on the :ref:`Backend Setting` before calling the function.
-#.  `outputs_to_ivy_shapes`_ : This wrapping function converts all :class:`ivy.NativeShape` instances in the outputs to their :class:`ivy.Shape` counterparts, based on the :ref:`Backend Setting` before calling the function.
+#.  `inputs_to_native_shapes`_ : This wrapping function converts all :class:`ivy.Shape` instances in the arguments to their :class:`ivy.NativeShape` counterparts, based on the `Backend Setting`_ before calling the function.
+#.  `outputs_to_ivy_shapes`_ : This wrapping function converts all :class:`ivy.NativeShape` instances in the outputs to their :class:`ivy.Shape` counterparts, based on the `Backend Setting`_ before calling the function.
 #.  `to_native_shapes_and_back`_ : This wrapping function converts all :class:`ivy.Shape` instances in the arguments to their :class:`ivy.NativeShape` counterparts, calls the function with those arguments and then converts the :class:`ivy.NativeShape` instances in the output back to :class:`ivy.Shape`.
 
 View Handling
 ^^^^^^^^^^^^^
 
-#.  `handle_view`_ : This wrapping function performs view handling based on our :ref:`Views` policy.
+#.  `handle_view`_ : This wrapping function performs view handling based on our :ref:`overview/deep_dive/inplace_updates:Views` policy.
 #.  `handle_view_indexing`_ : This wrapping function is aimed at handling views for indexing.
 
 Exception Handling 
 ^^^^^^^^^^^^^^^^^^
 
-#. `handle_exceptions`_ : This wrapping function helps in catching native exceptions and unifying them into `IvyException` or the relevant subclasses. More information can be found in the :ref:`Exception Handling` section.
+#. `handle_exceptions`_ : This wrapping function helps in catching native exceptions and unifying them into `IvyException` or the relevant subclasses. More information can be found in the :ref:`overview/deep_dive/function_wrapping:Exception Handling` section.
 
 Miscellaneous Wrappers 
 ^^^^^^^^^^^^^^^^^^^^^^
 
-#.  `handle_array_function`_ : This wrapping function enables :ref:`Integrating custom classes with Ivy`
+#.  `handle_array_function`_ : This wrapping function enables :ref:`overview/deep_dive/arrays:Integrating custom classes with Ivy`
 #.  `handle_complex_input`_ : This wrapping function enables handling of complex numbers. It introduces a keyword argument :code:`complex_mode`, which is used to choose the function's behaviour as per the wrapper's docstring.
 
 
-When calling `_wrap_function`_ during :ref:`Backend Setting`, firstly the attributes of the functions are checked to get all the wrapping functions for a particular function.
+When calling `_wrap_function`_ during `Backend Setting`_, firstly the attributes of the functions are checked to get all the wrapping functions for a particular function.
 Then all the wrapping functions applicable to a function are used to wrap the function.
 
 Each of these topics and each associated piece of logic added by the various wrapper functions are covered in more detail in the next sections.

--- a/docs/overview/deep_dive/function_wrapping.rst
+++ b/docs/overview/deep_dive/function_wrapping.rst
@@ -17,6 +17,7 @@ Function Wrapping
 .. _`handle_nestable`: https://github.com/unifyai/ivy/blob/5658401b266352d3bf72c95e4af6ae9233115722/ivy/func_wrapper.py#L896
 .. _`inputs_to_native_shapes`: https://github.com/unifyai/ivy/blob/5658401b266352d3bf72c95e4af6ae9233115722/ivy/func_wrapper.py#L488
 .. _`outputs_to_ivy_shapes`: https://github.com/unifyai/ivy/blob/5658401b266352d3bf72c95e4af6ae9233115722/ivy/func_wrapper.py#L501
+.. _`to_native_shapes_and_back`: https://github.com/unifyai/ivy/blob/5658401b266352d3bf72c95e4af6ae9233115722/ivy/func_wrapper.py#L514
 .. _`handle_view`: https://github.com/unifyai/ivy/blob/5658401b266352d3bf72c95e4af6ae9233115722/ivy/func_wrapper.py#L627
 .. _`handle_view_indexing`: https://github.com/unifyai/ivy/blob/5658401b266352d3bf72c95e4af6ae9233115722/ivy/func_wrapper.py#L659 
 .. _`handle_array_function`: https://github.com/unifyai/ivy/blob/5658401b266352d3bf72c95e4af6ae9233115722/ivy/func_wrapper.py#L299

--- a/docs/overview/deep_dive/inplace_updates.rst
+++ b/docs/overview/deep_dive/inplace_updates.rst
@@ -9,7 +9,6 @@ Inplace Updates
 .. _`jax.numpy.tan`: https://jax.readthedocs.io/en/latest/_autosummary/jax.numpy.tan.html?highlight=tan
 .. _`presence of this attribute`: https://github.com/unifyai/ivy/blob/8ded4a5fc13a278bcbf2d76d1fa58ab41f5797d0/ivy/func_wrapper.py#L341
 .. _`by the backend function`: https://github.com/unifyai/ivy/blob/8ded4a5fc13a278bcbf2d76d1fa58ab41f5797d0/ivy/func_wrapper.py#L372
-.. _`by the wrapper`: https://github.com/unifyai/ivy/blob/8ded4a5fc13a278bcbf2d76d1fa58ab41f5797d0/ivy/func_wrapper.py#L377
 .. _`handled by the wrapper`: https://github.com/unifyai/ivy/blob/8ded4a5fc13a278bcbf2d76d1fa58ab41f5797d0/ivy/func_wrapper.py#L373
 .. _`_wrap_fn`: https://github.com/unifyai/ivy/blob/6497b8a3d6b0d8aac735a158cd03c8f98eb288c2/ivy/container/wrapping.py#L69
 .. _`NON_WRAPPED_FUNCTIONS`: https://github.com/unifyai/ivy/blob/fdaea62380c9892e679eba37f26c14a7333013fe/ivy/func_wrapper.py#L9
@@ -17,8 +16,6 @@ Inplace Updates
 .. _`ivy.reshape`: https://github.com/unifyai/ivy/blob/633eb420c5006a0a17c238bfa794cf5b6add8598/ivy/functional/ivy/manipulation.py#L418
 .. _`ivy.astype`: https://github.com/unifyai/ivy/blob/8482eb3fcadd0721f339a1a55c3f3b9f5c86d8ba/ivy/functional/ivy/data_type.py#L46
 .. _`ivy.asarray`: https://github.com/unifyai/ivy/blob/8482eb3fcadd0721f339a1a55c3f3b9f5c86d8ba/ivy/functional/ivy/creation.py#L114
-.. _`wrapping`:
-.. _`ivy.inplace_update`: https://github.com/unifyai/ivy/blob/3a21a6bef52b93989f2fa2fa90e3b0f08cc2eb1b/ivy/functional/ivy/general.py#L1137
 .. _`repo`: https://github.com/unifyai/ivy
 .. _`discord`: https://discord.gg/sXyFF8tDtm
 .. _`inplace updates channel`: https://discord.com/channels/799879767196958751/1028681763947552778
@@ -28,7 +25,7 @@ Inplace Updates
 Inplace updates enable users to overwrite the contents of existing arrays with new data.
 This enables much more control over the memory-efficiency of the program, preventing old unused arrays from being kept in memory for any longer than is strictly necessary.
 
-The function `ivy.inplace_update`_ enables explicit inplace updates.
+The function :func:`ivy.inplace_update` enables explicit inplace updates.
 :func:`ivy.inplace_update` is a *primary* function, and the backend-specific implementations for each backend are presented below.
 We also explain the rationale for why each implementation is the way it is, and the important differences.
 
@@ -313,7 +310,7 @@ The implementations of :func:`ivy.tan` for each backend are as follows.
 
     tan.support_native_out = True
 
-It's very important to ensure the :code:`support_native_out` attribute is not added to backend implementations that do not handle the :code:`out` argument, as the `presence of this attribute`_ dictates whether the argument should be handled `by the backend function`_ or `by the wrapper`_.
+It's very important to ensure the :code:`support_native_out` attribute is not added to backend implementations that do not handle the :code:`out` argument, as the `presence of this attribute`_ dictates whether the argument should be handled `by the backend function`_ or `by the wrapper <function_wrapping.rst>`_.
 
 This distinction only concerns how the inplace update is applied to the native array, which is operated upon directly by the backend.
 If :code:`out` is specified in an Ivy function, then an inplace update is always **also** performed on the :class:`ivy.Array` instance itself, which is how :code:`out` is provided to the function originally.
@@ -351,7 +348,7 @@ Here we still have the :attr:`support_native_out` attribute since we want to tak
 However, in the :code:`else` statement, the last operation is :func:`torch.transpose` which does not support the :code:`out` argument, and so the native inplace update can't be performed by torch here.
 This is why we need to call :func:`ivy.inplace_update` explicitly here, to ensure the native inplace update is performed, as well as the :class:`ivy.Array` inplace update.
 
-Another case where we need to use :func:`ivy.inplace_update`_ with a function that has :attr:`support_native_out` is for the example of the :code:`torch` backend implementation of the :func:`ivy.remainder` function
+Another case where we need to use :func:`ivy.inplace_update` with a function that has :attr:`support_native_out` is for the example of the :code:`torch` backend implementation of the :func:`ivy.remainder` function
 
 .. code-block:: python
  

--- a/docs/overview/deep_dive/inplace_updates.rst
+++ b/docs/overview/deep_dive/inplace_updates.rst
@@ -256,14 +256,14 @@ This could for example be the input array itself, but can also be any other arra
 All Ivy functions which return a single array should support inplace updates via the :code:`out` argument.
 The type hint of the :code:`out` argument is :code:`Optional[ivy.Array]`.
 However, as discussed above, if the function is *nestable* then :class:`ivy.Container` instances are also supported.
-:class:`ivy.Container` is omitted from the type hint in such cases, as explained in the :ref:`Function Arguments` section.
+:class:`ivy.Container` is omitted from the type hint in such cases, as explained in the `Function Arguments <function_arguments.rst>`_ section.
 
 When the :code:`out` argument is unspecified, then the return is simply provided in a newly created :class:`ivy.Array` (or :class:`ivy.Container` if *nestable*).
 However, when :code:`out` is specified, then the return is provided as an inplace update of the :code:`out` argument provided.
 This can for example be the same as the input to the function, resulting in a simple inplace update of the input.
 
 In the case of :class:`ivy.Array` return types, the :code:`out` argument is predominantly handled in `handle_out_argument`_.
-As explained in the :ref:`Function Wrapping` section, this wrapping is applied to every function with the :code:`@handle_out_argument` decorator dynamically during `backend setting`_.
+As explained in the `Function Wrapping <function_wrapping.rst>`_ section, this wrapping is applied to every function with the :code:`@handle_out_argument` decorator dynamically during `backend setting`_.
 
 **Primary Functions**
 
@@ -435,7 +435,7 @@ Technically, this could be handled using the `handle_out_argument`_ wrapping, bu
 
 **Mixed Functions**
 
-As explained in the :ref:`Function Types` section, *mixed* functions can effectively behave as either compositional or primary functions, depending on the backend that is selected. We must add the :code:`handle_out_argument` to the :code:`add_wrappers`key of
+As explained in the `Function Types <function_types.rst>`_ section, *mixed* functions can effectively behave as either compositional or primary functions, depending on the backend that is selected. We must add the :code:`handle_out_argument` to the :code:`add_wrappers`key of
 the :code:`mixed_backend_wrappers` attribute so that the decorator gets added to the primary implementation when the backend is set. Here's an `example`_ from the linear function.
 
 

--- a/docs/overview/deep_dive/inplace_updates.rst
+++ b/docs/overview/deep_dive/inplace_updates.rst
@@ -451,7 +451,7 @@ When :code:`copy` is not specified explicitly, then an inplace update is perform
 Setting :code:`copy=False` is equivalent to passing :code:`out=input_array`.
 If only one of :code:`copy` or :code:`out` is specified, then this specified argument is given priority.
 If both are specified, then priority is given to the more general :code:`out` argument.
-As with the :code:`out` argument, the :code:`copy` argument is also handled `by the wrapper <https://unify.ai/docs/ivy/overview/deep_dive/function_wrapping.html#function-wrapping>`_.
+As with the :code:`out` argument, the :code:`copy` argument is also handled `by the wrapper <function_wrapping.rst>`_.
 
 
 Views

--- a/docs/overview/deep_dive/ivy_frontends.rst
+++ b/docs/overview/deep_dive/ivy_frontends.rst
@@ -409,7 +409,7 @@ Classes and Instance Methods
 ----------------------------
 
 Most frameworks include instance methods and special methods on their array class for common array processing functions, such as :func:`reshape`, :func:`expand_dims` and :func:`add`.
-This simple design choice comes with many advantages, some of which are explained in our :ref:`Ivy Array` section.
+This simple design choice comes with many advantages, some of which are explained in our `Ivy Array <../design/ivy_as_a_framework/ivy_array.rst>`_ section.
 
 **Important Note**
 Before implementing the instance method or special method, make sure that the regular function in the specific frontend is already implemented.
@@ -516,7 +516,7 @@ For example, :class:`numpy.matrix` has an instance method of :meth:`any`:
         return any(self.A, axis=axis, out=out)
 
 We need to create these frontend array classes and all of their instance methods and also their special methods such that we are able to transpile code which makes use of these methods.
-As explained in :ref:`Ivy as a Transpiler`, when transpiling code we first extract the computation graph in the source framework.
+As explained in `Ivy as a Transpiler <../design/ivy_as_a_transpiler.rst>`_, when transpiling code we first extract the computation graph in the source framework.
 In the case of instance methods, we then replace each of the original instance methods in the extracted computation graph with these new instance methods defined in the Ivy frontend class.
 
 Frontend Data Type Promotion Rules

--- a/docs/overview/deep_dive/ivy_frontends.rst
+++ b/docs/overview/deep_dive/ivy_frontends.rst
@@ -17,7 +17,6 @@ Ivy Frontends
 .. _`YouTube tutorial series`: https://www.youtube.com/watch?v=72kBVJTpzIw&list=PLwNuX3xB_tv-wTpVDMSJr7XW6IP_qZH0t
 .. _`discord`: https://discord.gg/sXyFF8tDtm
 .. _`ivy frontends channel`: https://discord.com/channels/799879767196958751/998782045494976522
-.. _`open task`: https://unify.ai/docs/ivy/overview/contributing/open_tasks.html#frontend-apis
 .. _`Array manipulation routines`: https://numpy.org/doc/stable/reference/routines.array-manipulation.html#
 .. _`Array creation routines`: https://numpy.org/doc/stable/reference/routines.array-creation.html
 
@@ -62,7 +61,7 @@ Therefore, in order to avoid this potential conflict:
 * You should ensure that the tests are passing before merging any frontend PRs.
   The only exception to this rule is if the test is failing due to a bug in the Ivy functional API, which does not need to be solved as part of the frontend task.
 
-There will be some implicit discussion of the locations of frontend functions in these examples, however an explicit explanation of how to place a frontend function can be found in a sub-section of the Frontend APIs `open task`_.
+There will be some implicit discussion of the locations of frontend functions in these examples, however an explicit explanation of how to place a frontend function can be found in a sub-section of the Frontend APIs :ref:`open task <overview/contributing/open_tasks:Frontend APIs>`.
 
 
 **NOTE:** Type hints, docstrings, and examples are not required when working on frontend functions.
@@ -73,7 +72,7 @@ There will be some implicit discussion of the locations of frontend functions in
 The native arrays of each framework have their own attributes and instance methods which differ from the attributes and instance methods of :class:`ivy.Array`.
 As such we have implemented framework-specific array classes: :class:`tf_frontend.Tensor`, :class:`torch_frontend.Tensor`, :class:`numpy_frontend.ndarray`, and :class:`jax_frontend.DeviceArray`.
 These classes simply wrap an :class:`ivy.Array`, which is stored in the :code:`ivy_array` attribute, and behave as closely as possible to the native framework array classes.
-This is explained further in the `Classes and Instance Methods <https://unify.ai/docs/ivy/overview/deep_dive/ivy_frontends.html#id6>`_ section.
+This is explained further in the :ref:`overview/deep_dive/ivy_frontends:Classes and Instance Methods` section.
 
 As we aim to replicate the frontend frameworks as closely as possible, all functions accept their frontend array class (as well as :class:`ivy.Array` and :class:`ivy.NativeArray`) and return a frontend array.
 However, since most logic in each function is handled by Ivy, the :class:`ivy.Array` must be extracted from any frontend array inputs.
@@ -318,7 +317,7 @@ Short Frontend Implementations
 
 Ideally, all frontend functions should call the equivalent Ivy function and only be one line long. This is mainly because compositional implementations are bound to be slower than direct backend implementation calls.
 
-In case a frontend function is complex and there is no equivalent Ivy function to use, it is strongly advised to add that function to our Experimental API. To do so, you are invited to open a *Missing Function Suggestion* issue as described in the `Open Tasks <https://unify.ai/docs/ivy/overview/contributing/the_basics.html#id4>`_ section. A member of our team will then review your issue, and if the proposed addition is deemed to be timely and sensible, we will add the function to the "Extend Ivy Functional API" `ToDo list issue <https://github.com/unifyai/ivy/issues/3856>`_.
+In case a frontend function is complex and there is no equivalent Ivy function to use, it is strongly advised to add that function to our Experimental API. To do so, you are invited to open a *Missing Function Suggestion* issue as described in the `Open Tasks <../contributing/open_tasks.rst>`_ section. A member of our team will then review your issue, and if the proposed addition is deemed to be timely and sensible, we will add the function to the "Extend Ivy Functional API" `ToDo list issue <https://github.com/unifyai/ivy/issues/3856>`_.
 
 If you would rather not wait around for a member of our team to review your suggestion, you can instead go straight ahead and add the frontend function as a heavy composition of the existing Ivy functions, with a :code:`#ToDo` comment included, explaining that this frontend implementation will be simplified when :func:`ivy.func_name` is added.
 
@@ -348,7 +347,7 @@ The native TensorFlow function :func:`tf.reduce_logsumexp` does not have an equi
 
 Through compositions, we can easily meet the required input-output behaviour for the TensorFlow frontend function.
 
-The entire workflow for extending the Ivy Frontends as an external contributor is explained in more detail in the `Open Tasks <https://unify.ai/docs/ivy/overview/contributing/open_tasks.html#frontend-apis>`_ section.
+The entire workflow for extending the Ivy Frontends as an external contributor is explained in more detail in the :ref:`Open Tasks <overview/contributing/open_tasks:Frontend APIs>` section.
 
 Unused Arguments
 ----------------

--- a/docs/overview/deep_dive/ivy_frontends_tests.rst
+++ b/docs/overview/deep_dive/ivy_frontends_tests.rst
@@ -801,7 +801,7 @@ The CI Pipeline runs the entire collection of Frontend Tests for the frontend th
 You will need to make sure the Frontend Test is passing for each Ivy Frontend function you introduce/modify.
 If a test fails on the CI, you can see details about the failure under `Details -> Run Frontend Tests` as shown in `CI Pipeline`_.
 
-You can also run the tests locally before making a PR. See the relevant :ref:`Setting Up Testing in PyCharm` section for instructions on how to do so.
+You can also run the tests locally before making a PR. See the relevant :ref:`overview/contributing/setting_up:Setting Up Testing in PyCharm` section for instructions on how to do so.
 
 Frontend Framework Testing Configuration
 ----------------------------------------

--- a/docs/overview/deep_dive/ivy_frontends_tests.rst
+++ b/docs/overview/deep_dive/ivy_frontends_tests.rst
@@ -1,16 +1,16 @@
 Ivy Frontend Tests
 ==================
 
-.. _`here`: https://unify.ai/docs/ivy/design/ivy_as_a_transpiler.html
+.. _`here`: ../design/ivy_as_a_transpiler.rst
 .. _`ivy frontends tests channel`: https://discord.com/channels/799879767196958751/1028267758028337193
 .. _`test ivy`: https://github.com/unifyai/ivy/tree/db9a22d96efd3820fb289e9997eb41dda6570868/ivy_tests/test_ivy
 .. _`test_frontend_function`: https://github.com/unifyai/ivy/blob/591ac37a664ebdf2ca50a5b0751a3a54ee9d5934/ivy_tests/test_ivy/helpers.py#L1047
 .. _`discord`: https://discord.gg/sXyFF8tDtm
-.. _`Function Wrapping`: https://unify.ai/docs/ivy/overview/deep_dive/function_wrapping.html
-.. _`open task`: https://unify.ai/docs/ivy/overview/contributing/open_tasks.html
-.. _`Ivy Tests`: https://unify.ai/docs/ivy/overview/deep_dive/ivy_tests.html
+.. _`Function Wrapping`: function_wrapping.rst
+.. _`open task`: ../contributing/open_tasks.rst
+.. _`Ivy Tests`: ivy_tests.rst
 .. _`Function Testing Helpers`: https://github.com/unifyai/ivy/blob/bf0becd459004ae6cffeb3c38c02c94eab5b7721/ivy_tests/test_ivy/helpers/function_testing.py
-.. _`CI Pipeline`: https://unify.ai/docs/ivy/overview/deep_dive/continuous_integration.html
+.. _`CI Pipeline`: continuous_integration.rst
 
 
 Introduction

--- a/docs/overview/deep_dive/ivy_tests.rst
+++ b/docs/overview/deep_dive/ivy_tests.rst
@@ -616,7 +616,7 @@ It would be helpful to keep in mind the following points while writing test -:
 
 Testing Partial Mixed Functions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-As explained in the :ref:`Function Types` section, partial mixed functions are a special type of mixed functions that either utilize the compositional implementation
+As explained in the `Function Types <function_types.rst>`_ section, partial mixed functions are a special type of mixed functions that either utilize the compositional implementation
 or the primary implementation depending on some conditions on the input. Therefore, the data-types supported by partial mixed functions depend on which implementation will
 be used for the given input. For example, when :code:`function_supported_dtypes` is called with respect to `ivy.linear` with torch backend, the following output is returned:
 

--- a/docs/overview/deep_dive/ivy_tests.rst
+++ b/docs/overview/deep_dive/ivy_tests.rst
@@ -13,7 +13,7 @@ Ivy Tests
 .. _`methods`: https://hypothesis.readthedocs.io/en/latest/data.html
 .. _`finfo`: https://github.com/unifyai/ivy/blob/d8f1ffe8ebf38fa75161c1a9459170e95f3c82b6/ivy/functional/ivy/data_type.py#L276
 .. _`data generation`: https://github.com/unifyai/ivy/blob/7063bf4475b93f87a4a96ef26c56c2bd309a2338/ivy_tests/test_ivy/test_functional/test_core/test_dtype.py#L337
-.. _`Function Types`: https://unify.ai/docs/ivy/overview/deep_dive/function_types.html
+.. _`Function Types`: function_types.rst
 .. _`test_default_int_dtype`: https://github.com/unifyai/ivy/blob/7063bf4475b93f87a4a96ef26c56c2bd309a2338/ivy_tests/test_ivy/test_functional/test_core/test_dtype.py#L835
 .. _`sampled_from`: https://hypothesis.readthedocs.io/en/latest/data.html#hypothesis.strategies.sampled_from
 .. _`lists`: https://hypothesis.readthedocs.io/en/latest/data.html#hypothesis.strategies.lists
@@ -53,9 +53,7 @@ Ivy Tests
 .. _`dtype_and_values`: https://github.com/unifyai/ivy/blob/e50f71e283313caa9737f3c284496022ac67b58b/ivy_tests/test_ivy/helpers/hypothesis_helpers/array_helpers.py#L83
 .. _`dtype_values_axis`: https://github.com/unifyai/ivy/blob/e50f71e283313caa9737f3c284496022ac67b58b/ivy_tests/test_ivy/helpers/hypothesis_helpers/array_helpers.py#L235
 .. _`array_values`: https://github.com/unifyai/ivy/blob/e50f71e283313caa9737f3c284496022ac67b58b/ivy_tests/test_ivy/helpers/hypothesis_helpers/array_helpers.py#L543
-.. _`CI Pipeline`: https://unify.ai/docs/ivy/overview/deep_dive/continuous_integration.html
-.. _`Setting Up Testing in PyCharm`: https://unify.ai/docs/ivy/overview/contributing/setting_up.html#setting-up-testing-in-pycharm
-.. _`Setting up for Free`: https://unify.ai/docs/ivy/overview/contributing/setting_up.html#setting-up-for-free
+.. _`CI Pipeline`: continuous_integration.rst
 .. _`Hypothesis docs`: https://hypothesis.readthedocs.io/en/latest/data.html#core-strategies
 
 On top of the Array API `test suite`_, which is included as a submodule mapped to the folder :code:`test_array_api`, there is also a collection of Ivy tests, located in subfolder `test_ivy`_.
@@ -843,7 +841,7 @@ You will need to make sure the Ivy Test is passing for each Ivy function you int
 If a test fails on the CI, you can see details about the failure under `Details -> Run Ivy <module> Tests` as shown in `CI Pipeline`_.
 
 You can also run the tests locally before making a PR. The instructions differ according to the IDE you are using. For
-PyCharm and Visual Studio Code you can refer to the `Setting Up Testing in PyCharm`_ section and `Setting up for Free`_
+PyCharm and Visual Studio Code you can refer to the :ref:`overview/contributing/setting_up:Setting Up Testing in PyCharm` section and :ref:`overview/contributing/setting_up:Setting up for Free`
 section respectively.
 
 Re-Running Failed Ivy Tests

--- a/docs/overview/deep_dive/ivy_tests.rst
+++ b/docs/overview/deep_dive/ivy_tests.rst
@@ -53,6 +53,14 @@ Ivy Tests
 .. _`dtype_and_values`: https://github.com/unifyai/ivy/blob/e50f71e283313caa9737f3c284496022ac67b58b/ivy_tests/test_ivy/helpers/hypothesis_helpers/array_helpers.py#L83
 .. _`dtype_values_axis`: https://github.com/unifyai/ivy/blob/e50f71e283313caa9737f3c284496022ac67b58b/ivy_tests/test_ivy/helpers/hypothesis_helpers/array_helpers.py#L235
 .. _`array_values`: https://github.com/unifyai/ivy/blob/e50f71e283313caa9737f3c284496022ac67b58b/ivy_tests/test_ivy/helpers/hypothesis_helpers/array_helpers.py#L543
+.. _`array_dtypes`: https://github.com/unifyai/ivy/blob/e50f71e283313caa9737f3c284496022ac67b58b/ivy_tests/test_ivy/helpers/hypothesis_helpers/dtype_helpers.py#L15
+.. _`array_bools`: https://github.com/unifyai/ivy/blob/e50f71e283313caa9737f3c284496022ac67b58b/ivy_tests/test_ivy/helpers/hypothesis_helpers/array_helpers.py#L17
+.. _`reshape_shapes`: https://github.com/unifyai/ivy/blob/e50f71e283313caa9737f3c284496022ac67b58b/ivy_tests/test_ivy/helpers/hypothesis_helpers/general_helpers.py#L16
+.. _`get_axis`: https://github.com/unifyai/ivy/blob/e50f71e283313caa9737f3c284496022ac67b58b/ivy_tests/test_ivy/helpers/hypothesis_helpers/general_helpers.py#L178
+.. _`get_shape`: https://github.com/unifyai/ivy/blob/e50f71e283313caa9737f3c284496022ac67b58b/ivy_tests/test_ivy/helpers/hypothesis_helpers/general_helpers.py#L67
+.. _`get_bounds`: https://github.com/unifyai/ivy/blob/e50f71e283313caa9737f3c284496022ac67b58b/ivy_tests/test_ivy/helpers/hypothesis_helpers/general_helpers.py#L145
+.. _`subsets`: https://github.com/unifyai/ivy/blob/e50f71e283313caa9737f3c284496022ac67b58b/ivy_tests/test_ivy/helpers/hypothesis_helpers/general_helpers.py#L48
+.. _`num_positional_args`: https://github.com/unifyai/ivy/blob/e50f71e283313caa9737f3c284496022ac67b58b/ivy_tests/test_ivy/helpers/testing_helpers.py#L78
 .. _`CI Pipeline`: continuous_integration.rst
 .. _`Hypothesis docs`: https://hypothesis.readthedocs.io/en/latest/data.html#core-strategies
 
@@ -250,7 +258,7 @@ Writing Ivy Tests
 ^^^^^^^^^^^^^^^^^
 
 As mentioned previously, testing Ivy functions needs a lot of pre-processing and past-processing, using only :code:`given` decorator would not be sufficient
-to write an effective test, the following example describes how to implement a test for the function :code:`ivy.abs, using our test decorators and test helpers.
+to write an effective test, the following example describes how to implement a test for the function :code:`ivy.abs`, using our test decorators and test helpers.
 
 .. code-block:: python
     @handle_test(
@@ -483,7 +491,7 @@ Meaning if the input is to be treated as a container, at the same time, is it a 
 
 The generated values are then passed to the array creation functions inside the test function as tuples.
 
-9. `valid_axes`_ - This function generates valid axes for a given array dimension.
+9. valid_axes - This function generates valid axes for a given array dimension.
    For example -:
 
 .. code-block:: python
@@ -559,7 +567,7 @@ This function should be used in places where the result doesn’t depend on the 
 
 **Note** - Under the hood, **array_values** strategy is called if the data type is *integer*, and **none_or_list_of_floats** is called when the data type is *float*.
 
-15. `get_probs`_ -  This is used to generate a tuple containing two values.
+15. get_probs -  This is used to generate a tuple containing two values.
     The first one being the *unnormalized probabilities* for all elements in a population, the second one being the *population size*.
     For example-:
 

--- a/docs/overview/deep_dive/navigating_the_code.rst
+++ b/docs/overview/deep_dive/navigating_the_code.rst
@@ -7,7 +7,6 @@ Navigating the Code
 .. _`navigating the code channel`: https://discord.com/channels/799879767196958751/982737793476345888
 .. _`Array API Standard convention`: https://data-apis.org/array-api/2021.12/API_specification/array_object.html#api-specification-array-object--page-root
 .. _`flake8`: https://flake8.pycqa.org/en/latest/index.html
-.. _`pre-commit guide`: https://unify.ai/docs/ivy/overview/contributing/setting_up.html#pre-commit
 
 Categorization
 --------------

--- a/docs/overview/deep_dive/superset_behaviour.rst
+++ b/docs/overview/deep_dive/superset_behaviour.rst
@@ -73,7 +73,7 @@ We explore this through the examples of :func:`softplus`.
 
 **ivy.softplus**
 
-When looking at the :func:`softplus` (or closest equivalent) implementations for `Ivy <https://unify.ai/docs/ivy/docs/functional/ivy/activations/ivy.functional.ivy.activations.softplus.html#softplus>`_, `JAX <https://jax.readthedocs.io/en/latest/_autosummary/jax.nn.softplus.html>`_, `TensorFlow <https://www.tensorflow.org/api_docs/python/tf/math/softplus>`_, and `PyTorch <https://pytorch.org/docs/stable/generated/torch.nn.functional.softplus.html>`_, we can see that torch is the only framework which supports the inclusion of the :code:`beta` and :code:`threshold` arguments, which are added for improved numerical stability.
+When looking at the :func:`softplus` (or closest equivalent) implementations for `Ivy <../../docs/functional/ivy/activations/ivy.functional.ivy.activations.softplus.rst>`_, `JAX <https://jax.readthedocs.io/en/latest/_autosummary/jax.nn.softplus.html>`_, `TensorFlow <https://www.tensorflow.org/api_docs/python/tf/math/softplus>`_, and `PyTorch <https://pytorch.org/docs/stable/generated/torch.nn.functional.softplus.html>`_, we can see that torch is the only framework which supports the inclusion of the :code:`beta` and :code:`threshold` arguments, which are added for improved numerical stability.
 We can also see that numpy does not support a :func:`softplus` function at all.
 Ivy should also support the :code:`beta` and :code:`threshold` arguments, in order to provide the generalized superset implementation among the backend frameworks.
 
@@ -143,25 +143,25 @@ The first three examples are more-or-less superset examples, while the last exam
 
 **ivy.linspace**
 
-When looking at the :func:`linspace` (or closest equivalent) implementations for `Ivy <https://unify.ai/docs/ivy/docs/functional/ivy/creation/ivy.functional.ivy.creation.linspace.html#linspace>`_, `JAX <https://jax.readthedocs.io/en/latest/_autosummary/jax.numpy.linspace.html>`_, `NumPy <https://numpy.org/doc/stable/reference/generated/numpy.linspace.html>`_, `TensorFlow <https://www.tensorflow.org/api_docs/python/tf/linspace>`_, and `PyTorch <https://pytorch.org/docs/stable/generated/torch.linspace.html>`_, we can see that torch does not support arrays for the :code:`start` and :code:`end` arguments, while JAX, numpy, and tensorflow all do.
+When looking at the :func:`linspace` (or closest equivalent) implementations for `Ivy <../../docs/functional/ivy/creation/ivy.functional.ivy.creation.linspace.rst>`_, `JAX <https://jax.readthedocs.io/en/latest/_autosummary/jax.numpy.linspace.html>`_, `NumPy <https://numpy.org/doc/stable/reference/generated/numpy.linspace.html>`_, `TensorFlow <https://www.tensorflow.org/api_docs/python/tf/linspace>`_, and `PyTorch <https://pytorch.org/docs/stable/generated/torch.linspace.html>`_, we can see that torch does not support arrays for the :code:`start` and :code:`end` arguments, while JAX, numpy, and tensorflow all do.
 Likewise, Ivy also supports arrays for the :code:`start` and :code:`stop` arguments, and in doing so provides the generalized superset implementation among the backend frameworks.
 
 
 **ivy.eye**
 
-When looking at the :func:`eye` (or closest equivalent) implementations for `Ivy <https://unify.ai/docs/ivy/docs/functional/ivy/creation/ivy.functional.ivy.creation.eye.html#eye>`_, `JAX <https://jax.readthedocs.io/en/latest/_autosummary/jax.numpy.eye.html>`_, `NumPy <https://numpy.org/devdocs/reference/generated/numpy.eye.html>`_, `TensorFlow <https://www.tensorflow.org/api_docs/python/tf/eye>`_, and `PyTorch <https://pytorch.org/docs/stable/generated/torch.eye.html>`_, we can see that tensorflow is the only framework which supports a :code:`batch_shape` argument.
+When looking at the :func:`eye` (or closest equivalent) implementations for `Ivy <../../docs/functional/ivy/creation/ivy.functional.ivy.creation.eye.rst>`_, `JAX <https://jax.readthedocs.io/en/latest/_autosummary/jax.numpy.eye.html>`_, `NumPy <https://numpy.org/devdocs/reference/generated/numpy.eye.html>`_, `TensorFlow <https://www.tensorflow.org/api_docs/python/tf/eye>`_, and `PyTorch <https://pytorch.org/docs/stable/generated/torch.eye.html>`_, we can see that tensorflow is the only framework which supports a :code:`batch_shape` argument.
 Likewise, Ivy also supports a :code:`batch_shape` argument, and in doing so provides the generalized superset implementation among the backend frameworks.
 
 
 **ivy.scatter_nd**
 
-When looking at the :func:`scatter_nd` (or closest equivalent) implementations for `Ivy <https://unify.ai/docs/ivy/docs/functional/ivy/general/ivy.functional.ivy.general.scatter_nd.html#scatter-nd>`_, `JAX <https://jax.readthedocs.io/en/latest/_autosummary/jax.numpy.ndarray.at.html#jax.numpy.ndarray.at>`_, `NumPy <https://numpy.org/doc/stable/reference/generated/numpy.ufunc.at.html>`_, `TensorFlow <https://www.tensorflow.org/api_docs/python/tf/scatter_nd>`_, and `PyTorch <https://pytorch.org/docs/stable/generated/torch.scatter.html>`_, we can see that torch only supports scattering along a single dimension, while all other frameworks support scattering across multiple dimensions at once.
+When looking at the :func:`scatter_nd` (or closest equivalent) implementations for `Ivy <../../docs/functional/ivy/general/ivy.functional.ivy.general.scatter_nd.rst>`_, `JAX <https://jax.readthedocs.io/en/latest/_autosummary/jax.numpy.ndarray.at.html#jax.numpy.ndarray.at>`_, `NumPy <https://numpy.org/doc/stable/reference/generated/numpy.ufunc.at.html>`_, `TensorFlow <https://www.tensorflow.org/api_docs/python/tf/scatter_nd>`_, and `PyTorch <https://pytorch.org/docs/stable/generated/torch.scatter.html>`_, we can see that torch only supports scattering along a single dimension, while all other frameworks support scattering across multiple dimensions at once.
 Likewise, Ivy also supports scattering across multiple dimensions at once, and in doing so provides the generalized superset implementation among the backend frameworks.
 
 
 **ivy.logical_and**
 
-When looking at the :func:`logical_and` (or closest equivalent) implementations for `Ivy <https://unify.ai/docs/ivy/docs/functional/ivy/elementwise/ivy.functional.ivy.elementwise.logical_and.html#logical-and>`_, `JAX <https://jax.readthedocs.io/en/latest/_autosummary/jax.numpy.logical_and.html>`_, `NumPy <https://numpy.org/doc/stable/reference/generated/numpy.logical_and.html>`_, `TensorFlow <https://www.tensorflow.org/api_docs/python/tf/math/logical_and>`_, and `PyTorch <https://pytorch.org/docs/stable/generated/torch.logical_and.html>`_, we can see that numpy and torch support the :code:`out` argument for performing inplace updates, while JAX and tensorflow do not.
+When looking at the :func:`logical_and` (or closest equivalent) implementations for `Ivy <../../docs/functional/ivy/elementwise/ivy.functional.ivy.elementwise.logical_and.rst>`_, `JAX <https://jax.readthedocs.io/en/latest/_autosummary/jax.numpy.logical_and.html>`_, `NumPy <https://numpy.org/doc/stable/reference/generated/numpy.logical_and.html>`_, `TensorFlow <https://www.tensorflow.org/api_docs/python/tf/math/logical_and>`_, and `PyTorch <https://pytorch.org/docs/stable/generated/torch.logical_and.html>`_, we can see that numpy and torch support the :code:`out` argument for performing inplace updates, while JAX and tensorflow do not.
 With regards to the supported data types, JAX, numpy, and torch support numeric arrays, while tensorflow supports only boolean arrays.
 With regards to both of these points, Ivy provides the generalized superset implementation among the backend frameworks, with support for the :code:`out` argument and also support for both numeric and boolean arrays in the input.
 
@@ -174,8 +174,8 @@ Maximizing Usage of Native Functionality
 
 While achieving the objective of having superset behaviour across the backends, the native functionality of frameworks should be made use of as much as possible.
 Even if a framework-specific function doesn't provide complete superset behaviour, we should still make use of the partial behaviour that it provides and then add more logic for the remaining part.
-This is for efficiency reasons and is more explained under the `Mixed Function <https://unify.ai/docs/ivy/overview/deep_dive/function_types.html#mixed-functions>`_ section.
-In cases when a framework-specific function exists for one or two backends but not the others, we implement a `Mixed Function <https://unify.ai/docs/ivy/overview/deep_dive/function_types.html#mixed-functions>`_.
+This is for efficiency reasons and is more explained under the :ref:`Mixed Function <overview/deep_dive/function_types:Mixed Functions>` section.
+In cases when a framework-specific function exists for one or two backends but not the others, we implement a :ref:`Mixed Function <overview/deep_dive/function_types:Mixed Functions>`.
 But when the framework-specific functions do not cover all superset functionality, Ivy also allows for a mixed-compositional hybrid approach.
 
 Consider the example of :func:`interpolate`.

--- a/docs/overview/design.rst
+++ b/docs/overview/design.rst
@@ -1,11 +1,13 @@
 Design
 ======
 
+.. _`Deep Dive`: deep_dive.rst
+
 This section is aimed at general users, who would like to learn how to use Ivy, and are less concerned about how it all works under the hood 🔧
 
-The :ref:`Deep Dive` section is more targeted at potential contributors, and at users who would like to dive deeper into the weeds of the framework🌱, and gain a better understanding of what is actually going on behind the scenes 🎬
+The `Deep Dive`_ section is more targeted at potential contributors, and at users who would like to dive deeper into the weeds of the framework🌱, and gain a better understanding of what is actually going on behind the scenes 🎬
 
-If that sounds like you, feel free to check out the :ref:`Deep Dive` section after you've gone through the higher level overview which is covered in this *design* section!
+If that sounds like you, feel free to check out the `Deep Dive`_ section after you've gone through the higher level overview which is covered in this *design* section!
 
 | So, starting off with our higher level *design* section, Ivy can fulfill two distinct purposes:
 |
@@ -23,16 +25,16 @@ If that sounds like you, feel free to check out the :ref:`Deep Dive` section aft
    :align: center
    :width: 100%
 
-| (a) :ref:`Building Blocks`
+| (a) `Building Blocks <design/building_blocks.rst>`_
 | back-end functional APIs ✅
 | Ivy functional API ✅
 | Framework Handler ✅
 | Ivy Compiler 🚧
 |
-| (b) :ref:`Ivy as a Transpiler`
+| (b) `Ivy as a Transpiler <design/ivy_as_a_transpiler.rst>`_
 | front-end functional APIs 🚧
 |
-| (c) :ref:`Ivy as a Framework`
+| (c) `Ivy as a Framework <design/ivy_as_a_framework.rst>`_
 | Ivy stateful API ✅
 | Ivy Container ✅
 | Ivy Array ✅

--- a/docs/overview/design/building_blocks.rst
+++ b/docs/overview/design/building_blocks.rst
@@ -491,7 +491,7 @@ The example above further emphasizes that the graph compiler creates a computati
 Specifically, the same Ivy code compiles to different graphs depending on the selected backend.
 However, when compiling native framework code, we are only able to compile a graph for that same framework.
 For example, we cannot take torch code and compile this into tensorflow code.
-However, we can transpile torch code into tensorflow code (see :ref:`Ivy as a Transpiler` for more details).
+However, we can transpile torch code into tensorflow code (see `Ivy as a Transpiler <ivy_as_a_transpiler.rst>`_ for more details).
 
 The graph compiler does not compile to C++, CUDA, or any other lower level language.
 It simply traces the backend functional methods in the graph, stores this graph, and then efficiently traverses this graph at execution time, all in Python.

--- a/docs/overview/design/building_blocks.rst
+++ b/docs/overview/design/building_blocks.rst
@@ -1,8 +1,6 @@
 Building Blocks
 ===============
 
-.. _`out argument`: https://unify.ai/docs/ivy/overview/deep_dive/inplace_updates.html#out-argument
- 
 Here we explain the components of Ivy which are fundamental to its usage either as a code converter or as a fully-fledged framework-agnostic ML framework.
 These are the 4 parts labelled as (a) in the image below:
 
@@ -73,7 +71,7 @@ There are separate backend modules for JAX, TensorFlow, PyTorch, and NumPy, and 
 
     stack.support_native_out = True
 
-There were no changes required for this function, however NumPy and PyTorch both had to be marked as supporting the `out argument`_ natively.
+There were no changes required for this function, however NumPy and PyTorch both had to be marked as supporting the :ref:`overview/deep_dive/inplace_updates:out argument` natively.
 
 For more complicated functions, we need to do more than simply wrap and maybe change the name.
 For functions with differing behavior then we must modify the function to fit the unified in-out behavior of Ivy’s API.

--- a/docs/overview/design/ivy_as_a_framework.rst
+++ b/docs/overview/design/ivy_as_a_framework.rst
@@ -1,10 +1,10 @@
 Ivy as a Framework
 ==================
 
-On the :ref:`Building Blocks` page, we explored the role of the backend functional APIs, the Ivy functional API, the framework handler, and the graph compiler.
+On the `Building Blocks <building_blocks.rst>`_ page, we explored the role of the backend functional APIs, the Ivy functional API, the framework handler, and the graph compiler.
 These are parts labeled as (a) in the image below.
 
-On the :ref:`Ivy as a Transpiler` page, we explained the role of the backend-specific frontends in Ivy, and how these enable automatic code conversions between different ML frameworks.
+On the `Ivy as a Transpiler <ivy_as_a_transpiler.rst>`_ page, we explained the role of the backend-specific frontends in Ivy, and how these enable automatic code conversions between different ML frameworks.
 This part is labeled as (b) in the image below.
 
 So far, by considering parts (a) and (b), we have mainly treated Ivy as a fully functional framework with code conversion abilities.
@@ -19,13 +19,13 @@ These parts are labeled as (c) in the image below.
 
 You may choose from the following upcoming discussions or click next.
 
-| (a) :ref:`Ivy Container`
+| (a) `Ivy Container <ivy_as_a_framework/ivy_container.rst>`_
 | Hierarchical container solving almost everything behind the scenes in Ivy
 |
-| (b) :ref:`Ivy Stateful API`
+| (b) `Ivy Stateful API <ivy_as_a_framework/ivy_stateful_api.rst>`_
 | Trainable Layers, Modules, Optimizers, and more built on the functional API and the Ivy Container
 |
-| (c) :ref:`Ivy Array`
+| (c) `Ivy Array <ivy_as_a_framework/ivy_array.rst>`_
 | Bringing methods as array attributes to Ivy, cleaning up and simplifying code
 
 .. toctree::

--- a/docs/overview/design/ivy_as_a_framework/ivy_array.rst
+++ b/docs/overview/design/ivy_as_a_framework/ivy_array.rst
@@ -197,7 +197,7 @@ API Monkey Patching
 
 All ivy functions with array inputs/outputs have been wrapped to return :class:`ivy.Array` instances while accepting both :class:`ivy.Array` and :class:`ivy.NativeArray` instances.
 This allows for the control required to provide a unified array interface.
-For more details on wrapping, see the `Function Wrapping <https://unify.ai/docs/ivy/overview/deep_dive/function_wrapping.html>`_ page in deep dive.
+For more details on wrapping, see the `Function Wrapping <../../deep_dive/function_wrapping.rst>`_ page in deep dive.
 
 
 Instance Methods

--- a/docs/overview/design/ivy_as_a_framework/ivy_container.rst
+++ b/docs/overview/design/ivy_as_a_framework/ivy_container.rst
@@ -145,7 +145,7 @@ Or we can flip each sub-array:
         }
     }
 
-There are about 200 such functions for the :class:`ivy.Container` class in total, check out the `code <https://github.com/unifyai/ivy/tree/main/ivy/data_classes/container>`_ or `docs <https://unify.ai/docs/ivy/docs/data_classes/data_classes/ivy.data_classes.container.html>`_ to see what they are!
+There are about 200 such functions for the :class:`ivy.Container` class in total, check out the `code <https://github.com/unifyai/ivy/tree/main/ivy/data_classes/container>`_ or `docs <../../../docs/data_classes/data_classes/ivy.data_classes.container.rst>`_ to see what they are!
 
 Built-ins
 ----------
@@ -458,7 +458,7 @@ All nested structures above this height are truncated into single keys with a â€
 These are very useful methods when stepping through code and debugging complex nested structures such as the weights of a network.
 
 There are also methods: :code:`cont_with_print_limit` for controlling the printable size of arrays before the shape is instead displayed, :code:`cont_with_key_length_limit` for setting the maximum key length before string clipping, :code:`cont_with_print_indent` for controlling the nested indent, and many more.
-Check out the `docs <https://unify.ai/docs/ivy/docs/data_classes/data_classes/ivy.data_classes.container.html>`_ for more details!
+Check out the `docs <../../../docs/data_classes/data_classes/ivy.data_classes.container.rst>`_ for more details!
 
 Use Cases
 ---------

--- a/docs/overview/design/ivy_as_a_framework/ivy_stateful_api.rst
+++ b/docs/overview/design/ivy_as_a_framework/ivy_stateful_api.rst
@@ -370,7 +370,7 @@ The actual implementation for the :class:`ivy.Linear` layer exposed in the Ivy s
               self.v.b if self._with_bias else None)
 
 The :class:`ivy.Initializer` class has a single abstract method, :code:`create_variables(var_shape, dev, fan_out=None, fan_in=None, *args, **kwargs)`.
-Check out the `code <https://github.com/unifyai/ivy/blob/main/ivy/stateful/initializers.py>`_ or `docs <https://unify.ai/docs/ivy/overview/design/ivy_as_a_framework/ivy_stateful_api.html#initializers>`_ for more details.
+Check out the `code <https://github.com/unifyai/ivy/blob/main/ivy/stateful/initializers.py>`_ or :ref:`docs <overview/design/ivy_as_a_framework/ivy_stateful_api:Initializers>` for more details.
 The default initializer for the weights is :class:`ivy.GlorotUniform` and for this bias is :class:`ivy.Zeros`.
 Let’s take a quick look at what these look like.
 :class:`ivy.GlorotUniform` derives from a more general :class:`ivy.Uniform` initializer class, and is then simply implemented as follows:

--- a/docs/overview/design/ivy_as_a_transpiler.rst
+++ b/docs/overview/design/ivy_as_a_transpiler.rst
@@ -1,7 +1,7 @@
 Ivy as a Transpiler
 ===================
 
-On the :ref:`Building Blocks` page, we explored the role of the backend functional APIs, the Ivy functional API, the backend handler, and the graph compiler.
+On the `Building Blocks <building_blocks.rst>`_ page, we explored the role of the backend functional APIs, the Ivy functional API, the backend handler, and the graph compiler.
 These parts are labelled (a) in the image below.
 
 Here, we explain the role of the backend-specific frontends in Ivy, and how these enable automatic code conversions between different ML frameworks.

--- a/docs/overview/get_started.rst
+++ b/docs/overview/get_started.rst
@@ -4,7 +4,7 @@ Get Started
 ..
 
    If you want to use **Ivy's compiler and transpiler**, make sure to follow the 
-   :ref:`setting up instructions for the API key <Ivy's compiler and transpiler>`
+   :ref:`setting up instructions for the API key <overview/get_started:Ivy's compiler and transpiler>`
    after installing Ivy!
 
 

--- a/docs/overview/get_started.rst
+++ b/docs/overview/get_started.rst
@@ -52,7 +52,7 @@ changes, but we can't ensure everything will work as expected!
 
 If you are planning to contribute, you want to run the tests, or you are looking 
 for more in-depth instructions, it's probably best to check out 
-the `Contributing - Setting Up <https://unify.ai/docs/ivy/overview/contributing/setting_up.html#setting-up>`_ page, 
+the `Contributing - Setting Up <contributing/setting_up.rst>`_ page, 
 where OS-specific and IDE-specific instructions and video tutorials to install Ivy are available!
 
 

--- a/docs/overview/motivation.rst
+++ b/docs/overview/motivation.rst
@@ -1,13 +1,13 @@
 Motivation
 ==========
 
-| (a) :ref:`ML Explosion`
+| (a) `ML Explosion <motivation/ml_explosion.rst>`_
 | A huge number of ML tools have exploded onto the scene!
 |
-| (b) :ref:`Why Unify?`
+| (b) `Why Unify? <motivation/why_unify.rst>`_
 | Why should we try to unify them?
 |
-| (c) :ref:`Standardization`
+| (c) `Standardization <motivation/standardization.rst>`_
 | We’re collaborating with The `Consortium for Python Data API Standards <https://data-apis.org>`_
 
 .. toctree::

--- a/docs/overview/one_liners/transpile.rst
+++ b/docs/overview/one_liners/transpile.rst
@@ -241,7 +241,7 @@ still working on some rough edges. These include:
    the inference to be correct. 
 
 Keep in mind that the transpiler uses the graph compiler under the hood, so the 
-`sharp bits of the compiler <https://unify.ai/docs/ivy/overview/one_liners/compile.html#sharp-bits>`_ 
+:ref:`sharp bits of the compiler <overview/one_liners/compile:Sharp bits>` 
 apply here as well!
 
 Examples

--- a/docs/overview/related_work.rst
+++ b/docs/overview/related_work.rst
@@ -1,11 +1,23 @@
 Related Work
 ============
 
+.. _`RWorks API Standards`: related_work/api_standards.rst
+.. _`RWorks Wrapper Frameworks`: related_work/wrapper_frameworks.rst
+.. _`RWorks Frameworks`: related_work/frameworks.rst
+.. _`RWorks Graph Tracers`: related_work/graph_tracers.rst
+.. _`RWorks Exchange Formats`: related_work/exchange_formats.rst
+.. _`RWorks Compiler Infrastructure`: related_work/compiler_infrastructure.rst
+.. _`RWorks Multi-Vendor Compiler Frameworks`: related_work/multi_vendor_compiler_frameworks.rst
+.. _`RWorks Vendor-Specific APIs`: related_work/vendor_specific_apis.rst
+.. _`RWorks Vendor-Specific Compilers`: related_work/vendor_specific_compilers.rst
+.. _`RWorks ML-Unifying Companies`: related_work/ml_unifying_companies.rst
+.. _`RWorks What does Ivy Add?`: related_work/what_does_ivy_add.rst
+
 In this section, we explain how Ivy compares to many other very important and related pieces of work, which also address fragmentation but at other areas within the ML stack.
 
 Firstly, we need to look at the overall ML stack, and understand how the high level frameworks relate to the low level components.
 
-In order to conceptualize this rather complex hierarchy, we have broken the ML stack into 9 groups, which are: :ref:`RWorks API Standards`, :ref:`RWorks Wrapper Frameworks`, :ref:`RWorks Frameworks`, :ref:`RWorks Graph Tracers`, :ref:`RWorks Exchange Formats`, :ref:`RWorks Compiler Infrastructure`, :ref:`RWorks Multi-Vendor Compiler Frameworks`, :ref:`RWorks Vendor-Specific APIs` and :ref:`RWorks Vendor-Specific Compilers`, going from high level to low level respectively.
+In order to conceptualize this rather complex hierarchy, we have broken the ML stack into 9 groups, which are: `RWorks API Standards`_, `RWorks Wrapper Frameworks`_, `RWorks Frameworks`_, `RWorks Graph Tracers`_, `RWorks Exchange Formats`_, `RWorks Compiler Infrastructure`_, `RWorks Multi-Vendor Compiler Frameworks`_, `RWorks Vendor-Specific APIs`_ and `RWorks Vendor-Specific Compilers`_, going from high level to low level respectively.
 
 .. image:: https://github.com/unifyai/unifyai.github.io/blob/main/img/externally_linked/related_work/ml_stack.png?raw=true
    :width: 100%
@@ -18,37 +30,37 @@ We see these efforts as being very complimentary to Ivy's vision for high level 
 Finally, we discuss how Ivy compares to each of these important works at all levels within the ML stack.
 
 
-| (a) :ref:`RWorks API Standards` 🤝🏽
+| (a) `RWorks API Standards`_ 🤝🏽
 | Standardized APIs which similar libraries should adhere to
 |
-| (b) :ref:`RWorks Wrapper Frameworks` 🎁
+| (b) `RWorks Wrapper Frameworks`_ 🎁
 | Frameworks which wrap other ML frameworks
 |
-| (c) :ref:`RWorks Frameworks` 🔢
+| (c) `RWorks Frameworks`_ 🔢
 | Standalone ML Frameworks
 |
-| (d) :ref:`RWorks Graph Tracers` 🕸️
+| (d) `RWorks Graph Tracers`_ 🕸️
 | Extracting acyclic directed computation graphs from code
 |
-| (e) :ref:`RWorks Exchange Formats` 💱
+| (e) `RWorks Exchange Formats`_ 💱
 | File formats to exchange neural networks between frameworks
 |
-| (f) :ref:`RWorks Compiler Infrastructure` 🔟️🏗️
+| (f) `RWorks Compiler Infrastructure`_ 🔟️🏗️
 | Infrastructure and standards to simplify the lives of compiler designers
 |
-| (g) :ref:`RWorks Multi-Vendor Compiler Frameworks` 🖥️💻🔟
+| (g) `RWorks Multi-Vendor Compiler Frameworks`_ 🖥️💻🔟
 | Executing ML code on a variety of hardware targets
 |
-| (h) :ref:`RWorks Vendor-Specific APIs` 💻🔢
+| (h) `RWorks Vendor-Specific APIs`_ 💻🔢
 | Interfacing with specific hardware in an intuitive manner
 |
-| (i) :ref:`RWorks Vendor-Specific Compilers` 💻🔟
+| (i) `RWorks Vendor-Specific Compilers`_ 💻🔟
 | Compiling code to specific hardware
 |
-| (j) :ref:`RWorks ML-Unifying Companies` 📈
+| (j) `RWorks ML-Unifying Companies`_ 📈
 | Companies working towards unification in ML
 |
-| (k) :ref:`RWorks What does Ivy Add?` 🟢
+| (k) `RWorks What does Ivy Add?`_ 🟢
 | How does Ivy fit into all of this?
 
 .. toctree::

--- a/docs/overview/related_work/compiler_infrastructure.rst
+++ b/docs/overview/related_work/compiler_infrastructure.rst
@@ -39,7 +39,7 @@ OneAPI
 The set of APIs spans several domains that benefit from acceleration, including libraries for linear algebra math, deep learning, machine learning, video processing, and others.
 `OneDNN`_ is particularly relevant, focusing on neural network functions for deep learning training and inference.
 Intel CPUs and GPUs have accelerators for Deep Learning software, and OneDNN provides a unified interface to utilize these accelerators, with much of the hardware-specific complexity abstracted away.
-In a similar manner to `MLIR`_, OneAPI is also designed to operate at a lower level than the Neural Network :ref:`Exchange Formats`.
+In a similar manner to `MLIR`_, OneAPI is also designed to operate at a lower level than the Neural Network :ref:`overview/related_work/what_does_ivy_add:Exchange Formats`.
 The interface is lower level and more primitive than the neural network exchange formats, with a focus on the core low-level operations such as convolutions, matrix multiplications, batch normalization etc.
 This makes OneDNN very much complementary to these formats, where OneDNN can sit below the exchange formats in the overall stack, enabling accelerators to be fully leveraged with minimal hardware-specific considerations, with this all helpfully being abstracted by the OneDNN API.
 Indeed, OneAPI and MLIR can work together in tandem, and OneDNN is working to `integrate Tensor Possessing Primitives in the MLIR compilers used underneath TensorFlow <https://www.oneapi.io/blog/tensorflow-and-onednn-in-partnership/>`_.

--- a/docs/overview/related_work/what_does_ivy_add.rst
+++ b/docs/overview/related_work/what_does_ivy_add.rst
@@ -38,7 +38,7 @@ However, for the time being, we are focusing exclusively on Python, in order to 
 Wrapper Frameworks
 ------------------
 Ivy is itself a Python Wrapper Framework.
-The biggest difference between Ivy and all others listed in the :ref:`Wrapper Frameworks` section is that Ivy supports transpilations between frameworks, while all other frameworks only enable the creation of entirely new code which itself is framework-agnostic.
+The biggest difference between Ivy and all others listed in the `Wrapper Frameworks <wrapper_frameworks.rst>`_ section is that Ivy supports transpilations between frameworks, while all other frameworks only enable the creation of entirely new code which itself is framework-agnostic.
 There are also other more subtle differences.
 For example, Ivy includes both a low level fully functional API and a high level stateful API, offering both low level control and high level convenience.
 In contrast, `EagerPy`_ and `TensorLy`_ both only include functional APIs, `Thinc`_ only includes a high level stateful API, and `NeuroPod`_ only supports an even higher level wrapper for deployment.
@@ -51,7 +51,7 @@ It therefore extends what is possible in any of the specific individual framewor
 
 Graph Tracers
 -------------
-Ivy’s :ref:`Graph Compiler` exhibits similar properties to many of the framework-specific graph tracers.
+Ivy’s `Graph Compiler <../one_liners/compile>`_ exhibits similar properties to many of the framework-specific graph tracers.
 Ivy’s graph compiler employs function tracing for computing the graph, and uses this graph as an intermediate representation during the transpilation process.
 Of all the graph tracers, Ivy’s graph compiler is most similar to `torch.fx`_.
 This is because :code:`torch.fx` also operates entirely in Python, without deferring to lower level languages for tracing and extracting the computation graph or the intermediate representation.
@@ -99,7 +99,7 @@ However, again they do nothing to address the challenge of running code from one
 
 ML-Unifying Companies
 ---------------------
-The ML-unifying companies `Quansight`_, `OctoML`_ and `Modular`_ are/were directly involved with the `Array API Standard`_, `Apache TVM`_ and `MLIR`_ respectively, as explained in the :ref:`ML-Unifying Companies` section.
+The ML-unifying companies `Quansight`_, `OctoML`_ and `Modular`_ are/were directly involved with the `Array API Standard`_, `Apache TVM`_ and `MLIR`_ respectively, as explained in the `ML-Unifying Companies <ml_unifying_companies.rst>`_ section.
 For the same reasons that Ivy as a framework is complementary to these three frameworks, Ivy as a company is also complementary to these three companies.
 Firstly, we are adhering to the `Array API Standard`_ defined by Quansight.
 In essence, they have written the standard and we have implemented it, which is pretty much as complementary as it gets.

--- a/docs/partial_conf.py
+++ b/docs/partial_conf.py
@@ -42,6 +42,8 @@ autosummary_generate = ["index.rst"]
 
 skippable_method_attributes = [{"__qualname__": "_wrap_function.<locals>.new_function"}]
 
+autosectionlabel_prefix_document = True
+
 # Retrieve html_theme_options from docs/conf.py
 from docs.conf import html_theme_options
 
@@ -49,4 +51,5 @@ html_theme_options["switcher"]["json_url"] = "https://unify.ai/docs/versions/ivy
 
 repo_name = "ivy"
 
+# Retrieve demos specific configuration
 from docs.demos.demos_conf import *  # noqa


### PR DESCRIPTION
These changes meant to set `autosectionlabel_prefix_document` to `True`, so we can work around conflicts when using `:ref:`