### PR TITLE
feat: Implement ifft2 in numpy frontend and close #26773

### DIFF
--- a/ivy/functional/frontends/numpy/fft/discrete_fourier_transform.py
+++ b/ivy/functional/frontends/numpy/fft/discrete_fourier_transform.py
@@ -76,6 +76,14 @@ def ifft(a, n=None, axis=-1, norm=None):
 
 @with_unsupported_dtypes({"1.24.3 and below": ("float16",)}, "numpy")
 @to_ivy_arrays_and_back
+def ifft2(a, s=None, axes=(-2, -1), norm=None):
+    a = ivy.asarray(a, dtype=ivy.complex128)
+    a = ivy.ifftn(a, s=s, axes=axes, norm=norm)
+    return a
+
+
+@with_unsupported_dtypes({"1.24.3 and below": ("float16",)}, "numpy")
+@to_ivy_arrays_and_back
 def ifftn(a, s=None, axes=None, norm=None):
     a = ivy.asarray(a, dtype=ivy.complex128)
     a = ivy.ifftn(a, s=s, axes=axes, norm=norm)

--- a/ivy_tests/test_ivy/test_frontends/test_numpy/test_fft/test_discrete_fourier_transform.py
+++ b/ivy_tests/test_ivy/test_frontends/test_numpy/test_fft/test_discrete_fourier_transform.py
@@ -110,6 +110,27 @@ def test_numpy_ifft(dtype_and_x, backend_fw, frontend, test_flags, fn_tree, on_d
 
 
 @handle_frontend_test(
+    fn_tree="numpy.fft.ifft2",
+    dtype_and_x=_x_and_ifft(),
+)
+def test_numpy_ifft2(dtype_and_x, backend_fw, frontend, test_flags, fn_tree, on_device):
+    input_dtype, x, dim, norm, n = dtype_and_x
+    helpers.test_frontend_function(
+        input_dtypes=input_dtype,
+        frontend=frontend,
+        backend_to_test=backend_fw,
+        test_flags=test_flags,
+        fn_tree=fn_tree,
+        on_device=on_device,
+        test_values=True,
+        a=x,
+        s=None,
+        axes=None,
+        norm=norm,
+    )
+
+
+@handle_frontend_test(
     fn_tree="numpy.fft.ifftn",
     dtype_and_x=_x_and_ifft(),
 )


### PR DESCRIPTION
# PR Description

This PR implements the `ifft2` function for the numpy frontend. 

## Related Issue

Close #26773

## Checklist

- [x] Implemented the `ifft2` function for the numpy frontend.
- [x] Added Tests for the new function
- [x] Ran tests to ensure functionality.
- [x] Ensured that pre-commit checks pass.
- [x] Followed the provided steps.
