### PR TITLE
fix: Raised `ValueError` to improve error handling.

### DIFF
--- a/ivy/functional/frontends/paddle/vision/transforms.py
+++ b/ivy/functional/frontends/paddle/vision/transforms.py
@@ -192,12 +192,12 @@ def pad(img, padding, fill=0, padding_mode="constant"):
         elif dim_size == 3:
             trans_padding = ((0, 0), (padding[1], padding[3]), (padding[0], padding[2]))
     else:
-        raise "padding can only be 1D with size 1, 2, 4 only"
+        raise ValueError("padding can only be 1D with size 1, 2, 4 only")
 
     if padding_mode in ["constant", "edge", "reflect", "symmetric"]:
         return ivy.pad(img, trans_padding, mode=padding_mode, constant_values=fill)
     else:
-        raise "Unsupported padding_mode"
+        raise ValueError("Unsupported padding_mode")
 
 
 @with_supported_dtypes(


### PR DESCRIPTION
# PR Description
In the file [`ivy\functional\frontends\paddle\vision\transforms.py`](https://github.com/unifyai/ivy/blob/main/ivy/functional/frontends/paddle/vision/transforms.py):
In the following lines:
https://github.com/unifyai/ivy/blob/540534cfc788822012eec764ebab4daca1709da1/ivy/functional/frontends/paddle/vision/transforms.py#L195
https://github.com/unifyai/ivy/blob/540534cfc788822012eec764ebab4daca1709da1/ivy/functional/frontends/paddle/vision/transforms.py#L200
In both the cases a `string` is being raised which is not a good way, I think something like `ValueError` should be raised.

## Related Issue
Closes #27092

## Checklist

- [ ] Did you add a function?
- [ ] Did you add the tests?
- [ ] Did you run your tests and are your tests passing?
- [x] Did pre-commit not fail on any check?
- [ ] Did you follow the steps we provided?

### Socials
https://twitter.com/Sai_Suraj_27