### PR TITLE
refactor: Extract `Duplicate Code` into Helper Function in `ivy\func_wrapper.py`

### DIFF
--- a/ivy/func_wrapper.py
+++ b/ivy/func_wrapper.py
@@ -94,88 +94,47 @@ def caster(dtype, intersect):
 def upcaster(dtype, intersect):
     # upcasting is enabled, we upcast to the highest
     if "uint" in str(dtype):
-        index = casting_modes_dict["uint"]().index(dtype) + 1
-        result = ""
-        while index < len(casting_modes_dict["uint"]()):
-            if casting_modes_dict["uint"]()[index] not in intersect:
-                result = casting_modes_dict["uint"]()[index]
-                break
-            index += 1
-        return result
-
+        return upcast_helper("uint", dtype, intersect)
     if "int" in dtype:
-        index = casting_modes_dict["int"]().index(dtype) + 1
-        result = ""
-        while index < len(casting_modes_dict["int"]()):
-            if casting_modes_dict["int"]()[index] not in intersect:
-                result = casting_modes_dict["int"]()[index]
-                break
-            index += 1
-        return result
-
+        return upcast_helper("int", dtype, intersect)
     if "float" in dtype:
-        index = casting_modes_dict["float"]().index(dtype) + 1
-        result = ""
-        while index < len(casting_modes_dict["float"]()):
-            if casting_modes_dict["float"]()[index] not in intersect:
-                result = casting_modes_dict["float"]()[index]
-                break
-            index += 1
-        return result
-
+        return upcast_helper("float", dtype, intersect)
     if "complex" in dtype:
-        index = casting_modes_dict["complex"]().index(dtype) + 1
-        result = ""
-        while index < len(casting_modes_dict["complex"]()):
-            if casting_modes_dict["complex"]()[index] not in intersect:
-                result = casting_modes_dict["complex"]()[index]
-                break
-            index += 1
-        return result
+        return upcast_helper("complex", dtype, intersect)
+
+
+def upcast_helper(arg0, dtype, intersect):
+    index = casting_modes_dict[arg0]().index(dtype) + 1
+    result = ""
+    while index < len(casting_modes_dict[arg0]()):
+        if casting_modes_dict[arg0]()[index] not in intersect:
+            result = casting_modes_dict[arg0]()[index]
+            break
+        index += 1
+    return result
 
 
 def downcaster(dtype, intersect):
     # downcasting is enabled, we upcast to the highest
     if "uint" in str(dtype):
-        index = casting_modes_dict["uint"]().index(dtype) - 1
-        result = ""
-        while index >= 0:
-            if casting_modes_dict["int"]()[index] not in intersect:
-                result = casting_modes_dict["uint"]()[index]
-                break
-            index -= 1
-        return result
-
+        return downcast_helper("uint", dtype, "int", intersect)
     if "int" in dtype:
-        index = casting_modes_dict["int"]().index(dtype) - 1
-        result = ""
-        while index >= 0:
-            if casting_modes_dict["int"]()[index] not in intersect:
-                result = casting_modes_dict["int"]()[index]
-                break
-            index -= 1
-        return result
-
+        return downcast_helper("int", dtype, "int", intersect)
     if "float" in dtype:
-        index = casting_modes_dict["float"]().index(dtype) - 1
-
-        result = ""
-        while index >= 0:
-            if casting_modes_dict["float"]()[index] not in intersect:
-                result = casting_modes_dict["float"]()[index]
-                break
-            index -= 1
-        return result
-
+        return downcast_helper("float", dtype, "float", intersect)
     if "complex" in dtype:
-        index = casting_modes_dict["complex"]().index(dtype) - 1
-        result = ""
-        while index >= 0:
-            if casting_modes_dict["complex"]()[index] not in intersect:
-                result = casting_modes_dict["complex"]()[index]
-                break
-            index -= 1
-        return result
+        return downcast_helper("complex", dtype, "complex", intersect)
+
+
+def downcast_helper(arg0, dtype, arg2, intersect):
+    index = casting_modes_dict[arg0]().index(dtype) - 1
+    result = ""
+    while index >= 0:
+        if casting_modes_dict[arg2]()[index] not in intersect:
+            result = casting_modes_dict[arg0]()[index]
+            break
+        index -= 1
+    return result
 
 
 def cross_caster(intersect):


### PR DESCRIPTION
# PR Description
I identified duplicate sections of code in the following functions:
https://github.com/unifyai/ivy/blob/2bfb19a2ca3b277e95cba987353aa349ef28015e/ivy/func_wrapper.py#L94
https://github.com/unifyai/ivy/blob/2bfb19a2ca3b277e95cba987353aa349ef28015e/ivy/func_wrapper.py#L137

So, I extracted these into their own method/function to increase the readability and decrease the amount of duplicate/repeating code in the file. This refactoring simplifies the code, and reduces redundancy.

## Checklist

- [ ] Did you add a function?
- [ ] Did you add the tests?
- [ ] Did you run your tests and are your tests passing?
- [x] Did pre-commit not fail on any check?
- [ ] Did you follow the steps we provided?

### Socials
https://twitter.com/Sai_Suraj_27