### PR TITLE
fix: updated supported python versions in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -122,10 +122,13 @@ setup(
         _strip(line)
         for line in open("requirements/requirements.txt", "r", encoding="utf-8")
     ],
-    python_requires="==3.10.*",
+    python_requires=">=3.8,<=3.11",
     classifiers=[
         "License :: OSI Approved :: Apache Software License",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
     ],
     license="Apache 2.0",
 )


### PR DESCRIPTION
As we have binaries for python 3.8, 3.9, 3.10 and 3.11