### PR TITLE
fix: updated the run_tests.py script to skip instance methods

### DIFF
--- a/run_tests.py
+++ b/run_tests.py
@@ -209,12 +209,6 @@ if __name__ == "__main__":
                     ".", "_"
                 )
                 test_info["frontend"] = frontend
-                if report_content:
-                    test_info = {
-                        **test_info,
-                        "fw_time": report_content["fw_time"],
-                        "ivy_nodes": report_content["ivy_nodes"],
-                    }
                 prefix_str = f"{frontend_version}."
 
             # initialize test information for ci_dashboard db
@@ -232,6 +226,12 @@ if __name__ == "__main__":
 
             # add transpilation metrics if report generated
             if not failed and report_content:
+                if is_frontend_test:
+                    test_info = {
+                        **test_info,
+                        "fw_time": report_content["fw_time"],
+                        "ivy_nodes": report_content["ivy_nodes"],
+                    }
                 transpilation_metrics = {
                     "nodes": report_content["nodes"][backend],
                     "time": report_content["time"][backend],

--- a/run_tests.py
+++ b/run_tests.py
@@ -241,7 +241,8 @@ if __name__ == "__main__":
                 for metric, value in transpilation_metrics.items():
                     test_info[f"{prefix_str}{backend}.{version}.{metric}"] = value
 
-                # populate the ci_dashboard db
+            # populate the ci_dashboard db, skip instance methods
+            if function_name:
                 id = test_info.pop("_id")
                 print(
                     collection.update_one({"_id": id}, {"$set": test_info}, upsert=True)

--- a/run_tests.py
+++ b/run_tests.py
@@ -33,9 +33,7 @@ def get_submodule_and_function_name(test_path, is_frontend_test=False):
             fn_tree_idx = test_file_content[:test_function_idx].rfind('fn_tree="')
             if fn_tree_idx == -1:
                 return submodule, None
-            function_name = test_file_content[
-                test_file_content[:test_function_idx].rfind('fn_tree="') + 9 :
-            ].split('"')[0]
+            function_name = test_file_content[fn_tree_idx + 9 :].split('"')[0]
     return submodule, function_name
 
 


### PR DESCRIPTION
Avoids populating the new database for instance method tests for now and also skips populating the ci_dashboard if the report wasn't generated
