### PR TITLE
fix: bug where fn_unsupported_dnd is a tuple on the latest paddle ver…

### DIFF
--- a/ivy/functional/ivy/general.py
+++ b/ivy/functional/ivy/general.py
@@ -4069,8 +4069,9 @@ def _get_devices_and_dtypes(fn, recurse=False, complement=True):
                 list(fn_supported_dnd.values())[0], tuple
             )
 
-        for device, dtypes in fn_supported_dnd.items():
-            fn_supported_dnd[device] = tuple(_expand_typesets(dtypes))
+        if isinstance(fn_supported_dnd, dict):
+            for device, dtypes in fn_supported_dnd.items():
+                fn_supported_dnd[device] = tuple(_expand_typesets(dtypes))
 
         # dict intersection
         supported = _dnd_dict_intersection(supported, fn_supported_dnd)

--- a/ivy/functional/ivy/general.py
+++ b/ivy/functional/ivy/general.py
@@ -4086,8 +4086,9 @@ def _get_devices_and_dtypes(fn, recurse=False, complement=True):
                 list(fn_unsupported_dnd.values())[0], tuple
             )
 
-        for device, dtypes in fn_unsupported_dnd.items():
-            fn_unsupported_dnd[device] = tuple(_expand_typesets(dtypes))
+        if isinstance(fn_unsupported_dnd, dict):
+            for device, dtypes in fn_unsupported_dnd.items():
+                fn_unsupported_dnd[device] = tuple(_expand_typesets(dtypes))
 
         # dict difference
         supported = _dnd_dict_difference(supported, fn_unsupported_dnd)


### PR DESCRIPTION
@vedpatwardhan On the latest paddle version (2.5.2) `fn_unsupported_dnd` is a (empty) tuple, which is causing quite a lot of the checks in the tracer-transpiler to fail when .items() is attempted on it. This simple solution does fix the problem, but  there may well be a better fix.