### PR TITLE
fix: Added missing `return` for 2 functions.

### DIFF
--- a/ivy_tests/test_ivy/test_frontends/test_jax/test_random.py
+++ b/ivy_tests/test_ivy/test_frontends/test_jax/test_random.py
@@ -1027,7 +1027,7 @@ def test_jax_multivariate_normal(
     spd = np.matmul(cov.T, cov) + np.identity(cov.shape[0])
 
     def call():
-        helpers.test_frontend_function(
+        return helpers.test_frontend_function(
             input_dtypes=input_dtype + [shared_dtype],
             frontend=frontend,
             test_flags=test_flags,

--- a/ivy_tests/test_ivy/test_frontends/test_torch/test_random_sampling.py
+++ b/ivy_tests/test_ivy/test_frontends/test_torch/test_random_sampling.py
@@ -344,7 +344,7 @@ def test_torch_randint(
     backend_fw,
 ):
     def call():
-        helpers.test_frontend_function(
+        return helpers.test_frontend_function(
             input_dtypes=dtype,
             backend_to_test=backend_fw,
             frontend=frontend,


### PR DESCRIPTION
# PR Description
In the following files for the following `def call()` functions return statement is missing in these lines. So, the `call()` function calls will not actually return anything:
https://github.com/unifyai/ivy/blob/72d1cdc9bdc1056ca561128f7f7864ac1cd91bce/ivy_tests/test_ivy/test_frontends/test_torch/test_random_sampling.py#L347
https://github.com/unifyai/ivy/blob/72d1cdc9bdc1056ca561128f7f7864ac1cd91bce/ivy_tests/test_ivy/test_frontends/test_torch/test_random_sampling.py#L359
https://github.com/unifyai/ivy/blob/72d1cdc9bdc1056ca561128f7f7864ac1cd91bce/ivy_tests/test_ivy/test_frontends/test_jax/test_random.py#L1030
https://github.com/unifyai/ivy/blob/72d1cdc9bdc1056ca561128f7f7864ac1cd91bce/ivy_tests/test_ivy/test_frontends/test_jax/test_random.py#L1045
I fixed this by adding the return statement.

## Related Issue
Closes #27075

## Checklist

- [ ] Did you add a function?
- [ ] Did you add the tests?
- [ ] Did you run your tests and are your tests passing?
- [x] Did pre-commit not fail on any check?
- [ ] Did you follow the steps we provided?

### Socials
https://twitter.com/Sai_Suraj_27