### PR TITLE
fix: paddle.less_than frontend function

### DIFF
--- a/ivy/functional/frontends/paddle/logic.py
+++ b/ivy/functional/frontends/paddle/logic.py
@@ -189,13 +189,13 @@ def less_equal(x, y, /, *, name=None):
     return ivy.less_equal(x, y)
 
 
-@with_unsupported_dtypes(
-    {"2.5.1 and below": ("bool", "uint8", "int8", "int16", "complex64", "complex128")},
+@with_supported_dtypes(
+    {"2.5.1 and below": ("bool", "float16", "float32", "float64", "int32", "int64")},
     "paddle",
 )
 @to_ivy_arrays_and_back
 def less_than(x, y, /, *, name=None):
-    return ivy.less(x, y)
+    return ivy.astype(ivy.less(x, y), ivy.bool)
 
 
 @with_supported_dtypes(


### PR DESCRIPTION
Fixes #17274

PR Description:
* Made all tests pass except for Tensorflow test in which the problem seems to be from the backend side. paddle.less_than supports `bool` dtype, while less backend Tensorflow function doesn't, though `bool` dtype in the backend isn't excluded from the supported dtypes in the backend for some reason, so I made a PR to do so [here](https://github.com/unifyai/ivy/pull/23786), after that one got merged, this PR should have all tests pass :)