### PR TITLE
fix(torch-frontend): Added unsupported dtype for  `torch.nn.functional.linear`

### DIFF
--- a/ivy/functional/backends/paddle/linear_algebra.py
+++ b/ivy/functional/backends/paddle/linear_algebra.py
@@ -227,6 +227,7 @@ def matmul(
         paddle.uint8,
         paddle.float16,
         paddle.bool,
+        paddle.bfloat16,
     ]:
         x1, x2 = x1.cast("float32"), x2.cast("float32")
 

--- a/ivy/functional/frontends/torch/nn/functional/linear_functions.py
+++ b/ivy/functional/frontends/torch/nn/functional/linear_functions.py
@@ -1,8 +1,10 @@
 # local
 import ivy
+from ivy.func_wrapper import with_unsupported_dtypes
 from ivy.functional.frontends.torch.func_wrapper import to_ivy_arrays_and_back
 
 
+@with_unsupported_dtypes({"2.0.1 and below": ("float16",)}, "torch")
 @to_ivy_arrays_and_back
 def linear(input, weight, bias=None):
     return ivy.linear(input, weight, bias=bias)


### PR DESCRIPTION
<!--
This template will help you to have a meaningful PR, please follow it and do not leave it blank.
-->

# PR Description

<!--
If there is no related issue, please add a short description about your PR.
-->

## Related Issue

<!--
Please use this format to link other issues with their numbers: Close #123
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Close #

## Checklist

- [ ] Did you add a function?
- [ ] Did you add the tests?
- [ ] Did you run your tests and are your tests passing?
- [ ] Did pre-commit not fail on any check?
- [ ] Did you follow the steps we provided?

<!--
Please mark your PR as a draft if you realise after the fact that your tests are not passing or
that your pre-commit check has some failures.

Here are some relevant resources regarding tests and pre-commit:

https://unify.ai/docs/ivy/overview/deep_dive/ivy_tests.html
https://unify.ai/docs/ivy/overview/deep_dive/formatting.html#pre-commit

-->

### Socials:

<!--
If you have Twitter, please provide it here otherwise just ignore this.
-->
