### PR TITLE
removed infer_device and changed handle_device_shifting to handle_device

### DIFF
--- a/ivy/func_wrapper.py
+++ b/ivy/func_wrapper.py
@@ -17,7 +17,7 @@ from ivy.utils.exceptions import IvyValueError
 FN_DECORATORS = [
     "handle_complex_input",
     "infer_device",
-    "handle_device_shifting",
+    "handle_device",
     "infer_dtype",
     "handle_array_function",
     "outputs_to_ivy_arrays",
@@ -812,9 +812,9 @@ def infer_device(fn: Callable) -> Callable:
     return _infer_device
 
 
-def handle_device_shifting(fn: Callable) -> Callable:
+def handle_device(fn: Callable) -> Callable:
     @functools.wraps(fn)
-    def _handle_device_shifting(*args, **kwargs):
+    def _handle_device(*args, **kwargs):
         """
         Move all array inputs of the function to `ivy.default_device()`.
 
@@ -857,8 +857,8 @@ def handle_device_shifting(fn: Callable) -> Callable:
             )
         return fn(*args, **kwargs)
 
-    _handle_device_shifting.handle_device_shifting = True
-    return _handle_device_shifting
+    _handle_device.handle_device = True
+    return _handle_device
 
 
 # Inplace Update Handling #

--- a/ivy/functional/ivy/activations.py
+++ b/ivy/functional/ivy/activations.py
@@ -11,7 +11,7 @@ from ivy.func_wrapper import (
     to_native_arrays_and_back,
     handle_nestable,
     handle_array_like_without_promotion,
-    handle_device_shifting,
+    handle_device,
     handle_complex_input,
     handle_backend_invalid,
 )
@@ -38,7 +38,7 @@ def _gelu_jax_like(
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 @handle_complex_input
 def gelu(
     x: Union[ivy.Array, ivy.NativeArray],
@@ -128,7 +128,7 @@ def _leaky_relu_jax_like(
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 @handle_complex_input
 def leaky_relu(
     x: Union[ivy.Array, ivy.NativeArray],
@@ -209,7 +209,7 @@ leaky_relu.jax_like = _leaky_relu_jax_like
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def log_softmax(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -301,7 +301,7 @@ def _relu_jax_like(
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 @handle_complex_input
 def relu(
     x: Union[ivy.Array, ivy.NativeArray],
@@ -373,7 +373,7 @@ relu.jax_like = _relu_jax_like
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def sigmoid(
     x: Union[ivy.Array, ivy.NativeArray], /, *, out: Optional[ivy.Array] = None
 ) -> ivy.Array:
@@ -451,7 +451,7 @@ def sigmoid(
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 @handle_complex_input
 def softmax(
     x: Union[ivy.Array, ivy.NativeArray],
@@ -548,7 +548,7 @@ def _softplus_jax_like(
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 @handle_complex_input
 def softplus(
     x: Union[ivy.Array, ivy.NativeArray],
@@ -622,7 +622,7 @@ softplus.jax_like = _softplus_jax_like
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def softsign(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -662,7 +662,7 @@ def softsign(
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def mish(
     x: Union[ivy.Array, ivy.NativeArray], /, *, out: Optional[ivy.Array] = None
 ) -> ivy.Array:

--- a/ivy/functional/ivy/control_flow_ops.py
+++ b/ivy/functional/ivy/control_flow_ops.py
@@ -5,7 +5,7 @@ from ivy.func_wrapper import (
     handle_array_like_without_promotion,
     to_native_arrays_and_back,
     to_ivy_arrays_and_back,
-    handle_device_shifting,
+    handle_device,
 )
 
 
@@ -60,7 +60,7 @@ def if_else(
 
     @to_native_arrays_and_back
     @handle_array_like_without_promotion
-    @handle_device_shifting
+    @handle_device
     def _if_else(cond, body_fn, orelse_fn, vars):
         return current_backend().if_else(cond, body_fn, orelse_fn, vars)
 
@@ -116,7 +116,7 @@ def while_loop(
 
     @to_native_arrays_and_back
     @handle_array_like_without_promotion
-    @handle_device_shifting
+    @handle_device
     def _while_loop(test_fn, body_fn, vars):
         return current_backend().while_loop(test_fn, body_fn, vars)
 

--- a/ivy/functional/ivy/creation.py
+++ b/ivy/functional/ivy/creation.py
@@ -31,7 +31,7 @@ from ivy.func_wrapper import (
     to_native_arrays_and_back,
     handle_nestable,
     handle_array_like_without_promotion,
-    handle_device_shifting,
+    handle_device,
     handle_backend_invalid,
 )
 
@@ -283,8 +283,7 @@ class NestedSequence(Protocol[_T_co]):
 @handle_out_argument
 @outputs_to_ivy_arrays
 @handle_array_function
-@handle_device_shifting
-@infer_device
+@handle_device
 def arange(
     start: Number,
     /,
@@ -385,7 +384,7 @@ def arange(
 @handle_array_like_without_promotion
 @handle_out_argument
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def asarray(
     obj: Union[
         ivy.Array,
@@ -484,8 +483,7 @@ def asarray(
 @outputs_to_ivy_arrays
 @handle_array_function
 @infer_dtype
-@handle_device_shifting
-@infer_device
+@handle_device
 def zeros(
     shape: Union[ivy.Shape, ivy.NativeShape],
     *,
@@ -550,8 +548,7 @@ def zeros(
 @outputs_to_ivy_arrays
 @handle_array_function
 @infer_dtype
-@handle_device_shifting
-@infer_device
+@handle_device
 def ones(
     shape: Union[ivy.Shape, ivy.NativeShape],
     *,
@@ -648,8 +645,7 @@ def ones(
 @to_native_arrays_and_back
 @handle_array_function
 @infer_dtype
-@handle_device_shifting
-@infer_device
+@handle_device
 def full_like(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -758,8 +754,7 @@ def full_like(
 @to_native_arrays_and_back
 @handle_array_function
 @infer_dtype
-@handle_device_shifting
-@infer_device
+@handle_device
 def ones_like(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -879,8 +874,7 @@ def ones_like(
 @to_native_arrays_and_back
 @handle_array_function
 @infer_dtype
-@handle_device_shifting
-@infer_device
+@handle_device
 def zeros_like(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -994,7 +988,7 @@ def zeros_like(
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def tril(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -1050,7 +1044,7 @@ def tril(
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def triu(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -1108,8 +1102,7 @@ def triu(
 @outputs_to_ivy_arrays
 @handle_array_function
 @infer_dtype
-@handle_device_shifting
-@infer_device
+@handle_device
 def empty(
     shape: Union[ivy.Shape, ivy.NativeShape],
     *,
@@ -1159,8 +1152,7 @@ def empty(
 @to_native_arrays_and_back
 @handle_array_function
 @infer_dtype
-@handle_device_shifting
-@infer_device
+@handle_device
 def empty_like(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -1354,8 +1346,7 @@ def eye(
 @to_native_arrays_and_back
 @handle_array_function
 @infer_dtype
-@handle_device_shifting
-@infer_device
+@handle_device
 def linspace(
     start: Union[ivy.Array, ivy.NativeArray, float],
     stop: Union[ivy.Array, ivy.NativeArray, float],
@@ -1464,7 +1455,7 @@ def linspace(
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def meshgrid(
     *arrays: Union[ivy.Array, ivy.NativeArray],
     sparse: bool = False,
@@ -1586,8 +1577,7 @@ def meshgrid(
 @inputs_to_native_arrays
 @outputs_to_ivy_arrays
 @handle_array_function
-@handle_device_shifting
-@infer_device
+@handle_device
 def full(
     shape: Union[ivy.Shape, ivy.NativeShape],
     fill_value: Union[float, bool],
@@ -1695,7 +1685,7 @@ def full(
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def from_dlpack(
     x: Union[ivy.Array, ivy.NativeArray], /, *, out: Optional[ivy.Array] = None
 ) -> ivy.Array:
@@ -1749,7 +1739,7 @@ array = asarray
 @handle_out_argument
 @inputs_to_native_arrays
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def copy_array(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -1915,8 +1905,7 @@ def native_array(
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
-@infer_device
+@handle_device
 def one_hot(
     indices: Union[ivy.Array, ivy.NativeArray],
     depth: int,

--- a/ivy/functional/ivy/data_type.py
+++ b/ivy/functional/ivy/data_type.py
@@ -20,7 +20,7 @@ from ivy.func_wrapper import (
     handle_array_like_without_promotion,
     inputs_to_ivy_arrays,
     inputs_to_native_shapes,
-    handle_device_shifting,
+    handle_device,
     handle_backend_invalid,
 )
 from ivy.utils.exceptions import handle_exceptions
@@ -252,7 +252,7 @@ Iinfo = None
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def astype(
     x: Union[ivy.Array, ivy.NativeArray],
     dtype: Union[ivy.Dtype, ivy.NativeDtype],
@@ -359,7 +359,7 @@ def astype(
 @handle_nestable
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def broadcast_arrays(*arrays: Union[ivy.Array, ivy.NativeArray]) -> List[ivy.Array]:
     """
     Broadcasts one or more arrays against one another.
@@ -441,7 +441,7 @@ def broadcast_arrays(*arrays: Union[ivy.Array, ivy.NativeArray]) -> List[ivy.Arr
 @inputs_to_native_shapes
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def broadcast_to(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -512,7 +512,7 @@ def broadcast_to(
 @handle_nestable
 @inputs_to_ivy_arrays
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def can_cast(
     from_: Union[ivy.Dtype, ivy.Array, ivy.NativeArray],
     to: ivy.Dtype,
@@ -588,7 +588,7 @@ def can_cast(
 @handle_exceptions
 @handle_backend_invalid
 @inputs_to_native_arrays
-@handle_device_shifting
+@handle_device
 def finfo(
     type: Union[ivy.Dtype, str, ivy.Array, ivy.NativeArray],
     /,
@@ -676,7 +676,7 @@ def finfo(
 @handle_exceptions
 @handle_backend_invalid
 @inputs_to_native_arrays
-@handle_device_shifting
+@handle_device
 def iinfo(
     type: Union[ivy.Dtype, str, ivy.Array, ivy.NativeArray],
     /,
@@ -754,7 +754,7 @@ def iinfo(
 @handle_backend_invalid
 @handle_nestable
 @inputs_to_native_arrays
-@handle_device_shifting
+@handle_device
 def result_type(
     *arrays_and_dtypes: Union[ivy.Array, ivy.NativeArray, ivy.Dtype]
 ) -> ivy.Dtype:
@@ -1518,7 +1518,7 @@ def default_uint_dtype(
 @handle_exceptions
 @handle_nestable
 @inputs_to_ivy_arrays
-@handle_device_shifting
+@handle_device
 def default_complex_dtype(
     *,
     input: Optional[Union[ivy.Array, ivy.NativeArray]] = None,
@@ -1615,7 +1615,7 @@ def default_complex_dtype(
 @handle_backend_invalid
 @handle_nestable
 @inputs_to_native_arrays
-@handle_device_shifting
+@handle_device
 def dtype(
     x: Union[ivy.Array, ivy.NativeArray], *, as_native: bool = False
 ) -> Union[ivy.Dtype, ivy.NativeDtype]:

--- a/ivy/functional/ivy/elementwise.py
+++ b/ivy/functional/ivy/elementwise.py
@@ -11,7 +11,7 @@ from ivy.func_wrapper import (
     handle_nestable,
     handle_array_like_without_promotion,
     inputs_to_ivy_arrays,
-    handle_device_shifting,
+    handle_device,
     handle_complex_input,
     handle_backend_invalid,
 )
@@ -29,7 +29,7 @@ from ivy.utils.exceptions import handle_exceptions
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def abs(
     x: Union[float, ivy.Array, ivy.NativeArray],
     /,
@@ -134,7 +134,7 @@ def abs(
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def acos(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -244,7 +244,7 @@ def acos(
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def acosh(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -353,7 +353,7 @@ def acosh(
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def add(
     x1: Union[float, ivy.Array, ivy.NativeArray],
     x2: Union[float, ivy.Array, ivy.NativeArray],
@@ -505,7 +505,7 @@ def add(
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def asin(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -594,7 +594,7 @@ def asin(
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def asinh(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -703,7 +703,7 @@ def asinh(
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def atan(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -787,7 +787,7 @@ def atan(
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def atan2(
     x1: Union[ivy.Array, ivy.NativeArray],
     x2: Union[ivy.Array, ivy.NativeArray],
@@ -964,7 +964,7 @@ def atan2(
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def atanh(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -1066,7 +1066,7 @@ def atanh(
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def bitwise_and(
     x1: Union[int, bool, ivy.Array, ivy.NativeArray],
     x2: Union[int, bool, ivy.Array, ivy.NativeArray],
@@ -1161,7 +1161,7 @@ def bitwise_and(
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def bitwise_invert(
     x: Union[int, bool, ivy.Array, ivy.NativeArray, ivy.Container],
     /,
@@ -1238,7 +1238,7 @@ def bitwise_invert(
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def bitwise_left_shift(
     x1: Union[int, ivy.Array, ivy.NativeArray],
     x2: Union[int, ivy.Array, ivy.NativeArray],
@@ -1289,7 +1289,7 @@ def bitwise_left_shift(
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def bitwise_or(
     x1: Union[int, bool, ivy.Array, ivy.NativeArray],
     x2: Union[int, bool, ivy.Array, ivy.NativeArray],
@@ -1378,7 +1378,7 @@ def bitwise_or(
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def bitwise_right_shift(
     x1: Union[int, ivy.Array, ivy.NativeArray],
     x2: Union[int, ivy.Array, ivy.NativeArray],
@@ -1494,7 +1494,7 @@ def bitwise_right_shift(
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def bitwise_xor(
     x1: Union[int, bool, ivy.Array, ivy.NativeArray],
     x2: Union[int, bool, ivy.Array, ivy.NativeArray],
@@ -1601,7 +1601,7 @@ def bitwise_xor(
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def ceil(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -1692,7 +1692,7 @@ def ceil(
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def cos(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -1779,7 +1779,7 @@ def cos(
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def cosh(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -1898,7 +1898,7 @@ def cosh(
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def divide(
     x1: Union[float, ivy.Array, ivy.NativeArray],
     x2: Union[float, ivy.Array, ivy.NativeArray],
@@ -2090,7 +2090,7 @@ def divide(
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def equal(
     x1: Union[float, ivy.Array, ivy.NativeArray, ivy.Container],
     x2: Union[float, ivy.Array, ivy.NativeArray, ivy.Container],
@@ -2208,7 +2208,7 @@ def equal(
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def exp(
     x: Union[ivy.Array, ivy.NativeArray, Number],
     /,
@@ -2347,7 +2347,7 @@ def exp(
 @handle_array_like_without_promotion
 @handle_out_argument
 @to_native_arrays_and_back
-@handle_device_shifting
+@handle_device
 def imag(
     val: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -2400,7 +2400,7 @@ def imag(
 @handle_array_like_without_promotion
 @handle_out_argument
 @to_native_arrays_and_back
-@handle_device_shifting
+@handle_device
 def angle(
     z: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -2444,7 +2444,7 @@ def angle(
 @handle_nestable
 @handle_out_argument
 @to_native_arrays_and_back
-@handle_device_shifting
+@handle_device
 def gcd(
     x1: Union[ivy.Array, ivy.NativeArray, int, list, tuple],
     x2: Union[ivy.Array, ivy.NativeArray, int, list, tuple],
@@ -2487,7 +2487,7 @@ def gcd(
 @handle_array_like_without_promotion
 @handle_out_argument
 @to_native_arrays_and_back
-@handle_device_shifting
+@handle_device
 def exp2(
     x: Union[ivy.Array, float, list, tuple],
     /,
@@ -2528,7 +2528,7 @@ def exp2(
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def expm1(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -2655,7 +2655,7 @@ def expm1(
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def floor(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -2745,7 +2745,7 @@ def floor(
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def floor_divide(
     x1: Union[float, ivy.Array, ivy.NativeArray],
     x2: Union[float, ivy.Array, ivy.NativeArray],
@@ -2929,7 +2929,7 @@ def floor_divide(
 @handle_nestable
 @handle_out_argument
 @to_native_arrays_and_back
-@handle_device_shifting
+@handle_device
 def fmin(
     x1: Union[ivy.Array, ivy.NativeArray],
     x2: Union[ivy.Array, ivy.NativeArray],
@@ -2977,7 +2977,7 @@ def fmin(
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def greater(
     x1: Union[float, ivy.Array, ivy.NativeArray],
     x2: Union[float, ivy.Array, ivy.NativeArray],
@@ -3078,7 +3078,7 @@ def greater(
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def greater_equal(
     x1: Union[ivy.Array, ivy.NativeArray],
     x2: Union[ivy.Array, ivy.NativeArray],
@@ -3165,7 +3165,7 @@ def greater_equal(
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def less_equal(
     x1: Union[ivy.Array, ivy.NativeArray],
     x2: Union[ivy.Array, ivy.NativeArray],
@@ -3252,7 +3252,7 @@ def less_equal(
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def multiply(
     x1: Union[float, ivy.Array, ivy.NativeArray],
     x2: Union[float, ivy.Array, ivy.NativeArray],
@@ -3439,7 +3439,7 @@ def multiply(
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def isfinite(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -3537,7 +3537,7 @@ def isfinite(
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def isinf(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -3662,7 +3662,7 @@ def isinf(
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def isnan(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -3771,7 +3771,7 @@ def isnan(
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def less(
     x1: Union[float, ivy.Array, ivy.NativeArray],
     x2: Union[float, ivy.Array, ivy.NativeArray],
@@ -3862,7 +3862,7 @@ def less(
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def log(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -3963,7 +3963,7 @@ def log(
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def log10(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -4058,7 +4058,7 @@ def log10(
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def log1p(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -4177,7 +4177,7 @@ def log1p(
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def log2(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -4243,7 +4243,7 @@ def log2(
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def logaddexp(
     x1: Union[ivy.Array, ivy.NativeArray],
     x2: Union[ivy.Array, ivy.NativeArray],
@@ -4344,7 +4344,7 @@ def logaddexp(
 @handle_nestable
 @handle_out_argument
 @to_native_arrays_and_back
-@handle_device_shifting
+@handle_device
 def logaddexp2(
     x1: Union[ivy.Array, ivy.NativeArray, float, list, tuple],
     x2: Union[ivy.Array, ivy.NativeArray, float, list, tuple],
@@ -4388,7 +4388,7 @@ def logaddexp2(
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def logical_and(
     x1: Union[ivy.Array, ivy.NativeArray],
     x2: Union[ivy.Array, ivy.NativeArray],
@@ -4490,7 +4490,7 @@ def logical_and(
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def logical_not(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -4587,7 +4587,7 @@ def logical_not(
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def logical_or(
     x1: Union[ivy.Array, ivy.NativeArray],
     x2: Union[ivy.Array, ivy.NativeArray],
@@ -4679,7 +4679,7 @@ def logical_or(
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def logical_xor(
     x1: Union[ivy.Array, ivy.NativeArray],
     x2: Union[ivy.Array, ivy.NativeArray],
@@ -4778,7 +4778,7 @@ def logical_xor(
 @handle_array_like_without_promotion
 @handle_out_argument
 @to_native_arrays_and_back
-@handle_device_shifting
+@handle_device
 def nan_to_num(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -4841,7 +4841,7 @@ def nan_to_num(
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def negative(
     x: Union[float, ivy.Array, ivy.NativeArray],
     /,
@@ -4927,7 +4927,7 @@ def negative(
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def not_equal(
     x1: Union[float, ivy.Array, ivy.NativeArray, ivy.Container],
     x2: Union[float, ivy.Array, ivy.NativeArray, ivy.Container],
@@ -5111,7 +5111,7 @@ def not_equal(
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def positive(
     x: Union[float, ivy.Array, ivy.NativeArray],
     /,
@@ -5187,7 +5187,7 @@ def positive(
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def pow(
     x1: Union[ivy.Array, ivy.NativeArray],
     x2: Union[int, float, ivy.Array, ivy.NativeArray],
@@ -5323,7 +5323,7 @@ pow.unsupported_gradients = {"torch": ["float16"]}
 
 def _complex_to_inf(exponent):
     if exponent < 0:
-        return float('inf') + ivy.nan * 1j
+        return float("inf") + ivy.nan * 1j
     else:
         return -0 * 1j
 
@@ -5334,7 +5334,7 @@ def _complex_to_inf(exponent):
 @handle_array_like_without_promotion
 @handle_out_argument
 @to_native_arrays_and_back
-@handle_device_shifting
+@handle_device
 def real(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -5405,7 +5405,7 @@ def real(
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def remainder(
     x1: Union[float, ivy.Array, ivy.NativeArray],
     x2: Union[float, ivy.Array, ivy.NativeArray],
@@ -5536,7 +5536,7 @@ def remainder(
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def round(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -5658,7 +5658,7 @@ def round(
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def sign(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -5768,7 +5768,7 @@ def sign(
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def sin(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -5863,7 +5863,7 @@ def sin(
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def sinh(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -5987,7 +5987,7 @@ def sinh(
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def sqrt(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -6119,7 +6119,7 @@ def sqrt(
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def square(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -6192,7 +6192,7 @@ def square(
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def subtract(
     x1: Union[float, ivy.Array, ivy.NativeArray],
     x2: Union[float, ivy.Array, ivy.NativeArray],
@@ -6258,7 +6258,7 @@ def subtract(
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def tan(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -6362,7 +6362,7 @@ def tan(
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 @handle_complex_input
 def tanh(
     x: Union[ivy.Array, ivy.NativeArray],
@@ -6504,7 +6504,7 @@ def tanh(
 @handle_array_like_without_promotion
 @handle_out_argument
 @to_native_arrays_and_back
-@handle_device_shifting
+@handle_device
 def trapz(
     y: ivy.Array,
     /,
@@ -6565,7 +6565,7 @@ def trapz(
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def trunc(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -6658,7 +6658,7 @@ def trunc(
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def erf(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -6696,7 +6696,7 @@ def erf(
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def maximum(
     x1: Union[ivy.Array, ivy.NativeArray, Number],
     x2: Union[ivy.Array, ivy.NativeArray, Number],
@@ -6788,7 +6788,7 @@ def maximum(
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def minimum(
     x1: Union[ivy.Array, ivy.NativeArray],
     x2: Union[ivy.Array, ivy.NativeArray],
@@ -6881,7 +6881,7 @@ def minimum(
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def reciprocal(
     x: Union[float, ivy.Array, ivy.NativeArray],
     /,
@@ -6920,7 +6920,7 @@ def reciprocal(
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def deg2rad(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -6999,7 +6999,7 @@ def deg2rad(
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def rad2deg(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -7124,7 +7124,7 @@ trunc_divide.mixed_backend_wrappers = {
         "handle_out_argument",
         "inputs_to_native_arrays",
         "outputs_to_ivy_arrays",
-        "handle_device_shifting",
+        "handle_device",
         "handle_backend_invalid",
     ),
     "to_skip": ("inputs_to_ivy_arrays",),
@@ -7138,7 +7138,7 @@ trunc_divide.mixed_backend_wrappers = {
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def isreal(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -7203,7 +7203,7 @@ def isreal(
 @handle_nestable
 @handle_out_argument
 @to_native_arrays_and_back
-@handle_device_shifting
+@handle_device
 def fmod(
     x1: Union[ivy.Array, ivy.NativeArray],
     x2: Union[ivy.Array, ivy.NativeArray],
@@ -7247,7 +7247,7 @@ def fmod(
 @handle_nestable
 @handle_out_argument
 @to_native_arrays_and_back
-@handle_device_shifting
+@handle_device
 def lcm(
     x1: Union[ivy.Array, ivy.NativeArray],
     x2: Union[ivy.Array, ivy.NativeArray],

--- a/ivy/functional/ivy/experimental/activations.py
+++ b/ivy/functional/ivy/experimental/activations.py
@@ -12,7 +12,7 @@ from ivy.func_wrapper import (
     handle_array_like_without_promotion,
     handle_out_argument,
     inputs_to_ivy_arrays,
-    handle_device_shifting,
+    handle_device,
     handle_backend_invalid,
     handle_complex_input,
 )
@@ -43,7 +43,7 @@ def _logit_jax_like(
 @handle_array_like_without_promotion
 @handle_out_argument
 @to_native_arrays_and_back
-@handle_device_shifting
+@handle_device
 @handle_complex_input
 def logit(
     x: Union[float, int, ivy.Array],
@@ -159,7 +159,7 @@ def prelu(
 @handle_array_like_without_promotion
 @handle_out_argument
 @to_native_arrays_and_back
-@handle_device_shifting
+@handle_device
 def thresholded_relu(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -221,7 +221,7 @@ def thresholded_relu(
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def relu6(
     x: Union[ivy.Array, ivy.NativeArray], /, *, out: Optional[ivy.Array] = None
 ) -> ivy.Array:
@@ -266,7 +266,7 @@ def relu6(
 @handle_array_like_without_promotion
 @handle_out_argument
 @to_native_arrays_and_back
-@handle_device_shifting
+@handle_device
 @handle_complex_input
 def logsigmoid(
     input: Union[ivy.NativeArray, ivy.Array],
@@ -326,7 +326,7 @@ def logsigmoid(
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def selu(
     x: Union[ivy.Array, ivy.NativeArray], /, *, out: Optional[ivy.Array] = None
 ) -> ivy.Array:
@@ -385,7 +385,7 @@ def selu(
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def silu(
     x: Union[ivy.Array, ivy.NativeArray], /, *, out: Optional[ivy.Array] = None
 ) -> ivy.Array:

--- a/ivy/functional/ivy/experimental/creation.py
+++ b/ivy/functional/ivy/experimental/creation.py
@@ -15,7 +15,7 @@ from ivy.func_wrapper import (
     infer_dtype,
     handle_array_like_without_promotion,
     inputs_to_ivy_arrays,
-    handle_device_shifting,
+    handle_device,
     handle_backend_invalid,
     handle_array_function,
 )
@@ -27,7 +27,7 @@ from ivy.func_wrapper import (
 @handle_out_argument
 @to_native_arrays_and_back
 @infer_dtype
-@handle_device_shifting
+@handle_device
 def vorbis_window(
     window_length: Union[ivy.Array, ivy.NativeArray],
     *,
@@ -69,7 +69,7 @@ def vorbis_window(
 @handle_out_argument
 @to_native_arrays_and_back
 @infer_dtype
-@handle_device_shifting
+@handle_device
 def hann_window(
     size: int,
     *,
@@ -117,7 +117,7 @@ def hann_window(
 @handle_out_argument
 @to_native_arrays_and_back
 @infer_dtype
-@handle_device_shifting
+@handle_device
 def kaiser_window(
     window_length: int,
     periodic: bool = True,
@@ -276,7 +276,7 @@ hamming_window.mixed_backend_wrappers = {
     "to_add": (
         "handle_backend_invalid",
         "handle_out_argument",
-        "handle_device_shifting",
+        "handle_device",
     ),
     "to_skip": (),
 }
@@ -605,7 +605,7 @@ def indices(
 
 
 indices.mixed_backend_wrappers = {
-    "to_add": ("handle_device_shifting",),
+    "to_add": ("handle_device",),
     "to_skip": (),
 }
 
@@ -691,7 +691,7 @@ def unsorted_segment_sum(
 @handle_out_argument
 @to_native_arrays_and_back
 @infer_dtype
-@handle_device_shifting
+@handle_device
 def blackman_window(
     size: int,
     *,
@@ -866,7 +866,7 @@ def random_cp(
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def trilu(
     x: Union[ivy.Array, ivy.NativeArray],
     /,

--- a/ivy/functional/ivy/experimental/elementwise.py
+++ b/ivy/functional/ivy/experimental/elementwise.py
@@ -11,7 +11,7 @@ from ivy.func_wrapper import (
     inputs_to_ivy_arrays,
     handle_array_function,
     infer_dtype,
-    handle_device_shifting,
+    handle_device,
     handle_backend_invalid,
 )
 from ivy.utils.exceptions import handle_exceptions
@@ -74,7 +74,7 @@ def lgamma(
 @handle_array_like_without_promotion
 @handle_out_argument
 @to_native_arrays_and_back
-@handle_device_shifting
+@handle_device
 def sinc(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -150,7 +150,7 @@ def sinc(
 @handle_nestable
 @handle_out_argument
 @to_native_arrays_and_back
-@handle_device_shifting
+@handle_device
 def fmax(
     x1: Union[ivy.Array, ivy.NativeArray],
     x2: Union[ivy.Array, ivy.NativeArray],
@@ -196,7 +196,7 @@ def fmax(
 @handle_nestable
 @handle_out_argument
 @to_native_arrays_and_back
-@handle_device_shifting
+@handle_device
 def float_power(
     x1: Union[ivy.Array, float, list, tuple],
     x2: Union[ivy.Array, float, list, tuple],
@@ -245,7 +245,7 @@ def float_power(
 @handle_nestable
 @handle_out_argument
 @to_native_arrays_and_back
-@handle_device_shifting
+@handle_device
 def copysign(
     x1: Union[ivy.Array, ivy.NativeArray, Number],
     x2: Union[ivy.Array, ivy.NativeArray, Number],
@@ -293,7 +293,7 @@ def copysign(
 @handle_array_like_without_promotion
 @to_native_arrays_and_back
 @infer_dtype
-@handle_device_shifting
+@handle_device
 def count_nonzero(
     a: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -353,7 +353,7 @@ def count_nonzero(
 @handle_out_argument
 @to_native_arrays_and_back
 @infer_dtype
-@handle_device_shifting
+@handle_device
 def nansum(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -411,7 +411,7 @@ def nansum(
 @handle_array_like_without_promotion
 @handle_out_argument
 @to_native_arrays_and_back
-@handle_device_shifting
+@handle_device
 def isclose(
     a: Union[ivy.Array, ivy.NativeArray],
     b: Union[ivy.Array, ivy.NativeArray],
@@ -476,7 +476,7 @@ def isclose(
 @handle_array_like_without_promotion
 @handle_out_argument
 @to_native_arrays_and_back
-@handle_device_shifting
+@handle_device
 def signbit(
     x: Union[ivy.Array, ivy.NativeArray, float, int, list, tuple],
     /,
@@ -512,7 +512,7 @@ def signbit(
 @handle_nestable
 @handle_out_argument
 @to_native_arrays_and_back
-@handle_device_shifting
+@handle_device
 def hypot(
     x1: Union[ivy.Array, ivy.NativeArray],
     x2: Union[ivy.Array, ivy.NativeArray],
@@ -550,7 +550,7 @@ def hypot(
 @handle_array_like_without_promotion
 @handle_out_argument
 @to_native_arrays_and_back
-@handle_device_shifting
+@handle_device
 def diff(
     x: Union[ivy.Array, ivy.NativeArray, list, tuple],
     /,
@@ -606,7 +606,7 @@ def diff(
 @handle_nestable
 @handle_array_like_without_promotion
 @to_native_arrays_and_back
-@handle_device_shifting
+@handle_device
 def allclose(
     a: Union[ivy.Array, ivy.NativeArray],
     b: Union[ivy.Array, ivy.NativeArray],
@@ -681,7 +681,7 @@ def allclose(
 @handle_array_like_without_promotion
 @handle_out_argument
 @to_native_arrays_and_back
-@handle_device_shifting
+@handle_device
 def fix(
     x: Union[ivy.Array, ivy.NativeArray, float, int, list, tuple],
     /,
@@ -720,7 +720,7 @@ def fix(
 @handle_array_like_without_promotion
 @handle_out_argument
 @to_native_arrays_and_back
-@handle_device_shifting
+@handle_device
 def nextafter(
     x1: Union[ivy.Array, ivy.NativeArray],
     x2: Union[ivy.Array, ivy.NativeArray],
@@ -762,7 +762,7 @@ def nextafter(
 @handle_array_like_without_promotion
 @handle_out_argument
 @to_native_arrays_and_back
-@handle_device_shifting
+@handle_device
 def zeta(
     x: Union[ivy.Array, ivy.NativeArray],
     q: Union[ivy.Array, ivy.NativeArray],
@@ -805,7 +805,7 @@ def zeta(
 @handle_nestable
 @handle_array_like_without_promotion
 @to_native_arrays_and_back
-@handle_device_shifting
+@handle_device
 def gradient(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -885,7 +885,7 @@ def gradient(
 @handle_nestable
 @handle_out_argument
 @to_native_arrays_and_back
-@handle_device_shifting
+@handle_device
 def xlogy(
     x: Union[ivy.Array, ivy.NativeArray],
     y: Union[ivy.Array, ivy.NativeArray],
@@ -973,7 +973,7 @@ def binarizer(
 @handle_array_like_without_promotion
 @handle_out_argument
 @to_native_arrays_and_back
-@handle_device_shifting
+@handle_device
 def conj(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -1056,7 +1056,7 @@ def conj(
 @handle_array_like_without_promotion
 @handle_out_argument
 @to_native_arrays_and_back
-@handle_device_shifting
+@handle_device
 def ldexp(
     x1: Union[ivy.Array, ivy.NativeArray],
     x2: Union[ivy.Array, ivy.NativeArray],
@@ -1098,7 +1098,7 @@ def ldexp(
 @handle_array_like_without_promotion
 @inputs_to_ivy_arrays
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def lerp(
     input: Union[ivy.Array, ivy.NativeArray],
     end: Union[ivy.Array, ivy.NativeArray],
@@ -1216,7 +1216,7 @@ lerp.mixed_backend_wrappers = {
         "handle_backend_invalid",
         "inputs_to_native_arrays",
         "outputs_to_ivy_arrays",
-        "handle_device_shifting",
+        "handle_device",
     ),
     "to_skip": ("inputs_to_ivy_arrays", "handle_partial_mixed_function"),
 }
@@ -1228,7 +1228,7 @@ lerp.mixed_backend_wrappers = {
 @handle_array_like_without_promotion
 @handle_out_argument
 @to_native_arrays_and_back
-@handle_device_shifting
+@handle_device
 def frexp(
     x: Union[ivy.Array, ivy.NativeArray],
     /,

--- a/ivy/functional/ivy/experimental/general.py
+++ b/ivy/functional/ivy/experimental/general.py
@@ -91,7 +91,7 @@ reduce.mixed_backend_wrappers = {
         "handle_backend_invalid",
         "inputs_to_native_arrays",
         "outputs_to_ivy_arrays",
-        "handle_device_shifting",
+        "handle_device",
     ),
     "to_skip": ("inputs_to_ivy_arrays",),
 }

--- a/ivy/functional/ivy/experimental/layers.py
+++ b/ivy/functional/ivy/experimental/layers.py
@@ -15,7 +15,7 @@ from ivy.func_wrapper import (
     handle_partial_mixed_function,
     inputs_to_ivy_arrays,
     handle_array_function,
-    handle_device_shifting,
+    handle_device,
     handle_backend_invalid,
 )
 from ivy.functional.ivy.experimental.general import _correct_ivy_callable
@@ -30,7 +30,7 @@ _max = builtins.max
 @handle_nestable
 @handle_out_argument
 @to_native_arrays_and_back
-@handle_device_shifting
+@handle_device
 def max_pool1d(
     x: Union[ivy.Array, ivy.NativeArray],
     kernel: Union[int, Tuple[int, ...]],
@@ -118,7 +118,7 @@ def max_pool1d(
 @handle_nestable
 @handle_out_argument
 @to_native_arrays_and_back
-@handle_device_shifting
+@handle_device
 def max_unpool1d(
     x: ivy.Union[ivy.Array, ivy.NativeArray],
     indices: Union[ivy.Array, ivy.NativeArray],
@@ -189,7 +189,7 @@ def max_unpool1d(
 @handle_nestable
 @handle_out_argument
 @to_native_arrays_and_back
-@handle_device_shifting
+@handle_device
 def max_pool2d(
     x: Union[ivy.Array, ivy.NativeArray],
     kernel: Union[int, Tuple[int, ...]],
@@ -277,7 +277,7 @@ def max_pool2d(
 @handle_nestable
 @handle_out_argument
 @to_native_arrays_and_back
-@handle_device_shifting
+@handle_device
 def max_pool3d(
     x: Union[ivy.Array, ivy.NativeArray],
     kernel: Union[int, Tuple[int, ...]],
@@ -363,7 +363,7 @@ def max_pool3d(
 @handle_nestable
 @handle_out_argument
 @to_native_arrays_and_back
-@handle_device_shifting
+@handle_device
 def avg_pool1d(
     x: Union[ivy.Array, ivy.NativeArray],
     kernel: Union[int, Tuple[int]],
@@ -446,7 +446,7 @@ def avg_pool1d(
 @handle_nestable
 @handle_out_argument
 @to_native_arrays_and_back
-@handle_device_shifting
+@handle_device
 def avg_pool2d(
     x: Union[ivy.Array, ivy.NativeArray],
     kernel: Union[int, Tuple[int], Tuple[int, int]],
@@ -534,7 +534,7 @@ def avg_pool2d(
 @handle_nestable
 @handle_out_argument
 @to_native_arrays_and_back
-@handle_device_shifting
+@handle_device
 def avg_pool3d(
     x: Union[ivy.Array, ivy.NativeArray],
     kernel: Union[int, Tuple[int], Tuple[int, int, int]],
@@ -701,7 +701,7 @@ def pool(
 @handle_nestable
 @handle_out_argument
 @to_native_arrays_and_back
-@handle_device_shifting
+@handle_device
 def dct(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -925,7 +925,7 @@ def idct(
 idct.mixed_backend_wrappers = {
     "to_add": (
         "handle_backend_invalid",
-        "handle_device_shifting",
+        "handle_device",
     ),
     "to_skip": (),
 }
@@ -937,7 +937,7 @@ idct.mixed_backend_wrappers = {
 @handle_array_like_without_promotion
 @handle_out_argument
 @to_native_arrays_and_back
-@handle_device_shifting
+@handle_device
 def fft(
     x: Union[ivy.Array, ivy.NativeArray],
     dim: int,
@@ -1007,7 +1007,7 @@ def fft(
 @handle_array_like_without_promotion
 @handle_out_argument
 @to_native_arrays_and_back
-@handle_device_shifting
+@handle_device
 def dropout1d(
     x: Union[ivy.Array, ivy.NativeArray],
     prob: float,
@@ -1083,7 +1083,7 @@ def dropout1d(
 @handle_array_like_without_promotion
 @handle_out_argument
 @to_native_arrays_and_back
-@handle_device_shifting
+@handle_device
 def dropout2d(
     x: Union[ivy.Array, ivy.NativeArray],
     prob: float,
@@ -1149,7 +1149,7 @@ def dropout2d(
 @handle_array_like_without_promotion
 @handle_out_argument
 @to_native_arrays_and_back
-@handle_device_shifting
+@handle_device
 def dropout3d(
     x: Union[ivy.Array, ivy.NativeArray],
     prob: float,
@@ -1201,7 +1201,7 @@ def dropout3d(
 @handle_array_like_without_promotion
 @handle_out_argument
 @to_native_arrays_and_back
-@handle_device_shifting
+@handle_device
 def ifft(
     x: Union[ivy.Array, ivy.NativeArray],
     dim: int,
@@ -1270,7 +1270,7 @@ def ifft(
 @handle_array_like_without_promotion
 @handle_out_argument
 @to_native_arrays_and_back
-@handle_device_shifting
+@handle_device
 def embedding(
     weights: Union[ivy.Array, ivy.NativeArray],
     indices: Union[ivy.Array, ivy.NativeArray],
@@ -2053,7 +2053,7 @@ def interpolate(
 interpolate.mixed_backend_wrappers = {
     "to_add": (
         "handle_backend_invalid",
-        "handle_device_shifting",
+        "handle_device",
     ),
     "to_skip": (),
 }
@@ -2248,7 +2248,7 @@ adaptive_max_pool2d.mixed_backend_wrappers = {
         "handle_backend_invalid",
         "inputs_to_native_arrays",
         "outputs_to_ivy_arrays",
-        "handle_device_shifting",
+        "handle_device",
     ),
     "to_skip": ("inputs_to_ivy_arrays",),
 }
@@ -2328,7 +2328,7 @@ adaptive_avg_pool1d.mixed_backend_wrappers = {
         "handle_backend_invalid",
         "inputs_to_native_arrays",
         "outputs_to_ivy_arrays",
-        "handle_device_shifting",
+        "handle_device",
     ),
     "to_skip": ("inputs_to_ivy_arrays",),
 }
@@ -2418,7 +2418,7 @@ adaptive_avg_pool2d.mixed_backend_wrappers = {
         "handle_backend_invalid",
         "inputs_to_native_arrays",
         "outputs_to_ivy_arrays",
-        "handle_device_shifting",
+        "handle_device",
     ),
     "to_skip": ("inputs_to_ivy_arrays",),
 }
@@ -2624,7 +2624,7 @@ reduce_window.mixed_backend_wrappers = {
         "handle_backend_invalid",
         "inputs_to_native_arrays",
         "outputs_to_ivy_arrays",
-        "handle_device_shifting",
+        "handle_device",
     ),
     "to_skip": ("inputs_to_ivy_arrays",),
 }
@@ -2702,7 +2702,7 @@ def fft2(
 
 
 fft2.mixed_backend_wrappers = {
-    "to_add": ("handle_device_shifting",),
+    "to_add": ("handle_device",),
     "to_skip": (),
 }
 

--- a/ivy/functional/ivy/experimental/linear_algebra.py
+++ b/ivy/functional/ivy/experimental/linear_algebra.py
@@ -11,7 +11,7 @@ from ivy.func_wrapper import (
     handle_nestable,
     handle_array_like_without_promotion,
     handle_array_function,
-    handle_device_shifting,
+    handle_device,
     inputs_to_ivy_arrays,
     handle_backend_invalid,
 )
@@ -168,7 +168,7 @@ def eigh_tridiagonal(
 @handle_array_like_without_promotion
 @handle_out_argument
 @to_native_arrays_and_back
-@handle_device_shifting
+@handle_device
 def diagflat(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -235,7 +235,7 @@ def diagflat(
 @handle_array_like_without_promotion
 @handle_out_argument
 @to_native_arrays_and_back
-@handle_device_shifting
+@handle_device
 def kron(
     a: Union[ivy.Array, ivy.NativeArray],
     b: Union[ivy.Array, ivy.NativeArray],
@@ -278,7 +278,7 @@ def kron(
 @handle_array_like_without_promotion
 @handle_out_argument
 @to_native_arrays_and_back
-@handle_device_shifting
+@handle_device
 def matrix_exp(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -321,7 +321,7 @@ def matrix_exp(
 @handle_nestable
 @handle_array_like_without_promotion
 @to_native_arrays_and_back
-@handle_device_shifting
+@handle_device
 def eig(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -385,7 +385,7 @@ def eig(
 @handle_nestable
 @handle_array_like_without_promotion
 @to_native_arrays_and_back
-@handle_device_shifting
+@handle_device
 def eigvals(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -430,7 +430,7 @@ def eigvals(
 @handle_array_like_without_promotion
 @handle_out_argument
 @to_native_arrays_and_back
-@handle_device_shifting
+@handle_device
 def adjoint(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -518,7 +518,7 @@ def multi_dot(
 
 
 multi_dot.mixed_backend_wrappers = {
-    "to_add": ("handle_device_shifting",),
+    "to_add": ("handle_device",),
     "to_skip": (),
 }
 
@@ -529,7 +529,7 @@ multi_dot.mixed_backend_wrappers = {
 @handle_array_like_without_promotion
 @handle_out_argument
 @to_native_arrays_and_back
-@handle_device_shifting
+@handle_device
 def cond(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -578,7 +578,7 @@ def cond(
 @handle_array_like_without_promotion
 @handle_out_argument
 @to_native_arrays_and_back
-@handle_device_shifting
+@handle_device
 def kronecker(
     x: Sequence[Union[ivy.Array, ivy.NativeArray]],
     skip_matrix: Optional[int] = None,
@@ -628,7 +628,7 @@ def kronecker(
 @handle_array_like_without_promotion
 @inputs_to_ivy_arrays
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def khatri_rao(
     x: Sequence[Union[ivy.Array, ivy.NativeArray]],
     weights: Optional[Union[ivy.Array, ivy.NativeArray]] = None,
@@ -731,7 +731,7 @@ def khatri_rao(
 @handle_array_like_without_promotion
 @inputs_to_ivy_arrays
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def mode_dot(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -824,7 +824,7 @@ def mode_dot(
 @handle_array_like_without_promotion
 @inputs_to_ivy_arrays
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def multi_mode_dot(
     x: Union[ivy.Array, ivy.NativeArray],
     mat_or_vec_list: Sequence[Union[ivy.Array, ivy.NativeArray]],
@@ -949,7 +949,7 @@ def _svd_checks(x, n_eigenvecs=None):
 @handle_array_like_without_promotion
 @inputs_to_ivy_arrays
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def svd_flip(
     U: Union[ivy.Array, ivy.NativeArray],
     V: Union[ivy.Array, ivy.NativeArray],
@@ -1019,7 +1019,7 @@ def svd_flip(
 @handle_array_like_without_promotion
 @inputs_to_ivy_arrays
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def make_svd_non_negative(
     x: Union[ivy.Array, ivy.NativeArray],
     U: Union[ivy.Array, ivy.NativeArray],
@@ -1114,7 +1114,7 @@ def make_svd_non_negative(
 @handle_array_like_without_promotion
 @inputs_to_ivy_arrays
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def truncated_svd(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -1204,7 +1204,7 @@ def _svd_interface(
 @handle_array_like_without_promotion
 @inputs_to_ivy_arrays
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def initialize_tucker(
     x: Union[ivy.Array, ivy.NativeArray],
     rank: Sequence[int],
@@ -1317,7 +1317,7 @@ def initialize_tucker(
 @handle_array_like_without_promotion
 @inputs_to_ivy_arrays
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def partial_tucker(
     x: Union[ivy.Array, ivy.NativeArray],
     rank: Optional[Sequence[int]] = None,
@@ -1466,7 +1466,7 @@ def partial_tucker(
 @handle_array_like_without_promotion
 @inputs_to_ivy_arrays
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def tucker(
     x: Union[ivy.Array, ivy.NativeArray],
     rank: Optional[Sequence[int]] = None,
@@ -1673,7 +1673,7 @@ def dot(
 @handle_array_like_without_promotion
 @inputs_to_ivy_arrays
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def general_inner_product(
     a: Union[ivy.Array, ivy.NativeArray],
     b: Union[ivy.Array, ivy.NativeArray],

--- a/ivy/functional/ivy/experimental/manipulation.py
+++ b/ivy/functional/ivy/experimental/manipulation.py
@@ -26,7 +26,7 @@ from ivy.func_wrapper import (
     handle_view,
     inputs_to_ivy_arrays,
     handle_array_function,
-    handle_device_shifting,
+    handle_device,
     handle_backend_invalid,
 )
 from ivy.utils.backend import current_backend
@@ -230,7 +230,7 @@ flatten.mixed_backend_wrappers = {
         "handle_out_argument",
         "inputs_to_native_arrays",
         "outputs_to_ivy_arrays",
-        "handle_device_shifting",
+        "handle_device",
     ),
     "to_skip": ("inputs_to_ivy_arrays", "handle_partial_mixed_function"),
 }
@@ -242,7 +242,7 @@ flatten.mixed_backend_wrappers = {
 @handle_view
 @handle_out_argument
 @to_native_arrays_and_back
-@handle_device_shifting
+@handle_device
 def moveaxis(
     a: Union[ivy.Array, ivy.NativeArray],
     source: Union[int, Sequence[int]],
@@ -294,7 +294,7 @@ def moveaxis(
 @handle_array_like_without_promotion
 @handle_out_argument
 @to_native_arrays_and_back
-@handle_device_shifting
+@handle_device
 def heaviside(
     x1: Union[ivy.Array, ivy.NativeArray],
     x2: Union[ivy.Array, ivy.NativeArray],
@@ -343,7 +343,7 @@ def heaviside(
 @handle_view
 @handle_out_argument
 @to_native_arrays_and_back
-@handle_device_shifting
+@handle_device
 def flipud(
     m: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -388,7 +388,7 @@ def flipud(
 @handle_nestable
 @handle_out_argument
 @to_native_arrays_and_back
-@handle_device_shifting
+@handle_device
 def vstack(
     arrays: Sequence[ivy.Array],
     /,
@@ -433,7 +433,7 @@ def vstack(
 @handle_nestable
 @handle_out_argument
 @to_native_arrays_and_back
-@handle_device_shifting
+@handle_device
 def hstack(
     arrays: Sequence[ivy.Array],
     /,
@@ -477,7 +477,7 @@ def hstack(
 @handle_view
 @handle_out_argument
 @to_native_arrays_and_back
-@handle_device_shifting
+@handle_device
 def rot90(
     m: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -564,7 +564,7 @@ def rot90(
 @handle_array_like_without_promotion
 @handle_out_argument
 @to_native_arrays_and_back
-@handle_device_shifting
+@handle_device
 def top_k(
     x: Union[ivy.Array, ivy.NativeArray],
     k: int,
@@ -646,7 +646,7 @@ def top_k(
 @handle_view
 @handle_out_argument
 @to_native_arrays_and_back
-@handle_device_shifting
+@handle_device
 def fliplr(
     m: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -693,7 +693,7 @@ def fliplr(
 @handle_array_like_without_promotion
 @handle_out_argument
 @to_native_arrays_and_back
-@handle_device_shifting
+@handle_device
 def i0(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -1280,7 +1280,7 @@ pad.mixed_backend_wrappers = {
         "handle_backend_invalid",
         "inputs_to_native_arrays",
         "outputs_to_ivy_arrays",
-        "handle_device_shifting",
+        "handle_device",
     ),
     "to_skip": ("inputs_to_ivy_arrays",),
 }
@@ -1293,7 +1293,7 @@ pad.mixed_backend_wrappers = {
 @handle_view
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def vsplit(
     ary: Union[ivy.Array, ivy.NativeArray],
     indices_or_sections: Union[int, Sequence[int], ivy.Array, ivy.NativeArray],
@@ -1344,7 +1344,7 @@ def vsplit(
 @handle_array_like_without_promotion
 @handle_view
 @to_native_arrays_and_back
-@handle_device_shifting
+@handle_device
 def dsplit(
     ary: Union[ivy.Array, ivy.NativeArray],
     indices_or_sections: Union[int, Sequence[int], ivy.Array, ivy.NativeArray],
@@ -1398,7 +1398,7 @@ def dsplit(
 @handle_array_like_without_promotion
 @handle_view
 @to_native_arrays_and_back
-@handle_device_shifting
+@handle_device
 def atleast_1d(
     *arys: Union[ivy.Array, ivy.NativeArray, bool, Number],
     copy: Optional[bool] = None,
@@ -1441,7 +1441,7 @@ def atleast_1d(
 @handle_nestable
 @handle_out_argument
 @to_native_arrays_and_back
-@handle_device_shifting
+@handle_device
 def dstack(
     arrays: Sequence[ivy.Array],
     /,
@@ -1484,7 +1484,7 @@ def dstack(
 @handle_array_like_without_promotion
 @handle_view
 @to_native_arrays_and_back
-@handle_device_shifting
+@handle_device
 def atleast_2d(
     *arys: Union[ivy.Array, ivy.NativeArray],
     copy: Optional[bool] = None,
@@ -1530,7 +1530,7 @@ def atleast_2d(
 @handle_array_like_without_promotion
 @handle_view
 @to_native_arrays_and_back
-@handle_device_shifting
+@handle_device
 def atleast_3d(
     *arys: Union[ivy.Array, ivy.NativeArray, bool, Number],
     copy: Optional[bool] = None,
@@ -1586,7 +1586,7 @@ def atleast_3d(
 @handle_array_like_without_promotion
 @handle_out_argument
 @to_native_arrays_and_back
-@handle_device_shifting
+@handle_device
 def take_along_axis(
     arr: Union[ivy.Array, ivy.NativeArray],
     indices: Union[ivy.Array, ivy.NativeArray],
@@ -1639,7 +1639,7 @@ def take_along_axis(
 @handle_view
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def hsplit(
     ary: Union[ivy.Array, ivy.NativeArray],
     indices_or_sections: Union[int, Sequence[int], ivy.Array, ivy.NativeArray],
@@ -1727,7 +1727,7 @@ def broadcast_shapes(*shapes: Union[List[int], List[Tuple]]) -> Tuple[int]:
 @handle_out_argument
 @inputs_to_native_shapes
 @to_native_arrays_and_back
-@handle_device_shifting
+@handle_device
 def expand(
     x: Union[ivy.Array, ivy.NativeArray],
     shape: Union[ivy.Shape, ivy.NativeShape],
@@ -1923,7 +1923,7 @@ as_strided.mixed_backend_wrappers = {
         "handle_backend_invalid",
         "inputs_to_native_arrays",
         "outputs_to_ivy_arrays",
-        "handle_device_shifting",
+        "handle_device",
     ),
     "to_skip": ("inputs_to_ivy_arrays",),
 }
@@ -1935,7 +1935,7 @@ as_strided.mixed_backend_wrappers = {
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def concat_from_sequence(
     input_sequence: Union[
         Tuple[Union[ivy.Array, ivy.NativeArray]],
@@ -2129,7 +2129,7 @@ def associative_scan(
 @handle_array_like_without_promotion
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def unique_consecutive(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -2214,7 +2214,7 @@ def fill_diagonal(
 @handle_array_like_without_promotion
 @inputs_to_ivy_arrays
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def unfold(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -2247,7 +2247,7 @@ def unfold(
 @handle_array_like_without_promotion
 @inputs_to_ivy_arrays
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def fold(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -2287,7 +2287,7 @@ def fold(
 @handle_array_like_without_promotion
 @inputs_to_ivy_arrays
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def partial_unfold(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -2345,7 +2345,7 @@ def partial_unfold(
 @handle_array_like_without_promotion
 @inputs_to_ivy_arrays
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def partial_fold(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -2389,7 +2389,7 @@ def partial_fold(
 @handle_array_like_without_promotion
 @inputs_to_ivy_arrays
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def partial_tensor_to_vec(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -2434,7 +2434,7 @@ def partial_tensor_to_vec(
 @handle_array_like_without_promotion
 @inputs_to_ivy_arrays
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def partial_vec_to_tensor(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -2470,7 +2470,7 @@ def partial_vec_to_tensor(
 @handle_array_like_without_promotion
 @inputs_to_ivy_arrays
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def matricize(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -2529,7 +2529,7 @@ def matricize(
 @handle_array_like_without_promotion
 @inputs_to_ivy_arrays
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def soft_thresholding(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -2589,7 +2589,7 @@ def soft_thresholding(
 @handle_array_like_without_promotion
 @handle_out_argument
 @to_native_arrays_and_back
-@handle_device_shifting
+@handle_device
 def choose(
     arr: Union[ivy.Array, ivy.NativeArray],
     choices: Union[ivy.Array, ivy.NativeArray],
@@ -2638,7 +2638,7 @@ def choose(
 @inputs_to_ivy_arrays
 @handle_nestable
 @handle_exceptions
-@handle_device_shifting
+@handle_device
 def column_stack(
     arrays: Sequence[Union[ivy.Array, ivy.NativeArray]],
     /,

--- a/ivy/functional/ivy/experimental/norms.py
+++ b/ivy/functional/ivy/experimental/norms.py
@@ -11,7 +11,7 @@ from ivy.func_wrapper import (
     handle_array_like_without_promotion,
     inputs_to_ivy_arrays,
     handle_array_function,
-    handle_device_shifting,
+    handle_device,
     handle_backend_invalid,
 )
 from ivy.utils.exceptions import handle_exceptions
@@ -22,7 +22,7 @@ from ivy.utils.exceptions import handle_exceptions
 @handle_nestable
 @handle_out_argument
 @to_native_arrays_and_back
-@handle_device_shifting
+@handle_device
 def l1_normalize(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -65,7 +65,7 @@ def l1_normalize(
 @handle_nestable
 @handle_out_argument
 @to_native_arrays_and_back
-@handle_device_shifting
+@handle_device
 def l2_normalize(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -218,7 +218,7 @@ batch_norm.mixed_backend_wrappers = {
         "handle_out_argument",
         "inputs_to_native_arrays",
         "outputs_to_ivy_arrays",
-        "handle_device_shifting",
+        "handle_device",
     ),
     "to_skip": ("inputs_to_ivy_arrays", "handle_partial_mixed_function"),
 }
@@ -350,7 +350,7 @@ instance_norm.mixed_backend_wrappers = {
         "handle_out_argument",
         "inputs_to_native_arrays",
         "outputs_to_ivy_arrays",
-        "handle_device_shifting",
+        "handle_device",
     ),
     "to_skip": ("inputs_to_ivy_arrays", "handle_partial_mixed_function"),
 }
@@ -448,7 +448,7 @@ group_norm.mixed_backend_wrappers = {
 @handle_nestable
 @handle_out_argument
 @to_native_arrays_and_back
-@handle_device_shifting
+@handle_device
 def lp_normalize(
     x: Union[ivy.Array, ivy.NativeArray],
     /,

--- a/ivy/functional/ivy/experimental/random.py
+++ b/ivy/functional/ivy/experimental/random.py
@@ -7,8 +7,7 @@ from ivy.func_wrapper import (
     inputs_to_native_shapes,
     handle_nestable,
     infer_dtype,
-    infer_device,
-    handle_device_shifting,
+    handle_device,
     handle_backend_invalid,
 )
 from ivy.utils.exceptions import handle_exceptions
@@ -20,7 +19,7 @@ from ivy.utils.exceptions import handle_exceptions
 @handle_nestable
 @handle_out_argument
 @to_native_arrays_and_back
-@handle_device_shifting
+@handle_device
 def dirichlet(
     alpha: Union[ivy.Array, ivy.NativeArray, float, Sequence[float]],
     /,
@@ -88,7 +87,7 @@ def dirichlet(
 @handle_out_argument
 @inputs_to_native_shapes
 @to_native_arrays_and_back
-@handle_device_shifting
+@handle_device
 def beta(
     a: Union[float, ivy.NativeArray, ivy.Array],
     b: Union[float, ivy.NativeArray, ivy.Array],
@@ -143,7 +142,7 @@ def beta(
 @handle_out_argument
 @inputs_to_native_shapes
 @to_native_arrays_and_back
-@handle_device_shifting
+@handle_device
 def gamma(
     alpha: Union[float, ivy.NativeArray, ivy.Array],
     beta: Union[float, ivy.NativeArray, ivy.Array],
@@ -195,8 +194,7 @@ def gamma(
 @inputs_to_native_shapes
 @to_native_arrays_and_back
 @infer_dtype
-@handle_device_shifting
-@infer_device
+@handle_device
 def poisson(
     lam: Union[float, ivy.Array, ivy.NativeArray],
     *,
@@ -267,8 +265,7 @@ def poisson(
 @inputs_to_native_shapes
 @to_native_arrays_and_back
 @infer_dtype
-@handle_device_shifting
-@infer_device
+@handle_device
 def bernoulli(
     probs: Union[float, ivy.Array, ivy.NativeArray],
     *,

--- a/ivy/functional/ivy/experimental/searching.py
+++ b/ivy/functional/ivy/experimental/searching.py
@@ -4,7 +4,7 @@ from ivy.func_wrapper import (
     handle_out_argument,
     to_native_arrays_and_back,
     handle_nestable,
-    handle_device_shifting,
+    handle_device,
     handle_backend_invalid,
 )
 from ivy.utils.exceptions import handle_exceptions
@@ -15,7 +15,7 @@ from ivy.utils.exceptions import handle_exceptions
 @handle_nestable
 @handle_out_argument
 @to_native_arrays_and_back
-@handle_device_shifting
+@handle_device
 def unravel_index(
     indices: Union[ivy.Array, ivy.NativeArray],
     shape: Tuple[int],

--- a/ivy/functional/ivy/experimental/sorting.py
+++ b/ivy/functional/ivy/experimental/sorting.py
@@ -7,7 +7,7 @@ from ivy.func_wrapper import (
     to_native_arrays_and_back,
     handle_out_argument,
     handle_nestable,
-    handle_device_shifting,
+    handle_device,
     handle_backend_invalid,
 )
 from ivy.utils.exceptions import handle_exceptions
@@ -17,7 +17,7 @@ from ivy.utils.exceptions import handle_exceptions
 @handle_backend_invalid
 @handle_nestable
 @to_native_arrays_and_back
-@handle_device_shifting
+@handle_device
 def invert_permutation(
     x: Union[ivy.Array, ivy.NativeArray, list, tuple],
     /,
@@ -54,7 +54,7 @@ def invert_permutation(
 @handle_nestable
 @handle_out_argument
 @to_native_arrays_and_back
-@handle_device_shifting
+@handle_device
 def lexsort(
     keys: Union[ivy.Array, ivy.NativeArray],
     /,

--- a/ivy/functional/ivy/experimental/statistical.py
+++ b/ivy/functional/ivy/experimental/statistical.py
@@ -7,7 +7,7 @@ from ivy.func_wrapper import (
     handle_array_like_without_promotion,
     handle_nestable,
     infer_dtype,
-    handle_device_shifting,
+    handle_device,
     handle_backend_invalid,
 )
 from ivy.utils.exceptions import handle_exceptions
@@ -23,7 +23,7 @@ from ivy.utils.exceptions import handle_exceptions
 @handle_nestable
 @handle_out_argument
 @to_native_arrays_and_back
-@handle_device_shifting
+@handle_device
 def histogram(
     a: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -156,7 +156,7 @@ def histogram(
 @handle_nestable
 @handle_out_argument
 @to_native_arrays_and_back
-@handle_device_shifting
+@handle_device
 def median(
     input: ivy.Array,
     /,
@@ -203,7 +203,7 @@ def median(
 @handle_out_argument
 @to_native_arrays_and_back
 @infer_dtype
-@handle_device_shifting
+@handle_device
 def nanmean(
     a: ivy.Array,
     /,
@@ -259,7 +259,7 @@ def nanmean(
 @handle_out_argument
 @to_native_arrays_and_back
 @infer_dtype
-@handle_device_shifting
+@handle_device
 def nanprod(
     a: ivy.Array,
     /,
@@ -326,7 +326,7 @@ def nanprod(
 @handle_nestable
 @handle_out_argument
 @to_native_arrays_and_back
-@handle_device_shifting
+@handle_device
 def quantile(
     a: ivy.Array,
     q: Union[ivy.Array, float],
@@ -413,7 +413,7 @@ def quantile(
 @handle_nestable
 @handle_out_argument
 @to_native_arrays_and_back
-@handle_device_shifting
+@handle_device
 def corrcoef(
     x: ivy.Array,
     /,
@@ -430,7 +430,7 @@ def corrcoef(
 @handle_nestable
 @handle_out_argument
 @to_native_arrays_and_back
-@handle_device_shifting
+@handle_device
 def nanmedian(
     input: ivy.Array,
     /,
@@ -503,7 +503,7 @@ def nanmedian(
 @handle_nestable
 @handle_out_argument
 @to_native_arrays_and_back
-@handle_device_shifting
+@handle_device
 def bincount(
     x: ivy.Array,
     /,
@@ -547,7 +547,7 @@ def bincount(
 @handle_nestable
 @handle_out_argument
 @to_native_arrays_and_back
-@handle_device_shifting
+@handle_device
 def igamma(
     a: Union[ivy.Array, ivy.NativeArray],
     /,

--- a/ivy/functional/ivy/general.py
+++ b/ivy/functional/ivy/general.py
@@ -38,7 +38,7 @@ from ivy.func_wrapper import (
     handle_nestable,
     handle_array_like_without_promotion,
     handle_view_indexing,
-    handle_device_shifting,
+    handle_device,
     handle_partial_mixed_function,
     handle_backend_invalid,
 )
@@ -189,7 +189,8 @@ def get_referrers_recursive(
     """
     Recursively retrieve referrers for an object.
 
-    This function recursively fetches referrers for the specified `item` up to a given `max_depth`.
+    This function recursively fetches referrers for the specified `item`
+    up to a given `max_depth`.
 
     Parameters
     ----------
@@ -207,7 +208,8 @@ def get_referrers_recursive(
     Returns
     -------
     ivy.Container
-        A container representing referrers and their sub-referrers, respecting the `max_depth`.
+        A container representing referrers and their sub-referrers,
+        respecting the `max_depth`.
 
     Examples
     --------
@@ -641,7 +643,7 @@ def unset_show_func_wrapper_trace_mode() -> None:
 @handle_array_like_without_promotion
 @inputs_to_native_arrays
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def array_equal(
     x0: Union[ivy.Array, ivy.NativeArray],
     x1: Union[ivy.Array, ivy.NativeArray],
@@ -782,7 +784,7 @@ def all_equal(
 @handle_array_like_without_promotion
 @inputs_to_native_arrays
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def to_numpy(
     x: Union[ivy.Array, ivy.NativeArray], /, *, copy: bool = True
 ) -> np.ndarray:
@@ -855,7 +857,7 @@ def isscalar(x: Any, /) -> bool:
 @handle_array_like_without_promotion
 @inputs_to_native_arrays
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def to_scalar(x: Union[ivy.Array, ivy.NativeArray], /) -> Number:
     """
     Convert an array with a single element into a scalar.
@@ -912,7 +914,7 @@ def to_scalar(x: Union[ivy.Array, ivy.NativeArray], /) -> Number:
 @handle_array_like_without_promotion
 @inputs_to_native_arrays
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def to_list(x: Union[ivy.Array, ivy.NativeArray], /) -> List:
     """
     Create a (possibly nested) list from input array.
@@ -2777,7 +2779,7 @@ def assert_supports_inplace(x: Union[ivy.Array, ivy.NativeArray], /) -> bool:
 @handle_view_indexing
 @inputs_to_ivy_arrays
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def get_item(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -2974,7 +2976,7 @@ def _broadcast_to(input, target_shape):
 @handle_nestable
 @inputs_to_ivy_arrays
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def inplace_update(
     x: Union[ivy.Array, ivy.NativeArray],
     val: Union[ivy.Array, ivy.NativeArray],
@@ -3154,7 +3156,7 @@ def unset_inplace_mode() -> None:
 @handle_nestable
 @inputs_to_ivy_arrays
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def inplace_decrement(
     x: Union[ivy.Array, ivy.NativeArray],
     val: Union[ivy.Array, ivy.NativeArray],
@@ -3226,7 +3228,7 @@ def inplace_decrement(
 @handle_nestable
 @inputs_to_ivy_arrays
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def inplace_increment(
     x: Union[ivy.Array, ivy.NativeArray],
     val: Union[ivy.Array, ivy.NativeArray],
@@ -3286,7 +3288,7 @@ def inplace_increment(
 @handle_array_like_without_promotion
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def scatter_flat(
     indices: Union[ivy.Array, ivy.NativeArray],
     updates: Union[ivy.Array, ivy.NativeArray],
@@ -3376,7 +3378,7 @@ def scatter_flat(
 @inputs_to_native_shapes
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def scatter_nd(
     indices: Union[ivy.Array, ivy.NativeArray],
     updates: Union[ivy.Array, ivy.NativeArray],
@@ -3461,7 +3463,7 @@ def scatter_nd(
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def gather(
     params: Union[ivy.Array, ivy.NativeArray],
     indices: Union[ivy.Array, ivy.NativeArray],
@@ -3572,7 +3574,7 @@ def gather(
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def gather_nd(
     params: Union[ivy.Array, ivy.NativeArray],
     indices: Union[ivy.Array, ivy.NativeArray],
@@ -3674,7 +3676,7 @@ def multiprocessing(context: Optional[str] = None):
 @outputs_to_ivy_shapes
 @outputs_to_ivy_arrays
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def shape(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -3767,7 +3769,7 @@ def unset_shape_array_mode() -> None:
 @handle_array_like_without_promotion
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def get_num_dims(
     x: Union[ivy.Array, ivy.NativeArray], /, *, as_array: bool = False
 ) -> int:
@@ -4152,7 +4154,7 @@ def vmap(
 @handle_backend_invalid
 @handle_nestable
 @to_native_arrays_and_back
-@handle_device_shifting
+@handle_device
 def isin(
     elements: Union[ivy.Array, ivy.NativeArray],
     test_elements: Union[ivy.Array, ivy.NativeArray],
@@ -4204,7 +4206,7 @@ def isin(
 @handle_backend_invalid
 @handle_nestable
 @inputs_to_native_arrays
-@handle_device_shifting
+@handle_device
 def itemsize(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -4237,7 +4239,7 @@ def itemsize(
 
 @handle_exceptions
 @handle_nestable
-@handle_device_shifting
+@handle_device
 def strides(
     x: Union[ivy.Array, ivy.NativeArray],
     /,

--- a/ivy/functional/ivy/gradients.py
+++ b/ivy/functional/ivy/gradients.py
@@ -16,7 +16,7 @@ from ivy.func_wrapper import (
     handle_out_argument,
     handle_nestable,
     handle_array_like_without_promotion,
-    handle_device_shifting,
+    handle_device,
     handle_backend_invalid,
 )
 from ivy.utils.exceptions import handle_exceptions
@@ -325,7 +325,7 @@ def _variable_data(
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def stop_gradient(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -400,7 +400,7 @@ def stop_gradient(
 
 
 @handle_exceptions
-@handle_device_shifting
+@handle_device
 def execute_with_gradients(
     func,
     xs: Union[ivy.Array, ivy.NativeArray],

--- a/ivy/functional/ivy/layers.py
+++ b/ivy/functional/ivy/layers.py
@@ -15,7 +15,7 @@ from ivy.func_wrapper import (
     handle_out_argument,
     handle_nestable,
     handle_array_like_without_promotion,
-    handle_device_shifting,
+    handle_device,
     handle_backend_invalid,
 )
 from ivy.utils.exceptions import handle_exceptions
@@ -224,7 +224,7 @@ linear.mixed_backend_wrappers = {
         "handle_out_argument",
         "inputs_to_native_arrays",
         "outputs_to_ivy_arrays",
-        "handle_device_shifting",
+        "handle_device",
     ),
     "to_skip": ("inputs_to_ivy_arrays", "handle_partial_mixed_function"),
 }
@@ -411,7 +411,7 @@ dropout.mixed_backend_wrappers = {
         "handle_out_argument",
         "inputs_to_native_arrays",
         "outputs_to_ivy_arrays",
-        "handle_device_shifting",
+        "handle_device",
     ),
     "to_skip": ("inputs_to_ivy_arrays", "handle_partial_mixed_function"),
 }
@@ -891,7 +891,7 @@ def multi_head_attention(
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def conv1d(
     x: Union[ivy.Array, ivy.NativeArray],
     filters: Union[ivy.Array, ivy.NativeArray],
@@ -1002,7 +1002,7 @@ def conv1d(
 @inputs_to_native_shapes
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def conv1d_transpose(
     x: Union[ivy.Array, ivy.NativeArray],
     filters: Union[ivy.Array, ivy.NativeArray],
@@ -1147,7 +1147,7 @@ def conv1d_transpose(
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def conv2d(
     x: Union[ivy.Array, ivy.NativeArray],
     filters: Union[ivy.Array, ivy.NativeArray],
@@ -1288,7 +1288,7 @@ def conv2d(
 @inputs_to_native_shapes
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def conv2d_transpose(
     x: Union[ivy.Array, ivy.NativeArray],
     filters: Union[ivy.Array, ivy.NativeArray],
@@ -1426,7 +1426,7 @@ def conv2d_transpose(
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def depthwise_conv2d(
     x: Union[ivy.Array, ivy.NativeArray],
     filters: Union[ivy.Array, ivy.NativeArray],
@@ -1565,7 +1565,7 @@ def depthwise_conv2d(
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def conv3d(
     x: Union[ivy.Array, ivy.NativeArray, ivy.Container],
     filters: Union[ivy.Array, ivy.NativeArray, ivy.Container],
@@ -1687,7 +1687,7 @@ def conv3d(
 @inputs_to_native_shapes
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def conv3d_transpose(
     x: Union[ivy.Array, ivy.NativeArray],
     filters: Union[ivy.Array, ivy.NativeArray],
@@ -1825,7 +1825,7 @@ def conv3d_transpose(
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def conv_general_dilated(
     x: Union[ivy.Array, ivy.NativeArray],
     filters: Union[ivy.Array, ivy.NativeArray],
@@ -1910,7 +1910,7 @@ def conv_general_dilated(
 @inputs_to_native_shapes
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def conv_general_transpose(
     x: Union[ivy.Array, ivy.NativeArray],
     filters: Union[ivy.Array, ivy.NativeArray],

--- a/ivy/functional/ivy/linear_algebra.py
+++ b/ivy/functional/ivy/linear_algebra.py
@@ -10,7 +10,7 @@ from ivy.func_wrapper import (
     handle_out_argument,
     handle_nestable,
     handle_array_like_without_promotion,
-    handle_device_shifting,
+    handle_device,
     handle_backend_invalid,
 )
 from ivy.utils.exceptions import handle_exceptions
@@ -30,7 +30,7 @@ inf = float("inf")
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def cholesky(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -170,7 +170,7 @@ def cholesky(
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def cross(
     x1: Union[ivy.Array, ivy.NativeArray],
     x2: Union[ivy.Array, ivy.NativeArray],
@@ -278,7 +278,7 @@ def cross(
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def det(
     x: Union[ivy.Array, ivy.NativeArray], /, *, out: Optional[ivy.Array] = None
 ) -> ivy.Array:
@@ -352,7 +352,7 @@ def det(
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def diagonal(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -532,7 +532,7 @@ def diagonal(
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def eig(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -585,7 +585,7 @@ def eig(
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def eigh(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -656,7 +656,7 @@ def eigh(
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def eigvalsh(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -764,7 +764,7 @@ def eigvalsh(
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def inner(
     x1: Union[ivy.Array, ivy.NativeArray],
     x2: Union[ivy.Array, ivy.NativeArray],
@@ -843,7 +843,7 @@ def inner(
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def inv(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -937,7 +937,7 @@ def inv(
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def matmul(
     x1: Union[ivy.Array, ivy.NativeArray],
     x2: Union[ivy.Array, ivy.NativeArray],
@@ -1100,7 +1100,7 @@ def matmul(
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def matrix_norm(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -1262,7 +1262,7 @@ def matrix_norm(
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def matrix_power(
     x: Union[ivy.Array, ivy.NativeArray], n: int, /, *, out: Optional[ivy.Array] = None
 ) -> ivy.Array:
@@ -1363,7 +1363,7 @@ def matrix_power(
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def matrix_rank(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -1479,7 +1479,7 @@ def matrix_rank(
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def matrix_transpose(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -1569,7 +1569,7 @@ def matrix_transpose(
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def outer(
     x1: Union[ivy.Array, ivy.NativeArray],
     x2: Union[ivy.Array, ivy.NativeArray],
@@ -1660,7 +1660,7 @@ def outer(
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def pinv(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -1736,7 +1736,7 @@ def pinv(
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def qr(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -1801,7 +1801,7 @@ def qr(
 @handle_array_like_without_promotion
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def slogdet(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -1909,7 +1909,7 @@ def slogdet(
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def solve(
     x1: Union[ivy.Array, ivy.NativeArray],
     x2: Union[ivy.Array, ivy.NativeArray],
@@ -1965,7 +1965,7 @@ def solve(
 @handle_array_like_without_promotion
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def svd(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -2097,7 +2097,7 @@ def svd(
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def svdvals(
     x: Union[ivy.Array, ivy.NativeArray], /, *, out: Optional[ivy.Array] = None
 ) -> ivy.Array:
@@ -2231,7 +2231,7 @@ def svdvals(
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def tensordot(
     x1: Union[ivy.Array, ivy.NativeArray],
     x2: Union[ivy.Array, ivy.NativeArray],
@@ -2322,7 +2322,7 @@ def tensordot(
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def trace(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -2449,7 +2449,7 @@ def trace(
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def vecdot(
     x1: Union[ivy.Array, ivy.NativeArray],
     x2: Union[ivy.Array, ivy.NativeArray],
@@ -2519,7 +2519,7 @@ def vecdot(
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def vector_norm(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -2668,7 +2668,7 @@ def vector_norm(
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def diag(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -2752,7 +2752,7 @@ def diag(
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def vander(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -2826,7 +2826,7 @@ def vander(
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def vector_to_skew_symmetric_matrix(
     vector: Union[ivy.Array, ivy.NativeArray], /, *, out: Optional[ivy.Array] = None
 ) -> ivy.Array:
@@ -2861,7 +2861,7 @@ def vector_to_skew_symmetric_matrix(
 @handle_array_like_without_promotion
 @handle_out_argument
 @to_native_arrays_and_back
-@handle_device_shifting
+@handle_device
 def lu_factor(
     A: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -2896,7 +2896,7 @@ def lu_factor(
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def tensorsolve(
     x1: Union[ivy.Array, ivy.NativeArray],
     x2: Union[ivy.Array, ivy.NativeArray],

--- a/ivy/functional/ivy/manipulation.py
+++ b/ivy/functional/ivy/manipulation.py
@@ -14,7 +14,7 @@ from ivy.func_wrapper import (
     handle_nestable,
     handle_array_like_without_promotion,
     handle_view,
-    handle_device_shifting,
+    handle_device,
     handle_backend_invalid,
 )
 from ivy.utils.exceptions import handle_exceptions
@@ -43,7 +43,7 @@ def _calculate_out_shape(axis, array_shape):
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def concat(
     xs: Union[
         Tuple[Union[ivy.Array, ivy.NativeArray], ...],
@@ -105,7 +105,7 @@ def concat(
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def expand_dims(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -243,7 +243,7 @@ def expand_dims(
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def flip(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -338,7 +338,7 @@ def flip(
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def permute_dims(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -439,7 +439,7 @@ def permute_dims(
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def reshape(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -565,7 +565,7 @@ def reshape(
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def roll(
     x: Union[ivy.Array, ivy.NativeArray, ivy.Container],
     /,
@@ -679,7 +679,7 @@ def roll(
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def squeeze(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -770,7 +770,7 @@ def squeeze(
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def stack(
     arrays: Union[
         Tuple[Union[ivy.Array, ivy.NativeArray], ...],
@@ -860,7 +860,7 @@ def stack(
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def clip(
     x: Union[ivy.Array, ivy.NativeArray],
     x_min: Union[Number, ivy.Array, ivy.NativeArray],
@@ -988,7 +988,7 @@ def clip(
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def constant_pad(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -1085,7 +1085,7 @@ def constant_pad(
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def repeat(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -1158,7 +1158,7 @@ def repeat(
 @handle_view
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def split(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -1246,7 +1246,7 @@ def split(
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def swapaxes(
     x: Union[ivy.Array, ivy.NativeArray],
     axis0: int,
@@ -1356,7 +1356,7 @@ def swapaxes(
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def tile(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -1438,7 +1438,7 @@ def tile(
 @handle_view
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def unstack(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -1534,7 +1534,7 @@ def unstack(
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def zero_pad(
     x: Union[ivy.Array, ivy.NativeArray],
     /,

--- a/ivy/functional/ivy/norms.py
+++ b/ivy/functional/ivy/norms.py
@@ -146,7 +146,7 @@ layer_norm.mixed_backend_wrappers = {
         "handle_out_argument",
         "inputs_to_native_arrays",
         "outputs_to_ivy_arrays",
-        "handle_device_shifting",
+        "handle_device",
     ),
     "to_skip": ("inputs_to_ivy_arrays",),
 }

--- a/ivy/functional/ivy/random.py
+++ b/ivy/functional/ivy/random.py
@@ -8,12 +8,11 @@ import ivy
 from ivy.func_wrapper import (
     handle_array_function,
     infer_dtype,
-    infer_device,
     handle_out_argument,
     to_native_arrays_and_back,
     inputs_to_native_shapes,
     handle_nestable,
-    handle_device_shifting,
+    handle_device,
     handle_backend_invalid,
 )
 from ivy.utils.backend import backend_stack
@@ -96,8 +95,7 @@ def _check_shapes_broadcastable(out, inp):
 @to_native_arrays_and_back
 @handle_array_function
 @infer_dtype
-@handle_device_shifting
-@infer_device
+@handle_device
 def random_uniform(
     *,
     low: Union[float, ivy.NativeArray, ivy.Array] = 0.0,
@@ -213,8 +211,7 @@ def random_uniform(
 @to_native_arrays_and_back
 @handle_array_function
 @infer_dtype
-@handle_device_shifting
-@infer_device
+@handle_device
 def random_normal(
     *,
     mean: Union[float, ivy.NativeArray, ivy.Array] = 0.0,
@@ -324,8 +321,7 @@ def random_normal(
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
-@infer_device
+@handle_device
 def multinomial(
     population_size: int,
     num_samples: int,
@@ -436,8 +432,7 @@ def multinomial(
 @inputs_to_native_shapes
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
-@infer_device
+@handle_device
 def randint(
     low: Union[int, ivy.NativeArray, ivy.Array],
     high: Union[int, ivy.NativeArray, ivy.Array],
@@ -535,7 +530,7 @@ def seed(*, seed_value: int = 0) -> None:
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def shuffle(
     x: Union[ivy.Array, ivy.NativeArray],
     axis: Optional[int] = 0,

--- a/ivy/functional/ivy/searching.py
+++ b/ivy/functional/ivy/searching.py
@@ -12,7 +12,7 @@ from ivy.func_wrapper import (
     handle_out_argument,
     handle_nestable,
     handle_array_like_without_promotion,
-    handle_device_shifting,
+    handle_device,
     handle_backend_invalid,
 )
 
@@ -28,7 +28,7 @@ from ivy.func_wrapper import (
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def argmax(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -145,7 +145,7 @@ def argmax(
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def argmin(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -255,7 +255,7 @@ def argmin(
 @handle_array_like_without_promotion
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def nonzero(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -392,7 +392,7 @@ def nonzero(
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def where(
     condition: Union[ivy.Array, ivy.NativeArray],
     x1: Union[ivy.Array, ivy.NativeArray],
@@ -478,7 +478,7 @@ def where(
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def argwhere(
     x: Union[ivy.Array, ivy.NativeArray],
     /,

--- a/ivy/functional/ivy/set.py
+++ b/ivy/functional/ivy/set.py
@@ -9,7 +9,7 @@ from ivy.func_wrapper import (
     handle_out_argument,
     handle_nestable,
     handle_array_like_without_promotion,
-    handle_device_shifting,
+    handle_device,
     handle_backend_invalid,
 )
 from ivy.utils.exceptions import handle_exceptions
@@ -25,7 +25,7 @@ from ivy.utils.exceptions import handle_exceptions
 @handle_array_like_without_promotion
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def unique_all(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -154,7 +154,7 @@ def unique_all(
 @handle_array_like_without_promotion
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def unique_inverse(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -263,7 +263,7 @@ def unique_inverse(
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def unique_values(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -356,7 +356,7 @@ def unique_values(
 @handle_array_like_without_promotion
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def unique_counts(
     x: Union[ivy.Array, ivy.NativeArray],
     /,

--- a/ivy/functional/ivy/sorting.py
+++ b/ivy/functional/ivy/sorting.py
@@ -9,7 +9,7 @@ from ivy.func_wrapper import (
     handle_out_argument,
     handle_nestable,
     handle_array_like_without_promotion,
-    handle_device_shifting,
+    handle_device,
     handle_backend_invalid,
 )
 from ivy.utils.exceptions import handle_exceptions
@@ -26,7 +26,7 @@ from ivy.utils.exceptions import handle_exceptions
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def argsort(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -147,7 +147,7 @@ def argsort(
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def sort(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -252,7 +252,7 @@ def sort(
 @handle_nestable
 @handle_out_argument
 @to_native_arrays_and_back
-@handle_device_shifting
+@handle_device
 def msort(
     a: Union[ivy.Array, ivy.NativeArray, list, tuple],
     /,
@@ -297,7 +297,7 @@ def msort(
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def searchsorted(
     x: Union[ivy.Array, ivy.NativeArray],
     v: Union[ivy.Array, ivy.NativeArray],

--- a/ivy/functional/ivy/statistical.py
+++ b/ivy/functional/ivy/statistical.py
@@ -10,7 +10,7 @@ from ivy.func_wrapper import (
     handle_out_argument,
     handle_nestable,
     handle_array_like_without_promotion,
-    handle_device_shifting,
+    handle_device,
     handle_backend_invalid,
 )
 from ivy.utils.exceptions import handle_exceptions
@@ -41,7 +41,7 @@ def _get_promoted_type_of_operands(operands):
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def min(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -150,7 +150,7 @@ def min(
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def max(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -261,7 +261,7 @@ def max(
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def mean(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -373,7 +373,7 @@ def mean(
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def prod(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -509,7 +509,7 @@ def prod(
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def std(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -648,7 +648,7 @@ def std(
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def sum(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -789,7 +789,7 @@ def sum(
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def var(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -906,7 +906,7 @@ def var(
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def cumsum(
     x: Union[ivy.Array, ivy.NativeArray],
     axis: int = 0,
@@ -1051,7 +1051,7 @@ def cumsum(
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def cumprod(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
@@ -1189,7 +1189,7 @@ def cumprod(
 @handle_out_argument
 @to_native_arrays_and_back
 @handle_array_function
-@handle_device_shifting
+@handle_device
 def einsum(
     equation: str,
     *operands: Union[ivy.Array, ivy.NativeArray],


### PR DESCRIPTION
<!--
This template will help you to have a meaningful PR, please follow it and do not leave it blank.
-->

# Replaced `handle_device_shifting` with `handle_device` and also removed the `infer_device` decorators where `handle_device` was present.

<!--
If there is no related issue, please add a short description about your PR.
-->

## [Related Issue](https://trello.com/c/9wR0CDCh/2700-remove-inferdevice-and-rename-handledeviceshifting-decorator)

