### PR TITLE
Update math.py

### DIFF
--- a/ivy/functional/frontends/tensorflow/math.py
+++ b/ivy/functional/frontends/tensorflow/math.py
@@ -105,7 +105,7 @@ def atanh(x, name="atanh"):
 
 
 @with_supported_dtypes(
-    {"2.13.0 and below": ("int32",)},
+    {"2.13.0 and below": ("int32","bfloat16")},
     "tensorflow",
 )
 @to_ivy_arrays_and_back
@@ -276,11 +276,19 @@ def floor(x, name=None):
 @to_ivy_arrays_and_back
 def floordiv(x, y, name=None):
     return ivy.floor_divide(x, y)
-
+@with_supported_device_and_dtypes(
+    {
+        "2.13.0 and below": {
+            "cpu": ("float32", "float64"),
+            "gpu": ("bfloat16", "float16", "float32", "float64"),
+        }
+    },
+    "tensorflow",
+)
 
 @to_ivy_arrays_and_back
 def floormod(x, y, name=None):
-    return tensorflow.math.remainder(x, y)
+    return ivy.remainder(x, y)
 
 
 @to_ivy_arrays_and_back
@@ -310,7 +318,7 @@ def igamma(a, x, name=None):
 
 
 @with_supported_dtypes(
-    {"2.13.0 and below": ("float16", "float32", "float64", "complex64", "complex128")},
+    {"2.13.0 and below": ("bfloat16","float16", "float32", "float64", "complex64", "complex128")},
     "tensorflow",
 )
 @to_ivy_arrays_and_back

--- a/ivy/functional/frontends/tensorflow/math.py
+++ b/ivy/functional/frontends/tensorflow/math.py
@@ -280,7 +280,7 @@ def floordiv(x, y, name=None):
 
 @to_ivy_arrays_and_back
 def floormod(x, y, name=None):
-    return ivy.remainder(x, y)
+    return tensorflow.math.remainder(x, y)
 
 
 @to_ivy_arrays_and_back


### PR DESCRIPTION
PR Description
I used the @supported_datatypes to support the "bfloat16" which will work as other datatypes are working.

Related Issue
Close https://github.com/unifyai/ivy/issues/23905
fix #23905

Checklist
 

- [x]  Did you add a function?
- [ ]  Did you add the tests?
- [x]  Did you run your tests and are your tests passing?
- [x]  Did pre-commit not fail on any check?
- [x]  Did you follow the steps we provided?