### PR TITLE
refactor: updated frontend function signature to match with torch.clone

### DIFF
--- a/ivy/functional/frontends/torch/miscellaneous_ops.py
+++ b/ivy/functional/frontends/torch/miscellaneous_ops.py
@@ -93,7 +93,7 @@ def cartesian_prod(*tensors):
 
 
 @to_ivy_arrays_and_back
-def clone(input):
+def clone(input, *, memory_format=None):
     return ivy.copy_array(input)
 
 


### PR DESCRIPTION
Even though we won't be using this new argument it is necessary to include it in the API to match with [`torch`](https://pytorch.org/docs/stable/generated/torch.clone.html)