### PR TITLE
fix(ivy-backends): fix import issue for losses at ivy backends

### DIFF
--- a/ivy/functional/backends/jax/experimental/__init__.py
+++ b/ivy/functional/backends/jax/experimental/__init__.py
@@ -14,6 +14,7 @@ from .general import *
 from .gradients import *
 from .layers import *
 from .linear_algebra import *
+from .losses import *
 from .manipulation import *
 from .norms import *
 from .random import *

--- a/ivy/functional/backends/jax/experimental/__init__.py
+++ b/ivy/functional/backends/jax/experimental/__init__.py
@@ -24,3 +24,26 @@ from .sorting import *
 from .sparse_array import *
 from .statistical import *
 from .utility import *
+
+del (
+    activations,
+    converters,
+    creation,
+    data_type,
+    device,
+    elementwise,
+    general,
+    gradients,
+    layers,
+    linear_algebra,
+    losses,
+    manipulation,
+    norms,
+    random,
+    searching,
+    set,
+    sorting,
+    sparse_array,
+    statistical,
+    utility,
+)

--- a/ivy/functional/backends/jax/experimental/__init__.py
+++ b/ivy/functional/backends/jax/experimental/__init__.py
@@ -24,26 +24,3 @@ from .sorting import *
 from .sparse_array import *
 from .statistical import *
 from .utility import *
-
-del (
-    activations,
-    converters,
-    creation,
-    data_type,
-    device,
-    elementwise,
-    general,
-    gradients,
-    layers,
-    linear_algebra,
-    losses,
-    manipulation,
-    norms,
-    random,
-    searching,
-    set,
-    sorting,
-    sparse_array,
-    statistical,
-    utility,
-)

--- a/ivy/functional/backends/numpy/experimental/__init__.py
+++ b/ivy/functional/backends/numpy/experimental/__init__.py
@@ -13,6 +13,7 @@ from .general import *
 from .gradients import *
 from .layers import *
 from .linear_algebra import *
+from .losses import *
 from .manipulation import *
 from .norms import *
 from .random import *

--- a/ivy/functional/backends/numpy/experimental/__init__.py
+++ b/ivy/functional/backends/numpy/experimental/__init__.py
@@ -23,3 +23,25 @@ from .sorting import *
 from .sparse_array import *
 from .statistical import *
 from .utility import *
+
+del (
+    activations,
+    creation,
+    data_type,
+    device,
+    elementwise,
+    general,
+    gradients,
+    layers,
+    linear_algebra,
+    losses,
+    manipulation,
+    norms,
+    random,
+    searching,
+    set,
+    sorting,
+    sparse_array,
+    statistical,
+    utility,
+)

--- a/ivy/functional/backends/numpy/experimental/__init__.py
+++ b/ivy/functional/backends/numpy/experimental/__init__.py
@@ -23,25 +23,3 @@ from .sorting import *
 from .sparse_array import *
 from .statistical import *
 from .utility import *
-
-del (
-    activations,
-    creation,
-    data_type,
-    device,
-    elementwise,
-    general,
-    gradients,
-    layers,
-    linear_algebra,
-    losses,
-    manipulation,
-    norms,
-    random,
-    searching,
-    set,
-    sorting,
-    sparse_array,
-    statistical,
-    utility,
-)

--- a/ivy/functional/backends/paddle/experimental/__init__.py
+++ b/ivy/functional/backends/paddle/experimental/__init__.py
@@ -12,6 +12,7 @@ from .elementwise import *
 from .general import *
 from .gradients import *
 from .layers import *
+from .losses import *
 from .linear_algebra import *
 from .manipulation import *
 from .norms import *

--- a/ivy/functional/backends/paddle/experimental/__init__.py
+++ b/ivy/functional/backends/paddle/experimental/__init__.py
@@ -23,26 +23,3 @@ from .sorting import *
 from .sparse_array import *
 from .statistical import *
 from .utility import *
-
-del (
-    activations,
-    converters,
-    creation,
-    data_type,
-    device,
-    elementwise,
-    general,
-    gradients,
-    layers,
-    linear_algebra,
-    losses,
-    manipulation,
-    norms,
-    random,
-    searching,
-    set,
-    sorting,
-    sparse_array,
-    statistical,
-    utility,
-)

--- a/ivy/functional/backends/paddle/experimental/__init__.py
+++ b/ivy/functional/backends/paddle/experimental/__init__.py
@@ -23,3 +23,26 @@ from .sorting import *
 from .sparse_array import *
 from .statistical import *
 from .utility import *
+
+del (
+    activations,
+    converters,
+    creation,
+    data_type,
+    device,
+    elementwise,
+    general,
+    gradients,
+    layers,
+    linear_algebra,
+    losses,
+    manipulation,
+    norms,
+    random,
+    searching,
+    set,
+    sorting,
+    sparse_array,
+    statistical,
+    utility,
+)

--- a/ivy/functional/backends/tensorflow/experimental/__init__.py
+++ b/ivy/functional/backends/tensorflow/experimental/__init__.py
@@ -13,6 +13,7 @@ from .general import *
 from .gradients import *
 from .layers import *
 from .linear_algebra import *
+from .losses import *
 from .manipulation import *
 from .norms import *
 from .random import *

--- a/ivy/functional/backends/tensorflow/experimental/__init__.py
+++ b/ivy/functional/backends/tensorflow/experimental/__init__.py
@@ -23,3 +23,25 @@ from .sorting import *
 from .sparse_array import *
 from .statistical import *
 from .utility import *
+
+del (
+    activations,
+    creation,
+    data_type,
+    device,
+    elementwise,
+    general,
+    gradients,
+    layers,
+    linear_algebra,
+    losses,
+    manipulation,
+    norms,
+    random,
+    searching,
+    set,
+    sorting,
+    sparse_array,
+    statistical,
+    utility,
+)

--- a/ivy/functional/backends/tensorflow/experimental/__init__.py
+++ b/ivy/functional/backends/tensorflow/experimental/__init__.py
@@ -23,25 +23,3 @@ from .sorting import *
 from .sparse_array import *
 from .statistical import *
 from .utility import *
-
-del (
-    activations,
-    creation,
-    data_type,
-    device,
-    elementwise,
-    general,
-    gradients,
-    layers,
-    linear_algebra,
-    losses,
-    manipulation,
-    norms,
-    random,
-    searching,
-    set,
-    sorting,
-    sparse_array,
-    statistical,
-    utility,
-)

--- a/ivy/functional/backends/torch/experimental/__init__.py
+++ b/ivy/functional/backends/torch/experimental/__init__.py
@@ -13,6 +13,7 @@ from .general import *
 from .gradients import *
 from .layers import *
 from .linear_algebra import *
+from .losses import *
 from .manipulation import *
 from .norms import *
 from .random import *

--- a/ivy/functional/backends/torch/experimental/__init__.py
+++ b/ivy/functional/backends/torch/experimental/__init__.py
@@ -23,26 +23,3 @@ from .sorting import *
 from .sparse_array import *
 from .statistical import *
 from .utility import *
-
-del (
-    activations,
-    converters,
-    creation,
-    data_type,
-    device,
-    elementwise,
-    general,
-    gradients,
-    layers,
-    linear_algebra,
-    losses,
-    manipulation,
-    norms,
-    random,
-    searching,
-    set,
-    sorting,
-    sparse_array,
-    statistical,
-    utility,
-)

--- a/ivy/functional/backends/torch/experimental/__init__.py
+++ b/ivy/functional/backends/torch/experimental/__init__.py
@@ -23,3 +23,26 @@ from .sorting import *
 from .sparse_array import *
 from .statistical import *
 from .utility import *
+
+del (
+    activations,
+    converters,
+    creation,
+    data_type,
+    device,
+    elementwise,
+    general,
+    gradients,
+    layers,
+    linear_algebra,
+    losses,
+    manipulation,
+    norms,
+    random,
+    searching,
+    set,
+    sorting,
+    sparse_array,
+    statistical,
+    utility,
+)


### PR DESCRIPTION


# PR Description

This commit adds missing support for losses across all Ivy backends (TensorFlow, Paddle, Jax, NumPy, and Torch).

# Reviewer Request
@HaiderSultanArc 


