### PR TITLE
Add test for precision_score function in test_classification.py

### DIFF
--- a/ivy_tests/test_ivy/test_frontends/test_sklearn/test_metrics/test_classification.py
+++ b/ivy_tests/test_ivy/test_frontends/test_sklearn/test_metrics/test_classification.py
@@ -43,3 +43,44 @@ def test_sklearn_accuracy_score(
         normalize=normalize,
         sample_weight=None,
     )
+
+
+@handle_frontend_test(
+    fn_tree="sklearn.metrics.precision_score",
+    arrays_and_dtypes=helpers.dtype_and_values(
+        available_dtypes=helpers.get_dtypes("float_and_integer"),
+        num_arrays=2,
+        min_value=0,
+        max_value=1,  # Precision score typically works with binary classification
+        shared_dtype=True,
+        shape=(helpers.ints(min_value=2, max_value=5)),
+    ),
+    average=st.sampled_from(["micro", "macro", "weighted"]),
+)
+def test_sklearn_precision_score(
+    arrays_and_dtypes,
+    on_device,
+    fn_tree,
+    frontend,
+    test_flags,
+    backend_fw,
+    average,
+):
+    dtypes, values = arrays_and_dtypes
+
+    # Ensure binary classification labels (0 and 1)
+    for i in range(2):
+        values[i] = np.round(values[i])
+
+    helpers.test_frontend_function(
+        input_dtypes=dtypes,
+        backend_to_test=backend_fw,
+        test_flags=test_flags,
+        fn_tree=fn_tree,
+        frontend=frontend,
+        on_device=on_device,
+        y_true=values[0],
+        y_pred=values[1],
+        average=average,
+        sample_weight=None,
+    )


### PR DESCRIPTION
This commit adds a test suite for the precision_score function in the sklearn.metrics module. The test covers various input data types, average options, and scenarios for binary classification. It ensures that the precision_score function behaves correctly and consistently across different cases.

Tested with Hypothesis-based test generation.


<!--
This template will help you to have a meaningful PR, please follow it and do not leave it blank.
-->

# PR Description

<!--
If there is no related issue, please add a short description about your PR.
-->

## Related Issue

<!--
Please use this format to link other issues with their numbers: Close #123
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Close #

## Checklist

- [ ] Did you add a function?
- [ ] Did you add the tests?
- [ ] Did you follow the steps we provided?

### Socials:

<!--
If you have Twitter, please provide it here otherwise just ignore this.
-->
