### PR TITLE
fix: Fixed passing `positional` arguments in few functions

### DIFF
--- a/ivy/data_classes/array/experimental/manipulation.py
+++ b/ivy/data_classes/array/experimental/manipulation.py
@@ -1197,7 +1197,7 @@ class _ArrayWithManipulationExperimental(abc.ABC):
         >>> ivy.trim_zeros([0, 8, 3, 0, 0])
         [8, 3]
         """
-        return ivy.trim_zeros(self, trim)
+        return ivy.trim_zeros(self, trim=trim)
 
     def unfold(
         self: Union[ivy.Array, ivy.NativeArray],

--- a/ivy/functional/frontends/paddle/nn/functional/pooling.py
+++ b/ivy/functional/frontends/paddle/nn/functional/pooling.py
@@ -112,4 +112,11 @@ def max_unpool1d(
     output_size=None,
     name=None,
 ):
-    return ivy.max_unpool1d(x, indices, kernel_size, stride, padding, data_format)
+    return ivy.max_unpool1d(
+        x,
+        indices,
+        kernel_size,
+        strides=stride,
+        padding=padding,
+        data_format=data_format,
+    )

--- a/ivy/functional/frontends/sklearn/model_selection/_split.py
+++ b/ivy/functional/frontends/sklearn/model_selection/_split.py
@@ -74,7 +74,7 @@ class StratifiedKFold(KFold):
         )
 
     def _iter_test_indices(self, X=None, y=None, groups=None):
-        ivy.seed(self.random_state)
+        ivy.seed(seed_value=self.random_state)
         y = ivy.array(y)
         y = column_or_1d(y)
         _, y_idx, y_inv, _ = ivy.unique_all(y, return_index=True, return_inverse=True)
@@ -139,7 +139,7 @@ def train_test_split(
     indices = ivy.arange(0, n_train + n_test)
     if shuffle:
         if random_state is not None:
-            ivy.seed(random_state)
+            ivy.seed(seed_value=random_state)
         indices = ivy.shuffle(indices)
     train_indices = indices[:n_train]
     test_indices = indices[n_train:]

--- a/ivy/functional/frontends/torch/tensor.py
+++ b/ivy/functional/frontends/torch/tensor.py
@@ -883,7 +883,7 @@ class Tensor:
     @numpy_to_torch_style_args
     @with_unsupported_dtypes({"2.1.0 and below": ("float16",)}, "torch")
     def cumsum_(self, dim, *, dtype=None):
-        self.ivy_array = self.cumsum(dim, dtype).ivy_array
+        self.ivy_array = self.cumsum(dim, dtype=dtype).ivy_array
         return self
 
     @with_unsupported_dtypes({"2.1.0 and below": ("float16", "bfloat16")}, "torch")

--- a/ivy/functional/frontends/xgboost/sklearn.py
+++ b/ivy/functional/frontends/xgboost/sklearn.py
@@ -119,7 +119,7 @@ class XGBModel(XGBModelBase):
 
         # take random_state into account only if it's an integer
         if isinstance(params["random_state"], int):
-            ivy.seed(params["random_state"])
+            ivy.seed(seed_value=params["random_state"])
 
         return params
 


### PR DESCRIPTION
# PR Description
In the file [`ivy\functional\frontends\torch\tensor.py`](https://github.com/unifyai/ivy/blob/main/ivy/functional/frontends/torch/tensor.py), in the following line (886):
https://github.com/unifyai/ivy/blob/0b943a88e001568b04d4b0907891eda6d529d986/ivy/functional/frontends/torch/tensor.py#L886
The `dtype` is getting passed as positional argument but from the definition of the function, I think it should be passed as a key-word argument to avoid un-intended behavior.
https://github.com/unifyai/ivy/blob/0b943a88e001568b04d4b0907891eda6d529d986/ivy/functional/frontends/torch/tensor.py#L880

Edit: I found these type of mistake (passing as a positional argument instead of a key-word argument) in few other files, so i have tried to correct them also.

## Related Issue
Closes #27081

## Checklist

- [ ] Did you add a function?
- [ ] Did you add the tests?
- [ ] Did you run your tests and are your tests passing?
- [x] Did pre-commit not fail on any check?
- [ ] Did you follow the steps we provided?

### Socials
https://twitter.com/Sai_Suraj_27