### PR TITLE
fix: ensure jax device checking doesn't cause abstract tracer values …

### DIFF
--- a/ivy/functional/backends/jax/creation.py
+++ b/ivy/functional/backends/jax/creation.py
@@ -12,6 +12,7 @@ import jaxlib.xla_extension
 import ivy
 from ivy import as_native_dtype
 from ivy.functional.backends.jax import JaxArray
+from ivy.functional.backends.jax.device import dev
 from ivy.functional.ivy.creation import (
     _asarray_to_native_arrays_and_back,
     _asarray_infer_device,
@@ -79,10 +80,7 @@ def asarray(
     # jax device objects aren't serializable and prevent saving transpiled graphs
     # this workaround only works because we are inside jax.default_device context
     # invoked in @handle_device decorator
-    current_device = (
-        ret.device_buffer.device() if hasattr(ret, "device_buffer") else None
-    )
-    return jnp.copy(ret) if (current_device != device or copy) else ret
+    return jnp.copy(ret) if (dev(ret, as_native=True) != device or copy) else ret
 
 
 def empty(

--- a/ivy/functional/backends/jax/creation.py
+++ b/ivy/functional/backends/jax/creation.py
@@ -79,7 +79,8 @@ def asarray(
     # jax device objects aren't serializable and prevent saving transpiled graphs
     # this workaround only works because we are inside jax.default_device context
     # invoked in @handle_device decorator
-    return jnp.copy(ret) if (ret.device() != device or copy) else ret
+    current_device = ret.device_buffer.device() if hasattr(ret, 'device_buffer') else None
+    return jnp.copy(ret) if (current_device != device or copy) else ret
 
 
 def empty(

--- a/ivy/functional/backends/jax/creation.py
+++ b/ivy/functional/backends/jax/creation.py
@@ -79,7 +79,9 @@ def asarray(
     # jax device objects aren't serializable and prevent saving transpiled graphs
     # this workaround only works because we are inside jax.default_device context
     # invoked in @handle_device decorator
-    current_device = ret.device_buffer.device() if hasattr(ret, 'device_buffer') else None
+    current_device = (
+        ret.device_buffer.device() if hasattr(ret, "device_buffer") else None
+    )
     return jnp.copy(ret) if (current_device != device or copy) else ret
 
 

--- a/ivy/functional/backends/jax/device.py
+++ b/ivy/functional/backends/jax/device.py
@@ -41,14 +41,11 @@ def dev(
 ) -> Union[ivy.Device, jaxlib.xla_extension.Device]:
     if isinstance(x, jax.interpreters.partial_eval.DynamicJaxprTracer):
         return ""
-    try:
-        dv = _to_array(x).device_buffer.device
-        dv = dv()
-    except Exception:
+    if hasattr(x, "device_buffer"):
+        dv = _to_array(x).device_buffer.device()
+    else:
         dv = jax.devices()[0]
-    if as_native:
-        return dv
-    return as_ivy_dev(dv)
+    return dv if as_native else as_ivy_dev(dv)
 
 
 def to_device(


### PR DESCRIPTION
@MahmoudAshraf97 the method you implemented the other day for getting the jax device was causing errors like this after transpilation is certain cases:
`ivy.utils.exceptions.IvyBackendException: jax: execute_with_gradients: Abstract tracer value encountered where concrete value is expected: traced array with shape float32[2,4].`

I've made a minor tweak to fix the problem here, does this look ok to you? Also, not totally sure if we should default the `current_device` to `None` or `device`, thoughts?