### PR TITLE
Version fix in frontends

### DIFF
--- a/ivy/functional/frontends/jax/__init__.py
+++ b/ivy/functional/frontends/jax/__init__.py
@@ -15,7 +15,7 @@ from . import random
 from . import _src
 from ._src import tree_util
 
-__version__ = ivy.__version__
+__version__ = ivy.backend_version.get("version", "version not available!")
 
 _frontend_array = numpy.array
 

--- a/ivy/functional/frontends/jax/__init__.py
+++ b/ivy/functional/frontends/jax/__init__.py
@@ -15,6 +15,7 @@ from . import random
 from . import _src
 from ._src import tree_util
 
+__version__ = ivy.__version__
 
 _frontend_array = numpy.array
 

--- a/ivy/functional/frontends/numpy/__init__.py
+++ b/ivy/functional/frontends/numpy/__init__.py
@@ -13,7 +13,7 @@ from .ndarray import *
 from . import scalars
 from .scalars import *
 
-__version__ = ivy.__version__
+__version__ = ivy.backend_version.get("version", "version not available!")
 
 # Constructing dtypes are required as ivy.<dtype>
 # will change dynamically on the backend and may not be available

--- a/ivy/functional/frontends/numpy/__init__.py
+++ b/ivy/functional/frontends/numpy/__init__.py
@@ -13,6 +13,7 @@ from .ndarray import *
 from . import scalars
 from .scalars import *
 
+__version__ = ivy.__version__
 
 # Constructing dtypes are required as ivy.<dtype>
 # will change dynamically on the backend and may not be available

--- a/ivy/functional/frontends/paddle/__init__.py
+++ b/ivy/functional/frontends/paddle/__init__.py
@@ -8,7 +8,7 @@ from ivy.functional.frontends import set_frontend_to_specific_version
 from numbers import Number
 from typing import Union, Tuple, Iterable
 
-__version__ = ivy.__version__
+__version__ = ivy.backend_version.get("version", "version not available!")
 
 # Constructing dtypes are required as ivy.<dtype>
 # will change dynamically on the backend and may not be available

--- a/ivy/functional/frontends/paddle/__init__.py
+++ b/ivy/functional/frontends/paddle/__init__.py
@@ -8,6 +8,7 @@ from ivy.functional.frontends import set_frontend_to_specific_version
 from numbers import Number
 from typing import Union, Tuple, Iterable
 
+__version__ = ivy.__version__
 
 # Constructing dtypes are required as ivy.<dtype>
 # will change dynamically on the backend and may not be available

--- a/ivy/functional/frontends/tensorflow/__init__.py
+++ b/ivy/functional/frontends/tensorflow/__init__.py
@@ -9,7 +9,7 @@ from numbers import Number
 from typing import Union, Tuple, Iterable
 from .dtypes import DType
 
-__version__ = ivy.__version__
+__version__ = ivy.backend_version.get("version", "version not available!")
 
 # Constructing dtypes are required as ivy.<dtype>
 # will change dynamically on the backend and may not be available

--- a/ivy/functional/frontends/tensorflow/__init__.py
+++ b/ivy/functional/frontends/tensorflow/__init__.py
@@ -9,6 +9,7 @@ from numbers import Number
 from typing import Union, Tuple, Iterable
 from .dtypes import DType
 
+__version__ = ivy.__version__
 
 # Constructing dtypes are required as ivy.<dtype>
 # will change dynamically on the backend and may not be available

--- a/ivy/functional/frontends/torch/__init__.py
+++ b/ivy/functional/frontends/torch/__init__.py
@@ -8,6 +8,7 @@ import ivy
 from ivy.utils.exceptions import handle_exceptions
 from ivy.functional.frontends import set_frontend_to_specific_version
 
+__version__ = ivy.__version__
 
 # Constructing dtypes are required as ivy.<dtype>
 # will change dynamically on the backend and may not be available

--- a/ivy/functional/frontends/torch/__init__.py
+++ b/ivy/functional/frontends/torch/__init__.py
@@ -8,7 +8,7 @@ import ivy
 from ivy.utils.exceptions import handle_exceptions
 from ivy.functional.frontends import set_frontend_to_specific_version
 
-__version__ = ivy.__version__
+__version__ = ivy.backend_version.get("version", "version not available!")
 
 # Constructing dtypes are required as ivy.<dtype>
 # will change dynamically on the backend and may not be available


### PR DESCRIPTION
This allows frontends to get version of the selected backend by doing `frontend.__version__`. If the version is not available it'll mention that.
