### PR TITLE
Added serialize function to activations.py

### DIFF
--- a/ivy/functional/frontends/tensorflow/keras/activations.py
+++ b/ivy/functional/frontends/tensorflow/keras/activations.py
@@ -47,6 +47,44 @@ def deserialize(name, custom_objects=None):
 
 
 @with_supported_dtypes(
+    {"2.13.0 and below": ("float16", "float32", "float64")},
+    "tensorflow",
+)
+def serialize(func, custom_objects=None):
+    # If the activation function is None, return None
+    if func is None:
+        return None
+
+    # If the activation function is already a string, return it
+    elif isinstance(func, str):
+        return func
+
+    # If the activation function is callable (a function), get its name
+    elif callable(func):
+        # Check if the function is in the custom_objects dictionary
+        if custom_objects:
+            for name, custom_func in custom_objects.items():
+                if custom_func == func:
+                    return name
+
+        # Check if the function is in the ACTIVATION_FUNCTIONS list
+        if func.__name__ in ACTIVATION_FUNCTIONS:
+            return func.__name__
+
+        # Check if the function is in the tensorflow frontend activations
+        elif func in tf_frontend.keras.activations.__dict__.values():
+            for name, tf_func in tf_frontend.keras.activations.__dict__.items():
+                if tf_func == func:
+                    return name
+
+        else:
+            raise ValueError(f"Unknown activation function: {func}.")
+
+    else:
+        raise ValueError(f"Could not interpret activation function: {func}")
+
+
+@with_supported_dtypes(
     {"2.13.0 and below": ("bfloat16", "float16", "float32", "float64")},
     "tensorflow",
 )


### PR DESCRIPTION
## PR Description

- Modified file: https://github.com/unifyai/ivy/blob/main/ivy/functional/frontends/tensorflow/keras/activations.py
- Added a serialize function to convert activation functions back into their string identifiers.
- Ensured compatibility with supported TensorFlow versions and data types.

## Related Issue

<!--
Please use this format to link other issues with their numbers: Close #123
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes #1569 