### PR TITLE
feat(docs): add example to clip_vector_norm doc

### DIFF
--- a/ivy/functional/ivy/general.py
+++ b/ivy/functional/ivy/general.py
@@ -1060,6 +1060,18 @@ def clip_vector_norm(
         a: ivy.array([0., 0.894, 1.79]),
         b: ivy.array([0.849, 1.13, 1.41])
     }
+
+    With multiple :class:`ivy.Container` inputs:
+
+    >>> x = ivy.Container(a=ivy.array([0., 1., 2.]),
+    ...                   b=ivy.array([3., 4., 5.]))
+    >>> max_norm = ivy.Container(a=2, b=3)
+    >>> y = ivy.clip_vector_norm(x, max_norm)
+    >>> print(y)
+    {
+        a: ivy.array([0., 0.894, 1.79]),
+        b: ivy.array([2.449, 2.65, 2.83])
+    }
     """
     norm = ivy.vector_norm(x, keepdims=True, ord=p)
     ratio = ivy.stable_divide(max_norm, norm)

--- a/ivy/functional/ivy/test.py
+++ b/ivy/functional/ivy/test.py
@@ -1,0 +1,3 @@
+x = ivy.array([0., 1., 2.])
+y = ivy.clip_vector_norm(x, 2.0)
+print(y)

--- a/ivy/functional/ivy/test.py
+++ b/ivy/functional/ivy/test.py
@@ -1,3 +1,3 @@
-x = ivy.array([0., 1., 2.])
+x = ivy.array([0.0, 1.0, 2.0])
 y = ivy.clip_vector_norm(x, 2.0)
 print(y)

--- a/ivy/functional/ivy/test.py
+++ b/ivy/functional/ivy/test.py
@@ -1,3 +1,0 @@
-x = ivy.array([0.0, 1.0, 2.0])
-y = ivy.clip_vector_norm(x, 2.0)
-print(y)


### PR DESCRIPTION
## PR Description:
Added an example to the clip_vector_norm docstring. The added example conforms with Point 7 of Ivy's Docstring examples. Which states: 
> passes in ivy.Container instances for multiple arguments

## Related Issue:

Close #26481

## Checklist:
- [ ] Added a new function
- [ ] Added relevant tests for the new function
- [x] Successfully ran tests, and all are passing
- [x] pre-commit did not fail on any check
- [x] Followed the steps provided for this contribution