### PR TITLE
refactor: remove bfloat16 from decorators

### DIFF
--- a/ivy/functional/frontends/torch/tensor.py
+++ b/ivy/functional/frontends/torch/tensor.py
@@ -243,7 +243,7 @@ class Tensor:
     def cosh(self):
         return torch_frontend.cosh(self)
 
-    @with_unsupported_dtypes({"2.0.1 and below": ("float16", "bfloat16")}, "torch")
+    @with_unsupported_dtypes({"2.0.1 and below": ("float16",)}, "torch")
     def cosh_(self):
         self.ivy_array = self.cosh().ivy_array
         return self
@@ -571,7 +571,7 @@ class Tensor:
     def acos(self):
         return torch_frontend.acos(self)
 
-    @with_unsupported_dtypes({"2.0.1 and below": ("float16", "bfloat16")}, "torch")
+    @with_unsupported_dtypes({"2.0.1 and below": ("float16",)}, "torch")
     def acos_(self):
         self.ivy_array = self.acos().ivy_array
         return self
@@ -620,7 +620,7 @@ class Tensor:
         self.ivy_array = self.detach().ivy_array
         return self
 
-    @with_unsupported_dtypes({"2.0.1 and below": ("bfloat16", "uint16")}, "torch")
+    @with_unsupported_dtypes({"2.0.1 and below": ("uint16",)}, "torch")
     @numpy_to_torch_style_args
     def unsqueeze(self, dim):
         return torch_frontend.unsqueeze(self, dim)
@@ -894,7 +894,7 @@ class Tensor:
         return torch_frontend.squeeze(self, dim)
 
     @numpy_to_torch_style_args
-    @with_unsupported_dtypes({"2.0.1 and below": ("bfloat16", "uint16")}, "torch")
+    @with_unsupported_dtypes({"2.0.1 and below": ("uint16",)}, "torch")
     def squeeze_(self, dim=None):
         self.ivy_array = self.squeeze(dim).ivy_array
         return self
@@ -996,7 +996,7 @@ class Tensor:
     def sigmoid(self):
         return torch_frontend.sigmoid(self)
 
-    @with_unsupported_dtypes({"2.0.1 and below": ("float16", "bfloat16")}, "torch")
+    @with_unsupported_dtypes({"2.0.1 and below": ("float16",)}, "torch")
     def sigmoid_(self):
         self.ivy_array = self.sigmoid().ivy_array
         return self
@@ -1066,9 +1066,7 @@ class Tensor:
     def msort(self):
         return torch_frontend.msort(self)
 
-    @with_unsupported_dtypes(
-        {"2.0.1 and below": ("float16", "bfloat16", "complex")}, "torch"
-    )
+    @with_unsupported_dtypes({"2.0.1 and below": ("float16", "complex")}, "torch")
     def trunc(self):
         return torch_frontend.trunc(self)
 
@@ -1081,9 +1079,7 @@ class Tensor:
     def fix(self):
         return torch_frontend.fix(self)
 
-    @with_unsupported_dtypes(
-        {"2.0.1 and below": ("float16", "bfloat16", "complex")}, "torch"
-    )
+    @with_unsupported_dtypes({"2.0.1 and below": ("float16", "complex")}, "torch")
     def fix_(self):
         self.ivy_array = self.fix().ivy_array
         return self
@@ -1386,7 +1382,7 @@ class Tensor:
     def square(self):
         return torch_frontend.square(self._ivy_array)
 
-    @with_unsupported_dtypes({"2.0.1 and below": ("float16", "bfloat16")}, "torch")
+    @with_unsupported_dtypes({"2.0.1 and below": ("float16",)}, "torch")
     def log10(self):
         return torch_frontend.log10(self._ivy_array)
 
@@ -1395,7 +1391,7 @@ class Tensor:
         self.ivy_array = self.log10().ivy_array
         return self
 
-    @with_unsupported_dtypes({"2.0.1 and below": ("bfloat16", "uint16")}, "torch")
+    @with_unsupported_dtypes({"2.0.1 and below": ("uint16",)}, "torch")
     def zero_(self):
         self.ivy_array = torch_frontend.zeros_like(self).ivy_array
         return self


### PR DESCRIPTION
<!--
This template will help you to have a meaningful PR, please follow it and do not leave it blank.
-->

# PR Description

This PR will remove bfloat16 from some `with_unsupported_dtypes` decorators.
<!--
If there is no related issue, please add a short description about your PR.
-->

## Related Issue

<!--
Please use this format to link other issues with their numbers: Close #123
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

This PR is related to the Trello task: https://trello.com/c/mWrhZsRl/2816-remove-bfloat16-from-a-few-decorators

## Checklist

- [ ] Did you add a function?
- [ ] Did you add the tests?
- [X] Did you run your tests and are your tests passing?
- [X] Did pre-commit not fail on any check?
- [X] Did you follow the steps we provided?
