### PR TITLE
fix(ivy): updated the jax cuda version to be 11.8 and fixed an issue with dynamic backend setting

### DIFF
--- a/docker/gpu_framework_directory.py
+++ b/docker/gpu_framework_directory.py
@@ -45,7 +45,7 @@ def install_pkg(path, pkg, base="fw/"):
         )
     elif pkg.split("==")[0] if "==" in pkg else pkg == "jax":
         subprocess.run(
-            f"yes |pip install --upgrade --target {path} 'jax[cuda12_pip]' -f"
+            f"yes |pip install --upgrade --target {path} 'jax[cuda11_pip]' -f"
             " https://storage.googleapis.com/jax-releases/jax_cuda_releases.html  "
             " --no-cache-dir",
             shell=True,

--- a/ivy/utils/backend/handler.py
+++ b/ivy/utils/backend/handler.py
@@ -416,7 +416,6 @@ def set_backend(backend: str, dynamic: bool = False):
                 ivy.functional.__dict__[key] = ivy.__dict__[key]
 
         if dynamic:
-            print(f"devices {devices}")
             convert_from_numpy_to_target_backend(variable_ids, numpy_objs, devices)
         for sub_backend in ivy.available_sub_backends:
             ivy.set_sub_backend(sub_backend)

--- a/ivy/utils/backend/handler.py
+++ b/ivy/utils/backend/handler.py
@@ -327,7 +327,7 @@ def convert_from_numpy_to_target_backend(variable_ids, numpy_objs, devices):
         # check if object was originally a variable
         if id(obj) in variable_ids:
             native_arr = ivy.nested_map(
-                lambda x: current_backend().asarray(x, device=device),
+                lambda x: ivy.asarray(x, device=device),
                 np_arr,
                 include_derived=True,
                 shallow=False,
@@ -336,7 +336,7 @@ def convert_from_numpy_to_target_backend(variable_ids, numpy_objs, devices):
 
         else:
             new_data = ivy.nested_map(
-                lambda x: current_backend().asarray(x, device=device),
+                lambda x: ivy.asarray(x, device=device),
                 np_arr,
                 include_derived=True,
                 shallow=False,
@@ -416,6 +416,7 @@ def set_backend(backend: str, dynamic: bool = False):
                 ivy.functional.__dict__[key] = ivy.__dict__[key]
 
         if dynamic:
+            print(f"devices {devices}")
             convert_from_numpy_to_target_backend(variable_ids, numpy_objs, devices)
         for sub_backend in ivy.available_sub_backends:
             ivy.set_sub_backend(sub_backend)


### PR DESCRIPTION
As jax and torch can't be used together with cuda 12.1, and fixed an issue with dynamic backend setting to retain the initial backend device in the target backend