### PR TITLE
refactor(ivy): refactored the inplace update modes logic to avoid unnecessary warnings when using with_backend

### DIFF
--- a/ivy/utils/backend/handler.py
+++ b/ivy/utils/backend/handler.py
@@ -657,5 +657,5 @@ def with_backend(backend: str, cached: bool = True):
         compiled_backends[backend] = [ivy_pack]
     if ivy.backend != backend:
         # to avoid warning users when not using set_backend with ivy.Array.__repr__
-        _handle_inplace_mode()
+        _handle_inplace_mode(ivy_pack=ivy_pack)
     return ivy_pack

--- a/ivy/utils/exceptions.py
+++ b/ivy/utils/exceptions.py
@@ -409,9 +409,11 @@ def handle_exceptions(fn: Callable) -> Callable:
 # Inplace Update
 
 
-def _handle_inplace_mode():
-    current_backend = ivy.current_backend_str()
-    if not ivy.native_inplace_support and ivy.inplace_mode == "lenient":
+def _handle_inplace_mode(ivy_pack=None):
+    if not ivy_pack:
+        ivy_pack = ivy
+    current_backend = ivy_pack.current_backend_str()
+    if not ivy_pack.native_inplace_support and ivy_pack.inplace_mode == "lenient":
         warnings.warn(
             f"The current backend: '{current_backend}' does not support "
             "inplace updates natively. Ivy would quietly create new arrays when "


### PR DESCRIPTION
This was leading to throwing warnings when using with_backend regardless of the backend used