### PR TITLE
feat(activations): add scaled_tanh(stanh) to ivy experimental API.

### DIFF
--- a/ivy/data_classes/array/experimental/activations.py
+++ b/ivy/data_classes/array/experimental/activations.py
@@ -400,3 +400,45 @@ class _ArrayWithActivationsExperimental(abc.ABC):
         ivy.array([ 0.39, -0.57])
         """
         return ivy.celu(self._data, alpha=alpha, complex_mode=complex_mode, out=out)
+
+    def scaled_tanh(
+        self: ivy.Array,
+        /,
+        *,
+        alpha: float = 1.7159,
+        beta: float = 0.67,
+        out: Optional[ivy.Array] = None,
+    ) -> ivy.Array:
+        """
+        ivy.Array instance method variant of ivy.scaled_tanh. This method simply wraps
+        the function, and so the docstring for ivy.scaled_tanh also applies to this
+        method with minimal changes.
+
+        Parameters
+        ----------
+        self
+            input array.
+        alpha
+            The scaling parameter for the output.
+            Determines the amplitude of the tanh function.
+            Default: 1.7159
+        beta
+            The scaling parameter for the input.
+            Determines the slope of the tanh function.
+            Default: 0.67
+        out
+            optional output array, for writing the result to. It must have a shape
+            that the inputs broadcast to.
+
+        Returns
+        -------
+        ret
+            an array after applying the scaled_tanh activation.
+
+        Examples
+        --------
+        >>> x = ivy.array([-3., 2., 3.])
+        >>> x.scaled_tanh()
+        ivy.array([-1.65537548,  1.49570239,  1.65537548])
+        """
+        return ivy.scaled_tanh(self._data, alpha=alpha, beta=beta, out=out)

--- a/ivy/data_classes/container/experimental/activations.py
+++ b/ivy/data_classes/container/experimental/activations.py
@@ -1324,3 +1324,144 @@ class _ContainerWithActivationExperimental(ContainerBase):
             complex_mode=complex_mode,
             out=out,
         )
+
+    @staticmethod
+    def _static_scaled_tanh(
+        x: Union[ivy.Array, ivy.NativeArray, ivy.Container],
+        /,
+        *,
+        alpha: Union[float, ivy.Container] = 1.7159,
+        beta: Union[float, ivy.Container] = 0.67,
+        key_chains: Optional[Union[List[str], Dict[str, str], ivy.Container]] = None,
+        to_apply: Union[bool, ivy.Container] = True,
+        prune_unapplied: Union[bool, ivy.Container] = False,
+        map_sequences: Union[bool, ivy.Container] = False,
+        out: Optional[ivy.Container] = None,
+    ) -> ivy.Container:
+        """
+        ivy.Container static method variant of ivy.scaled_tanh. This method simply wraps
+        the function, and so the docstring for ivy.scaled_tanh also applies to this
+        method with minimal changes.
+
+        Parameters
+        ----------
+        x
+            input container.
+        alpha
+            The scaling parameter for the output.
+            Determines the amplitude of the tanh function.
+            Default: 1.7159
+        beta
+            The scaling parameter for the input.
+            Determines the slope of the tanh function.
+            Default: 0.67
+        key_chains
+            The key-chains to apply or not apply the method to. Default is ``None``.
+        to_apply
+            If True, the method will be applied to key_chains, otherwise key_chains
+            will be skipped. Default is ``True``.
+        prune_unapplied
+            Whether to prune key_chains for which the function was not applied.
+            Default is ``False``.
+        map_sequences
+            Whether to also map method to sequences (lists, tuples).
+            Default is ``False``.
+        out
+            optional output container, for writing the result to. It must have a shape
+            that the inputs broadcast to.
+
+        Returns
+        -------
+        ret
+             a container with the scaled_tanh function applied.
+
+        Examples
+        --------
+        >>> x = ivy.Container(a=ivy.array([8.931, -0.85]), b=ivy.array([1., -0.2])))
+        >>> y = ivy.Container._static_scaled_tanh(x)
+        >>> print(y)
+        {
+            a: ivy.array([1.71587813, -0.88367474]),
+            b: ivy.array([1.00376701, -0.2285642])
+        }
+        """
+        return ContainerBase.cont_multi_map_in_function(
+            "scaled_tanh",
+            x,
+            alpha=alpha,
+            beta=beta,
+            key_chains=key_chains,
+            to_apply=to_apply,
+            prune_unapplied=prune_unapplied,
+            map_sequences=map_sequences,
+            out=out,
+        )
+
+    def scaled_tanh(
+        self: ivy.Container,
+        /,
+        *,
+        alpha: Union[float, ivy.Container] = 1.7159,
+        beta: Union[float, ivy.Container] = 0.67,
+        key_chains: Optional[Union[List[str], Dict[str, str], ivy.Container]] = None,
+        to_apply: Union[bool, ivy.Container] = True,
+        prune_unapplied: Union[bool, ivy.Container] = False,
+        map_sequences: Union[bool, ivy.Container] = False,
+        out: Optional[ivy.Container] = None,
+    ) -> ivy.Container:
+        """
+        ivy.Container instance method variant of ivy.scaled_tanh. This method
+        simplywraps the function, and so the docstring for ivy.scaled_tanh also applies
+        to this method with minimal changes.
+
+        Parameters
+        ----------
+        x
+           input container.
+        alpha
+           The scaling parameter for the output.
+           Determines the amplitude of the tanh function.
+           Default: 1.7159
+        beta
+            The scaling parameter for the input.
+            Determines the slope of the tanh function.
+            Default: 0.67
+        key_chains
+            The key-chains to apply or not apply the method to. Default is ``None``.
+        to_apply
+            If True, the method will be applied to key_chains, otherwise key_chains
+            will be skipped. Default is ``True``.
+        prune_unapplied
+            Whether to prune key_chains for which the function was not applied.
+            Default is ``False``.
+        map_sequences
+            Whether to also map method to sequences (lists, tuples).
+            Default is ``False``.
+        out
+            optional output container, for writing the result to. It must have a shape
+            that the inputs broadcast to.
+
+        Returns
+        -------
+        ret
+             a container with the scaled_tanh function applied.
+
+        Examples
+        --------
+        >>> x = ivy.Container(a=ivy.array([2., 3.]), b=ivy.array([1., 2.]))
+        >>> x.scaled_tanh()
+        {
+            a: ivy.array([1.49570239, 1.65537548]),
+            b: ivy.array([1.00376701, 1.49570239])
+        }
+        """
+        return self._static_scaled_tanh(
+            self,
+            alpha=alpha,
+            beta=beta,
+            key_chains=key_chains,
+            to_apply=to_apply,
+            prune_unapplied=prune_unapplied,
+            map_sequences=map_sequences,
+            out=out,
+        )

--- a/ivy/functional/backends/jax/experimental/activations.py
+++ b/ivy/functional/backends/jax/experimental/activations.py
@@ -113,3 +113,15 @@ def tanhshrink(x: JaxArray, /, *, out: Optional[JaxArray] = None) -> JaxArray:
     if ivy.exists(out):
         return ivy.inplace_update(out, ret).astype(x.dtype)
     return ret
+
+
+@with_unsupported_dtypes({"0.4.17 and below": ("float64",)}, backend_version)
+def scaled_tanh(
+    x: JaxArray,
+    /,
+    *,
+    alpha: float = 1.7159,
+    beta: float = 0.67,
+    out: Optional[JaxArray] = None,
+) -> JaxArray:
+    return alpha * jax.nn.tanh(beta * x)

--- a/ivy/functional/backends/numpy/experimental/activations.py
+++ b/ivy/functional/backends/numpy/experimental/activations.py
@@ -6,7 +6,9 @@ import numpy as np
 # local
 import ivy
 from ivy.functional.backends.numpy.helpers import _scalar_output_to_0d_array
-from ivy.func_wrapper import with_unsupported_dtypes
+from ivy.func_wrapper import (
+    with_unsupported_dtypes,
+)
 from . import backend_version
 
 
@@ -144,3 +146,15 @@ def tanhshrink(x: np.ndarray, /, *, out: Optional[np.ndarray] = None) -> np.ndar
 
 
 tanhshrink.support_native_out = True
+
+
+@_scalar_output_to_0d_array
+def scaled_tanh(
+    x: np.ndarray,
+    /,
+    *,
+    alpha: float = 1.7159,
+    beta: float = 0.67,
+    out: Optional[np.ndarray] = None,
+) -> np.ndarray:
+    return alpha * np.tanh(beta * x)

--- a/ivy/functional/backends/paddle/experimental/activations.py
+++ b/ivy/functional/backends/paddle/experimental/activations.py
@@ -5,7 +5,11 @@ import paddle.nn.functional as F
 
 # local
 import ivy.functional.backends.paddle as paddle_backend
-from ivy.func_wrapper import with_unsupported_device_and_dtypes, with_supported_dtypes
+from ivy.func_wrapper import (
+    with_unsupported_device_and_dtypes,
+    with_supported_dtypes,
+    with_supported_device_and_dtypes,
+)
 from . import backend_version
 
 
@@ -174,3 +178,23 @@ def celu(
     out: Optional[paddle.Tensor] = None,
 ) -> paddle.Tensor:
     return F.celu(x, alpha=alpha)
+
+
+@with_supported_device_and_dtypes(
+    {
+        "2.5.1 and below": {
+            "cpu": ("float32", "float64"),
+            "gpu": ("uint16", "float16", "float32", "float64"),
+        }
+    },
+    backend_version,
+)
+def scaled_tanh(
+    x: paddle.Tensor,
+    /,
+    *,
+    alpha: float = 1.7159,
+    beta: float = 0.67,
+    out: Optional[paddle.Tensor] = None,
+) -> paddle.Tensor:
+    return paddle.stanh(x, scale_a=beta, scale_b=alpha)

--- a/ivy/functional/backends/tensorflow/experimental/activations.py
+++ b/ivy/functional/backends/tensorflow/experimental/activations.py
@@ -123,3 +123,15 @@ def celu(
     out: Optional[Tensor] = None,
 ) -> Tensor:
     return tf.math.maximum(0, x) + alpha * tf.math.expm1(tf.math.minimum(0, x) / alpha)
+
+
+@with_unsupported_dtypes({"2.14.0 and below": ("uint16",)}, backend_version)
+def scaled_tanh(
+    x: Tensor,
+    /,
+    *,
+    alpha: float = 1.7159,
+    beta: float = 0.67,
+    out: Optional[Tensor] = None,
+) -> Tensor:
+    return alpha * tf.nn.tanh(beta * x)

--- a/ivy/functional/backends/torch/experimental/activations.py
+++ b/ivy/functional/backends/torch/experimental/activations.py
@@ -116,3 +116,14 @@ def tanhshrink(
     if ivy.exists(out):
         return ivy.inplace_update(out, ret).astype(x.dtype)
     return ivy.astype(ret, x.dtype)
+
+
+def scaled_tanh(
+    x: torch.Tensor,
+    /,
+    *,
+    alpha: float = 1.7159,
+    beta: float = 0.67,
+    out: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    return alpha * torch.nn.functional.tanh(beta * x)

--- a/ivy/functional/ivy/experimental/activations.py
+++ b/ivy/functional/ivy/experimental/activations.py
@@ -731,3 +731,68 @@ def celu(
 
 
 celu.jax_like = _celu_jax_like
+
+
+@handle_exceptions
+@handle_backend_invalid
+@handle_nestable
+@handle_array_like_without_promotion
+@handle_out_argument
+@to_native_arrays_and_back
+@handle_array_function
+def scaled_tanh(
+    x: Union[ivy.Array, ivy.NativeArray],
+    /,
+    *,
+    alpha: float = 1.7159,
+    beta: float = 0.67,
+    out: Optional[ivy.Array] = None,
+) -> ivy.Array:
+    """
+    Compute the scaled hyperbolic tangent (tanh) activation.
+
+    The scaled tanh activation function is defined as:
+    out = alpha * tanh(beta * x)
+
+
+    Parameters
+    ----------
+    x
+        input array.
+    alpha
+        The scaling parameter for the output.
+        Determines the amplitude of the tanh function.
+        Default: 1.7159
+    beta
+        The scaling parameter for the input.
+        Determines the slope of the tanh function.
+        Default: 0.67
+    out
+        optional output array, for writing the result to. It must have a shape that the
+        inputs broadcast to.
+
+    Returns
+    -------
+    ret
+         The input array after applying the scaled tanh activation.
+
+    Examples
+    --------
+    With :class:`ivy.Array` input:
+
+    >>> x = ivy.array([22.])
+    >>> y = ivy.elu(x)
+    >>> y
+    ivy.array([1.71589994]))
+
+    With :class:`ivy.Container` input:
+
+    >>> x = ivy.Container(a=ivy.array([1.2, -1.2]), b=ivy.array([4.4, -2.2]))
+    >>> y = ivy.scaled_tanh(x)
+    >>> y
+    {
+        a: ivy.array([1.14324772, -1.14324772]),
+        b: ivy.array([1.70648694, -1.54488957])
+    }
+    """
+    return current_backend(x).scaled_tanh(x, alpha=alpha, beta=beta, out=out)

--- a/ivy_tests/test_ivy/test_functional/test_experimental/test_nn/test_activations.py
+++ b/ivy_tests/test_ivy/test_functional/test_experimental/test_nn/test_activations.py
@@ -208,6 +208,36 @@ def test_relu6(
     )
 
 
+# scaled_tanh
+@handle_test(
+    fn_tree="functional.ivy.experimental.scaled_tanh",
+    dtype_and_x=helpers.dtype_and_values(
+        available_dtypes=helpers.get_dtypes("valid"),
+        min_dim_size=1,
+        min_num_dims=1,
+    ),
+    alpha=st.floats(min_value=0.1, max_value=5.0),
+    beta=st.floats(min_value=0.1, max_value=5.0),
+    ground_truth_backend="paddle",
+)
+def test_scaled_tanh(
+    *, dtype_and_x, alpha, beta, test_flags, backend_fw, fn_name, on_device
+):
+    dtype, x = dtype_and_x
+    helpers.test_function(
+        input_dtypes=dtype,
+        backend_to_test=backend_fw,
+        test_flags=test_flags,
+        fn_name=fn_name,
+        on_device=on_device,
+        rtol_=1e-5,
+        atol_=1e-5,
+        x=x[0],
+        alpha=alpha,
+        beta=beta,
+    )
+
+
 # selu
 @handle_test(
     fn_tree="functional.ivy.experimental.selu",


### PR DESCRIPTION


# PR Description
In this PR, we introduce the `scaled_tanh` activation function to the` ivy` experimental API. While this function is natively present in `PaddlePaddle` , where it is referred to as [stanh](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/stanh_cn.html#stanh), we have decided to define it as `scaled_tanh`  in `ivy` for improved clarity and consistency with common naming conventions. Additionally, this naming choice aligns with how the [Y. Lecun, L. Bottou, Y. Bengio and P. Haffner, "Gradient-based learning applied to document recognition," in Proceedings of the IEEE, vol. 86, no. 11, pp. 2278-2324, Nov. 1998, doi: 10.1109/5.726791.](https://ieeexplore.ieee.org/document/726791) originally described it.

## Related Issue

Close #26818

## Checklist

- [ ] Did you add a function?
- [ ] Did you add the tests?
- [ ] Did you run your tests and are your tests passing?
- [ ] Did pre-commit not fail on any check?
- [ ] Did you follow the steps we provided?




