### PR TITLE
fix: Add missing `ivy` import in one file.

### DIFF
--- a/ivy_tests/test_ivy/test_frontends/test_torch/test_nn/test_functional/test_layer_functions.py
+++ b/ivy_tests/test_ivy/test_frontends/test_torch/test_nn/test_functional/test_layer_functions.py
@@ -2,6 +2,7 @@
 from hypothesis import strategies as st
 
 # local
+import ivy
 from ivy.functional.backends.torch.layers import _get_embed_dim
 from ivy_tests.test_ivy import helpers
 from ivy_tests.test_ivy.helpers import handle_frontend_test


### PR DESCRIPTION
# PR Description
In the file [`ivy_tests\test_ivy\test_frontends\test_torch\test_nn\test_functional\test_layer_functions.py`](https://github.com/unifyai/ivy/blob/main/ivy_tests/test_ivy/test_frontends/test_torch/test_nn/test_functional/test_layer_functions.py), In the following line:
https://github.com/unifyai/ivy/blob/4cd7770b02bfb8d7367424ececc8b17b0c2852c3/ivy_tests/test_ivy/test_frontends/test_torch/test_nn/test_functional/test_layer_functions.py#L90
We are using `ivy.is_array()` but we have `not imported ivy` in this file. So, I have added the ivy import.

## Related Issue
Close #26559

## Checklist

- [ ] Did you add a function?
- [ ] Did you add the tests?
- [ ] Did you run your tests and are your tests passing?
- [x] Did pre-commit not fail on any check?
- [ ] Did you follow the steps we provided?

### Socials
https://twitter.com/Sai_Suraj_27