### PR TITLE
fix: Added missing `logging` import in `ivy\__init__.py`

### DIFF
--- a/ivy/__init__.py
+++ b/ivy/__init__.py
@@ -2,6 +2,7 @@
 import copy
 import re
 import warnings
+import logging
 import builtins
 import numpy as np
 import sys


### PR DESCRIPTION
# PR Description
In the file [`ivy\__init__.py`](https://github.com/unifyai/ivy/blob/main/ivy/__init__.py)
I noticed that the logging import is missing. This could potentially lead to issues with logging and debugging in the codebase. 
For the following lines to work as intended I think the logging import should be added.
https://github.com/unifyai/ivy/blob/86afb43b97dab3ca2cd10f24bbe631a6cbfcdc6f/ivy/__init__.py#L1464
https://github.com/unifyai/ivy/blob/86afb43b97dab3ca2cd10f24bbe631a6cbfcdc6f/ivy/__init__.py#L1465
https://github.com/unifyai/ivy/blob/86afb43b97dab3ca2cd10f24bbe631a6cbfcdc6f/ivy/__init__.py#L1478
https://github.com/unifyai/ivy/blob/86afb43b97dab3ca2cd10f24bbe631a6cbfcdc6f/ivy/__init__.py#L1488
So, I have added it.

## Related Issue
Close #26357

## Checklist
- [ ] Did you add a function?
- [ ] Did you add the tests?
- [ ] Did you run your tests and are your tests passing?
- [x] Did pre-commit not fail on any check?
- [ ] Did you follow the steps we provided?

### Socials
https://twitter.com/Sai_Suraj_27