### PR TITLE
fix(paddle_backend.round): align rounding behavior with `np.round`

### DIFF
--- a/ivy/functional/backends/paddle/elementwise.py
+++ b/ivy/functional/backends/paddle/elementwise.py
@@ -830,39 +830,45 @@ def pow(
     return paddle.pow(x1, x2)
 
 
+# Implementation based on TensorFlow's scalar_round_half_to_even_op logic
+# Reference: https://github.com/tensorflow/tensorflow/blob/7f1050a6976d11bfb0bb37bdfc82350c0a238faa/tensorflow/core/kernels/cwise_ops.h#L510  # noqa: E501
+def _round_half_to_even(x):
+    round_val = paddle.floor(x + 0.5)
+    fraction = round_val - x
+
+    # Identify elements with a fractional part of 0.5
+    mask = paddle.equal(fraction, paddle.to_tensor(0.5, dtype=fraction.dtype))
+
+    # Round to the nearest even number if the fraction is 0.5
+    even_round_val = 2 * paddle.floor(0.5 * x + 0.5)
+
+    # Combine the results
+    return paddle.where(mask, even_round_val, round_val)
+
+
+# This function aims to mimic the behavior of np.round similar to how tf.experimental.numpy.round does # noqa: E501
+# Reference for tf.experimental.numpy.round:https://github.com/tensorflow/tensorflow/blob/v2.13.0/tensorflow/python/ops/numpy_ops/np_array_ops.py#L724 # noqa: E501
 def round(
     x: paddle.Tensor, /, *, decimals: int = 0, out: Optional[paddle.Tensor] = None
 ) -> paddle.Tensor:
-    def _np_round(x):
-        # this is a logic to mimic np.round behaviour
-        # which rounds odd numbers up and even numbers down at limits like 0.5
+    x = paddle.to_tensor(x, dtype=x.dtype)
+    dtype_ = x.dtype
+    factor = math.pow(10, decimals)
 
-        one = paddle.to_tensor(1, dtype="int64")
+    # Handle floating point and complex numbers
+    if paddle.is_floating_point(x) or paddle.is_complex(x):
+        factor = paddle.to_tensor(factor)
+        factor = paddle.cast(factor, dtype_)
+    else:
+        float_dtype_ = paddle.float32  # paddle.get_default_dtype()
+        x = x.astype(float_dtype_)
+        factor = paddle.cast(factor, float_dtype_)
 
-        # check if the number is even or odd
-        is_even = paddle.bitwise_and(paddle_backend.trunc(x).astype("int64"), one) == 0
+    x = paddle.multiply(x, factor)
+    x = _round_half_to_even(x)
+    x = paddle.divide(x, factor)
 
-        # round the number to the nearest integer
-        round_x = paddle.sign(x) * paddle.where(
-            is_even, paddle.floor(x.abs()), paddle.ceil(x.abs())
-        )
-
-        # if the number was rounded up from an even number
-        #   round the number down to the nearest even number
-        return paddle.where(
-            paddle.logical_and(
-                paddle.bitwise_and(round_x.astype("int64"), one) == 1.0,
-                is_even,
-            ),
-            round_x - 1.0,
-            round_x,
-        )
-
-    if x.dtype not in [paddle.float32, paddle.float64]:
-        if paddle.is_complex(x):
-            return paddle.complex(_np_round(x.real()), _np_round(x.imag()))
-        return _np_round(x.astype("float32")).astype(x.dtype)
-    return _np_round(x).astype(x.dtype)
+    return x.astype(dtype_)
 
 
 def trunc(x: paddle.Tensor, /, *, out: Optional[paddle.Tensor] = None) -> paddle.Tensor:

--- a/ivy/functional/backends/paddle/elementwise.py
+++ b/ivy/functional/backends/paddle/elementwise.py
@@ -849,7 +849,7 @@ def _round_half_to_even(x):
 # This function aims to mimic the behavior of np.round similar to how tf.experimental.numpy.round does # noqa: E501
 # Reference for tf.experimental.numpy.round:https://github.com/tensorflow/tensorflow/blob/v2.13.0/tensorflow/python/ops/numpy_ops/np_array_ops.py#L724 # noqa: E501
 @with_unsupported_device_and_dtypes(
-    {"2.5.1 and below": {"cpu": ("bfloat16", "float16")}}, backend_version
+    {"2.5.1 and below": {"cpu": ("bfloat16", "float16", "complex")}}, backend_version
 )
 def round(
     x: paddle.Tensor, /, *, decimals: int = 0, out: Optional[paddle.Tensor] = None

--- a/ivy/functional/frontends/paddle/math.py
+++ b/ivy/functional/frontends/paddle/math.py
@@ -1,6 +1,10 @@
 # global
 import ivy
-from ivy.func_wrapper import with_unsupported_dtypes, with_supported_dtypes
+from ivy.func_wrapper import (
+    with_unsupported_dtypes,
+    with_supported_dtypes,
+    with_supported_device_and_dtypes,
+)
 from ivy.functional.frontends.paddle.func_wrapper import to_ivy_arrays_and_back
 
 
@@ -446,10 +450,20 @@ def remainder(x, y, name=None):
     return ivy.remainder(x, y)
 
 
-@with_unsupported_dtypes({"2.5.1 and below": ("float16", "bfloat16")}, "paddle")
+@with_supported_device_and_dtypes(
+    {
+        "2.5.1 and below": {
+            "cpu": ("float32", "float64"),
+            "gpu": ("float16", "float32", "float64"),
+        }
+    },
+    "paddle",
+)
 @to_ivy_arrays_and_back
 def round(x, name=None):
-    return ivy.round(x)
+    sign = ivy.sign(x)
+    x = sign * ivy.floor(ivy.abs(x) + 0.5)
+    return x
 
 
 @with_supported_dtypes({"2.5.1 and below": ("float32", "float64")}, "paddle")


### PR DESCRIPTION
# PR Description

The rounding function is now aligned to behave similarly to np.round.

## Related Issue

Close #25865

## Checklist

- [x] Did you add a function?
- [ ] Did you add the tests?
- [ ] Did you run your tests and are your tests passing?
- [x] Did pre-commit not fail on any check?
- [ ] Did you follow the steps we provided?


