### PR TITLE
fix: setting min and max as default `None` in `ivy.clip`

### DIFF
--- a/ivy/data_classes/array/manipulation.py
+++ b/ivy/data_classes/array/manipulation.py
@@ -448,8 +448,8 @@ class _ArrayWithManipulation(abc.ABC):
 
     def clip(
         self: ivy.Array,
-        x_min: Union[Number, ivy.Array, ivy.NativeArray],
-        x_max: Union[Number, ivy.Array, ivy.NativeArray],
+        x_min: Optional[Union[Number, ivy.Array, ivy.NativeArray]] = None,
+        x_max: Optional[Union[Number, ivy.Array, ivy.NativeArray]] = None,
         /,
         *,
         out: Optional[ivy.Array] = None,

--- a/ivy/functional/backends/jax/manipulation.py
+++ b/ivy/functional/backends/jax/manipulation.py
@@ -203,9 +203,9 @@ def tile(
 
 def clip(
     x: JaxArray,
+    /,
     x_min: Optional[Union[Number, JaxArray]] = None,
     x_max: Optional[Union[Number, JaxArray]] = None,
-    /,
     *,
     out: Optional[JaxArray] = None,
 ) -> JaxArray:

--- a/ivy/functional/backends/numpy/manipulation.py
+++ b/ivy/functional/backends/numpy/manipulation.py
@@ -262,8 +262,8 @@ def unstack(
 def clip(
     x: np.ndarray,
     /,
-    x_min: Union[Number, np.ndarray] = None,
-    x_max: Union[Number, np.ndarray] = None,
+    x_min: Optional[Union[Number, np.ndarray]] = None,
+    x_max: Optional[Union[Number, np.ndarray]] = None,
     *,
     out: Optional[np.ndarray] = None,
 ) -> np.ndarray:

--- a/ivy/functional/backends/numpy/manipulation.py
+++ b/ivy/functional/backends/numpy/manipulation.py
@@ -261,9 +261,9 @@ def unstack(
 
 def clip(
     x: np.ndarray,
-    x_min: Union[Number, np.ndarray],
-    x_max: Union[Number, np.ndarray],
     /,
+    x_min: Union[Number, np.ndarray] = None,
+    x_max: Union[Number, np.ndarray] = None,
     *,
     out: Optional[np.ndarray] = None,
 ) -> np.ndarray:

--- a/ivy/functional/backends/paddle/manipulation.py
+++ b/ivy/functional/backends/paddle/manipulation.py
@@ -438,9 +438,9 @@ def swapaxes(
 
 def clip(
     x: paddle.Tensor,
-    x_min: Union[Number, paddle.Tensor],
-    x_max: Union[Number, paddle.Tensor],
     /,
+    x_min: Union[Number, paddle.Tensor] = None,
+    x_max: Union[Number, paddle.Tensor] = None,
     *,
     out: Optional[paddle.Tensor] = None,
 ) -> paddle.Tensor:

--- a/ivy/functional/backends/paddle/manipulation.py
+++ b/ivy/functional/backends/paddle/manipulation.py
@@ -439,8 +439,8 @@ def swapaxes(
 def clip(
     x: paddle.Tensor,
     /,
-    x_min: Union[Number, paddle.Tensor] = None,
-    x_max: Union[Number, paddle.Tensor] = None,
+    x_min: Optional[Union[Number, paddle.Tensor]] = None,
+    x_max: Optional[Union[Number, paddle.Tensor]] = None,
     *,
     out: Optional[paddle.Tensor] = None,
 ) -> paddle.Tensor:

--- a/ivy/functional/backends/tensorflow/manipulation.py
+++ b/ivy/functional/backends/tensorflow/manipulation.py
@@ -331,9 +331,9 @@ def swapaxes(
 @with_unsupported_dtypes({"2.13.0 and below": ("complex",)}, backend_version)
 def clip(
     x: Union[tf.Tensor, tf.Variable],
-    x_min: Union[Number, tf.Tensor, tf.Variable],
-    x_max: Union[Number, tf.Tensor, tf.Variable],
     /,
+    x_min: Union[Number, tf.Tensor, tf.Variable] = None,
+    x_max: Union[Number, tf.Tensor, tf.Variable] = None,
     *,
     out: Optional[Union[tf.Tensor, tf.Variable]] = None,
 ) -> Union[tf.Tensor, tf.Variable]:

--- a/ivy/functional/backends/tensorflow/manipulation.py
+++ b/ivy/functional/backends/tensorflow/manipulation.py
@@ -332,8 +332,8 @@ def swapaxes(
 def clip(
     x: Union[tf.Tensor, tf.Variable],
     /,
-    x_min: Union[Number, tf.Tensor, tf.Variable] = None,
-    x_max: Union[Number, tf.Tensor, tf.Variable] = None,
+    x_min: Optional[Union[Number, tf.Tensor, tf.Variable]] = None,
+    x_max: Optional[Union[Number, tf.Tensor, tf.Variable]] = None,
     *,
     out: Optional[Union[tf.Tensor, tf.Variable]] = None,
 ) -> Union[tf.Tensor, tf.Variable]:

--- a/ivy/functional/backends/torch/manipulation.py
+++ b/ivy/functional/backends/torch/manipulation.py
@@ -318,9 +318,9 @@ def swapaxes(
 )
 def clip(
     x: torch.Tensor,
-    x_min: Union[Number, torch.Tensor],
-    x_max: Union[Number, torch.Tensor],
     /,
+    x_min: Union[Number, torch.Tensor] = None,
+    x_max: Union[Number, torch.Tensor] = None,
     *,
     out: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:

--- a/ivy/functional/backends/torch/manipulation.py
+++ b/ivy/functional/backends/torch/manipulation.py
@@ -319,8 +319,8 @@ def swapaxes(
 def clip(
     x: torch.Tensor,
     /,
-    x_min: Union[Number, torch.Tensor] = None,
-    x_max: Union[Number, torch.Tensor] = None,
+    x_min: Optional[Union[Number, torch.Tensor]] = None,
+    x_max: Optional[Union[Number, torch.Tensor]] = None,
     *,
     out: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:

--- a/ivy/functional/ivy/manipulation.py
+++ b/ivy/functional/ivy/manipulation.py
@@ -864,8 +864,8 @@ def stack(
 def clip(
     x: Union[ivy.Array, ivy.NativeArray],
     /,
-    x_min: Union[Number, ivy.Array, ivy.NativeArray] = None,
-    x_max: Union[Number, ivy.Array, ivy.NativeArray] = None,
+    x_min: Optional[Union[Number, ivy.Array, ivy.NativeArray]] = None,
+    x_max: Optional[Union[Number, ivy.Array, ivy.NativeArray]] = None,
     *,
     out: Optional[ivy.Array] = None,
 ) -> ivy.Array:

--- a/ivy/functional/ivy/manipulation.py
+++ b/ivy/functional/ivy/manipulation.py
@@ -863,9 +863,9 @@ def stack(
 @handle_device_shifting
 def clip(
     x: Union[ivy.Array, ivy.NativeArray],
-    x_min: Union[Number, ivy.Array, ivy.NativeArray],
-    x_max: Union[Number, ivy.Array, ivy.NativeArray],
     /,
+    x_min: Union[Number, ivy.Array, ivy.NativeArray] = None,
+    x_max: Union[Number, ivy.Array, ivy.NativeArray] = None,
     *,
     out: Optional[ivy.Array] = None,
 ) -> ivy.Array:


### PR DESCRIPTION


# PR Description
Hey @hello-fri-end, even though we refactored ivy.clip we missed updating the function signature, thus not enabling the user to pass only min or max as arguments. Also to make this work, I have removed the condition of them being positional-only  arguments.

## Related Issue

<!--
Please use this format to link other issues with their numbers: Close #123
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Close #

## Checklist

- [ ] Did you add a function?
- [ ] Did you add the tests?
- [ ] Did you run your tests and are your tests passing?
- [ ] Did pre-commit not fail on any check?
- [ ] Did you follow the steps we provided?

<!--
Please mark your PR as a draft if you realise after the fact that your tests are not passing or
that your pre-commit check has some failures.

Here are some relevant resources regarding tests and pre-commit:

https://unify.ai/docs/ivy/overview/deep_dive/ivy_tests.html
https://unify.ai/docs/ivy/overview/deep_dive/formatting.html#pre-commit

-->

### Socials:

<!--
If you have Twitter, please provide it here otherwise just ignore this.
-->
