### PR TITLE
feat(paddle-backend): support list in `quantile` function's `q` parameter

### DIFF
--- a/ivy/functional/backends/paddle/experimental/statistical.py
+++ b/ivy/functional/backends/paddle/experimental/statistical.py
@@ -104,7 +104,7 @@ def _infer_dtype(dtype: paddle.dtype):
 
 
 def _validate_quantile(q):
-    if isinstance(q, float):
+    if isinstance(q, float) or isinstance(q, list):
         q = paddle.to_tensor(q)
     if q.ndim == 1 and q.size < 10:
         for i in range(q.size):
@@ -207,7 +207,7 @@ def _handle_axis(a, q, fn, keepdims=False, axis=None, interpolation="nearest"):
 
 
 def _quantile(a, q, axis=None, interpolation="nearest"):
-    if isinstance(q, float):
+    if isinstance(q, float) or isinstance(q, list):
         q = paddle.to_tensor(q)
     ret_dtype = a.dtype
     if q.ndim > 1:


### PR DESCRIPTION
# PR Description

Added the ability for the `quantile` function in the Ivy paddle backend to accept a `list` as a type for its `q` parameter. This enhancement ensures consistency with the native Paddle framework.



## Related Issue

Close #23608

## Additional Information

All test for `ivy.quantile` fails locally(even if you run it without making these changes ). So, it might need some refactoring!
 
```bash
python3 -m pytest -v ivy_tests/test_ivy/test_functional/test_experimental/test_core/test_statistical.py::test_quantile
```
![image](https://github.com/unifyai/ivy/assets/33392262/9f76d3db-396b-4996-90b5-35d04fd444d4)

## Checklist

- [ ] Did you add a function?
- [ ] Did you add the tests?
- [ ] Did you run your tests and are your tests passing?
- [x] Did pre-commit not fail on any check?
- [ ] Did you follow the steps we provided?


### Socials:

[fun](https://newskit.social/blog/posts/glg)
