### PR TITLE
refactor(np_frontend.random.chisquare): remove to_ivy_arrays_and_back decorator

### DIFF
--- a/ivy/functional/frontends/numpy/random/functions.py
+++ b/ivy/functional/frontends/numpy/random/functions.py
@@ -30,7 +30,6 @@ def binomial(n, p, size=None):
     return ivy.poisson(lambda_, shape=size)
 
 
-@to_ivy_arrays_and_back
 @from_zero_dim_arrays_to_scalar
 def chisquare(df, size=None):
     df = ivy.array(df)  # scalar ints and floats are also array_like


### PR DESCRIPTION
# PR Description

Removed the `@to_ivy_arrays_and_back`  decorator from the `numpy_frontend.random.chisquare` function to ensure it returns `ivy.array`. This resolves issues with nested function calls having unexpected return types.

## Related Issue

Close #24873

## Checklist

- [ ] Did you add a function?
- [ ] Did you add the tests?
- [ ] Did you run your tests and are your tests passing?
- [x] Did pre-commit not fail on any check?
- [ ] Did you follow the steps we provided?


