### PR TITLE
fix: Replaced `logging.warn()` with `logging.warning()` everywhere.

### DIFF
--- a/ivy/functional/backends/tensorflow/__init__.py
+++ b/ivy/functional/backends/tensorflow/__init__.py
@@ -7,7 +7,7 @@ for device in tf.config.experimental.list_physical_devices("GPU"):
     try:
         tf.config.experimental.set_memory_growth(device, True)
     except RuntimeError as e:
-        logging.warn(f"can not set {device} to dynamically allocate memory. {e}")
+        logging.warning(f"can not set {device} to dynamically allocate memory. {e}")
 
 
 from tensorflow.python.framework.dtypes import DType

--- a/ivy/utils/backend/sub_backend_handler.py
+++ b/ivy/utils/backend/sub_backend_handler.py
@@ -51,11 +51,11 @@ original_backend_dict = None
 
 def set_sub_backend(sub_backend_str: str):
     if ivy.backend == "":
-        logging.warn("You must set a backend first")
+        logging.warning("You must set a backend first")
         return
 
     if ivy.current_backend_str() not in _backend_to_sub_backends_dict.keys():
-        logging.warn(
+        logging.warning(
             f"backend {ivy.current_backend_str()} does not have any"
             " supported sub_backends"
         )
@@ -68,7 +68,7 @@ def set_sub_backend(sub_backend_str: str):
         )
 
     if sub_backend_str not in _backend_to_sub_backends_dict[ivy.current_backend_str()]:
-        logging.warn(
+        logging.warning(
             f"{ivy.current_backend_str()} does not support"
             f" {sub_backend_str} as a sub_backend"
         )

--- a/ivy/utils/profiler.py
+++ b/ivy/utils/profiler.py
@@ -50,7 +50,7 @@ class Profiler(cProfile.Profile):
                         stats.dump_stats(filename=f.name)
                         subprocess.run(["snakeviz", f"{f.name}"])
                 else:
-                    logging.warn("snakeviz must be installed for visualization")
+                    logging.warning("snakeviz must be installed for visualization")
 
             if self.print_stats:
                 stats.print_stats()


### PR DESCRIPTION
# PR Description
Replaced `logging.warn()` with `logging.warning()` everywhere.
The two functions are functionally equivalent, but logging.warn() is no longer considered the preferred way to log warnings.

## Related Issue
Close #24637 

## Checklist

- [ ] Did you add a function?
- [ ] Did you add the tests?
- [ ] Did you run your tests and are your tests passing?
- [x] Did pre-commit not fail on any check?
- [ ] Did you follow the steps we provided?

<!--
Please mark your PR as a draft if you realise after the fact that your tests are not passing or
that your pre-commit check has some failures.

Here are some relevant resources regarding tests and pre-commit:

https://unify.ai/docs/ivy/overview/deep_dive/ivy_tests.html
https://unify.ai/docs/ivy/overview/deep_dive/formatting.html#pre-commit

-->

### Socials:
https://twitter.com/Sai_Suraj_27