### PR TITLE
Added count_nonzero to paddle_frontend

### DIFF
--- a/ivy/functional/frontends/paddle/math.py
+++ b/ivy/functional/frontends/paddle/math.py
@@ -139,8 +139,8 @@ def cosh(x, name=None):
     "paddle",
 )
 @to_ivy_arrays_and_back
-def count_nonzero(x, axis=None, keepdims=False, name=None):
-    return ivy.astype(ivy.count_nonzero(x, axis=axis, keepdims=keepdims), ivy.int64)
+def count_nonzero(x, axis=None, keepdim=False, name=None):
+    return ivy.astype(ivy.count_nonzero(x, axis=axis, keepdims=keepdim), ivy.int64)
 
 
 @with_supported_dtypes(

--- a/ivy/functional/frontends/paddle/math.py
+++ b/ivy/functional/frontends/paddle/math.py
@@ -139,10 +139,8 @@ def cosh(x, name=None):
     "paddle",
 )
 @to_ivy_arrays_and_back
-def count_nonzero(x, axis=None, dtype=None, keepdims=False, name=None):
-    return ivy.astype(
-        ivy.count_nonzero(x, axis=axis, dtype=dtype, keepdims=keepdims), ivy.int64
-    )
+def count_nonzero(x, axis=None, keepdims=False, name=None):
+    return ivy.astype(ivy.count_nonzero(x, axis=axis, keepdims=keepdims), ivy.int64)
 
 
 @with_supported_dtypes(

--- a/ivy/functional/frontends/paddle/math.py
+++ b/ivy/functional/frontends/paddle/math.py
@@ -135,6 +135,17 @@ def cosh(x, name=None):
 
 
 @with_supported_dtypes(
+    {"2.5.1 and below": ("int32", "int64", "float16", "float32", "float64", "bool")},
+    "paddle",
+)
+@to_ivy_arrays_and_back
+def count_nonzero(x, axis=None, dtype=None, keepdims=False, name=None):
+    return ivy.astype(
+        ivy.count_nonzero(x, axis=axis, dtype=dtype, keepdims=keepdims), ivy.int64
+    )
+
+
+@with_supported_dtypes(
     {
         "2.5.1 and below": (
             "int32",

--- a/ivy_tests/test_ivy/test_frontends/test_paddle/test_math.py
+++ b/ivy_tests/test_ivy/test_frontends/test_paddle/test_math.py
@@ -586,6 +586,38 @@ def test_paddle_cosh(
     )
 
 
+# count_nonzero
+@handle_frontend_test(
+    fn_tree="paddle.count_nonzero",
+    dtype_and_x=helpers.dtype_values_axis(
+        available_dtypes=helpers.get_dtypes(kind="integer"),
+        valid_axis=True,
+        force_int_axis=True,
+        min_num_dims=1,
+    ),
+)
+def test_paddle_count_nonzero(
+    *,
+    dtype_and_x,
+    on_device,
+    fn_tree,
+    frontend,
+    backend_fw,
+    test_flags,
+):
+    input_dtype, x, axis = dtype_and_x
+    helpers.test_frontend_function(
+        input_dtypes=input_dtype,
+        backend_to_test=backend_fw,
+        on_device=on_device,
+        fn_tree=fn_tree,
+        test_flags=test_flags,
+        frontend=frontend,
+        x=x[0],
+        axis=axis,
+    )
+
+
 # cumprod
 @handle_frontend_test(
     fn_tree="paddle.cumprod",


### PR DESCRIPTION
close #23118

Local env Function test result:

<img width="1440" alt="Screenshot 2023-09-07 at 10 26 52 AM" src="https://github.com/unifyai/ivy/assets/78106056/ccebda98-e77d-45f3-87f0-b9c84d7e9c57">

Local env lint formatting test:

<img width="1440" alt="Screenshot 2023-09-08 at 8 58 35 PM" src="https://github.com/unifyai/ivy/assets/78106056/13f9b6f1-975e-4029-bbf4-6a0f91283308">

