### PR TITLE
fixed wrong returned shape of paddle.mean function

### DIFF
--- a/ivy/functional/frontends/paddle/stat.py
+++ b/ivy/functional/frontends/paddle/stat.py
@@ -10,7 +10,6 @@ from ivy.functional.frontends.paddle.func_wrapper import (
 @to_ivy_arrays_and_back
 def mean(input, axis=None, keepdim=False, out=None):
     ret = ivy.mean(input, axis=axis, keepdims=keepdim, out=out)
-    ret = ivy.expand_dims(ret, axis=-1) if ret.ndim == 0 else ret
     return ret
 
 


### PR DESCRIPTION
This PR is meant to fix the wrong returned shape by mean function `AssertionError: returned shape = (1,), ground-truth returned shape = ()`