### PR TITLE
fix: bug causing jax to make array copies on every asarray call

### DIFF
--- a/ivy/functional/backends/jax/creation.py
+++ b/ivy/functional/backends/jax/creation.py
@@ -79,7 +79,7 @@ def asarray(
     # jax device objects aren't serializable and prevent saving transpiled graphs
     # this workaround only works because we are inside jax.default_device context
     # invoked in @handle_device decorator
-    return jnp.copy(ret) if (ret.device != device or copy) else ret
+    return jnp.copy(ret) if (ret.device() != device or copy) else ret
 
 
 def empty(


### PR DESCRIPTION
fyi @MahmoudAshraf97 