### PR TITLE
fix(ci): replaced pull_request_target by pull_request in the lint workflow

### DIFF
--- a/.github/workflows/intelligent-tests-pr.yml
+++ b/.github/workflows/intelligent-tests-pr.yml
@@ -2,6 +2,7 @@ name: intelligent-tests-pr
 on:
   workflow_dispatch:
   pull_request:
+    types: [labeled, opened, synchronize, reopened, review_requested]
 
 permissions:
   actions: read

--- a/.github/workflows/pr-lint-bot.yml
+++ b/.github/workflows/pr-lint-bot.yml
@@ -1,7 +1,7 @@
 name: Trigger lint format
 
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, edited, synchronize, reopened]
 
 permissions:

--- a/.github/workflows/welcome-message.yml
+++ b/.github/workflows/welcome-message.yml
@@ -1,7 +1,7 @@
 name: Check Semantic and welcome new contributors
 
 on:
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - edited

--- a/.github/workflows/welcome-message.yml
+++ b/.github/workflows/welcome-message.yml
@@ -1,7 +1,7 @@
 name: Check Semantic and welcome new contributors
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - opened
       - edited


### PR DESCRIPTION
Given that pull_request_target provides write permissions to github secrets, checking out arbitrary user code in that workflow isn't really recommended ([ref](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)). Ofc that doesn't apply to the welcome message [workflow](https://github.com/unifyai/ivy/blob/main/.github/workflows/welcome-message.yml) as it doesn't check out user code.

Happy to hear your thoughts @KareemMAX @NripeshN, thanks! 