### PR TITLE
fix: exclude bool dtypes in less backend function for tensorflow

### DIFF
--- a/ivy/functional/backends/tensorflow/elementwise.py
+++ b/ivy/functional/backends/tensorflow/elementwise.py
@@ -399,7 +399,15 @@ def lcm(
     return tf.experimental.numpy.lcm(x1, x2)
 
 
-@with_unsupported_dtypes({"2.13.0 and below": ("complex",)}, backend_version)
+@with_unsupported_dtypes(
+    {
+        "2.13.0 and below": (
+            "bool",
+            "complex",
+        )
+    },
+    backend_version,
+)
 def less(
     x1: Union[float, tf.Tensor, tf.Variable],
     x2: Union[float, tf.Tensor, tf.Variable],


### PR DESCRIPTION
According to docs [here](https://www.tensorflow.org/api_docs/python/tf/math/less) `bool` is not of the supported dtypes, and It caused failed tests for frontend functions that supports `bool` dtype