### PR TITLE
fix: added tensorflow support for bool to ivy.greater and extended testing for torch.tensor.__gt__ to all valid dtypes

### DIFF
--- a/ivy/functional/backends/tensorflow/elementwise.py
+++ b/ivy/functional/backends/tensorflow/elementwise.py
@@ -322,7 +322,7 @@ def greater(
     out: Optional[Union[tf.Tensor, tf.Variable]] = None,
 ) -> Union[tf.Tensor, tf.Variable]:
     x1, x2 = ivy.promote_types_of_inputs(x1, x2)
-    return tf.math.greater(x1, x2)
+    return tf.experimental.numpy.greater(x1, x2)
 
 
 @with_unsupported_dtypes({"2.13.0 and below": ("complex",)}, backend_version)

--- a/ivy/functional/frontends/torch/tensor.py
+++ b/ivy/functional/frontends/torch/tensor.py
@@ -1240,7 +1240,7 @@ class Tensor:
     def __eq__(self, other):
         return torch_frontend.eq(self, other)
 
-    @with_unsupported_dtypes({"2.0.1 and below": ("bfloat16",)}, "torch")
+    @with_unsupported_dtypes({"2.0.1 and below": ("complex",)}, "torch")
     def __gt__(self, other):
         return torch_frontend.greater(self, other)
 

--- a/ivy_tests/test_ivy/test_frontends/test_torch/test_tensor.py
+++ b/ivy_tests/test_ivy/test_frontends/test_torch/test_tensor.py
@@ -706,11 +706,8 @@ def test_torch___getitem__(
     init_tree="torch.tensor",
     method_name="__gt__",
     dtype_and_x=helpers.dtype_and_values(
-        available_dtypes=helpers.get_dtypes("float"),
+        available_dtypes=helpers.get_dtypes("valid"),
         num_arrays=2,
-        min_value=-1e04,
-        max_value=1e04,
-        allow_inf=False,
     ),
 )
 def test_torch___gt__(


### PR DESCRIPTION
`torch.tensor.__gt__` doesn't support only `complex`, thus extended coverage and fixed the issue of `bool` dtype for `ivy.greater` with `tensorflow` as backend