### PR TITLE
fix: torch cat axis argument fix

### DIFF
--- a/ivy/functional/frontends/torch/indexing_slicing_joining_mutating_ops.py
+++ b/ivy/functional/frontends/torch/indexing_slicing_joining_mutating_ops.py
@@ -17,6 +17,7 @@ def argwhere(input):
     return ivy.argwhere(input)
 
 
+@numpy_to_torch_style_args
 @to_ivy_arrays_and_back
 def cat(tensors, dim=0, *, out=None):
     return ivy.concat(tensors, axis=dim, out=out)


### PR DESCRIPTION
Torch Frontend Function `cat` can take numpy style args and it can cause an issue during transpilation. So a decorator for tha is added to the function