### PR TITLE
feat: Add fill_diagonal_tensor function to tensor.tensor

### DIFF
--- a/ivy/functional/frontends/paddle/tensor/tensor.py
+++ b/ivy/functional/frontends/paddle/tensor/tensor.py
@@ -6,6 +6,9 @@ from ivy.func_wrapper import (
     with_unsupported_dtypes,
 )
 from ivy.functional.frontends.paddle.func_wrapper import _to_ivy_array
+from typing import (
+    Union,
+)
 
 
 class Tensor:
@@ -739,3 +742,8 @@ class Tensor:
 
     def is_floating_point(self):
         return paddle_frontend.is_floating_point(self._ivy_array)
+
+    def fill_diagonal_tensor(
+        self, x: Union[ivy.Array, ivy.NativeArray], y, dim1=0, dim2=1, name=None
+    ):
+        return ivy.fill_diagonal(self._ivy_array, x, y)


### PR DESCRIPTION
- Unfortunately fill_diagonal_tensor is not defined in the paddlepaddle source code, but it is presented in the documentation. So I couldn't understand it well. A little enlightenment would be much appreciated

