### PR TITLE
fix: fixed all issues breaking pytest discovery on vscode

### DIFF
--- a/ivy/func_wrapper.py
+++ b/ivy/func_wrapper.py
@@ -1298,6 +1298,9 @@ def _versioned_attribute_factory(attribute_function, base):
         def __repr__(self):
             return repr(self.__get__())
 
+        def __bool__(self):
+            return bool(self.__get__())
+
     return VersionedAttributes()
 
 
@@ -1366,7 +1369,10 @@ def _dtype_device_wrapper_creator(attrib, t):
                             # for conflicting ones we do nothing
                             pass
             else:
-                setattr(func, attrib, val)
+                if not val and attrib.startswith("supported"):
+                    setattr(func, f"un{attrib}", val)
+                else:
+                    setattr(func, attrib, val)
                 setattr(func, "dictionary_info", (version_dict, version))
             if "frontends" in func.__module__:
                 # it's a frontend func, no casting modes for this

--- a/ivy/functional/ivy/general.py
+++ b/ivy/functional/ivy/general.py
@@ -3895,12 +3895,16 @@ def _is_valid_device_and_dtypes_attributes(fn: Callable) -> bool:
     if hasattr(fn, "unsupported_device_and_dtype"):
         fn_unsupported_dnd = fn.unsupported_device_and_dtype
         # if it's a nested dict, unwrap for the current backend
-        if isinstance(list(fn_unsupported_dnd.__get__().values())[0], dict):
+        if fn_unsupported_dnd and isinstance(
+            list(fn_unsupported_dnd.__get__().values())[0], dict
+        ):
             fn_unsupported_dnd = fn_unsupported_dnd.get(backend, {})
     if hasattr(fn, "supported_device_and_dtype"):
         fn_supported_dnd = fn.supported_device_and_dtype
         # if it's a nested dict, unwrap for the current backend
-        if isinstance(list(fn_supported_dnd.__get__().values())[0], dict):
+        if fn_supported_dnd and isinstance(
+            list(fn_supported_dnd.__get__().values())[0], dict
+        ):
             fn_supported_dnd = fn_supported_dnd.get(backend, {})
 
     ivy.utils.assertions.check_false(
@@ -3991,7 +3995,11 @@ def _get_devices_and_dtypes(fn, recurse=False, complement=True):
         if "einops" in fn.__name__ and isinstance(fn_supported_dnd, dict):
             fn_supported_dnd = fn_supported_dnd.get(backend, supported)
 
-        ivy.utils.assertions.check_isinstance(list(fn_supported_dnd.values())[0], tuple)
+        if fn_supported_dnd:
+            ivy.utils.assertions.check_isinstance(
+                list(fn_supported_dnd.values())[0], tuple
+            )
+
         # dict intersection
         supported = _dnd_dict_intersection(supported, fn_supported_dnd)
 
@@ -4001,9 +4009,10 @@ def _get_devices_and_dtypes(fn, recurse=False, complement=True):
         if "einops" in fn.__name__ and isinstance(fn_unsupported_dnd, dict):
             fn_unsupported_dnd = fn_unsupported_dnd.get(backend, supported)
 
-        ivy.utils.assertions.check_isinstance(
-            list(fn_unsupported_dnd.values())[0], tuple
-        )
+        if fn_unsupported_dnd:
+            ivy.utils.assertions.check_isinstance(
+                list(fn_unsupported_dnd.values())[0], tuple
+            )
         # dict difference
         supported = _dnd_dict_difference(supported, fn_unsupported_dnd)
 

--- a/ivy_tests/test_ivy/test_misc/test_shape.py
+++ b/ivy_tests/test_ivy/test_misc/test_shape.py
@@ -497,7 +497,7 @@ def test_shape__radd__(
 
 
 @handle_method(
-    method_tree="Shape.__rdivmod__",
+    method_tree="Shape.__rdiv__",
     dtype_and_x=helpers.dtype_and_values(
         available_dtypes=helpers.get_dtypes("numeric"),
         num_arrays=2,
@@ -507,7 +507,7 @@ def test_shape__radd__(
         shared_dtype=True,
     ),
 )
-def test_shape__rdivmod__(
+def test_shape__rdiv__(
     dtype_and_x,
     method_name,
     class_name,
@@ -645,43 +645,6 @@ def test_shape__rsub__(
 
 
 @handle_method(
-    method_tree="Shape.__rtruediv__",
-    dtype_and_x=helpers.dtype_and_values(
-        available_dtypes=helpers.get_dtypes("numeric"),
-        num_arrays=2,
-        large_abs_safety_factor=2.5,
-        small_abs_safety_factor=2.5,
-        safety_factor_scale="log",
-        shared_dtype=True,
-    ),
-)
-def test_shape__rtruediv__(
-    dtype_and_x,
-    method_name,
-    class_name,
-    ground_truth_backend,
-    backend_fw,
-    init_flags,
-    method_flags,
-    on_device,
-):
-    dtype, x = dtype_and_x
-    helpers.test_method(
-        on_device=on_device,
-        ground_truth_backend=ground_truth_backend,
-        backend_to_test=backend_fw,
-        init_flags=init_flags,
-        method_flags=method_flags,
-        init_all_as_kwargs_np={"shape": x[0]},
-        init_input_dtypes=dtype,
-        method_input_dtypes=dtype,
-        method_all_as_kwargs_np={"other": x[1]},
-        class_name=class_name,
-        method_name=method_name,
-    )
-
-
-@handle_method(
     method_tree="Shape.__sub__",
     dtype_and_x=helpers.dtype_and_values(
         available_dtypes=helpers.get_dtypes("numeric"),
@@ -693,43 +656,6 @@ def test_shape__rtruediv__(
     ),
 )
 def test_shape__sub__(
-    dtype_and_x,
-    method_name,
-    class_name,
-    ground_truth_backend,
-    backend_fw,
-    init_flags,
-    method_flags,
-    on_device,
-):
-    dtype, x = dtype_and_x
-    helpers.test_method(
-        on_device=on_device,
-        ground_truth_backend=ground_truth_backend,
-        backend_to_test=backend_fw,
-        init_flags=init_flags,
-        method_flags=method_flags,
-        init_all_as_kwargs_np={"shape": x[0]},
-        init_input_dtypes=dtype,
-        method_input_dtypes=dtype,
-        method_all_as_kwargs_np={"other": x[1]},
-        class_name=class_name,
-        method_name=method_name,
-    )
-
-
-@handle_method(
-    method_tree="Shape.__truediv__",
-    dtype_and_x=helpers.dtype_and_values(
-        available_dtypes=helpers.get_dtypes("numeric"),
-        num_arrays=2,
-        large_abs_safety_factor=2.5,
-        small_abs_safety_factor=2.5,
-        safety_factor_scale="log",
-        shared_dtype=True,
-    ),
-)
-def test_shape__truediv__(
     dtype_and_x,
     method_name,
     class_name,


### PR DESCRIPTION
1. updated the supported/unsupported dtypes decorators to deal with the case when with_supported_dtypes was used with an invalid version interval
2. updated function_unsupported_devices_and_dtypes helpers to work with a decorator without any dtypes in the current version
3. removed tests from test_shape for which methods don't exist
