### PR TITLE
fix: paddle.numel frontend function

### DIFF
--- a/ivy/functional/frontends/paddle/stat.py
+++ b/ivy/functional/frontends/paddle/stat.py
@@ -41,7 +41,10 @@ def nanmedian(x, axis=None, keepdim=True, name=None):
     return ivy.median(x, axis=axis, keepdims=keepdim)
 
 
-@with_unsupported_dtypes({"2.5.1 and below": ("complex", "int8")}, "paddle")
+@with_supported_dtypes(
+    {"2.5.1 and below": ("bool", "float16", "float32", "float64", "int32", "int64")},
+    "paddle",
+)
 @to_ivy_arrays_and_back
 def numel(x, name=None):
     prod = ivy.prod(x.size, dtype=ivy.int64)


### PR DESCRIPTION
Fixes #17498

PR Description:
* `numel` tests were failing due to incorrect dtype