### PR TITLE
fix: Function Reformatting of is_int_dtype function

### DIFF
--- a/ivy/functional/ivy/data_type.py
+++ b/ivy/functional/ivy/data_type.py
@@ -1915,18 +1915,14 @@ def is_int_dtype(
             else False
         )
     elif isinstance(dtype_in, (list, tuple, dict)):
-        return (
-            True
-            if ivy.nested_argwhere(
-                dtype_in,
-                lambda x: (
-                    isinstance(x, (int, np.integer))
-                    or (ivy.is_array(x) and "int" in ivy.dtype(x))
-                )
-                and x is not bool,
-            )
-            else False
-        )
+
+        def nested_fun(x):
+            return (
+                isinstance(x, (int, np.integer))
+                or (ivy.is_array(x) and "int" in ivy.dtype(x))
+            ) and x is not bool
+
+        return True if ivy.nested_argwhere(dtype_in, nested_fun) else False
     return "int" in ivy.as_ivy_dtype(dtype_in)
 
 


### PR DESCRIPTION
Replacing lambda function with function defined with def in is_int_dtype function of data_type.py submodule


<!--
This template will help you to have a meaningful PR, please follow it and do not leave it blank.
-->

# PR Description

<!--
Replacing lambda function with function defined with def in is_int_dtype of data_type.py submodule
Close #23534
-->

## Related Issue

<!--
Please use this format to link other issues with their numbers: Close #123
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Close #23534 

## Checklist

- [ ] Did you add a function?
- [ ] Did you add the tests?
- [ ] Did you run your tests and are your tests passing?
- [ ] Did pre-commit not fail on any check?
- [x] Did you follow the steps we provided?

<!--
Please mark your PR as a draft if you realise after the fact that your tests are not passing or
that your pre-commit check has some failures.

Here are some relevant resources regarding tests and pre-commit:

https://unify.ai/docs/ivy/overview/deep_dive/ivy_tests.html
https://unify.ai/docs/ivy/overview/deep_dive/formatting.html#pre-commit

-->

### Socials:

<!--
https://twitter.com/Pavan_00006
-->
