### PR TITLE
Chore: Cache the ivy docker files

### DIFF
--- a/.github/workflows/dockerfile-push.yml
+++ b/.github/workflows/dockerfile-push.yml
@@ -36,7 +36,7 @@ jobs:
 
     # Build and push Docker image
     - name: Build and push Dockerfile
-      uses: docker/build-push-action@v3
+      uses: docker/build-push-action@v5
       with:
         context: .
         file: docker/Dockerfile

--- a/.github/workflows/dockerfile-push.yml
+++ b/.github/workflows/dockerfile-push.yml
@@ -2,14 +2,12 @@ name: Dockerfile Push
 
 on:
   schedule:
-    # run at everyday at 00:00 UTC
+    # run everyday at 00:00 UTC
     - cron:  '0 0 * * *'
   workflow_dispatch:
 
 jobs:
-
   build:
-
     runs-on: ubuntu-20.04
 
     steps:
@@ -24,8 +22,25 @@ jobs:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
 
+    # Cache Docker layers
+    - name: Cache Docker layers
+      uses: actions/cache@v3
+      with:
+        path: /tmp/.buildx-cache
+        key: ${{ runner.os }}-buildx-${{ github.sha }}
+        restore-keys: |
+          ${{ runner.os }}-buildx-
+
+    # Build and push Docker image
     - name: Build and push Dockerfile
-      run: |
-        docker build . --file docker/Dockerfile --tag unifyai/ivy:latest
-        docker push unifyai/ivy:latest
+      uses: docker/build-push-action@v3
+      with:
+        context: .
+        file: docker/Dockerfile
+        push: true
+        tags: unifyai/ivy:latest
+        cache-from: type=local,src=/tmp/.buildx-cache
+        cache-to: type=local,dest=/tmp/.buildx-cache


### PR DESCRIPTION
Cache the docker image created in https://github.com/unifyai/ivy/blob/main/.github/workflows/dockerfile-push.yml to be cached for the whole organisation to use.