### PR TITLE
feat(numpy backend): removed manual dtype casting.

### DIFF
--- a/ivy/functional/backends/numpy/experimental/linear_algebra.py
+++ b/ivy/functional/backends/numpy/experimental/linear_algebra.py
@@ -3,7 +3,7 @@ from typing import Optional, Tuple, Sequence, Union, Any
 import numpy as np
 
 import ivy
-from ivy.func_wrapper import with_supported_dtypes
+from ivy.func_wrapper import with_supported_dtypes, with_unsupported_dtypes
 from ivy.utils.exceptions import IvyNotImplementedException
 from .. import backend_version
 
@@ -114,14 +114,13 @@ def matrix_exp(
     return exp_mat.astype(x.dtype)
 
 
+@with_unsupported_dtypes({"1.25.2 and below": ("float16",)}, backend_version)
 def eig(
     x: np.ndarray,
     /,
     *,
     out: Optional[np.ndarray] = None,
-) -> Tuple[np.ndarray]:
-    if ivy.dtype(x) == ivy.float16:
-        x = x.astype(np.float32)
+) -> Tuple[np.ndarray, np.ndarray]:
     e, v = np.linalg.eig(x)
     return e.astype(complex), v.astype(complex)
 
@@ -129,9 +128,8 @@ def eig(
 eig.support_native_out = False
 
 
+@with_unsupported_dtypes({"1.25.2 and below": ("float16",)}, backend_version)
 def eigvals(x: np.ndarray, /) -> np.ndarray:
-    if ivy.dtype(x) == ivy.float16:
-        x = x.astype(np.float32)
     e = np.linalg.eigvals(x)
     return e.astype(complex)
 

--- a/ivy/functional/backends/numpy/experimental/statistical.py
+++ b/ivy/functional/backends/numpy/experimental/statistical.py
@@ -428,13 +428,6 @@ def cummax(
     dtype: Optional[np.dtype] = None,
     out: Optional[np.ndarray] = None,
 ) -> Tuple[np.ndarray, np.ndarray]:
-    if x.dtype in (np.bool_, np.float16):
-        x = x.astype(np.float64)
-    elif x.dtype in (np.int16, np.int8, np.uint8):
-        x = x.astype(np.int64)
-    elif x.dtype in (np.complex128, np.complex64):
-        x = np.real(x).astype(np.float64)
-
     if exclusive or reverse:
         if exclusive and reverse:
             indices = __find_cummax_indices(np.flip(x, axis=axis), axis=axis)
@@ -527,10 +520,7 @@ def cummin(
     out: Optional[np.ndarray] = None,
 ) -> np.ndarray:
     if dtype is None:
-        if x.dtype == "bool":
-            dtype = ivy.default_int_dtype(as_native=True)
-        else:
-            dtype = _infer_dtype(x.dtype)
+        dtype = _infer_dtype(x.dtype)
     if not (reverse):
         return np.minimum.accumulate(x, axis, dtype=dtype, out=out)
     elif reverse:

--- a/ivy/functional/backends/numpy/statistical.py
+++ b/ivy/functional/backends/numpy/statistical.py
@@ -171,7 +171,7 @@ var.support_native_out = True
 # ------#
 
 
-@with_unsupported_dtypes({"1.25.2 and below": "bfloat16"}, backend_version)
+@with_unsupported_dtypes({"1.25.2 and below": ("bfloat16",)}, backend_version)
 def cumprod(
     x: np.ndarray,
     /,
@@ -183,10 +183,7 @@ def cumprod(
     out: Optional[np.ndarray] = None,
 ) -> np.ndarray:
     if dtype is None:
-        if x.dtype == "bool":
-            dtype = ivy.default_int_dtype(as_native=True)
-        else:
-            dtype = _infer_dtype(x.dtype)
+        dtype = _infer_dtype(x.dtype)
     if not (exclusive or reverse):
         return np.cumprod(x, axis, dtype=dtype, out=out)
     elif exclusive and reverse:
@@ -218,10 +215,6 @@ def cumsum(
     out: Optional[np.ndarray] = None,
 ) -> np.ndarray:
     if dtype is None:
-        if x.dtype == "bool":
-            dtype = ivy.default_int_dtype(as_native=True)
-        if ivy.is_int_dtype(x.dtype):
-            dtype = ivy.promote_types(x.dtype, ivy.default_int_dtype(as_native=True))
         dtype = _infer_dtype(x.dtype)
 
     if exclusive or reverse:

--- a/ivy_tests/test_ivy/test_functional/test_core/test_statistical.py
+++ b/ivy_tests/test_ivy/test_functional/test_core/test_statistical.py
@@ -14,7 +14,7 @@ from ivy_tests.test_ivy.helpers import handle_test
 
 @st.composite
 def _get_castable_dtype(draw, min_value=None, max_value=None):
-    available_dtypes = helpers.get_dtypes("numeric")
+    available_dtypes = helpers.get_dtypes("valid")
     shape = draw(helpers.get_shape(min_num_dims=1, max_num_dims=4, max_dim_size=6))
     dtype, values = draw(
         helpers.dtype_and_values(

--- a/ivy_tests/test_ivy/test_functional/test_experimental/test_core/test_linalg.py
+++ b/ivy_tests/test_ivy/test_functional/test_experimental/test_core/test_linalg.py
@@ -895,12 +895,13 @@ def test_dot(*, data, test_flags, backend_fw, fn_name, on_device):
     test_with_out=st.just(False),
     test_gradients=st.just(False),
 )
-def test_eig(dtype_x, test_flags, backend_fw, fn_name):
+def test_eig(dtype_x, test_flags, backend_fw, fn_name, on_device):
     dtype, x = dtype_x
     helpers.test_function(
         input_dtypes=dtype,
         test_flags=test_flags,
         backend_to_test=backend_fw,
+        on_device=on_device,
         fn_name=fn_name,
         test_values=False,
         x=x[0],
@@ -1002,12 +1003,13 @@ def test_eigh_tridiagonal(
     test_with_out=st.just(False),
     test_gradients=st.just(False),
 )
-def test_eigvals(dtype_x, test_flags, backend_fw, fn_name):
+def test_eigvals(dtype_x, test_flags, backend_fw, fn_name, on_device):
     dtype, x = dtype_x
     helpers.test_function(
         input_dtypes=dtype,
         test_flags=test_flags,
         backend_to_test=backend_fw,
+        on_device=on_device,
         fn_name=fn_name,
         test_values=False,
         x=x[0],


### PR DESCRIPTION
<!--
This template will help you to have a meaningful PR, please follow it and do not leave it blank.
-->

# PR Description
used script for dtypes checking:
``` 
import numpy as np

dtypes = [
    np.dtype("int8"),
    np.dtype("int16"),
    np.dtype("int32"),
    np.dtype("int64"),
    np.dtype("uint8"),
    np.dtype("uint16"),
    np.dtype("uint32"),
    np.dtype("uint64"),
    np.dtype("float16"),
    np.dtype("float32"),
    np.dtype("float64"),
    np.dtype("complex64"),
    np.dtype("complex128"),
    np.dtype("bool"),
]


def get_supported_and_unsupported_dtypes():
    supported_dtypes = set()
    unsupported_dtypes = set()

    for dtype in dtypes:
        try:
            x = np.array(
                [[1, 2], [2, 1]],
                dtype=dtype,
            )
            x1 = np.array([1, 1, 1], dtype=dtype)
            x2 = np.array([1, 2, 3], dtype=dtype)
            print(dtype,  cummax(x1))
            supported_dtypes.add(dtype)
        except Exception as e:
            print(e)
            unsupported_dtypes.add(dtype)

    return supported_dtypes, unsupported_dtypes


if __name__ == "__main__":
    supported_dtypes, unsupported_dtypes = get_supported_and_unsupported_dtypes()

    supported_dtypes = sorted(str(d) for d in supported_dtypes)
    unsupported_dtypes = sorted(str(d) for d in unsupported_dtypes)


    print("Supported Data Types:")
    m = f"""@with_supported_dtypes(
            {{"1.25.2 and below": {tuple(supported_dtypes)}}}, backend_version
        )"""
    print(m)

    print("\nUnsupported Data Types:")
    m = f"""@with_unsupported_dtypes(
            {{"1.25.2 and below": {tuple(unsupported_dtypes)}}}, backend_version
        )"""
    print(m)

```


