### PR TITLE
Setting default device to cpu

### DIFF
--- a/ivy/functional/ivy/device.py
+++ b/ivy/functional/ivy/device.py
@@ -831,7 +831,7 @@ def default_device(
             return ivy.dev(item, as_native=as_native)
     global default_device_stack
     if not default_device_stack:
-        ret = "gpu:0" if ivy.gpu_is_available() else "cpu"
+        ret = "cpu"
     else:
         ret = default_device_stack[-1]
     if as_native:


### PR DESCRIPTION
This PR sets the default device to CPU in Ivy. 
CC: [Trello](https://trello.com/c/BELPNoeF/2684-set-the-default-device-to-cpu-by-default-even-when-gpu-is-available)