### PR TITLE
docs: Reformat unset_default_int_dtype

### DIFF
--- a/ivy/functional/ivy/data_type.py
+++ b/ivy/functional/ivy/data_type.py
@@ -2351,10 +2351,6 @@ def unset_default_int_dtype():
     """
     Reset the current default int dtype to the previous state.
 
-    Parameters
-    ----------
-    None-
-
     Examples
     --------
     >>> ivy.set_default_int_dtype(ivy.intDtype("int16"))


### PR DESCRIPTION
<!--
This template will help you to have a meaningful PR, please follow it and do not leave it blank.
-->

# PR Description

This PR reformat the unset_default_int_dtype function's docstring, in order to follow the same style as the similar data_type functions.
<!--
If there is no related issue, please add a short description about your PR.
-->

## Related Issue

<!--
Please use this format to link other issues with their numbers: Close #123
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Close #25278

## Checklist

- [ ] Did you add a function?
- [ ] Did you add the tests?
- [ ] Did you run your tests and are your tests passing?
- [x] Did pre-commit not fail on any check?
- [x] Did you follow the steps we provided?

<!--
Please mark your PR as a draft if you realise after the fact that your tests are not passing or
that your pre-commit check has some failures.

Here are some relevant resources regarding tests and pre-commit:

https://unify.ai/docs/ivy/overview/deep_dive/ivy_tests.html
https://unify.ai/docs/ivy/overview/deep_dive/formatting.html#pre-commit

-->

### Socials:

<!--
If you have Twitter, please provide it here otherwise just ignore this.
-->
