### PR TITLE
fix: Remove redefined `shape` method in `ivy\__init__.py`

### DIFF
--- a/ivy/__init__.py
+++ b/ivy/__init__.py
@@ -399,10 +399,6 @@ class Shape(Sequence):
         else:
             return self._shape[index]
 
-    @property
-    def shape(self):
-        return self._shape
-
     def as_dimension(self):
         if isinstance(self._shape, Shape):
             return self._shape


### PR DESCRIPTION
# PR Description
In the file [`ivy\__init__.py`](https://github.com/unifyai/ivy/blob/main/ivy/__init__.py), the following method is repeated at 2 places.
https://github.com/unifyai/ivy/blob/4e8178868cd69ff9ae1ee7f371fa984c8be1bae0/ivy/__init__.py#L382
https://github.com/unifyai/ivy/blob/4e8178868cd69ff9ae1ee7f371fa984c8be1bae0/ivy/__init__.py#L403
So, I removed it at one of the places.

## Related Issue
Closes #26886

## Checklist

- [ ] Did you add a function?
- [ ] Did you add the tests?
- [ ] Did you run your tests and are your tests passing?
- [x] Did pre-commit not fail on any check?
- [ ] Did you follow the steps we provided?

### Socials
https://twitter.com/Sai_Suraj_27