### PR TITLE
feat(torch backend): removed manual dtype casting.

### DIFF
--- a/ivy/functional/backends/torch/elementwise.py
+++ b/ivy/functional/backends/torch/elementwise.py
@@ -60,8 +60,7 @@ def imag(
     out: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
     if val.dtype not in (torch.complex64, torch.complex128):
-        ret = torch.imag(val.to(torch.complex64))
-        return ret.to(val.dtype)
+        return torch.zeros_like(val, dtype=val.dtype)
     return torch.imag(val)
 
 

--- a/ivy/functional/backends/torch/experimental/layers.py
+++ b/ivy/functional/backends/torch/experimental/layers.py
@@ -563,8 +563,6 @@ def dct(
 ) -> torch.tensor:
     if norm not in (None, "ortho"):
         raise ValueError("Norm must be either None or 'ortho'")
-    if x.dtype not in [torch.float32, torch.float64]:
-        x = x.type(torch.float32)
     if axis < 0:
         axis = axis + len(x.shape)
     if n is not None:

--- a/ivy/functional/backends/torch/experimental/statistical.py
+++ b/ivy/functional/backends/torch/experimental/statistical.py
@@ -567,7 +567,7 @@ cov.support_native_out = False
 
 
 @with_unsupported_dtypes(
-    {"2.0.1 and below": ("uint8", "bfloat16", "float16")},
+    {"2.0.1 and below": ("float16",)},
     backend_version,
 )
 def cummax(
@@ -580,11 +580,7 @@ def cummax(
     dtype: Optional[torch.dtype] = None,
     out: Optional[torch.Tensor] = None,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
-    if x.dtype in (torch.bool, torch.float16):
-        x = x.to(dtype=torch.float64)
-    elif x.dtype in (torch.int16, torch.int8, torch.uint8):
-        x = x.to(dtype=torch.int64)
-    elif x.dtype in (torch.complex64, torch.complex128):
+    if x.dtype in (torch.complex64, torch.complex128):
         x = x.real.to(dtype=torch.float64)
 
     if exclusive or reverse:

--- a/ivy/functional/backends/torch/statistical.py
+++ b/ivy/functional/backends/torch/statistical.py
@@ -7,7 +7,7 @@ import torch
 # local
 import ivy
 from ivy.functional.ivy.statistical import _get_promoted_type_of_operands
-from ivy.func_wrapper import with_unsupported_dtypes
+from ivy.func_wrapper import with_unsupported_dtypes, with_supported_dtypes
 from . import backend_version
 
 # Array API Standard #
@@ -66,6 +66,7 @@ def max(
 max.support_native_out = True
 
 
+@with_supported_dtypes({"2.0.1 and below": ("float", "complex")}, backend_version)
 def mean(
     x: torch.Tensor,
     /,
@@ -82,10 +83,6 @@ def mean(
             return ivy.inplace_update(out, x)
         else:
             return x
-    if "float" not in str(x.dtype) and "complex" not in str(x.dtype):  # unsupported
-        return torch.mean(x.to(torch.float32), dim=axis, keepdim=keepdims, out=out).to(
-            x.dtype
-        )
     return torch.mean(x, dim=axis, keepdim=keepdims, out=out)
 
 


### PR DESCRIPTION
<!--
This template will help you to have a meaningful PR, please follow it and do not leave it blank.
-->

# PR Description
used dtype checker script:
```
import torch


dtypes = [
    torch.int8,
    torch.int16,
    torch.int32,
    torch.int64,
    torch.uint8,
    torch.bfloat16,
    torch.float16,
    torch.float32,
    torch.float64,
    torch.complex64,
    torch.complex128,
    torch.bool,
]


def get_supported_and_unsupported_dtypes():
    supported_dtypes = set()
    unsupported_dtypes = set()

    for dtype in dtypes:
        try:
            x = torch.tensor(
                [
                    [
                        1,
                        2,
                    ],
                    [2, 1],
                ],
                dtype=dtype,
            )
            x1 = torch.tensor([1, 2, 3], dtype=dtype)
            x2 = torch.tensor([1, 2, 3], dtype=dtype)
            print(dtype, cummax(x))
            supported_dtypes.add(dtype)
        except Exception as e:
            print(e)
            unsupported_dtypes.add(dtype)

    return supported_dtypes, unsupported_dtypes


supported_dtypes, unsupported_dtypes = get_supported_and_unsupported_dtypes()

supported_dtypes = sorted(str(d).replace("torch.", "") for d in supported_dtypes)
unsupported_dtypes = sorted(str(d).replace("torch.", "") for d in unsupported_dtypes)

print("Supported Data Types:")
m = f"""@with_supported_dtypes(
        {{"2.0.1 and below": {tuple(supported_dtypes)}}}, backend_version
    )"""
print(m)

print("\nUnsupported Data Types:")
m = f"""@with_unsupported_dtypes(
        {{"2.0.1 and below": {tuple(unsupported_dtypes)}}}, backend_version
    )"""
print(m)

```