### PR TITLE
fix: ivy.floor to support 'bfloat16' 

### DIFF
--- a/ivy/functional/frontends/tensorflow/math.py
+++ b/ivy/functional/frontends/tensorflow/math.py
@@ -105,7 +105,7 @@ def atanh(x, name="atanh"):
 
 
 @with_supported_dtypes(
-    {"2.13.0 and below": ("int32",)},
+    {"2.13.0 and below": ("int32","bfloat16")},
     "tensorflow",
 )
 @to_ivy_arrays_and_back
@@ -276,11 +276,19 @@ def floor(x, name=None):
 @to_ivy_arrays_and_back
 def floordiv(x, y, name=None):
     return ivy.floor_divide(x, y)
-
+@with_supported_device_and_dtypes(
+    {
+        "2.13.0 and below": {
+            "cpu": ("float32", "float64"),
+            "gpu": ("bfloat16", "float16", "float32", "float64"),
+        }
+    },
+    "tensorflow",
+)
 
 @to_ivy_arrays_and_back
 def floormod(x, y, name=None):
-    return tensorflow.math.remainder(x, y)
+    return ivy.remainder(x, y)
 
 
 @to_ivy_arrays_and_back
@@ -310,7 +318,7 @@ def igamma(a, x, name=None):
 
 
 @with_supported_dtypes(
-    {"2.13.0 and below": ("float16", "float32", "float64", "complex64", "complex128")},
+    {"2.13.0 and below": ("bfloat16","float16", "float32", "float64", "complex64", "complex128")},
     "tensorflow",
 )
 @to_ivy_arrays_and_back

--- a/ivy/functional/frontends/tensorflow/math.py
+++ b/ivy/functional/frontends/tensorflow/math.py
@@ -280,7 +280,7 @@ def floordiv(x, y, name=None):
 
 @to_ivy_arrays_and_back
 def floormod(x, y, name=None):
-    return ivy.remainder(x, y)
+    return tensorflow.math.remainder(x, y)
 
 
 @to_ivy_arrays_and_back

--- a/ivy/functional/frontends/tensorflow/math.py
+++ b/ivy/functional/frontends/tensorflow/math.py
@@ -276,6 +276,7 @@ def floor(x, name=None):
 @to_ivy_arrays_and_back
 def floordiv(x, y, name=None):
     return ivy.floor_divide(x, y)
+
 @with_supported_device_and_dtypes(
     {
         "2.13.0 and below": {
@@ -285,10 +286,13 @@ def floordiv(x, y, name=None):
     },
     "tensorflow",
 )
-
 @to_ivy_arrays_and_back
 def floormod(x, y, name=None):
-    return ivy.remainder(x, y)
+    if ivy.dtype(x) == "bfloat16":
+        # Handle bfloat16 separately, as remainder is not supported
+        return ivy.floor(x) - ivy.floor(x / y) * y
+    else:
+        return ivy.remainder(x, y)
 
 
 @to_ivy_arrays_and_back

--- a/ivy/functional/frontends/tensorflow/math.py
+++ b/ivy/functional/frontends/tensorflow/math.py
@@ -105,7 +105,7 @@ def atanh(x, name="atanh"):
 
 
 @with_supported_dtypes(
-    {"2.13.0 and below": ("int32","bfloat16")},
+    {"2.13.0 and below": ("int32",)},
     "tensorflow",
 )
 @to_ivy_arrays_and_back
@@ -277,22 +277,10 @@ def floor(x, name=None):
 def floordiv(x, y, name=None):
     return ivy.floor_divide(x, y)
 
-@with_supported_device_and_dtypes(
-    {
-        "2.13.0 and below": {
-            "cpu": ("float32", "float64"),
-            "gpu": ("bfloat16", "float16", "float32", "float64"),
-        }
-    },
-    "tensorflow",
-)
+@with_unsupported_dtypes({"2.5.1 and below": ("float16", "bfloat16")}, "tensorflow")
 @to_ivy_arrays_and_back
 def floormod(x, y, name=None):
-    if ivy.dtype(x) == "bfloat16":
-        # Handle bfloat16 separately, as remainder is not supported
-        return ivy.floor(x) - ivy.floor(x / y) * y
-    else:
-        return ivy.remainder(x, y)
+    return ivy.remainder(x, y)
 
 
 @to_ivy_arrays_and_back
@@ -322,7 +310,7 @@ def igamma(a, x, name=None):
 
 
 @with_supported_dtypes(
-    {"2.13.0 and below": ("bfloat16","float16", "float32", "float64", "complex64", "complex128")},
+    {"2.13.0 and below": ("float16", "float32", "float64", "complex64", "complex128")},
     "tensorflow",
 )
 @to_ivy_arrays_and_back


### PR DESCRIPTION
<!--
This template will help you to have a meaningful PR, please follow it and do not leave it blank.
-->

# PR Description
I added one function which do following things:
It calculates the floor of x using ivy.floor(x).
It calculates the floor of the result of x / y using ivy.floor(x / y).
It subtracts the second floor result from the first floor result and multiplies it by y to compute the modulus.
<!--
If there is no related issue, please add a short description about your PR.

-->

## Related Issue

<!--
Please use this format to link other issues with their numbers: Close #123
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Close #23905

feat: allow provided function for 'bfloat16'
BREAKING CHANGE: 'bfloat16' remainder will be provided by floormod

## Checklist

- [x] Did you add a function?
- [ ] Did you add the tests?
- [x] Did you run your tests and are your tests passing?
- [ ] Did pre-commit not fail on any check?
- [x] Did you follow the steps we provided?

<!--
Please mark your PR as a draft if you realise after the fact that your tests are not passing or
that your pre-commit check has some failures.

Here are some relevant resources regarding tests and pre-commit:

https://unify.ai/docs/ivy/overview/deep_dive/ivy_tests.html
https://unify.ai/docs/ivy/overview/deep_dive/formatting.html#pre-commit

-->

### Socials:

<!--
If you have Twitter, please provide it here otherwise just ignore this.
-->
