### PR TITLE
feat(frontends): Implemented number casting rules to __init__ 

### DIFF
--- a/ivy/functional/frontends/jax/numpy/__init__.py
+++ b/ivy/functional/frontends/jax/numpy/__init__.py
@@ -411,8 +411,7 @@ def promote_types_jax(
     type2: Union[ivy.Dtype, ivy.NativeDtype],
     /,
 ) -> ivy.Dtype:
-    """
-    Promote the datatypes type1 and type2, returning the data type they
+    """Promote the datatypes type1 and type2, returning the data type they
     promote to.
 
     Parameters
@@ -445,8 +444,7 @@ def promote_types_of_jax_inputs(
     x2: Union[ivy.Array, Number, Iterable[Number]],
     /,
 ) -> Tuple[ivy.Array, ivy.Array]:
-    """
-    Promote the dtype of the given native array inputs to a common dtype
+    """Promote the dtype of the given native array inputs to a common dtype
     based on type promotion rules.
 
     While passing float or integer values or any other non-array input

--- a/ivy/functional/frontends/jax/numpy/__init__.py
+++ b/ivy/functional/frontends/jax/numpy/__init__.py
@@ -411,8 +411,8 @@ def promote_types_jax(
     type2: Union[ivy.Dtype, ivy.NativeDtype],
     /,
 ) -> ivy.Dtype:
-    """
-    Promote the datatypes type1 and type2, returning the data type they promote to.
+    """Promote the datatypes type1 and type2, returning the data type they
+    promote to.
 
     Parameters
     ----------
@@ -444,9 +444,8 @@ def promote_types_of_jax_inputs(
     x2: Union[ivy.Array, Number, Iterable[Number]],
     /,
 ) -> Tuple[ivy.Array, ivy.Array]:
-    """
-    Promote the dtype of the given native array inputs to a common dtype based on type
-    promotion rules.
+    """Promote the dtype of the given native array inputs to a common dtype
+    based on type promotion rules.
 
     While passing float or integer values or any other non-array input
     to this function, it should be noted that the return will be an

--- a/ivy/functional/frontends/jax/numpy/__init__.py
+++ b/ivy/functional/frontends/jax/numpy/__init__.py
@@ -411,7 +411,8 @@ def promote_types_jax(
     type2: Union[ivy.Dtype, ivy.NativeDtype],
     /,
 ) -> ivy.Dtype:
-    """Promote the datatypes type1 and type2, returning the data type they
+    """
+    Promote the datatypes type1 and type2, returning the data type they
     promote to.
 
     Parameters
@@ -444,7 +445,8 @@ def promote_types_of_jax_inputs(
     x2: Union[ivy.Array, Number, Iterable[Number]],
     /,
 ) -> Tuple[ivy.Array, ivy.Array]:
-    """Promote the dtype of the given native array inputs to a common dtype
+    """
+    Promote the dtype of the given native array inputs to a common dtype
     based on type promotion rules.
 
     While passing float or integer values or any other non-array input

--- a/ivy/functional/frontends/jax/numpy/__init__.py
+++ b/ivy/functional/frontends/jax/numpy/__init__.py
@@ -1,7 +1,7 @@
 # global
 from numbers import Number
 from typing import Union, Tuple, Iterable
-
+import jax.numpy as jnp
 
 # local
 import ivy
@@ -19,26 +19,26 @@ _uint8 = ivy.UintDtype("uint8")
 _uint16 = ivy.UintDtype("uint16")
 _uint32 = ivy.UintDtype("uint32")
 _uint64 = ivy.UintDtype("uint64")
-_bfloat16 = ivy.FloatDtype("bfloat16")
-_float16 = ivy.FloatDtype("float16")
-_float32 = ivy.FloatDtype("float32")
-_float64 = ivy.FloatDtype("float64")
-_complex64 = ivy.ComplexDtype("complex64")
-_complex128 = ivy.ComplexDtype("complex128")
-_bool = ivy.Dtype("bool")
+_bfloat16 = jnp.bfloat16
+_float16 = jnp.float16
+_float32 = jnp.float32
+_float64 = jnp.float64
+_complex64 = jnp.complex64
+_complex128 = jnp.complex128
+_bool = jnp.bool_
 
 # jax-numpy casting table
 jax_numpy_casting_table = {
     _bool: [
         _bool,
-        _int8,
-        _int16,
-        _int32,
-        _int64,
-        _uint8,
-        _uint16,
-        _uint32,
-        _uint64,
+        jnp.int8,
+        jnp.int16,
+        jnp.int32,
+        jnp.int64,
+        jnp.uint8,
+        jnp.uint16,
+        jnp.uint32,
+        jnp.uint64,
         _float16,
         _float32,
         _float64,
@@ -46,11 +46,11 @@ jax_numpy_casting_table = {
         _complex128,
         _bfloat16,
     ],
-    _int8: [
-        _int8,
-        _int16,
-        _int32,
-        _int64,
+    jnp.int8: [
+        jnp.int8,
+        jnp.int16,
+        jnp.int32,
+        jnp.int64,
         _float16,
         _float32,
         _float64,
@@ -58,34 +58,10 @@ jax_numpy_casting_table = {
         _complex128,
         _bfloat16,
     ],
-    _int16: [
-        _int16,
-        _int32,
-        _int64,
-        _float32,
-        _float64,
-        _complex64,
-        _complex128,
-    ],
-    _int32: [
-        _int32,
-        _int64,
-        _float64,
-        _complex128,
-    ],
-    _int64: [
-        _int64,
-        _float64,
-        _complex128,
-    ],
-    _uint8: [
-        _int16,
-        _int32,
-        _int64,
-        _uint8,
-        _uint16,
-        _uint32,
-        _uint64,
+    jnp.int16: [
+        jnp.int16,
+        jnp.int32,
+        jnp.int64,
         _float16,
         _float32,
         _float64,
@@ -93,27 +69,73 @@ jax_numpy_casting_table = {
         _complex128,
         _bfloat16,
     ],
-    _uint16: [
-        _int32,
-        _int64,
-        _uint16,
-        _uint32,
-        _uint64,
+    jnp.int32: [
+        jnp.int32,
+        jnp.int64,
+        _float16,
         _float32,
         _float64,
         _complex64,
         _complex128,
+        _bfloat16,
     ],
-    _uint32: [
-        _int64,
-        _uint32,
-        _uint64,
+    jnp.int64: [
+        jnp.int64,
+        _float16,
+        _float32,
         _float64,
+        _complex64,
         _complex128,
+        _bfloat16,
     ],
-    _uint64: [
-        _uint64,
+    jnp.uint8: [
+        jnp.uint8,
+        jnp.uint16,
+        jnp.uint32,
+        jnp.uint64,
+        _float16,
+        _float32,
         _float64,
+        _complex64,
+        _complex128,
+        _bfloat16,
+    ],
+    jnp.uint16: [
+        jnp.uint16,
+        jnp.uint32,
+        jnp.uint64,
+        _float16,
+        _float32,
+        _float64,
+        _complex64,
+        _complex128,
+        _bfloat16,
+    ],
+    jnp.uint32: [
+        jnp.uint32,
+        jnp.uint64,
+        _float16,
+        _float32,
+        _float64,
+        _complex64,
+        _complex128,
+        _bfloat16,
+    ],
+    jnp.uint64: [
+        jnp.uint64,
+        _float16,
+        _float32,
+        _float64,
+        _complex64,
+        _complex128,
+        _bfloat16,
+    ],
+    _bfloat16: [
+        _bfloat16,
+        _float16,
+        _float32,
+        _float64,
+        _complex64,
         _complex128,
     ],
     _float16: [
@@ -131,15 +153,14 @@ jax_numpy_casting_table = {
     ],
     _float64: [
         _float64,
+        _complex64,
         _complex128,
     ],
-    _complex64: [_complex64, ivy.complex128],
-    _complex128: [_complex128],
-    _bfloat16: [
-        _bfloat16,
-        _float32,
-        _float64,
+    _complex64: [
         _complex64,
+        _complex128,
+    ],
+    _complex128: [
         _complex128,
     ],
 }
@@ -390,8 +411,8 @@ def promote_types_jax(
     type2: Union[ivy.Dtype, ivy.NativeDtype],
     /,
 ) -> ivy.Dtype:
-    """Promote the datatypes type1 and type2, returning the data type they
-    promote to.
+    """
+    Promote the datatypes type1 and type2, returning the data type they promote to.
 
     Parameters
     ----------
@@ -423,8 +444,9 @@ def promote_types_of_jax_inputs(
     x2: Union[ivy.Array, Number, Iterable[Number]],
     /,
 ) -> Tuple[ivy.Array, ivy.Array]:
-    """Promote the dtype of the given native array inputs to a common dtype
-    based on type promotion rules.
+    """
+    Promote the dtype of the given native array inputs to a common dtype based on type
+    promotion rules.
 
     While passing float or integer values or any other non-array input
     to this function, it should be noted that the return will be an

--- a/ivy/utils/exceptions.py
+++ b/ivy/utils/exceptions.py
@@ -373,7 +373,7 @@ def handle_exceptions(fn: Callable) -> Callable:
 _inplace_warning_cache = {}
 
 
-def _handle_inplace_mode(ivy_pack=None):
+def _handle_(ivy_pack=None):
     if not ivy_pack:
         ivy_pack = ivy
     current_backend = ivy_pack.current_backend_str()
@@ -381,14 +381,14 @@ def _handle_inplace_mode(ivy_pack=None):
         current_backend != ""
         and not _inplace_warning_cache.get(current_backend)
         and not ivy_pack.native_inplace_support
-        and ivy_pack.inplace_mode == "strict"
+        and ivy_pack. == "lenient"
     ):
         warnings.warn(
             f"The current backend: '{current_backend}' does not support "
             "inplace updates natively. Ivy would quietly create new arrays when "
             "using inplace updates with this backend, leading to memory overhead "
             "(same applies for views). If you want to control your memory "
-            "management, consider doing ivy.set_inplace_mode('strict') which "
+            "management, consider doing ivy.set_('strict') which "
             "should raise an error whenever an inplace update is attempted "
             "with this backend."
         )
@@ -403,10 +403,10 @@ def _check_inplace_update_support(x, ensure_in_backend):
     if (
         ensure_in_backend
         or ivy.is_native_array(x)
-        or (ivy.inplace_mode == "strict" and not is_tf_variable)
+        or (ivy. == "strict" and not is_tf_variable)
     ):
         raise ivy.utils.exceptions.InplaceUpdateException(
             f"{current_backend} does not support inplace updates "
             "and ivy cannot support the operation in 'strict' mode\n"
-            "To enable inplace update, use ivy.set_inplace_mode('lenient')\n"
+            "To enable inplace update, use ivy.set_('lenient')\n"
         )

--- a/ivy/utils/exceptions.py
+++ b/ivy/utils/exceptions.py
@@ -373,7 +373,7 @@ def handle_exceptions(fn: Callable) -> Callable:
 _inplace_warning_cache = {}
 
 
-def _handle_(ivy_pack="strict"):
+def _handle_inplace_mode(ivy_pack=None):
     if not ivy_pack:
         ivy_pack = ivy
     current_backend = ivy_pack.current_backend_str()
@@ -381,14 +381,14 @@ def _handle_(ivy_pack="strict"):
         current_backend != ""
         and not _inplace_warning_cache.get(current_backend)
         and not ivy_pack.native_inplace_support
-        and ivy_pack. == "lenient"
+        and ivy_pack.inplace_mode == "lenient"
     ):
         warnings.warn(
             f"The current backend: '{current_backend}' does not support "
             "inplace updates natively. Ivy would quietly create new arrays when "
             "using inplace updates with this backend, leading to memory overhead "
             "(same applies for views). If you want to control your memory "
-            "management, consider doing ivy.set_('strict') which "
+            "management, consider doing ivy.set_inplace_mode('strict') which "
             "should raise an error whenever an inplace update is attempted "
             "with this backend."
         )
@@ -403,10 +403,10 @@ def _check_inplace_update_support(x, ensure_in_backend):
     if (
         ensure_in_backend
         or ivy.is_native_array(x)
-        or (ivy. == "strict" and not is_tf_variable)
+        or (ivy.inplace_mode == "strict" and not is_tf_variable)
     ):
         raise ivy.utils.exceptions.InplaceUpdateException(
             f"{current_backend} does not support inplace updates "
             "and ivy cannot support the operation in 'strict' mode\n"
-            "To enable inplace update, use ivy.set_('lenient')\n"
+            "To enable inplace update, use ivy.set_inplace_mode('lenient')\n"
         )

--- a/ivy/utils/exceptions.py
+++ b/ivy/utils/exceptions.py
@@ -381,7 +381,7 @@ def _handle_inplace_mode(ivy_pack=None):
         current_backend != ""
         and not _inplace_warning_cache.get(current_backend)
         and not ivy_pack.native_inplace_support
-        and ivy_pack.inplace_mode == "lenient"
+        and ivy_pack.inplace_mode == "strict"
     ):
         warnings.warn(
             f"The current backend: '{current_backend}' does not support "

--- a/ivy/utils/exceptions.py
+++ b/ivy/utils/exceptions.py
@@ -373,7 +373,7 @@ def handle_exceptions(fn: Callable) -> Callable:
 _inplace_warning_cache = {}
 
 
-def _handle_(ivy_pack=None):
+def _handle_(ivy_pack="strict"):
     if not ivy_pack:
         ivy_pack = ivy
     current_backend = ivy_pack.current_backend_str()


### PR DESCRIPTION
<!--
This template will help you to have a meaningful PR, please follow it and do not leave it blank.
-->

# PR Description

Since the number() function is an abstract base class that represents the numeric scalar types in JAX NumPy, and it is not used directly. I am using specific numeric types from the jax.numpy module, such as jnp.int32 or jnp.float64, rather than calling number() directly.

## Related Issue

<!--
Please use this format to link other issues with their numbers: Close #123
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes #26857

## Checklist

- [x] Did you add a function? Kinda.
- [ ] Did you add the tests?
- [ ] Did you run your tests and are your tests passing?
- [ ] Did pre-commit not fail on any check?
- [ ] Did you follow the steps we provided?

<!--
Please mark your PR as a draft if you realise after the fact that your tests are not passing or
that your pre-commit check has some failures.

Here are some relevant resources regarding tests and pre-commit:

https://unify.ai/docs/ivy/overview/deep_dive/ivy_tests.html
https://unify.ai/docs/ivy/overview/deep_dive/formatting.html#pre-commit

-->
