### PR TITLE
fix: Remove duplicate-keys in `ivy\functional\backends\numpy\__init__.py` 

### DIFF
--- a/ivy/functional/backends/numpy/__init__.py
+++ b/ivy/functional/backends/numpy/__init__.py
@@ -34,10 +34,8 @@ def wrap__array_ufunc__(func):
             "bitwise_and": "bitwise_and",
             "matmul": "matmul",
             "power": "pow",
-            "divide": "divide",
             "subtract": "subtract",
             "add": "add",
-            "not_equal": "not_equal",
         }
         if ufunc.__name__ in methods.keys():
             return eval("ivy." + methods[ufunc.__name__] + "(*inputs, **kwargs)")


### PR DESCRIPTION
# PR Description
In the file: `ivy\functional\backends\numpy\__init__.py` duplicate keys are present in the following lines, so I have removed them.
https://github.com/unifyai/ivy/blob/1be0f8c2c8d916b10f06ab538b43fc506a1992a6/ivy/functional/backends/numpy/__init__.py#L25
https://github.com/unifyai/ivy/blob/1be0f8c2c8d916b10f06ab538b43fc506a1992a6/ivy/functional/backends/numpy/__init__.py#L40
https://github.com/unifyai/ivy/blob/1be0f8c2c8d916b10f06ab538b43fc506a1992a6/ivy/functional/backends/numpy/__init__.py#L31
https://github.com/unifyai/ivy/blob/1be0f8c2c8d916b10f06ab538b43fc506a1992a6/ivy/functional/backends/numpy/__init__.py#L37

## Related Issue
Close #26784

## Checklist

- [ ] Did you add a function?
- [ ] Did you add the tests?
- [ ] Did you run your tests and are your tests passing?
- [x] Did pre-commit not fail on any check?
- [ ] Did you follow the steps we provided?

### Socials
https://twitter.com/Sai_Suraj_27