### PR TITLE
fix(paddle_frontend): reinstate `repeat_interleave`  at `manipulation.py` after namespace fix.

### DIFF
--- a/ivy/functional/frontends/paddle/manipulation.py
+++ b/ivy/functional/frontends/paddle/manipulation.py
@@ -78,6 +78,11 @@ def gather(params, indices, axis=-1, batch_dims=0, name=None):
 
 
 @to_ivy_arrays_and_back
+def repeat_interleave(x, repeats, axis=None, name=None):
+    return ivy.repeat(x, repeats, axis=axis)
+
+
+@to_ivy_arrays_and_back
 def reshape(x, shape):
     return ivy.reshape(x, shape)
 


### PR DESCRIPTION
# PR Description

During the application of the `fix(frontend-paddle): Corrects namespace issues` commit, the `repeat_interleave` functionality, initially added via PR 23139, appears to have been unintentionally removed.
This led to test errors at `ivy_tests/test_ivy/test_frontends/test_paddle/test_manipulation.py`. This commit ensures that `repeat_interleave` is correctly re-integrated into the `paddle_frontend`.







## Related Issue
Close #23441 


