### PR TITLE
fix(ci): set the max examples for the array api det coverage to 5

### DIFF
--- a/scripts/determine_tests/array_api_det_coverage.py
+++ b/scripts/determine_tests/array_api_det_coverage.py
@@ -79,7 +79,14 @@ def main():
     directories = set(directories_filtered)
     for test_backend in tqdm(test_names):
         test_name, backend = test_backend.split(",")
-        command = f'docker run --rm --env IVY_BACKEND={backend} --env ARRAY_API_TESTS_MODULE="ivy" -v "$(pwd)":/ivy unifyai/ivy:latest timeout 30m /bin/bash -c "coverage run --source=ivy,ivy_tests -m pytest {test_name} -k \\"{k_flag[backend]}\\" --disable-warnings --tb=short -vv > coverage_output;coverage annotate > coverage_output" '  # noqa
+        command = (
+            f"docker run --rm --env IVY_BACKEND={backend} --env "
+            'ARRAY_API_TESTS_MODULE="ivy" -v "$(pwd)":/ivy unifyai/ivy:latest '
+            'timeout 30m /bin/bash -c "coverage run --source=ivy,ivy_tests -m pytest '
+            f'{test_name} -k \\"{k_flag[backend]}\\" --disable-warnings --tb=short '
+            "--max-examples 5 -vv > coverage_output;coverage annotate > "
+            'coverage_output"'
+        )
         os.system(command)
         for directory in directories:
             for file_name in os.listdir(directory):


### PR DESCRIPTION
 As the determine coverage workflow times out after 6 hours and the default max examples is 100