### PR TITLE
feat(tensorflow): Add FFT3D function to tensorflow.raw_ops

### DIFF
--- a/ivy/functional/frontends/tensorflow/raw_ops.py
+++ b/ivy/functional/frontends/tensorflow/raw_ops.py
@@ -570,6 +570,14 @@ def FFT2D(*, input, name="FFT2D"):
 
 
 @to_ivy_arrays_and_back
+def FFT3D(*, input, name="FFT3D"):
+    fft_result = ivy.fft(input, -1)
+    fft_result = ivy.fft(fft_result, -2)
+    fft_result = ivy.fft(fft_result, -3)
+    return ivy.astype(fft_result, input.dtype)
+
+
+@to_ivy_arrays_and_back
 def Fill(*, dims, value, name="Full"):
     return ivy.full(dims, value)
 

--- a/ivy_tests/test_ivy/test_frontends/test_tensorflow/test_raw_ops.py
+++ b/ivy_tests/test_ivy/test_frontends/test_tensorflow/test_raw_ops.py
@@ -1885,6 +1885,45 @@ def test_tensorflow_FFT2D(
     )
 
 
+# FFT3D
+@handle_frontend_test(
+    fn_tree="tensorflow.raw_ops.FFT3D",
+    dtype_and_x=helpers.dtype_and_values(
+        available_dtypes=helpers.get_dtypes("complex"),
+        min_value=-1e5,
+        max_value=1e5,
+        min_num_dims=3,
+        max_num_dims=5,
+        min_dim_size=2,
+        max_dim_size=5,
+        large_abs_safety_factor=2.5,
+        small_abs_safety_factor=2.5,
+        safety_factor_scale="log",
+    ),
+)
+def test_tensorflow_FFT3D(
+    *,
+    dtype_and_x,
+    frontend,
+    test_flags,
+    fn_tree,
+    backend_fw,
+    on_device,
+):
+    dtype, x = dtype_and_x
+    helpers.test_frontend_function(
+        input_dtypes=dtype,
+        backend_to_test=backend_fw,
+        frontend=frontend,
+        test_flags=test_flags,
+        fn_tree=fn_tree,
+        on_device=on_device,
+        input=x[0],
+        rtol=1e-02,
+        atol=1e-02,
+    )
+
+
 # fill
 @handle_frontend_test(
     fn_tree="tensorflow.raw_ops.Fill",


### PR DESCRIPTION
# PR Description

feat: add FFT3D function to tensorflow.raw_ops

Fixes #26726

## Related Issue

Close #26726 

## Checklist

- [x] Added the `FFT3D` function to `tensorflow.raw_ops` in `raw_ops.py`.
- [x] Created tests for the `FFT3D` function in `test_raw_ops.py`.
- [x] Ensured that all tests are passing.
- [x] Ran the pre-commit checks without failures.
- [x] Followed the Ivy project's contribution guidelines.
