### PR TITLE
fix: Fixed function calls in `ivy_tests\test_ivy\test_stateful\test_modules.py`

### DIFF
--- a/ivy_tests/test_ivy/test_stateful/test_modules.py
+++ b/ivy_tests/test_ivy/test_stateful/test_modules.py
@@ -986,19 +986,19 @@ def test_top_module(batch_shape, input_channels, output_channels, on_device):
     module = WithNestedModules(input_channels, output_channels, device=on_device)
 
     # full depth
-    assert module._dl0.top_mod() is module
-    assert module._dl1.top_mod() is module
+    assert module._dl0._top_mod_fn() is module
+    assert module._dl1._top_mod_fn() is module
 
-    assert module._dl0._l0.top_mod() is module
-    assert module._dl0._l1.top_mod() is module
-    assert module._dl1._l0.top_mod() is module
-    assert module._dl1._l1.top_mod() is module
+    assert module._dl0._l0._top_mod_fn() is module
+    assert module._dl0._l1._top_mod_fn() is module
+    assert module._dl1._l0._top_mod_fn() is module
+    assert module._dl1._l1._top_mod_fn() is module
 
     # depth 1
-    assert module._dl0._l0.top_mod(1) is module._dl0
-    assert module._dl0._l1.top_mod(1) is module._dl0
-    assert module._dl1._l0.top_mod(1) is module._dl1
-    assert module._dl1._l1.top_mod(1) is module._dl1
+    assert module._dl0._l0._top_mod_fn(1) is module._dl0
+    assert module._dl0._l1._top_mod_fn(1) is module._dl0
+    assert module._dl1._l0._top_mod_fn(1) is module._dl1
+    assert module._dl1._l1._top_mod_fn(1) is module._dl1
 
 
 # top variables
@@ -1032,14 +1032,14 @@ def test_top_variables(batch_shape, input_channels, output_channels, on_device):
         "dl1/l1/w",
     ]:
         # depth 1
-        assert key_chain in module._dl0.top_v()
-        assert key_chain in module._dl1.top_v()
+        assert key_chain in module._dl0._top_v_fn()
+        assert key_chain in module._dl1._top_v_fn()
 
         # depth 2
-        assert key_chain in module._dl0._l0.top_v()
-        assert key_chain in module._dl0._l1.top_v()
-        assert key_chain in module._dl1._l0.top_v()
-        assert key_chain in module._dl1._l1.top_v()
+        assert key_chain in module._dl0._l0._top_v_fn()
+        assert key_chain in module._dl0._l1._top_v_fn()
+        assert key_chain in module._dl1._l0._top_v_fn()
+        assert key_chain in module._dl1._l1._top_v_fn()
 
 
 @given(mode=st.booleans())


### PR DESCRIPTION
# PR Description
I think In the file: `ivy_tests\test_ivy\test_stateful\test_modules.py`, the following function calls might be wrong because the actual name of the function is `def _top_mod_fn()`. Pylint was also showing me [`no-member / E1101`](https://pylint.readthedocs.io/en/latest/user_guide/messages/error/no-member.html) error for these function calls
https://github.com/unifyai/ivy/blob/18ecb7affb3ab7c924bd397658f90198c514d96a/ivy/stateful/helpers.py#L45
https://github.com/unifyai/ivy/blob/18ecb7affb3ab7c924bd397658f90198c514d96a/ivy_tests/test_ivy/test_stateful/test_modules.py#L992


https://github.com/unifyai/ivy/blob/18ecb7affb3ab7c924bd397658f90198c514d96a/ivy/stateful/helpers.py#L15
https://github.com/unifyai/ivy/blob/18ecb7affb3ab7c924bd397658f90198c514d96a/ivy_tests/test_ivy/test_stateful/test_modules.py#L1035


The same problem is there at multiple places in the file. I corrected these function calls properly to avoid unintended behavior.

## Related Issue
Close #26813

## Checklist

- [ ] Did you add a function?
- [ ] Did you add the tests?
- [ ] Did you run your tests and are your tests passing?
- [x] Did pre-commit not fail on any check?
- [ ] Did you follow the steps we provided?


### Socials
https://twitter.com/Sai_Suraj_27