### PR TITLE
22781 logistic jax frontend

### DIFF
--- a/ivy/functional/frontends/jax/random.py
+++ b/ivy/functional/frontends/jax/random.py
@@ -252,11 +252,10 @@ def loggamma(key, a, shape=None, dtype="float64"):
 @with_unsupported_dtypes(
     {"0.4.14 and below": ("float16", "bfloat16")},
 )
-def logistic(key, shape=None, dtype="float64"):
+def logistic(key, shape=(), dtype="float64"):
     seed = _get_seed(key)
     uniform_x = ivy.random_uniform(seed=seed, shape=shape, dtype=dtype)
-    # Could also be ivy.log(uniform_x / (1 - uniform_x)) should check this is faster
-    return ivy.log(uniform_x) - ivy.log(1 - uniform_x)
+    return ivy.log(ivy.divide(uniform_x, ivy.subtract(1.0, uniform_x)))
 
 
 @handle_jax_dtype

--- a/ivy/functional/frontends/jax/random.py
+++ b/ivy/functional/frontends/jax/random.py
@@ -250,6 +250,18 @@ def loggamma(key, a, shape=None, dtype="float64"):
 @handle_jax_dtype
 @to_ivy_arrays_and_back
 @with_unsupported_dtypes(
+    {"0.4.14 and below": ("float16", "bfloat16")},
+)
+def logistic(key, shape=None, dtype="float64"):
+    seed = _get_seed(key)
+    uniform_x = ivy.random_uniform(seed=seed, shape=shape, dtype=dtype)
+    # Could also be ivy.log(uniform_x / (1 - uniform_x)) should check this is faster
+    return ivy.log(uniform_x) - ivy.log(1 - uniform_x)
+
+
+@handle_jax_dtype
+@to_ivy_arrays_and_back
+@with_unsupported_dtypes(
     {
         "0.3.14 and below": (
             "float16",

--- a/ivy_tests/test_ivy/test_frontends/test_jax/test_random.py
+++ b/ivy_tests/test_ivy/test_frontends/test_jax/test_random.py
@@ -822,6 +822,62 @@ def test_jax_loggamma(
 
 @pytest.mark.xfail
 @handle_frontend_test(
+    fn_tree="jax.random.logistic",
+    dtype_key=helpers.dtype_and_values(
+        available_dtypes=["uint32"],
+        min_value=0,
+        max_value=2000,
+        min_num_dims=1,
+        max_num_dims=1,
+        min_dim_size=2,
+        max_dim_size=2,
+    ),
+    shape=helpers.get_shape(allow_none=False, min_num_dims=1, min_dim_size=1),
+    dtype=helpers.get_dtypes("float", full=False),
+    test_with_out=st.just(False),
+)
+def test_jax_logistic(
+    *,
+    dtype_key,
+    shape,
+    dtype,
+    on_device,
+    fn_tree,
+    frontend,
+    backend_fw,
+    test_flags,
+):
+    input_dtype, key = dtype_key
+
+    def call():
+        return helpers.test_frontend_function(
+            input_dtypes=input_dtype,
+            frontend=frontend,
+            backend_to_test=backend_fw,
+            test_flags=test_flags,
+            fn_tree=fn_tree,
+            on_device=on_device,
+            key=key[0],
+            shape=shape,
+            dtype=dtype[0],
+            test_values=False,
+        )
+
+    ret = call()
+
+    if not ivy.exists(ret):
+        return
+
+    ret_np, ret_from_np = ret
+    ret_np = helpers.flatten_and_to_np(ret=ret_np, backend=backend_fw)
+    ret_from_np = helpers.flatten_and_to_np(ret=ret_from_np, backend=backend_fw)
+    for u, v in zip(ret_np, ret_from_np):
+        assert u.dtype == v.dtype
+        assert u.shape == v.shape
+
+
+@pytest.mark.xfail
+@handle_frontend_test(
     fn_tree="jax.random.maxwell",
     dtype_key=helpers.dtype_and_values(
         available_dtypes=["uint32"],


### PR DESCRIPTION
<!--
This template will help you to have a meaningful PR, please follow it and do not leave it blank.
-->

# PR Description
Adds logistic function to jax frontend for `jax.random.logistic`.
<!--
If there is no related issue, please add a short description about your PR.
-->

## Related Issue

<!--
Please use this format to link other issues with their numbers: Close #123
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Close #22781

## Checklist

- [x] Did you add a function?
- [x] Did you add the tests?
- [x] Did you follow the steps we provided?

Implementation is based on performance testing of a number of different implementations. 
Assuming `uniform_x = ivy.random_uniform(seed=seed, shape=shape, dtype=dtype)`, to generate 1M numbers:

`ivy.log(uniform_x) - ivy.log(1 - uniform_x)` takes 0.1869s
`ivy.log(uniform_x / (1 - uniform_x))` takes 0.0193s
`ivy.log(ivy.divide(x, ivy.subtract(1.0, x)))` takes 0.0094s

### Socials:

<!--
If you have Twitter, please provide it here otherwise just ignore this.
-->
