### PR TITLE
fix: more efficient implementation of layernorm

### DIFF
--- a/ivy/functional/ivy/norms.py
+++ b/ivy/functional/ivy/norms.py
@@ -126,9 +126,8 @@ def layer_norm(
     """
     mean = ivy.mean(x, axis=normalized_idxs, keepdims=True)
     var = ivy.var(x, axis=normalized_idxs, keepdims=True)
-    x = ivy.divide(
-        ivy.add(ivy.negative(mean), x), ivy.stable_pow(var, 0.5, min_base=eps)
-    )
+
+    x = (x - mean) / (var + eps) ** 0.5
 
     if scale is not None:
         if offset is not None:


### PR DESCRIPTION
This implementation is 10x faster with JAX backend, was causing problems with transpiling llms.
Note doesn't add to failing tests, but does help with transpilation demos so thought better to merge now.