### PR TITLE
fix: Consider using `super()` without arguments.

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ torch_eff_encoder = ivy.transpile(eff_encoder, to="torch", args=(noise,))
 # Build a classifier using the transpiled encoder
 class Classifier(torch.nn.Module):
     def __init__(self, num_classes=20):
-        super(Classifier, self).__init__()
+        super().__init__()
         self.encoder = torch_eff_encoder
         self.fc = torch.nn.Linear(1280, num_classes)
 
@@ -318,7 +318,7 @@ backbone = ivy.transpile(
 # Build a classifier using the transpiled backbone
 class PerceiverIOClassifier(torch.nn.Module):
     def __init__(self, num_classes=20):
-        super(PerceiverIOClassifier, self).__init__()
+        super().__init__()
         self.backbone = backbone
         self.max_pool = torch.nn.MaxPool2d((512, 1))
         self.flatten = torch.nn.Flatten()
@@ -508,7 +508,7 @@ mlp_encoder = ivy.transpile(mlp_encoder, to="tensorflow", args=(noise,))
 # Build a classifier using the transpiled encoder
 class Classifier(tf.keras.Model):
     def __init__(self):
-        super(Classifier, self).__init__()
+        super().__init__()
         self.encoder = mlp_encoder
         self.output_dense = tf.keras.layers.Dense(units=1000, activation="softmax")
 
@@ -545,7 +545,7 @@ backbone = ivy.transpile(
 # Build a classifier using the transpiled backbone
 class PerceiverIOClassifier(tf.keras.Model):
     def __init__(self, num_classes=20):
-        super(PerceiverIOClassifier, self).__init__()
+        super().__init__()
         self.backbone = backbone
         self.max_pool = tf.keras.layers.MaxPooling1D(pool_size=512)
         self.flatten = tf.keras.layers.Flatten()
@@ -743,7 +743,7 @@ mlp_encoder = ivy.transpile(mlp_encoder, to="jax", args=(noise,))
 # Build a classifier using the transpiled encoder
 class Classifier(hk.Module):
     def __init__(self, num_classes=1000):
-        super(Classifier, self).__init__()
+        super().__init__()
         self.encoder = mlp_encoder()
         self.fc = hk.Linear(output_size=num_classes, with_bias=True)
 
@@ -787,7 +787,7 @@ hk_eff_encoder = ivy.transpile(eff_encoder, to="jax", args=(noise,))
 # Build a classifier using the transpiled encoder
 class Classifier(hk.Module):
     def __init__(self, num_classes=1000):
-        super(Classifier, self).__init__()
+        super().__init__()
         self.encoder = hk_eff_encoder()
         self.fc = hk.Linear(output_size=num_classes, with_bias=True)
 

--- a/docs/overview/design/ivy_as_a_transpiler.rst
+++ b/docs/overview/design/ivy_as_a_transpiler.rst
@@ -179,7 +179,7 @@ For example, let’s take the following PyTorch code and run it using JAX:
    class Network(torch.nn.Module):
 
        def __init__(self):
-        super(Network, self).__init__()
+        super().__init__()
         self._linear = torch.nn.Linear(3, 3)
 
        def forward(self, x):

--- a/docs/overview/one_liners/transpile.rst
+++ b/docs/overview/one_liners/transpile.rst
@@ -154,7 +154,7 @@ another, at the moment we support ``torch.nn.Module`` when ``to="torch"``,
   # Build a classifier using the transpiled encoder
   class Classifier(hk.Module):
       def __init__(self, num_classes=1000):
-          super(Classifier, self).__init__()
+          super().__init__()
               self.encoder = mlp_encoder()
               self.fc = hk.Linear(output_size=num_classes, with_bias=True)
 

--- a/ivy/functional/backends/jax/device.py
+++ b/ivy/functional/backends/jax/device.py
@@ -137,7 +137,7 @@ def tpu_is_available() -> bool:
 # noinspection PyMethodMayBeStatic
 class Profiler(BaseProfiler):
     def __init__(self, save_dir: str):
-        super(Profiler, self).__init__(save_dir)
+        super().__init__(save_dir)
         self._save_dir = os.path.join(self._save_dir, "profile")
 
     def start(self):

--- a/ivy/functional/backends/numpy/device.py
+++ b/ivy/functional/backends/numpy/device.py
@@ -92,7 +92,7 @@ def handle_soft_device_variable(*args, fn, **kwargs):
 class Profiler(BaseProfiler):
     def __init__(self, save_dir: str):
         # ToDO: add proper numpy profiler
-        super(Profiler, self).__init__(save_dir)
+        super().__init__(save_dir)
         os.makedirs(save_dir, exist_ok=True)
         self._start_time = None
 

--- a/ivy/functional/backends/paddle/device.py
+++ b/ivy/functional/backends/paddle/device.py
@@ -115,7 +115,7 @@ def handle_soft_device_variable(*args, fn, **kwargs):
 class Profiler(BaseProfiler):
     def __init__(self, save_dir: str):
         # ToDO: add proper Paddle profiler
-        super(Profiler, self).__init__(save_dir)
+        super().__init__(save_dir)
         os.makedirs(save_dir, exist_ok=True)
         self._start_time = None
 

--- a/ivy/functional/backends/tensorflow/device.py
+++ b/ivy/functional/backends/tensorflow/device.py
@@ -106,7 +106,7 @@ def handle_soft_device_variable(*args, fn, **kwargs):
 
 class Profiler(BaseProfiler):
     def __init__(self, save_dir: str):
-        super(Profiler, self).__init__(save_dir)
+        super().__init__(save_dir)
         self._options = tf.profiler.experimental.ProfilerOptions(
             host_tracer_level=3, python_tracer_level=1, device_tracer_level=1
         )

--- a/ivy/functional/backends/torch/device.py
+++ b/ivy/functional/backends/torch/device.py
@@ -121,7 +121,7 @@ def handle_soft_device_variable(*args, fn, **kwargs):
 
 class Profiler(BaseProfiler):
     def __init__(self, save_dir: str):
-        super(Profiler, self).__init__(save_dir)
+        super().__init__(save_dir)
         self._prof = profile(
             activities=[ProfilerActivity.CPU, ProfilerActivity.CUDA], with_stack=True
         )

--- a/ivy/functional/ivy/experimental/sparse_array.py
+++ b/ivy/functional/ivy/experimental/sparse_array.py
@@ -426,7 +426,7 @@ class SparseArray(ivy.Array):
             )
 
         # initialize parent class
-        super(SparseArray, self).__init__(self)
+        super().__init__(self)
 
     def _init_data(self, data):
         if ivy.is_ivy_sparse_array(data):

--- a/ivy_tests/test_ivy/test_stateful/test_converters.py
+++ b/ivy_tests/test_ivy/test_stateful/test_converters.py
@@ -99,11 +99,11 @@ FROM_CONVERTERS = {
 
 class TensorflowLinear(tf.keras.Model):
     def __init__(self, out_size):
-        super(TensorflowLinear, self).__init__()
+        super().__init__()
         self._linear = tf.keras.layers.Dense(out_size)
 
     def build(self, input_shape):
-        super(TensorflowLinear, self).build(input_shape)
+        super().build(input_shape)
 
     def call(self, x):
         return self._linear(x)
@@ -111,7 +111,7 @@ class TensorflowLinear(tf.keras.Model):
 
 class TensorflowModule(tf.keras.Model):
     def __init__(self, in_size, out_size, device=None, hidden_size=64):
-        super(TensorflowModule, self).__init__()
+        super().__init__()
         self._linear0 = TensorflowLinear(hidden_size)
         self._linear1 = TensorflowLinear(hidden_size)
         self._linear2 = TensorflowLinear(out_size)
@@ -125,7 +125,7 @@ class TensorflowModule(tf.keras.Model):
 
 class TorchLinearModule(nn.Module):
     def __init__(self, in_size, out_size):
-        super(TorchLinearModule, self).__init__()
+        super().__init__()
         self._linear = nn.Linear(in_size, out_size)
 
     def forward(self, x):
@@ -134,7 +134,7 @@ class TorchLinearModule(nn.Module):
 
 class TorchModule(nn.Module):
     def __init__(self, in_size, out_size, device=None, hidden_size=64):
-        super(TorchModule, self).__init__()
+        super().__init__()
         self._linear0 = TorchLinearModule(in_size, hidden_size)
         self._linear1 = TorchLinearModule(hidden_size, hidden_size)
         self._linear2 = TorchLinearModule(hidden_size, out_size)
@@ -148,7 +148,7 @@ class TorchModule(nn.Module):
 
 class HaikuLinear(hk.Module):
     def __init__(self, out_size):
-        super(HaikuLinear, self).__init__()
+        super().__init__()
         self._linear = hk.Linear(out_size)
 
     def __call__(self, x):
@@ -157,7 +157,7 @@ class HaikuLinear(hk.Module):
 
 class HaikuModule(hk.Module):
     def __init__(self, in_size, out_size, device=None, hidden_size=64):
-        super(HaikuModule, self).__init__()
+        super().__init__()
         self._linear0 = HaikuLinear(hidden_size)
         self._linear1 = HaikuLinear(hidden_size)
         self._linear2 = HaikuLinear(out_size)
@@ -199,7 +199,7 @@ class FlaxModule(flax.linen.Module):
 
 class PaddleLinearModule(paddle.nn.Layer):
     def __init__(self, in_size, out_size):
-        super(PaddleLinearModule, self).__init__()
+        super().__init__()
         self._linear = paddle.nn.Linear(in_size, out_size)
 
     def forward(self, x):
@@ -208,7 +208,7 @@ class PaddleLinearModule(paddle.nn.Layer):
 
 class PaddleModule(paddle.nn.Layer):
     def __init__(self, in_size, out_size, device=None, hidden_size=64):
-        super(PaddleModule, self).__init__()
+        super().__init__()
         self._linear0 = PaddleLinearModule(in_size, hidden_size)
         self._linear1 = PaddleLinearModule(hidden_size, hidden_size)
         self._linear2 = PaddleLinearModule(hidden_size, out_size)


### PR DESCRIPTION
# PR Description
In many files I see that `super()` is being called builtin with the current class and instance. On Python 3 these arguments are the default and they can be omitted.
Examples:
https://github.com/unifyai/ivy/blob/0d9e769776a48cbed15919fef7c123d824b547ff/ivy/functional/backends/numpy/device.py#L96
https://github.com/unifyai/ivy/blob/0d9e769776a48cbed15919fef7c123d824b547ff/ivy/functional/backends/tensorflow/device.py#L108
https://github.com/unifyai/ivy/blob/0d9e769776a48cbed15919fef7c123d824b547ff/ivy/functional/backends/paddle/device.py#L119
These arguments inside `super()` are by default from python 3, So they can be removed to make the code according to the latest standards.

## Related Issue
Closes #26931

## Checklist

- [ ] Did you add a function?
- [ ] Did you add the tests?
- [ ] Did you run your tests and are your tests passing?
- [x] Did pre-commit not fail on any check?
- [ ] Did you follow the steps we provided?

### Socials
https://twitter.com/Sai_Suraj_27