### PR TITLE
feat: building wheels for multiple configurations

### DIFF
--- a/available_configs.json
+++ b/available_configs.json
@@ -1,11 +1,11 @@
 {
     "compiler": [
-        "cp38-none-manylinux_2_17_x86_64",
-        "cp39-none-manylinux_2_17_x86_64",
-        "cp310-none-manylinux_2_17_x86_64",
-        "cp311-none-manylinux_2_17_x86_64"
+        "cp38-cp38-manylinux_2_17_x86_64",
+        "cp39-cp39-manylinux_2_17_x86_64",
+        "cp310-cp310-manylinux_2_17_x86_64",
+        "cp311-cp311-manylinux_2_17_x86_64"
     ],
     "engines": [
-        "cp310-none-manylinux_2_17_x86_64"
+        "cp310-cp310-manylinux_2_17_x86_64"
     ]
 }

--- a/binaries.json
+++ b/binaries.json
@@ -76,6 +76,7 @@
                             "creation.so",
                             "elementwise.so",
                             "general.so",
+                            "ivy2xla.so",
                             "layers.so",
                             "linear_algebra.so",
                             "manipulation.so",

--- a/scripts/shell/deploy_pypi.sh
+++ b/scripts/shell/deploy_pypi.sh
@@ -1,2 +1,5 @@
-python3 -m build
+jq -c '.compiler[]' available_configs.json | while read config; do
+    export TAG=${config:1:${#config}-2}
+    python -m build
+done
 python3 -m twine upload dist/* -u "__token__" -p "$PYPI_PASSWORD" --verbose

--- a/setup.py
+++ b/setup.py
@@ -44,13 +44,14 @@ def _strip(line):
 
 
 # Download all relevant binaries in binaries.json
-all_tags = list(tags.sys_tags())
 binaries_dict = json.load(open("binaries.json"))
 available_configs = json.load(open("available_configs.json"))
 binaries_paths = _get_paths_from_binaries(binaries_dict)
 version = os.environ["VERSION"] if "VERSION" in os.environ else "main"
 terminate = False
-
+fixed_tag = os.environ["TAG"] if "TAG" in os.environ else None
+all_tags = [fixed_tag] if fixed_tag else list(tags.sys_tags())
+python_tag, _, plat_name = fixed_tag.split("-")
 
 # download binaries for the tag with highest precedence
 for tag in all_tags:
@@ -127,4 +128,6 @@ setup(
         "License :: OSI Approved :: Apache Software License",
     ],
     license="Apache 2.0",
+    has_ext_modules=lambda: True,
+    options={"bdist_wheel": {"python_tag": python_tag, "plat_name": plat_name}},
 )


### PR DESCRIPTION
1. Updated available_configs.json and binaries.json with the abi tag
2. Updated the setup.py to allow an environment variable named TAG to use a fixed tag instead of the supported exploration of all available tags and pass those options to setuptools.setup
3. Updated deploy_pypi.sh to build for all configurations and generate wheels for each using the TAG env var