### PR TITLE
fix: reverted changes to the post_create_commands.sh script

### DIFF
--- a/.devcontainer/post_create_commands.sh
+++ b/.devcontainer/post_create_commands.sh
@@ -1,15 +1,11 @@
 #!/bin/bash
 
-cd ivy
-
 git submodule update --init --recursive
 
 python3 -m pip install --user -e .
 
 python3 -m pip install pre-commit
 
-git config --global --add safe.directory .
+git config --global --add safe.directory /workspaces/ivy
 
-pre-commit install
-
-cd ..
+( cd /workspaces/ivy/ && pre-commit install)


### PR DESCRIPTION
As it doesn't run `pip install .` correctly leading to not pulling the binaries on creating a codespace. This would break the building of the M1 dockerfile temporarily but getting the binaries pulled correctly on creating codespaces is urgent.