### PR TITLE
(fix): for older torch versions without mps backend

### DIFF
--- a/ivy/functional/backends/torch/device.py
+++ b/ivy/functional/backends/torch/device.py
@@ -96,7 +96,9 @@ def num_gpus() -> int:
 
 
 def gpu_is_available() -> bool:
-    return torch.backends.mps.is_available() or torch.cuda.is_available()
+    return (
+        hasattr(torch.backends, "mps") and torch.backends.mps.is_available()
+    ) or torch.cuda.is_available()
 
 
 # noinspection PyUnresolvedReferences

--- a/ivy/functional/backends/torch/device.py
+++ b/ivy/functional/backends/torch/device.py
@@ -74,7 +74,7 @@ def as_native_dev(
 ) -> Optional[torch.device]:
     if not isinstance(device, str):
         return device
-    if torch.backends.mps.is_available():
+    if hasattr(torch.backends, "mps") and torch.backends.mps.is_available():
         return torch.device(ivy.Device(device).replace("gpu", "mps"))
     return torch.device(ivy.Device(device).replace("gpu", "cuda"))
 


### PR DESCRIPTION

small fix for old torch versions which don't have an mps backend, was this picked up by the multiversion tests @vedpatwardhan ?