### PR TITLE
 feat: Added fill_diagonal_tensor function to tensor.tensor

### DIFF
--- a/ivy/functional/frontends/paddle/tensor/tensor.py
+++ b/ivy/functional/frontends/paddle/tensor/tensor.py
@@ -600,6 +600,13 @@ class Tensor:
     def deg2rad(self, name=None):
         return paddle_frontend.Tensor(ivy.deg2rad(self._ivy_array))
 
+    @with_supported_dtypes({"2.5.1 and below": ("float32", "float64")}, "paddle")
+    def digamma(self, name=None):
+        digamma_fun = ivy.digamma
+        return paddle_frontend.Tensor(
+            ivy.astype(digamma_fun(self._ivy_array), self.dtype)
+        )
+
     @with_supported_dtypes(
         {"2.5.1 and below": ("float32", "float64", "int32", "int64", "bool")}, "paddle"
     )

--- a/ivy/functional/frontends/paddle/tensor/tensor.py
+++ b/ivy/functional/frontends/paddle/tensor/tensor.py
@@ -770,6 +770,6 @@ class Tensor:
         return paddle_frontend.is_floating_point(self._ivy_array)
 
     def fill_diagonal_tensor(
-        self, x: Union[ivy.Array, ivy.NativeArray], y, dim9=0, dim2=1, name=None
+        self, x: Union[ivy.Array, ivy.NativeArray], y, dim1=0, dim2=1, name=None
     ):
         return ivy.fill_diagonal(self._ivy_array, x, y)

--- a/ivy/functional/frontends/paddle/tensor/tensor.py
+++ b/ivy/functional/frontends/paddle/tensor/tensor.py
@@ -770,6 +770,6 @@ class Tensor:
         return paddle_frontend.is_floating_point(self._ivy_array)
 
     def fill_diagonal_tensor(
-        self, x: Union[ivy.Array, ivy.NativeArray], y, dim1=0, dim2=1, name=None
+        self, x: Union[ivy.Array, ivy.NativeArray], y, dim9=0, dim2=1, name=None
     ):
         return ivy.fill_diagonal(self._ivy_array, x, y)

--- a/ivy/functional/frontends/paddle/tensor/tensor.py
+++ b/ivy/functional/frontends/paddle/tensor/tensor.py
@@ -5,9 +5,6 @@ from ivy.func_wrapper import (
     with_supported_dtypes,
     with_unsupported_dtypes,
 )
-from typing import (
-    Union,
-)
 from ivy.functional.frontends.paddle.func_wrapper import _to_ivy_array
 
 
@@ -768,8 +765,3 @@ class Tensor:
 
     def is_floating_point(self):
         return paddle_frontend.is_floating_point(self._ivy_array)
-
-    def fill_diagonal_tensor(
-        self, x: Union[ivy.Array, ivy.NativeArray], y, dim1=0, dim2=1, name=None
-    ):
-        return ivy.fill_diagonal(self._ivy_array, x, y)

--- a/ivy/functional/frontends/paddle/tensor/tensor.py
+++ b/ivy/functional/frontends/paddle/tensor/tensor.py
@@ -5,6 +5,9 @@ from ivy.func_wrapper import (
     with_supported_dtypes,
     with_unsupported_dtypes,
 )
+from typing import (
+    Union,
+)
 from ivy.functional.frontends.paddle.func_wrapper import _to_ivy_array
 
 
@@ -765,3 +768,8 @@ class Tensor:
 
     def is_floating_point(self):
         return paddle_frontend.is_floating_point(self._ivy_array)
+
+    def fill_diagonal_tensor(
+        self, x: Union[ivy.Array, ivy.NativeArray], y, dim1=0, dim2=1, name=None
+    ):
+        return ivy.fill_diagonal(self._ivy_array, x, y)

--- a/ivy_tests/test_ivy/test_frontends/test_paddle/test_tensor/test_tensor.py
+++ b/ivy_tests/test_ivy/test_frontends/test_paddle/test_tensor/test_tensor.py
@@ -1492,6 +1492,43 @@ def test_paddle_tensor_device(
     )
 
 
+# digamma
+@handle_frontend_method(
+    class_tree=CLASS_TREE,
+    init_tree="paddle.to_tensor",
+    method_name="digamma",
+    dtype_and_x=helpers.dtype_and_values(
+        available_dtypes=helpers.get_dtypes("float"),
+        min_value=1,
+        max_value=1e5,
+    ),
+)
+def test_paddle_tensor_digamma(
+    dtype_and_x,
+    frontend_method_data,
+    init_flags,
+    method_flags,
+    frontend,
+    on_device,
+    backend_fw,
+):
+    input_dtype, x = dtype_and_x
+    helpers.test_frontend_method(
+        init_input_dtypes=input_dtype,
+        backend_to_test=backend_fw,
+        init_all_as_kwargs_np={
+            "data": x[0],
+        },
+        method_input_dtypes=input_dtype,
+        method_all_as_kwargs_np={},
+        frontend_method_data=frontend_method_data,
+        init_flags=init_flags,
+        method_flags=method_flags,
+        frontend=frontend,
+        on_device=on_device,
+    )
+
+
 # dim
 @handle_frontend_method(
     class_tree=CLASS_TREE,


### PR DESCRIPTION
Close #23739
feat: Added fill_diagonal_tensor function to tensor.tensor

Unfortunately fill_diagonal_tensor is not defined in the paddlepaddle source code, but it is presented in the documentation. So I couldn't understand it well. A little enlightenment would be much appreciated

