### PR TITLE
feat(tensorflow backend): manual dtype casting removal

### DIFF
--- a/ivy/functional/backends/tensorflow/elementwise.py
+++ b/ivy/functional/backends/tensorflow/elementwise.py
@@ -566,17 +566,13 @@ def multiply(
     return tf.math.multiply(x1, x2)
 
 
-@with_unsupported_dtypes(
-    {"2.13.0 and below": ("uint8", "uint16", "uint32", "uint64")}, backend_version
-)
+@with_unsupported_dtypes({"2.13.0 and below": ("bool", "unsigned")}, backend_version)
 def negative(
     x: Union[float, tf.Tensor, tf.Variable],
     /,
     *,
     out: Optional[Union[tf.Tensor, tf.Variable]] = None,
 ) -> Union[tf.Tensor, tf.Variable]:
-    if x.dtype in [tf.uint8, tf.uint16, tf.uint32, tf.uint64]:
-        return tf.cast(tf.negative(tf.cast(x, tf.float32)), x.dtype)
     return tf.negative(x)
 
 
@@ -600,10 +596,7 @@ def positive(
     return tf.experimental.numpy.positive(x)
 
 
-@with_unsupported_dtypes(
-    {"2.13.0 and below": ("uint8", "uint16", "uint32", "uint64", "float64")},
-    backend_version,
-)
+@with_unsupported_dtypes({"2.13.0 and below": ("bool", "unsigned")}, backend_version)
 def pow(
     x1: Union[tf.Tensor, tf.Variable],
     x2: Union[int, float, tf.Tensor, tf.Variable],
@@ -620,14 +613,6 @@ def pow(
         ret = tf.experimental.numpy.power(x1, x2)
         return tf.where(x1 == 0, ivy.nan + ivy.nan * 1j, ret)
     x1, x2 = ivy.promote_types_of_inputs(x1, x2)
-    if isinstance(x1, tf.Tensor) and isinstance(x2, tf.Tensor):
-        if x1.dtype.is_unsigned or x2.dtype.is_unsigned:
-            promoted_type = tf.experimental.numpy.promote_types(x1.dtype, x2.dtype)
-            if x1.dtype.is_unsigned:
-                x1 = tf.cast(x1, tf.float64)
-            if x2.dtype.is_unsigned:
-                x2 = tf.cast(x2, tf.float64)
-            return tf.cast(tf.experimental.numpy.power(x1, x2), promoted_type)
     if ivy.is_int_dtype(x1) and ivy.any(x2 < 0):
         return tf.cast(
             tf.experimental.numpy.power(tf.cast(x1, tf.float32), x2),
@@ -676,6 +661,7 @@ def round(
         return tf.cast(tf.round(x * factor) / factor_deno, ret_dtype)
 
 
+@with_unsupported_dtypes({"2.13.0 and below": ("bool", "unsigned")}, backend_version)
 def sign(
     x: Union[tf.Tensor, tf.Variable],
     /,
@@ -683,12 +669,6 @@ def sign(
     np_variant: Optional[bool] = True,
     out: Optional[Union[tf.Tensor, tf.Variable]] = None,
 ) -> Union[tf.Tensor, tf.Variable]:
-    if x.dtype in [tf.uint8, tf.uint16, tf.uint32, tf.uint64]:
-        return tf.cast(tf.math.sign(tf.cast(x, tf.float32)), x.dtype)
-    if x.dtype in [tf.complex64, tf.complex128] and np_variant:
-        real = tf.math.real(x)
-        imag = tf.math.imag(x)
-        return tf.cast(tf.where(real != 0, tf.sign(real), tf.sign(imag)), x.dtype)
     return tf.math.sign(x)
 
 
@@ -812,18 +792,7 @@ def erf(
     return tf.math.erf(x)
 
 
-@with_unsupported_dtypes(
-    {
-        "2.13.0 and below": (
-            "uint8",
-            "uint16",
-            "uint32",
-            "uint64",
-            "complex",
-        )
-    },
-    backend_version,
-)
+@with_unsupported_dtypes({"2.13.0 and below": ("complex", "bool")}, backend_version)
 def maximum(
     x1: Union[tf.Tensor, tf.Variable],
     x2: Union[tf.Tensor, tf.Variable],
@@ -833,26 +802,10 @@ def maximum(
     out: Optional[Union[tf.Tensor, tf.Variable]] = None,
 ) -> Union[tf.Tensor, tf.Variable]:
     x1, x2 = ivy.promote_types_of_inputs(x1, x2)
-    dtype = x1.dtype
-    if use_where:
-        return tf.math.maximum(x1, x2)
-    x1 = tf.cast(x1, tf.float64)
-    x2 = tf.cast(x2, tf.float64)
-    return tf.cast((x1 + x2 + tf.math.abs(x1 - x2)) / 2, dtype=dtype)
+    return tf.math.maximum(x1, x2)
 
 
-@with_unsupported_dtypes(
-    {
-        "2.13.0 and below": (
-            "uint8",
-            "uint16",
-            "uint32",
-            "uint64",
-            "complex",
-        )
-    },
-    backend_version,
-)
+@with_unsupported_dtypes({"2.13.0 and below": ("complex", "bool")}, backend_version)
 def minimum(
     x1: Union[tf.Tensor, tf.Variable],
     x2: Union[tf.Tensor, tf.Variable],
@@ -862,12 +815,7 @@ def minimum(
     out: Optional[Union[tf.Tensor, tf.Variable]] = None,
 ) -> Union[tf.Tensor, tf.Variable]:
     x1, x2 = ivy.promote_types_of_inputs(x1, x2)
-    dtype = x1.dtype
-    if use_where:
-        return tf.math.minimum(x1, x2)
-    x1 = tf.cast(x1, tf.float64)
-    x2 = tf.cast(x2, tf.float64)
-    return tf.cast((x1 + x2 - tf.math.abs(x1 - x2)) / 2, dtype)
+    return tf.math.minimum(x1, x2)
 
 
 @with_unsupported_dtypes(

--- a/ivy/functional/backends/tensorflow/experimental/linear_algebra.py
+++ b/ivy/functional/backends/tensorflow/experimental/linear_algebra.py
@@ -94,23 +94,39 @@ def matrix_exp(
     return tf.linalg.expm(x)
 
 
+@with_supported_dtypes(
+    {
+        "2.13.0 and below": (
+            "complex",
+            "float32",
+            "float64",
+        )
+    },
+    backend_version,
+)
 def eig(
     x: Union[tf.Tensor, tf.Variable],
     /,
     *,
     out: Optional[Union[tf.Tensor, tf.Variable]] = None,
 ) -> Tuple[tf.Tensor]:
-    if not ivy.dtype(x) in (ivy.float32, ivy.float64, ivy.complex64, ivy.complex128):
-        return tf.linalg.eig(tf.cast(x, tf.float64))
     return tf.linalg.eig(x)
 
 
+@with_supported_dtypes(
+    {
+        "2.13.0 and below": (
+            "complex",
+            "float32",
+            "float64",
+        )
+    },
+    backend_version,
+)
 def eigvals(
     x: Union[tf.Tensor, tf.Variable],
     /,
 ) -> Union[tf.Tensor, tf.Variable]:
-    if not ivy.dtype(x) in (ivy.float32, ivy.float64, ivy.complex64, ivy.complex128):
-        return tf.linalg.eigvals(tf.cast(x, tf.float64))
     return tf.linalg.eigvals(x)
 
 

--- a/ivy/functional/backends/tensorflow/experimental/statistical.py
+++ b/ivy/functional/backends/tensorflow/experimental/statistical.py
@@ -653,6 +653,10 @@ def cov(
     return tf.math.truediv(c, fact)
 
 
+@with_unsupported_dtypes(
+    {"2.13.0 and below": ("bool",)},
+    backend_version,
+)
 def cummax(
     x: Union[tf.Tensor, tf.Variable],
     /,
@@ -663,12 +667,8 @@ def cummax(
     dtype: Optional[tf.DType] = None,
     out: Optional[Union[tf.Tensor, tf.Variable]] = None,
 ) -> Tuple[tf.Tensor, tf.Tensor]:
-    if x.dtype in (tf.bool, tf.float16):
-        x = tf.cast(x, tf.float64)
-    elif x.dtype in (tf.int16, tf.int8, tf.uint8):
-        x = tf.cast(x, tf.int64)
-    elif x.dtype in (tf.complex128, tf.complex64):
-        x = tf.cast(tf.math.real(x), tf.float64)
+    if x.dtype in (tf.complex128, tf.complex64):
+        x = tf.math.real(x)
 
     if exclusive or reverse:
         if exclusive and reverse:

--- a/ivy/functional/backends/tensorflow/linear_algebra.py
+++ b/ivy/functional/backends/tensorflow/linear_algebra.py
@@ -576,7 +576,9 @@ def svdvals(
     return ret
 
 
-@with_unsupported_dtypes({"2.13.0 and below": ("complex",)}, backend_version)
+@with_unsupported_dtypes(
+    {"2.13.0 and below": ("int16", "int8", "bool", "unsigned")}, backend_version
+)
 def tensordot(
     x1: Union[tf.Tensor, tf.Variable],
     x2: Union[tf.Tensor, tf.Variable],
@@ -587,10 +589,6 @@ def tensordot(
 ) -> Union[tf.Tensor, tf.Variable]:
     # find type to promote to
     dtype = ivy.as_native_dtype(ivy.promote_types(x1.dtype, x2.dtype))
-
-    # type casting to float32 which is acceptable for tf.tensordot
-    x1, x2 = tf.cast(x1, tf.float32), tf.cast(x2, tf.float32)
-
     ret = tf.cast(tf.tensordot(x1, x2, axes=axes), dtype)
     return ret
 
@@ -615,8 +613,7 @@ def trace(
 
 
 @with_unsupported_dtypes(
-    {"2.13.0 and below": ("bfloat16", "float16", "complex")},
-    backend_version,
+    {"2.13.0 and below": ("int16", "int8", "bool", "unsigned")}, backend_version
 )
 def vecdot(
     x1: Union[tf.Tensor, tf.Variable],
@@ -627,10 +624,6 @@ def vecdot(
     out: Optional[Union[tf.Tensor, tf.Variable]] = None,
 ) -> Union[tf.Tensor, tf.Variable]:
     dtype = ivy.as_native_dtype(ivy.promote_types(x1.dtype, x2.dtype))
-    if dtype != "float64":
-        x1, x2 = tf.cast(x1, tf.float32), tf.cast(x2, tf.float32)
-    else:
-        x1, x2 = tf.cast(x1, tf.float64), tf.cast(x2, tf.float64)
     return tf.cast(tf.tensordot(x1, x2, axes=(axis, axis)), dtype)
 
 

--- a/ivy/functional/backends/tensorflow/sorting.py
+++ b/ivy/functional/backends/tensorflow/sorting.py
@@ -8,7 +8,7 @@ from ivy.func_wrapper import with_unsupported_dtypes
 from . import backend_version
 
 
-@with_unsupported_dtypes({"2.13.0 and below": ("complex",)}, backend_version)
+@with_unsupported_dtypes({"2.13.0 and below": ("complex", "bool")}, backend_version)
 def argsort(
     x: Union[tf.Tensor, tf.Variable],
     /,
@@ -20,14 +20,11 @@ def argsort(
 ) -> Union[tf.Tensor, tf.Variable]:
     direction = "DESCENDING" if descending else "ASCENDING"
     x = tf.convert_to_tensor(x)
-    is_bool = x.dtype.is_bool
-    if is_bool:
-        x = tf.cast(x, tf.int32)
     ret = tf.argsort(x, axis=axis, direction=direction, stable=stable)
     return tf.cast(ret, dtype=tf.int64)
 
 
-@with_unsupported_dtypes({"2.13.0 and below": ("complex",)}, backend_version)
+@with_unsupported_dtypes({"2.13.0 and below": ("complex", "bool")}, backend_version)
 def sort(
     x: Union[tf.Tensor, tf.Variable],
     /,
@@ -41,17 +38,12 @@ def sort(
     # currently it supports only quicksort (unstable)
     direction = "DESCENDING" if descending else "ASCENDING"
     x = tf.convert_to_tensor(x)
-    is_bool = x.dtype.is_bool
-    if is_bool:
-        x = tf.cast(x, tf.int32)
     ret = tf.sort(x, axis=axis, direction=direction)
-    if is_bool:
-        ret = tf.cast(ret, dtype=tf.bool)
     return ret
 
 
 # msort
-@with_unsupported_dtypes({"2.13.0 and below": ("complex",)}, backend_version)
+@with_unsupported_dtypes({"2.13.0 and below": ("complex", "bool")}, backend_version)
 def msort(
     a: Union[tf.Tensor, tf.Variable, list, tuple],
     /,


### PR DESCRIPTION
# PR Description
this PR is for this [task](https://trello.com/c/kSyDbng5)
I came ready this time 😃 I used this script to figure out which dtypes are supported and which are not.
```python
import tensorflow as tf


dtypes = [
    tf.bfloat16,
    tf.float16,
    tf.float32,
    tf.float64,
    tf.int8,
    tf.int16,
    tf.int32,
    tf.int64,
    tf.uint8,
    tf.uint16,
    tf.uint32,
    tf.uint64,
    tf.bool,
    tf.complex64,
    tf.complex128,
    tf.double,
    tf.half,
]


def get_supported_and_unsupported_dtypes():
    supported_dtypes = set()
    unsupported_dtypes = set()

    for dtype in dtypes:
        try:
            x = tf.constant([[1, 2,] , [2, 1]], dtype=dtype)
            x1 = tf.constant([1, 2, 3], dtype=dtype)
            x2 = tf.constant([1, 2, 3], dtype=dtype)
            print(cummin(x))
            supported_dtypes.add(dtype)
        except Exception as e:
            print(e)
            unsupported_dtypes.add(dtype)

    return supported_dtypes, unsupported_dtypes


supported_dtypes, unsupported_dtypes = get_supported_and_unsupported_dtypes()

supported_dtypes = [repr(d).replace("tf.", "") for d in supported_dtypes]
unsupported_dtypes = [repr(d).replace("tf.", "") for d in unsupported_dtypes]

print("Supported Data Types:")
m = f"""@with_supported_dtypes(
        {{"2.13.0 and below": {tuple(supported_dtypes)}}}, backend_version
    )"""
print(m)

print("\nUnsupported Data Types:")
m = f"""@with_unsupported_dtypes(
        {{"2.13.0 and below": {tuple(unsupported_dtypes)}}}, backend_version
    )"""
print(m)

```
