### PR TITLE
implementation of nanquantile logic and test case

### DIFF
--- a/ivy/data_classes/container/base.py
+++ b/ivy/data_classes/container/base.py
@@ -1376,7 +1376,7 @@ class ContainerBase(dict, abc.ABC):
              (Default value = '__')
         """
         # noinspection RegExpSingleCharAlternation
-        flat_keys = re.split("/|\.", key_chain)  # noqa
+        flat_keys = re.split(r"/|\.", key_chain)  # noqa
         num_keys = len(flat_keys)
         pre_keys = []
         post_keys = []

--- a/ivy/functional/frontends/jax/numpy/statistical.py
+++ b/ivy/functional/frontends/jax/numpy/statistical.py
@@ -669,6 +669,34 @@ def var(a, axis=None, dtype=None, out=None, ddof=0, keepdims=False, *, where=Non
     return ivy.astype(ret, ivy.as_ivy_dtype(dtype), copy=False)
 
 
+@to_ivy_arrays_and_back
+def ptp(a, axis=None, out=None, keepdims=False):
+    x = ivy.max(a, axis=axis, keepdims=keepdims)
+    y = ivy.min(a, axis=axis, keepdims=keepdims)
+    return ivy.subtract(x, y)
+
+
+@to_ivy_arrays_and_back
+@with_unsupported_dtypes(
+    {"0.4.19 and below": ("complex64", "complex128", "bfloat16", "bool", "float16")},
+    "jax",
+)
+def nanquantile(
+    a,
+    q,
+    /,
+    *,
+    axis=None,
+    out=None,
+    overwrite_input=False,
+    method="linear",
+    keepdims=False,
+    interpolation=None,
+):
+    return ivy.nanquantile(
+        a, q, axis=axis, keepdims=keepdims, interpolation=method, out=out
+    )
+
 amax = max
 amin = min
 cumproduct = cumprod

--- a/ivy/functional/ivy/experimental/statistical.py
+++ b/ivy/functional/ivy/experimental/statistical.py
@@ -1024,3 +1024,89 @@ def cummin(
     return ivy.current_backend(x).cummin(
         x, axis=axis, exclusive=exclusive, reverse=reverse, dtype=dtype, out=out
     )
+
+
+@handle_exceptions
+@handle_nestable
+@handle_out_argument
+@to_native_arrays_and_back
+@handle_device
+def nanquantile(
+    a: ivy.Array,
+    q: Union[ivy.Array, float],
+    /,
+    *,
+    axis: Optional[Union[Sequence[int], int]] = None,
+    keepdims: bool = False,
+    interpolation: str = "linear",
+    out: Optional[ivy.Array] = None,
+) -> ivy.Array:
+    """
+    Compute the q-th nanquantile of the data along the specified axis.
+
+    Parameters
+    ----------
+    a
+        Input array.
+    q
+        Nanquantile or sequence of nanquantile to compute, which must be
+        between 0 and 1 inclusive.
+    axis
+        Axis or axes along which the nanquantile are computed. The default
+        is to compute the nanquantile(s) along a flattened version of the array.
+    keepdims
+        If this is set to True, the axes which are reduced are left in the result
+        as dimensions with size one. With this option, the result will broadcast
+        correctly against the original array a.
+    interpolation
+        {'nearest', 'linear', 'lower', 'higher', 'midpoint', 'nearest_jax'}.
+        Default value: 'linear'.
+        This specifies the interpolation method to use when the desired quantile lies
+        between two data points i < j:
+        - linear: i + (j - i) * fraction, where fraction is the fractional part of the
+        index surrounded by i and j.
+        - lower: i.
+        - higher: j.
+        - nearest: i or j, whichever is nearest.
+        - midpoint: (i + j) / 2. linear and midpoint interpolation do not work with
+        integer dtypes.
+        - nearest_jax: provides jax-like computation for interpolation='nearest'.
+    out
+        optional output array, for writing the result to.
+
+    Returns
+    -------
+    ret
+        A (rank(q) + N - len(axis)) dimensional array of same dtype as a, or, if axis
+        is None, a rank(q) array. The first rank(q) dimensions index quantiles for
+        different values of q.
+
+    Examples
+    --------
+    >>> a = ivy.array([[10., 7., 4.], [3., 2., 1.]])
+    >>> q = ivy.array(0.5)
+    >>> ivy.nanquantile(a, q)
+    ivy.array(3.5)
+
+    >>> a = ivy.array([[10., 7., 4.], [3., 2., 1.]])
+    >>> q = 0.5
+    >>> ivy.quantile(a, q)
+    ivy.array(3.5)
+
+    >>> ivy.quantile(a, q, axis=0)
+    ivy.array([6.5, 4.5, 2.5])
+
+    >>> ivy.quantile(a, q, axis=1)
+    ivy.array([7.,  2.])
+
+    >>> ivy.quantile(a, q, axis=1, keepdims=True)
+    ivy.array([[7.],[2.]])
+
+    >>> a = ivy.array([1., 2., 3., 4.])
+    >>> q = ivy.array([0.3, 0.7])
+    >>> ivy.quantile(a, q, interpolation='lower')
+    ivy.array([1., 3.])
+    """
+    return ivy.current_backend(a).nanquantile(
+        a, q, axis=axis, keepdims=keepdims, interpolation=interpolation, out=out
+    )

--- a/ivy_tests/test_ivy/test_frontends/test_jax/test_numpy/test_statistical.py
+++ b/ivy_tests/test_ivy/test_frontends/test_jax/test_numpy/test_statistical.py
@@ -1346,3 +1346,38 @@ def test_nanpercentile(
         interpolation=interpolation[0],
         keepdims=keep_dims,
     )
+
+@handle_frontend_test(
+    fn_tree="jax.numpy.nanquantile",
+    dtype_array_axes_q=_get_array_axes_probs(),
+    overwrite_input=st.just(False),
+    keepdims=st.booleans(),
+    method=st.sampled_from(["linear", "lower", "higher", "midpoint", "nearest"]),
+)
+def test_jax_nanquantile(
+    *,
+    dtype_array_axes_q,
+    overwrite_input,
+    keepdims,
+    method,
+    on_device,
+    fn_tree,
+    frontend,
+    test_flags,
+    backend_fw,
+):
+    dtypes, array, axes, q = dtype_array_axes_q
+    helpers.test_frontend_function(
+        input_dtypes=dtypes,
+        frontend=frontend,
+        test_flags=test_flags,
+        backend_to_test=backend_fw,
+        fn_tree=fn_tree,
+        on_device=on_device,
+        a=array[0],
+        q=q,
+        axis=axes,
+        overwrite_input=overwrite_input,
+        method=method,
+        keepdims=keepdims,
+    )


### PR DESCRIPTION
# PR Description

This PR concerns the implementation of the `ivy.nanquantile` function which calculates the quantile while ignoring `nan` values.

## Related Issue

<!--
 Open #27122
https://github.com/unifyai/ivy/issues/27122
-->
Open #27122

## Checklist

- [x] Did you add a function?
- [x] Did you add the tests?
- [x] Did you run your tests and are your tests passing?
- [x] Did pre-commit not fail on any check?
- [x] Did you follow the steps we provided?

<!--
Please mark your PR as a draft if you realise after the fact that your tests are not passing or
that your pre-commit check has some failures.

-->

### Socials

<!--
@amoungui
-->
