### PR TITLE
Fixed(Docstring) in Compiler, Added invert_permutarion to tensorflow frontend math.py

### DIFF
--- a/ivy/compiler/compiler.py
+++ b/ivy/compiler/compiler.py
@@ -178,52 +178,6 @@ def unify(
     with_numpy: bool = False,
     **transpile_kwargs,
 ) -> Callable:
-    """
-    Unify and Transpile Callable objects passed as arguments.
-    If args and kwargs specified.
-
-    one or more native Callable objects and transpiles them 
-    from the specified source framework to the target framework.
-        
-    Parameters:
-    objs (Callable):
-        One or more native Callable objects to be unified and transpiled.
-    source (Optional[str]):
-        The framework that the `objs` are originally from. 
-        If not provided, the function will attempt to infer it.
-    args (Optional[Tuple]):
-        If specified, arguments that will be used during transpilation.
-    kwargs (Optional[dict]):
-        If specified, keyword arguments that will be used during transpilation.
-    with_numpy (bool):
-        Whether to enable compatibility with NumPy when transpiling. Default is False.
-    **transpile_kwargs:
-        Additional keyword arguments to be passed to the transpiler.
-
-    Returns:
-    Callable:
-        A transpiled Callable object that can be executed in the target framework.
-
-    Examples:
-    --------
-
-    >>> import ivy
-    >>> ivy.set_backend("torch")
-    >>> x = ivy.array([1.])
-    >>> def fn(x):
-    ...     y = ivy.sum(x)
-    ...     z = ivy.prod(x)
-    ...     a = ivy.sin(y)
-    ...     b = ivy.cos(z)
-    ...     c = ivy.tan(z)
-    ...     i = ivy.round(a)
-    ...     j = ivy.floor(b)
-    ...     k = ivy.ceil(c)
-    ...     return i, j, k
-    >>> transpiled_fn = ivy.unify(fn, source="torch", args=(x,), with_numpy=True)
-
-    The `transpiled_fn` can now be executed in the specified target framework.
-    """
     if python_version[1] == "8":
         from ._compiler_38 import unify as _unify
     else:

--- a/ivy/compiler/compiler.py
+++ b/ivy/compiler/compiler.py
@@ -170,6 +170,7 @@ def transpile(
 
 
 # TODO: include docstring
+# fixed docstring, check for PR
 def unify(
     *objs: Callable,
     source: Optional[str] = None,
@@ -178,6 +179,58 @@ def unify(
     with_numpy: bool = False,
     **transpile_kwargs,
 ) -> Callable:
+    """
+    Unify and transpile one or more Callable objects from the source framework to the target framework.
+
+    This function takes one or more native Callable objects and transpiles them from the specified source framework
+    to the target framework. It provides a unified interface for working with different backend frameworks and allows
+    for seamless code execution across them.
+
+    Parameters:
+    objs (Callable):
+        One or more native Callable objects to be unified and transpiled.
+    source (Optional[str]):
+        The framework that the `objs` are originally from. If not provided, the function will attempt to infer it.
+    args (Optional[Tuple]):
+        If specified, arguments that will be used during transpilation.
+    kwargs (Optional[dict]):
+        If specified, keyword arguments that will be used during transpilation.
+    with_numpy (bool):
+        Whether to enable compatibility with NumPy when transpiling. Default is False.
+    **transpile_kwargs:
+        Additional keyword arguments to be passed to the transpiler.
+
+    Returns:
+    Callable:
+        A transpiled Callable object that can be executed in the target framework.
+
+    Examples:
+    --------
+
+    >>> import ivy
+    >>> ivy.set_backend("torch")
+    >>> x = ivy.array([1.])
+    >>> def fn(x):
+    ...     y = ivy.sum(x)
+    ...     z = ivy.prod(x)
+    ...     a = ivy.sin(y)
+    ...     b = ivy.cos(z)
+    ...     c = ivy.tan(z)
+    ...     i = ivy.round(a)
+    ...     j = ivy.floor(b)
+    ...     k = ivy.ceil(c)
+    ...     return i, j, k
+    >>> transpiled_fn = ivy.unify(fn, source="torch", args=(x,), with_numpy=True)
+
+    The `transpiled_fn` can now be executed in the specified target framework.
+
+    Note:
+    - This function is designed for interoperability between different backend frameworks, allowing you to work with
+      functions and models from various frameworks in a unified manner.
+    - The `with_numpy` parameter ensures that the transpiled code is compatible with NumPy, which can be useful when
+      working with functions that rely on NumPy features.
+
+    """
     if python_version[1] == "8":
         from ._compiler_38 import unify as _unify
     else:
@@ -190,3 +243,4 @@ def unify(
         with_numpy=with_numpy,
         **transpile_kwargs,
     )
+

--- a/ivy/compiler/compiler.py
+++ b/ivy/compiler/compiler.py
@@ -179,16 +179,17 @@ def unify(
     **transpile_kwargs,
 ) -> Callable:
     """
-    Unify and transpile one or more Callable objects from the source framework to the target framework.
+    Unify and Transpile Callable objects passed as arguments. If args and kwargs are specified.
 
-    This function takes one or more native Callable objects and transpiles them from the specified source framework
-    to the target framework.
+    one or more native Callable objects and transpiles them 
+    from the specified source framework to the target framework.
         
     Parameters:
     objs (Callable):
         One or more native Callable objects to be unified and transpiled.
     source (Optional[str]):
-        The framework that the `objs` are originally from. If not provided, the function will attempt to infer it.
+        The framework that the `objs` are originally from. 
+        If not provided, the function will attempt to infer it.
     args (Optional[Tuple]):
         If specified, arguments that will be used during transpilation.
     kwargs (Optional[dict]):

--- a/ivy/compiler/compiler.py
+++ b/ivy/compiler/compiler.py
@@ -180,7 +180,7 @@ def unify(
 ) -> Callable:
     """
     Unify and Transpile Callable objects passed as arguments.
-    If args and kwargs are specified.
+    If args and kwargs specified.
 
     one or more native Callable objects and transpiles them 
     from the specified source framework to the target framework.

--- a/ivy/compiler/compiler.py
+++ b/ivy/compiler/compiler.py
@@ -170,7 +170,6 @@ def transpile(
 
 
 # TODO: include docstring
-# fixed docstring, check for PR
 def unify(
     *objs: Callable,
     source: Optional[str] = None,
@@ -183,9 +182,8 @@ def unify(
     Unify and transpile one or more Callable objects from the source framework to the target framework.
 
     This function takes one or more native Callable objects and transpiles them from the specified source framework
-    to the target framework. It provides a unified interface for working with different backend frameworks and allows
-    for seamless code execution across them.
-
+    to the target framework.
+        
     Parameters:
     objs (Callable):
         One or more native Callable objects to be unified and transpiled.
@@ -223,13 +221,6 @@ def unify(
     >>> transpiled_fn = ivy.unify(fn, source="torch", args=(x,), with_numpy=True)
 
     The `transpiled_fn` can now be executed in the specified target framework.
-
-    Note:
-    - This function is designed for interoperability between different backend frameworks, allowing you to work with
-      functions and models from various frameworks in a unified manner.
-    - The `with_numpy` parameter ensures that the transpiled code is compatible with NumPy, which can be useful when
-      working with functions that rely on NumPy features.
-
     """
     if python_version[1] == "8":
         from ._compiler_38 import unify as _unify

--- a/ivy/compiler/compiler.py
+++ b/ivy/compiler/compiler.py
@@ -179,7 +179,8 @@ def unify(
     **transpile_kwargs,
 ) -> Callable:
     """
-    Unify and Transpile Callable objects passed as arguments. If args and kwargs are specified.
+    Unify and Transpile Callable objects passed as arguments.
+    If args and kwargs are specified.
 
     one or more native Callable objects and transpiles them 
     from the specified source framework to the target framework.

--- a/ivy/functional/frontends/tensorflow/math.py
+++ b/ivy/functional/frontends/tensorflow/math.py
@@ -324,6 +324,17 @@ def in_top_k(target, pred, k, name=None):
     return ivy.array([val in top_k.values for val in target])
 
 
+@to_ivy_arrays_and_back
+def invert_permutation(x, name=None):
+    x = ivy.array(x)
+    size = ivy.size(x)
+    identity = ivy.arange(size)
+    inverted = ivy.zeros_like(x)
+    inverted = ivy.scatter_update(inverted, x, identity)
+    return ivy.invert_permutation(inverted)
+
+
+
 @with_supported_dtypes(
     {
         "2.11.0 and below": ("bfloat16", "half", "float32", "float64"),

--- a/ivy/functional/frontends/tensorflow/math.py
+++ b/ivy/functional/frontends/tensorflow/math.py
@@ -327,10 +327,12 @@ def in_top_k(target, pred, k, name=None):
 @to_ivy_arrays_and_back
 def invert_permutation(x, name=None):
     x = ivy.array(x)
-    size = ivy.size(x)
+    size = ivy.shape(x)[0]
     identity = ivy.arange(size)
     inverted = ivy.zeros_like(x)
-    inverted = ivy.scatter_update(inverted, x, identity)
+    scatter_indices = ivy.reshape(x, [-1, 1])
+    scattered_values = ivy.reshape(identity, [-1, 1])
+    inverted = ivy.scatter_nd(scatter_indices, scattered_values, ivy.shape(inverted))
     return ivy.invert_permutation(inverted)
 
 

--- a/ivy_tests/test_ivy/test_frontends/test_tensorflow/test_math.py
+++ b/ivy_tests/test_ivy/test_frontends/test_tensorflow/test_math.py
@@ -1218,7 +1218,6 @@ def test_invert_permutation(
     fn_tree,
     backend_fw,
     on_device,
-    inverted,
     expected,
     actual,
 ):
@@ -1230,7 +1229,7 @@ def test_invert_permutation(
         test_flags=test_flags,
         fn_tree=fn_tree,
         on_device=on_device,
-        inputs=x,
+        inputs=x[0],
         expected=expected,
         actual=actual,
     )

--- a/ivy_tests/test_ivy/test_frontends/test_tensorflow/test_math.py
+++ b/ivy_tests/test_ivy/test_frontends/test_tensorflow/test_math.py
@@ -1201,6 +1201,36 @@ def test_tensorflow_in_top_k(
     )
 
 
+# invert_permutation
+@handle_frontend_test(
+    fn_tree="tensorflow.math.invert_permutation",  # Specify the function you want to test
+    dtype_and_x=helpers.dtype_and_values(
+        available_dtypes=helpers.get_dtypes("int"),  # Set the data types for testing
+        num_arrays=1,  # Specify the number of arrays to test
+    ),
+    test_with_out=st.just(False),
+)
+def test_invert_permutation(
+    *,
+    dtype_and_x,
+    frontend,
+    test_flags,
+    fn_tree,
+    backend_fw,
+    on_device,
+):
+    input_dtype, x = dtype_and_x
+    helpers.test_frontend_function(
+        input_dtypes=input_dtype,
+        backend_to_test=backend_fw,
+        frontend=frontend,
+        test_flags=test_flags,
+        fn_tree=fn_tree,
+        on_device=on_device,
+        inputs=x,
+    )
+
+
 # is_finite
 
 

--- a/ivy_tests/test_ivy/test_frontends/test_tensorflow/test_math.py
+++ b/ivy_tests/test_ivy/test_frontends/test_tensorflow/test_math.py
@@ -1201,12 +1201,13 @@ def test_tensorflow_in_top_k(
     )
 
 
-# invert_permutation 
+# invert_permutation
 @handle_frontend_test(
     fn_tree="tensorflow.math.invert_permutation",  
-    dtype_and_x=st.tuples(
-        helpers.get_dtypes(["numeric", "complex"]),  # Include numeric and complex data types
-        st.lists(st.integers(0, 10), min_size=1, max_size=10)  # Vary the size of the permutation array
+    dtype_and_x=helpers.dtype_and_values(
+        available_dtypes=helpers.get_dtypes("numeric"),  
+        num_arrays=1,
+        shared_dtype=True,  
     ),
     test_with_out=st.just(False),
 )

--- a/ivy_tests/test_ivy/test_frontends/test_tensorflow/test_math.py
+++ b/ivy_tests/test_ivy/test_frontends/test_tensorflow/test_math.py
@@ -1203,10 +1203,11 @@ def test_tensorflow_in_top_k(
 
 # invert_permutation
 @handle_frontend_test(
-    fn_tree="tensorflow.math.invert_permutation",  # Specify the function you want to test
+    fn_tree="tensorflow.math.invert_permutation",  
     dtype_and_x=helpers.dtype_and_values(
-        available_dtypes=helpers.get_dtypes("int"),  # Set the data types for testing
-        num_arrays=1,  # Specify the number of arrays to test
+        available_dtypes=helpers.get_dtypes("numeric"),  
+        num_arrays=2,
+        shared_dtype=True,  
     ),
     test_with_out=st.just(False),
 )

--- a/ivy_tests/test_ivy/test_frontends/test_tensorflow/test_math.py
+++ b/ivy_tests/test_ivy/test_frontends/test_tensorflow/test_math.py
@@ -1203,14 +1203,14 @@ def test_tensorflow_in_top_k(
 
 # invert_permutation
 @handle_frontend_test(
-    fn_tree="tensorflow.math.invert_permutation",  
+    fn_tree="tensorflow.math.invert_permutation",
     dtype_and_x=helpers.dtype_and_values(
-        available_dtypes=helpers.get_dtypes("numeric"),  
-        num_arrays=1,
-        shared_dtype=True,  
+        available_dtypes=helpers.get_dtypes("numeric"),
+        num_arrays=2,
     ),
     test_with_out=st.just(False),
 )
+
 def test_invert_permutation(
     *,
     dtype_and_x,
@@ -1219,7 +1219,10 @@ def test_invert_permutation(
     fn_tree,
     backend_fw,
     on_device,
-):
+    inverted,
+    expected,
+    actual,
+    ):
     input_dtype, x = dtype_and_x
     helpers.test_frontend_function(
         input_dtypes=input_dtype,
@@ -1229,8 +1232,10 @@ def test_invert_permutation(
         fn_tree=fn_tree,
         on_device=on_device,
         inputs=x,
+        expected=expected,
+        actual=actual,
     )
-
+   
 
 # is_finite
 

--- a/ivy_tests/test_ivy/test_frontends/test_tensorflow/test_math.py
+++ b/ivy_tests/test_ivy/test_frontends/test_tensorflow/test_math.py
@@ -1210,7 +1210,6 @@ def test_tensorflow_in_top_k(
     ),
     test_with_out=st.just(False),
 )
-
 def test_invert_permutation(
     *,
     dtype_and_x,
@@ -1222,7 +1221,7 @@ def test_invert_permutation(
     inverted,
     expected,
     actual,
-    ):
+):
     input_dtype, x = dtype_and_x
     helpers.test_frontend_function(
         input_dtypes=input_dtype,

--- a/ivy_tests/test_ivy/test_frontends/test_tensorflow/test_math.py
+++ b/ivy_tests/test_ivy/test_frontends/test_tensorflow/test_math.py
@@ -1201,13 +1201,12 @@ def test_tensorflow_in_top_k(
     )
 
 
-# invert_permutation
+# invert_permutation 
 @handle_frontend_test(
     fn_tree="tensorflow.math.invert_permutation",  
-    dtype_and_x=helpers.dtype_and_values(
-        available_dtypes=helpers.get_dtypes("numeric"),  
-        num_arrays=2,
-        shared_dtype=True,  
+    dtype_and_x=st.tuples(
+        helpers.get_dtypes(["numeric", "complex"]),  # Include numeric and complex data types
+        st.lists(st.integers(0, 10), min_size=1, max_size=10)  # Vary the size of the permutation array
     ),
     test_with_out=st.just(False),
 )


### PR DESCRIPTION
<!--
This template will help you to have a meaningful PR, please follow it and do not leave it blank.
-->

 Fixed Docstring in compiler for unify And added invert_permutation to the math function


The docstring for the unify function in the compiler was on the Todo, I didn't quite see any issue opened up for it but decided to handle it either way

added invert_permutation function at ivy/functional/frontends/tensorflow/math.py



## Related Issue

<!--
Please use this format to link other issues with their numbers: Close #123
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Close #22939

## Checklist

- [x] Did you add a function?
- [x] Did you add the tests?
- [x] Did you follow the steps we provided?

### Socials:


https://twitter.com/DanielBisina.


@Mr-Niraj-Kulkarni 