### PR TITLE
fix: paddle.median frontend function

### DIFF
--- a/ivy/functional/frontends/paddle/stat.py
+++ b/ivy/functional/frontends/paddle/stat.py
@@ -14,7 +14,7 @@ def mean(input, axis=None, keepdim=False, out=None):
 
 
 @with_supported_dtypes(
-    {"2.5.1 and below": ("bool", "float16", "float32", "float64", "int32", "int64")},
+    {"2.5.1 and below": ("float32", "float64", "int32", "int64")},
     "paddle",
 )
 @to_ivy_arrays_and_back


### PR DESCRIPTION
### PR Description
By Removing `float16` and `bool` all tests pass, the reason I chose to remove `float16` and `bool` even though they are mentioned in the docs, is that paddle actually errors out that they are not supported. And even if we assumed they are supported and the issue is from the testing pipeline, this won't affect the process of testing paddle.median as it always returns `float32` for all given dtypes except for `float64` (and the dtype conversion is done prior function implementation).

