### PR TITLE
fix: more fixes to the building wheels

### DIFF
--- a/scripts/rename_wheels.py
+++ b/scripts/rename_wheels.py
@@ -1,0 +1,14 @@
+import os
+
+if __name__ == "__main__":
+    tag = os.environ["TAG"]
+    python_tag, abi_tag, plat_name = tag.split("-")
+    if os.path.exists("dist"):
+        for file in os.listdir("dist"):
+            old_name = f"{python_tag}-none-{plat_name}.whl"
+            new_name = f"{python_tag}-{abi_tag}-{plat_name}.whl"
+            if file.endswith(old_name):
+                os.rename(
+                    os.path.join("dist", file),
+                    os.path.join("dist", file[: -len(old_name)] + new_name),
+                )

--- a/setup.py
+++ b/setup.py
@@ -50,8 +50,11 @@ binaries_paths = _get_paths_from_binaries(binaries_dict)
 version = os.environ["VERSION"] if "VERSION" in os.environ else "main"
 terminate = False
 fixed_tag = os.environ["TAG"] if "TAG" in os.environ else None
-all_tags = [fixed_tag] if fixed_tag else list(tags.sys_tags())
-python_tag, _, plat_name = fixed_tag.split("-")
+all_tags = list(tags.sys_tags())
+python_tag, plat_name = None, None
+if fixed_tag:
+    python_tag, _, plat_name = str(fixed_tag).split("-")
+    all_tags = [fixed_tag]
 
 # download binaries for the tag with highest precedence
 for tag in all_tags:
@@ -128,6 +131,5 @@ setup(
         "License :: OSI Approved :: Apache Software License",
     ],
     license="Apache 2.0",
-    has_ext_modules=lambda: True,
     options={"bdist_wheel": {"python_tag": python_tag, "plat_name": plat_name}},
 )


### PR DESCRIPTION
updated the setup.py code to work with and without the tag environment variable and also added the rename_wheels script to rename the wheel files to add the missing abi tag
