### PR TITLE
feat: Implement unsorted_segment_min function in Tensorflow frontend

### DIFF
--- a/ivy/functional/frontends/tensorflow/math.py
+++ b/ivy/functional/frontends/tensorflow/math.py
@@ -770,6 +770,23 @@ def unsorted_segment_mean(
         x[j] = ivy.divide(x[j], count[j])
     return x
 
+@to_ivy_arrays_and_back
+def unsorted_segment_min(data, segment_ids, num_segments, name = "unsorted_segment_min"):
+
+    data = ivy.array(data)
+    segment_ids = ivy.array(segment_ids)
+
+    ivy.utils.assertions.check_equal(
+        list(segment_ids.shape), [list(data.shape)[0]], as_array=False
+        )
+    min_array = ivy.zeros(
+        tuple([num_segments.item()] + (list(data.shape))[1:]), dtype=ivy.int32
+    )
+    for i in range((segment_ids).shape[0]):
+        min_array[segment_ids[i]] = ivy.minimum(min_array[segment_ids[i]], data[i])
+    return min_array
+
+
 
 @to_ivy_arrays_and_back
 def unsorted_segment_sqrt_n(

--- a/ivy/functional/frontends/tensorflow/math.py
+++ b/ivy/functional/frontends/tensorflow/math.py
@@ -770,22 +770,21 @@ def unsorted_segment_mean(
         x[j] = ivy.divide(x[j], count[j])
     return x
 
-@to_ivy_arrays_and_back
-def unsorted_segment_min(data, segment_ids, num_segments, name = "unsorted_segment_min"):
 
+@to_ivy_arrays_and_back
+def unsorted_segment_min(data, segment_ids, num_segments, name="unsorted_segment_min"):
     data = ivy.array(data)
     segment_ids = ivy.array(segment_ids)
 
     ivy.utils.assertions.check_equal(
         list(segment_ids.shape), [list(data.shape)[0]], as_array=False
-        )
+    )
     min_array = ivy.zeros(
         tuple([num_segments.item()] + (list(data.shape))[1:]), dtype=ivy.int32
     )
     for i in range((segment_ids).shape[0]):
         min_array[segment_ids[i]] = ivy.minimum(min_array[segment_ids[i]], data[i])
     return min_array
-
 
 
 @to_ivy_arrays_and_back

--- a/ivy_tests/test_ivy/test_frontends/test_tensorflow/test_math.py
+++ b/ivy_tests/test_ivy/test_frontends/test_tensorflow/test_math.py
@@ -3102,6 +3102,37 @@ def test_tensorflow_unsorted_segment_mean(
         num_segments=np.max(segment_ids) + 1,
     )
 
+# unsorted_segment_min
+@handle_frontend_test(
+    fn_tree="tensorflow.math.unsorted_segment_min",
+    data=helpers.array_values(dtype=ivy.int32, shape=(5, 6), min_value=1, max_value=9),
+    segment_ids=helpers.array_values(
+        dtype=ivy.int32, shape=(5,), min_value=0, max_value=4
+    ),
+    test_with_out=st.just(False),
+)
+def test_tensorflow_unsorted_segment_min(
+    *,
+    data,
+    segment_ids,
+    frontend,
+    test_flags,
+    fn_tree,
+    backend_fw,
+    on_device,
+):
+    helpers.test_frontend_function(
+        input_dtypes=["int32", "int64"],
+        frontend=frontend,
+        backend_to_test=backend_fw,
+        test_flags=test_flags,
+        fn_tree=fn_tree,
+        on_device=on_device,
+        data=data,
+        segment_ids=segment_ids,
+        num_segments=np.max(segment_ids) + 1,
+    )
+
 
 # unsorted_segment_sqrt_n
 @handle_frontend_test(

--- a/ivy_tests/test_ivy/test_frontends/test_tensorflow/test_math.py
+++ b/ivy_tests/test_ivy/test_frontends/test_tensorflow/test_math.py
@@ -3102,6 +3102,7 @@ def test_tensorflow_unsorted_segment_mean(
         num_segments=np.max(segment_ids) + 1,
     )
 
+
 # unsorted_segment_min
 @handle_frontend_test(
     fn_tree="tensorflow.math.unsorted_segment_min",


### PR DESCRIPTION
# PR Description

Implemented tf.math.unsorted_segment_min in ivy/frontend/tensorflow/math.py and test_tensorflow_unsorted_segment_min in ivy_tests/test_ivy/test_frontends/test_tensorflow/test_math.py
<!--
If there is no related issue, please add a short description about your PR.
-->

## Related Issue
#26518 

I cannot check any of the tests if they pass or not. I have tried implementing development mode in 4 different ways and there is always an error popping up regarding testing. 

<!--
Please use this format to link other issues with their numbers: Close #123
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Close #26518 

## Checklist

- [x] Did you add a function?
- [x] Did you add the tests?
- [ ] Did you run your tests and are your tests passing?
- [ ] Did pre-commit not fail on any check?
- [ ] Did you follow the steps we provided?

<!--
Please mark your PR as a draft if you realise after the fact that your tests are not passing or
that your pre-commit check has some failures.

Here are some relevant resources regarding tests and pre-commit:

https://unify.ai/docs/ivy/overview/deep_dive/ivy_tests.html
https://unify.ai/docs/ivy/overview/deep_dive/formatting.html#pre-commit

-->

### Socials

<!--
If you have Twitter, please provide it here otherwise just ignore this.
-->
