### PR TITLE
control_flow_ops refactor

### DIFF
--- a/ivy/functional/backends/jax/control_flow_ops.py
+++ b/ivy/functional/backends/jax/control_flow_ops.py
@@ -2,8 +2,10 @@ import jax
 
 
 def if_else(cond, body_fn, orelse_fn, vars):
+    cond_vars = list(vars.values())
+    pred = cond(**vars)
     with jax.disable_jit():
-        final_vars = jax.lax.cond(cond, body_fn, orelse_fn, *vars)
+        final_vars = jax.lax.cond(pred, body_fn, orelse_fn, *cond_vars)
     return final_vars
 
 
@@ -14,6 +16,7 @@ def while_loop(test_fn, body_fn, vars):
     def test_fn_wrapper(loop_vars):
         return test_fn(*loop_vars)
 
+    vars = list(vars.values())
     with jax.disable_jit():
         final_loop_vars = jax.lax.while_loop(test_fn_wrapper, body_fn_wrapper, vars)
     return final_loop_vars

--- a/ivy/functional/backends/numpy/control_flow_ops.py
+++ b/ivy/functional/backends/numpy/control_flow_ops.py
@@ -1,23 +1,17 @@
-# def if_exp(cond, if_true, if_false):
-#   return if_true() if cond else if_false()
-
-
 def if_else(cond, body_fn, orelse_fn, vars):
     # back-compatibility
-    if not callable(cond):
-        cond = bool(cond)
     if isinstance(cond, bool):
         v = cond
         cond = lambda *_: v
-    cond = cond(*vars)
+    cond = cond(**vars)
     if cond:
-        return body_fn(*vars)
+        return body_fn(**vars)
     else:
-        return orelse_fn(*vars)
+        return orelse_fn(**vars)
 
 
 def while_loop(test_fn, body_fn, vars):
-    result = vars
+    result = list(vars.values())
     while test_fn(*result):
         result = body_fn(*result)
         if not isinstance(result, tuple):

--- a/ivy/functional/backends/tensorflow/control_flow_ops.py
+++ b/ivy/functional/backends/tensorflow/control_flow_ops.py
@@ -1,29 +1,15 @@
 import tensorflow as tf
 
-# def if_exp(cond, if_true, if_false, expr_repr):
-#   def true_fn():
-#     return if_true()
-#
-#   def false_fn():
-#     return if_false()
-#
-#   return tf.cond(cond, true_fn, false_fn)
-
 
 def if_else(cond, body_fn, orelse_fn, vars):
     # back-compatibility
     if isinstance(cond, bool):
         v = cond
         cond = lambda *_: v
-    cond = bool(cond(*vars))
-    # return tf.cond(cond, lambda: body_fn(*vars), lambda: orelse_fn(*vars))
+    cond = bool(cond(**vars))
+    return tf.cond(cond, lambda: body_fn(**vars), lambda: orelse_fn(**vars))
 
     # use pythonic placeholder until the graph compiler supports callable arguments
-
-    if cond:
-        return body_fn(*vars)
-    else:
-        return orelse_fn(*vars)
 
 
 def while_loop(test_fn, body_fn, vars):
@@ -35,7 +21,8 @@ def while_loop(test_fn, body_fn, vars):
 
     if not vars:
         vars = (0,)
-
+    else:
+        vars = list(vars.values())
     return tf.while_loop(test_fn_wrapper, body_fn_wrapper, loop_vars=vars)
 
 

--- a/ivy/functional/backends/torch/control_flow_ops.py
+++ b/ivy/functional/backends/torch/control_flow_ops.py
@@ -1,24 +1,20 @@
-# def if_exp(cond, if_true, if_false):
-#   return if_true() if cond else if_false()
-
-
 def if_else(cond, body_fn, orelse_fn, vars):
     # back-compatibility
     if isinstance(cond, bool):
         v = cond
         cond = lambda *_: v
     if callable(cond):
-        cond = cond(*vars)
+        cond = cond(**vars)
     else:
         cond = bool(cond)
     if cond:
-        return body_fn(*vars)
+        return body_fn(**vars)
     else:
-        return orelse_fn(*vars)
+        return orelse_fn(**vars)
 
 
 def while_loop(test_fn, body_fn, vars):
-    result = vars
+    result = list(vars.values())
     while test_fn(*result):
         result = body_fn(*result)
         if not isinstance(result, tuple):

--- a/ivy/functional/frontends/torch/utilities.py
+++ b/ivy/functional/frontends/torch/utilities.py
@@ -1,7 +1,7 @@
 import ivy
 from ivy.functional.frontends.torch.func_wrapper import to_ivy_arrays_and_back
 from ivy.func_wrapper import with_supported_dtypes
-
+import inspect
 
 # --- Helpers --- #
 # --------------- #
@@ -28,3 +28,8 @@ def bincount(x, weights=None, minlength=0):
 @to_ivy_arrays_and_back
 def result_type(tensor, other):
     return ivy.result_type(tensor, other)
+
+def if_else(cond_fn, body_fn, orelse_fn, vars):
+    cond_keys = inspect.getargspec(cond_fn).args
+    cond_vars = dict(zip(cond_keys, vars))
+    return ivy.if_else(cond_fn, body_fn, orelse_fn, cond_vars)

--- a/ivy/functional/frontends/torch/utilities.py
+++ b/ivy/functional/frontends/torch/utilities.py
@@ -3,6 +3,7 @@ from ivy.functional.frontends.torch.func_wrapper import to_ivy_arrays_and_back
 from ivy.func_wrapper import with_supported_dtypes
 import inspect
 
+
 # --- Helpers --- #
 # --------------- #
 
@@ -25,11 +26,12 @@ def bincount(x, weights=None, minlength=0):
     return ivy.bincount(x, weights=weights, minlength=minlength)
 
 
-@to_ivy_arrays_and_back
-def result_type(tensor, other):
-    return ivy.result_type(tensor, other)
-
 def if_else(cond_fn, body_fn, orelse_fn, vars):
     cond_keys = inspect.getargspec(cond_fn).args
     cond_vars = dict(zip(cond_keys, vars))
     return ivy.if_else(cond_fn, body_fn, orelse_fn, cond_vars)
+
+
+@to_ivy_arrays_and_back
+def result_type(tensor, other):
+    return ivy.result_type(tensor, other)

--- a/ivy/functional/ivy/control_flow_ops.py
+++ b/ivy/functional/ivy/control_flow_ops.py
@@ -1,11 +1,10 @@
-from typing import Union, Callable, Any, Iterable
+from typing import Union, Callable, Any, Iterable, Dict
 import ivy
 from ivy.utils.backend import current_backend
 from ivy.func_wrapper import (
     handle_array_like_without_promotion,
     to_native_arrays_and_back,
     to_ivy_arrays_and_back,
-    handle_device_shifting,
 )
 
 
@@ -13,7 +12,7 @@ def if_else(
     cond: Callable,
     body_fn: Callable,
     orelse_fn: Callable,
-    vars: Iterable[Union[ivy.Array, ivy.NativeArray]],
+    vars: Dict[str, Union[ivy.Array, ivy.NativeArray]],
 ) -> Any:
     """
     Take a condition function and two functions as input. If the condition is True, the
@@ -39,8 +38,7 @@ def if_else(
 
     Examples
     --------
-    >>> x = 1
-    >>> cond = x > 0
+    >>> cond = lambda x: True
     >>> body_fn = lambda x: x + 1
     >>> orelse_fn = lambda x: x - 1
     >>> vars = (1,)
@@ -48,32 +46,27 @@ def if_else(
     >>> print(result)
     2
 
-    >>> x = 0
-    >>> cond = x - 2 == 0
+    >>> cond = lambda x: True
     >>> body_fn = lambda x: x * 2
     >>> orelse_fn = lambda x: x / 2
     >>> vars = ivy.array([1, 2, 3])
     >>> result = ivy.if_else(cond, body_fn, orelse_fn, vars=(vars,))
     >>> print(result)
-    ivy.array([0.5, 1. , 1.5])
+    ivy.array([0.5, 1.0, 1.5])
     """
 
     @to_native_arrays_and_back
     @handle_array_like_without_promotion
-    @handle_device_shifting
-    def _if_else(cond, body_fn, orelse_fn, vars):
+    def _if_else(cond, body_fn, orelse_fn, **vars):
         return current_backend().if_else(cond, body_fn, orelse_fn, vars)
 
-    body_fn = to_ivy_arrays_and_back(body_fn)
-    orelse_fn = to_ivy_arrays_and_back(orelse_fn)
-
-    return _if_else(cond, body_fn, orelse_fn, vars)
+    return _if_else(cond, body_fn, orelse_fn, **vars)
 
 
 def while_loop(
     test_fn: Callable,
     body_fn: Callable,
-    vars: Iterable[Union[ivy.Array, ivy.NativeArray]],
+    vars: Dict[str, Union[ivy.Array, ivy.NativeArray]],
 ) -> Any:
     """
     Take a test function, a body function and a set of variables as input. The body
@@ -111,19 +104,15 @@ def while_loop(
     >>> vars = (i, j)
     >>> result = ivy.while_loop(test_fn, body_fn, vars=vars)
     >>> print(result)
-    (3, 4)
+    (3, 8)
     """
 
     @to_native_arrays_and_back
     @handle_array_like_without_promotion
-    @handle_device_shifting
-    def _while_loop(test_fn, body_fn, vars):
+    def _while_loop(test_fn, body_fn, **vars):
         return current_backend().while_loop(test_fn, body_fn, vars)
 
-    test_fn = to_ivy_arrays_and_back(test_fn)
-    body_fn = to_ivy_arrays_and_back(body_fn)
-
-    return _while_loop(test_fn, body_fn, vars)
+    return _while_loop(test_fn, body_fn, **vars)
 
 
 def for_loop(
@@ -207,10 +196,6 @@ def cmp_is(left, right):
 
 def cmp_isnot(left, right):
     return left is not right
-
-
-def cast_bool(x):
-    return bool(x)
 
 
 def _tuple_to_dict(t):

--- a/ivy/functional/ivy/control_flow_ops.py
+++ b/ivy/functional/ivy/control_flow_ops.py
@@ -4,7 +4,6 @@ from ivy.utils.backend import current_backend
 from ivy.func_wrapper import (
     handle_array_like_without_promotion,
     to_native_arrays_and_back,
-    to_ivy_arrays_and_back,
 )
 
 


### PR DESCRIPTION
modified the signature of `ivy.if_else` and `ivy.while_loop` to accept a dict of vars instead of a tuple of vars.


