### PR TITLE
fix(ivy): Fixes misleading ivy array attribute error

### DIFF
--- a/ivy/data_classes/array/array.py
+++ b/ivy/data_classes/array/array.py
@@ -431,8 +431,11 @@ class Array(
     def __getattr__(self, item):
         try:
             attr = self._data.__getattribute__(item)
-        except AttributeError:
-            attr = self._data.__getattr__(item)
+        except AttributeError as e:
+            if "has no attribute '__getattribute__'" in str(e):
+                attr = self._data.__getattr__(item)
+            else:
+                raise e
         return to_ivy(attr)
 
     @handle_view_indexing


### PR DESCRIPTION
```
x = ivy.array([[1, 2]])
x.unsqueeze(1)
```
Before the fix: `AttributeError: 'numpy.ndarray' object has not attribute '__getattr__'. Did you mean: 'squeeze'?`
After the fix: `AttributeError: 'numpy.ndarray' object has no attribute 'unsqueeze'. Did you mean: 'squeeze'?`
