### PR TITLE
fix paddle.nanmedian frontend function

### DIFF
--- a/ivy/functional/frontends/paddle/stat.py
+++ b/ivy/functional/frontends/paddle/stat.py
@@ -28,17 +28,12 @@ def median(x, axis=None, keepdim=False, name=None):
 
 
 @with_supported_dtypes(
-    {"2.5.0 and below": ("float16", "float32", "float64", "uint16")},
+    {"2.5.0 and below": ("float16", "float32", "float64", "int32", "int64")},
     "paddle",
 )
 @to_ivy_arrays_and_back
 def nanmedian(x, axis=None, keepdim=True, name=None):
-    x = (
-        ivy.astype(x, ivy.float64)
-        if ivy.dtype(x) == "float64"
-        else ivy.astype(x, ivy.float32)
-    )
-    return ivy.median(x, axis=axis, keepdims=keepdim)
+    return ivy.nanmedian(x, axis=axis, keepdims=keepdim)
 
 
 @with_unsupported_dtypes({"2.5.1 and below": ("complex", "int8")}, "paddle")


### PR DESCRIPTION
### PR Description
* Replaced `ivy.median` with `ivy.nanmedian`
* Removed the dtype conversion since according to documentation [here](https://www.paddlepaddle.org.cn/documentation/docs/en/api/paddle/nanmedian_en.html) the returned dtype is the same of given input `x`.
* Updated supported dtypes according to documentation as well.