### PR TITLE
Fix: repeate_interleave key error

### DIFF
--- a/ivy/functional/frontends/paddle/manipulation.py
+++ b/ivy/functional/frontends/paddle/manipulation.py
@@ -77,6 +77,15 @@ def gather(params, indices, axis=-1, batch_dims=0, name=None):
     return ivy.gather(params, indices, axis=axis, batch_dims=batch_dims)
 
 
+@with_supported_dtypes(
+    {"2.5.1 and below": ("int32", "int64", "float32", "float64")},
+    "paddle",
+)
+@to_ivy_arrays_and_back
+def repeat_interleave(x, repeats, axis=None, name=None):
+    return ivy.repeat(x, repeats, axis=axis)
+
+
 @to_ivy_arrays_and_back
 def reshape(x, shape):
     return ivy.reshape(x, shape)


### PR DESCRIPTION
<!--
This template will help you to have a meaningful PR, please follow it and do not leave it blank.
-->

# PR Description
Seems the repeat_interleave function got missed out in this `fix(frontend-paddle): Corrects namespace issues` [commit](https://github.com/unifyai/ivy/commit/9e62a00942dd3dfadc23791060bd9df8a7611e2d)
This PR fixes the  repeate_interleave key error.  
<!--
If there is no related issue, please add a short description about your PR.
-->

## Related Issue

<!--
Please use this format to link other issues with their numbers: Close #123
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Close #23441 

## Checklist

- [x] Did you add a function?
- [x] Did you add the tests?
- [x] Did you follow the steps we provided?

### Socials: https://twitter.com/coder_dhanush

<!--
-->
