### PR TITLE
style: Consistent style for `pytest.mark.parametrize` arguments.

### DIFF
--- a/ivy_tests/test_ivy/test_frontends/test_sklearn/test_utils/test_multiclass.py
+++ b/ivy_tests/test_ivy/test_frontends/test_sklearn/test_utils/test_multiclass.py
@@ -5,7 +5,7 @@ from ivy.functional.frontends.sklearn.utils.multiclass import type_of_target
 
 # not suitable for usual frontend testing
 @pytest.mark.parametrize(
-    "y, label",
+    ("y", "label"),
     [
         ([1.2], "continuous"),
         ([1], "binary"),

--- a/ivy_tests/test_ivy/test_functional/test_experimental/test_core/test_linalg.py
+++ b/ivy_tests/test_ivy/test_functional/test_experimental/test_core/test_linalg.py
@@ -1292,7 +1292,7 @@ def test_khatri_rao(*, data, test_flags, backend_fw, fn_name, on_device):
 
 # The following two tests have been adapted from TensorLy
 # https://github.com/tensorly/tensorly/blob/main/tensorly/tenalg/tests/test_khatri_rao.py
-@pytest.mark.parametrize("columns, rows", [(4, [3, 4, 2])])
+@pytest.mark.parametrize(("columns", "rows"), [(4, [3, 4, 2])])
 def test_khatri_rao_tensorly_1(columns, rows):
     columns = columns
     rows = rows
@@ -1306,7 +1306,7 @@ def test_khatri_rao_tensorly_1(columns, rows):
 
 
 @pytest.mark.parametrize(
-    "t1, t2, true_res",
+    ("t1", "t2", "true_res"),
     [
         (
             [[1, 2, 3], [4, 5, 6], [7, 8, 9]],
@@ -1477,7 +1477,7 @@ def test_mode_dot(*, data, test_flags, backend_fw, fn_name, on_device):
 
 
 @pytest.mark.parametrize(
-    "X, U, true_res",
+    ("X", "U", "true_res"),
     [
         (
             [
@@ -1545,7 +1545,7 @@ def test_multi_mode_dot(*, data, test_flags, backend_fw, fn_name, on_device):
 # The following 2 tests have been adapted from TensorLy
 # https://github.com/tensorly/tensorly/blob/main/tensorly/tenalg/tests/test_n_mode_product.py#L81
 @pytest.mark.parametrize(
-    "X, U, true_res",
+    ("X", "U", "true_res"),
     [
         ([[1, 2], [0, -1]], [[2, 1], [-1, 1]], [1]),
     ],
@@ -1556,7 +1556,12 @@ def test_multi_mode_dot_tensorly_1(X, U, true_res):
     assert np.allclose(true_res, res)
 
 
-@pytest.mark.parametrize("shape", ((3, 5, 4, 2),))
+@pytest.mark.parametrize(
+    "shape",
+    [
+        (3, 5, 4, 2),
+    ],
+)
 def test_multi_mode_dot_tensorly_2(shape):
     print(shape)
     X = ivy.ones(shape)
@@ -1624,7 +1629,7 @@ def test_partial_tucker(*, data, test_flags, backend_fw, fn_name, on_device):
 # test adapted from TensorLy
 # https://github.com/tensorly/tensorly/blob/main/tensorly/decomposition/tests/test_tucker.py#L24
 @pytest.mark.parametrize(
-    "tol_norm_2, tol_max_abs, modes, shape",
+    ("tol_norm_2", "tol_max_abs", "modes", "shape"),
     [
         (
             10e-3,
@@ -1775,7 +1780,9 @@ def test_tensor_train(*, data, svd, test_flags, backend_fw, fn_name, on_device):
 
 # The following 3 tests have been adapted from TensorLy
 # https://github.com/tensorly/tensorly/blob/main/tensorly/decomposition/tests/test_tt_decomposition.py
-@pytest.mark.parametrize("shape, rank", [((3, 4, 5, 6, 2, 10), (1, 3, 3, 4, 2, 2, 1))])
+@pytest.mark.parametrize(
+    ("shape", "rank"), [((3, 4, 5, 6, 2, 10), (1, 3, 3, 4, 2, 2, 1))]
+)
 def test_tensor_train_tensorly_1(shape, rank):
     tensor = ivy.random_uniform(shape=shape)
     tensor_shape = tensor.shape
@@ -1800,7 +1807,9 @@ def test_tensor_train_tensorly_1(shape, rank):
         r_prev_iteration = r_k
 
 
-@pytest.mark.parametrize("shape, rank", [((3, 4, 5, 6, 2, 10), (1, 5, 4, 3, 8, 10, 1))])
+@pytest.mark.parametrize(
+    ("shape", "rank"), [((3, 4, 5, 6, 2, 10), (1, 5, 4, 3, 8, 10, 1))]
+)
 def test_tensor_train_tensorly_2(shape, rank):
     tensor = ivy.random_uniform(shape=shape)
     factors = ivy.tensor_train(tensor, rank)
@@ -1821,7 +1830,7 @@ def test_tensor_train_tensorly_2(shape, rank):
         assert r_k <= rank[k + 1], first_error_message
 
 
-@pytest.mark.parametrize("shape, rank, tol", [((3, 3, 3), (1, 3, 3, 1), (10e-5))])
+@pytest.mark.parametrize(("shape", "rank", "tol"), [((3, 3, 3), (1, 3, 3, 1), (10e-5))])
 def test_tensor_train_tensorly_3(shape, rank, tol):
     tensor = ivy.random_uniform(shape=shape)
     factors = ivy.tensor_train(tensor, rank)
@@ -1989,7 +1998,8 @@ def test_tucker(*, data, test_flags, backend_fw, fn_name, on_device):
 # test adapted from tensorly
 # https://github.com/tensorly/tensorly/blob/main/tensorly/decomposition/tests/test_tucker.py#L71
 @pytest.mark.parametrize(
-    "tol_norm_2, tol_max_abs, shape, ranks", [(10e-3, 10e-1, (3, 4, 3), [2, 3, 1])]
+    ("tol_norm_2", "tol_max_abs", "shape", "ranks"),
+    [(10e-3, 10e-1, (3, 4, 3), [2, 3, 1])],
 )
 def test_tucker_tensorly(tol_norm_2, tol_max_abs, shape, ranks):
     tensor = ivy.random_uniform(shape=shape)

--- a/ivy_tests/test_ivy/test_misc/test_assertions.py
+++ b/ivy_tests/test_ivy/test_misc/test_assertions.py
@@ -64,7 +64,7 @@ def test_check_all(results):
 
 
 @pytest.mark.parametrize(
-    "args, fn, type, limit",
+    ("args", "fn", "type", "limit"),
     [
         # INVALID CASES
         ((1, 2, 0), ivy.array, "all", [3]),
@@ -198,7 +198,7 @@ def test_check_dimensions(x):
 
 
 @pytest.mark.parametrize(
-    "elem, list, inverse",
+    ("elem", "list", "inverse"),
     [
         (1, [1, 2], False),
         ("a", [1, 2], False),
@@ -240,7 +240,7 @@ def test_check_elem_in_list(elem, list, inverse):
 
 
 @pytest.mark.parametrize(
-    "x1, x2, inverse",
+    ("x1", "x2", "inverse"),
     [
         (5, 10, False),
         (10, 10, False),
@@ -283,7 +283,7 @@ def test_check_equal(x1, x2, inverse):
 
 
 @pytest.mark.parametrize(
-    "x, inverse",
+    ("x", "inverse"),
     [(None, False), ([], False), (None, True), ("abc", True)],
 )
 def test_check_exists(x, inverse):
@@ -356,7 +356,7 @@ def test_check_false(expression):
 
 
 @pytest.mark.parametrize(
-    "params, indices, axis, batch_dims",
+    ("params", "indices", "axis", "batch_dims"),
     [
         # INVALID CASES
         (ivy.array([1, 2, 3]), ivy.array([1]), 2, 3),
@@ -402,7 +402,7 @@ def test_check_gather_input_valid(params, indices, axis, batch_dims):
 
 
 @pytest.mark.parametrize(
-    "params, indices, batch_dims",
+    ("params", "indices", "batch_dims"),
     [
         # INVALID CASES
         (ivy.array([1, 2, 3]), ivy.array([1]), 2),
@@ -450,7 +450,7 @@ def test_check_gather_nd_input_valid(params, indices, batch_dims):
 
 
 @pytest.mark.parametrize(
-    "x1, x2, allow_equal",
+    ("x1", "x2", "allow_equal"),
     [
         (5, 10, False),
         (10, 5, False),
@@ -488,7 +488,7 @@ def test_check_greater(x1, x2, allow_equal):
 
 
 @pytest.mark.parametrize(
-    "var, data",
+    ("var", "data"),
     [
         # INVALID CASES
         (ivy.array([1]), ivy.array([1, 2])),
@@ -528,7 +528,7 @@ def test_check_inplace_sizes_valid(var, data):
 
 
 @pytest.mark.parametrize(
-    "x, allowed_types",
+    ("x", "allowed_types"),
     [(5.0, float), (ivy.array(5), type(ivy.array(8))), (5, float), ([5, 10], tuple)],
 )
 def test_check_isinstance(x, allowed_types):
@@ -602,7 +602,7 @@ def test_check_jax_x64_flag(dtype):
 
 
 @pytest.mark.parametrize(
-    "kernel_size, padding_size",
+    ("kernel_size", "padding_size"),
     [
         # INVALID CASES
         (((2, 2), ((2, 2), (1, 1)))),
@@ -642,7 +642,7 @@ def test_check_kernel_padding_size(kernel_size, padding_size):
 
 
 @pytest.mark.parametrize(
-    "x1, x2, allow_equal",
+    ("x1", "x2", "allow_equal"),
     [
         (5, 10, False),
         (10, 5, False),
@@ -680,7 +680,7 @@ def test_check_less(x1, x2, allow_equal):
 
 
 @pytest.mark.parametrize(
-    "x1, x2",
+    ("x1", "x2"),
     [
         (ivy.array([1, 2, 3]), ivy.array([4, 5, 6])),
         (ivy.array([1.0, 2.0, 3.0]), ivy.array([4, 5, 6])),
@@ -718,7 +718,7 @@ def test_check_same_dtype(x1, x2):
 
 
 @pytest.mark.parametrize(
-    "x1, x2",
+    ("x1", "x2"),
     [
         (ivy.array([1, 2, 3]), ivy.array([[4, 5, 6], [2, 3, 1]])),
         (ivy.array([[1.0, 2.0], [3.0, 4.0]]), ivy.array([4, 5, 6])),
@@ -757,7 +757,7 @@ def test_check_shape(x1, x2):
 
 
 @pytest.mark.parametrize(
-    "var, data",
+    ("var", "data"),
     [
         # INVALID CASES
         ((2, 1), (1, 2, 1)),
@@ -832,7 +832,7 @@ def test_check_true(expression):
 
 
 @pytest.mark.parametrize(
-    "data, segment_ids, num_segments",
+    ("data", "segment_ids", "num_segments"),
     [
         # INVALID CASES
         (ivy.array([1, 2, 3]), ivy.array([0, 1, 0], dtype=ivy.int32), 2.0),

--- a/ivy_tests/test_ivy/test_misc/test_backend_utils/test_backend_handler.py
+++ b/ivy_tests/test_ivy/test_misc/test_backend_utils/test_backend_handler.py
@@ -88,7 +88,8 @@ def test_current_backend(backend, array_type):
 
 
 @pytest.mark.parametrize(
-    "middle_backend,end_backend", [(a, b) for a in backends for b in backends if a != b]
+    ("middle_backend", "end_backend"),
+    [(a, b) for a in backends for b in backends if a != b],
 )
 def test_dynamic_backend_all_combos(middle_backend, end_backend):
     # create an ivy array, container and native container

--- a/ivy_tests/test_ivy/test_misc/test_factorized_tensor/test_cp_tensor.py
+++ b/ivy_tests/test_ivy/test_misc/test_factorized_tensor/test_cp_tensor.py
@@ -5,7 +5,7 @@ import pytest
 
 
 @pytest.mark.parametrize(
-    "shape, rank",
+    ("shape", "rank"),
     [
         (
             (3, 4, 5),
@@ -28,7 +28,7 @@ def test_cp_flip_sign(shape, rank):
 
 
 @pytest.mark.parametrize(
-    "shape, rank",
+    ("shape", "rank"),
     [
         (
             (8, 5, 6, 4),
@@ -64,7 +64,7 @@ def test_cp_lstsq_grad(shape, rank):
 
 
 @pytest.mark.parametrize(
-    "shape, rank",
+    ("shape", "rank"),
     [
         (
             (5, 4, 6),
@@ -101,7 +101,7 @@ def test_cp_mode_dot(shape, rank):
 
 
 @pytest.mark.parametrize(
-    "shape, rank, tol",
+    ("shape", "rank", "tol"),
     [
         (
             (8, 5, 6, 4),
@@ -123,7 +123,7 @@ def test_cp_norm(shape, rank, tol):
 
 
 @pytest.mark.parametrize(
-    "shape, rank",
+    ("shape", "rank"),
     [
         (
             (3, 4, 5),
@@ -145,7 +145,7 @@ def test_cp_normalize(shape, rank):
 
 
 @pytest.mark.parametrize(
-    "shapeU1, shapeU2, shapeU3, shapeU4, true_res, columns, rows",
+    ("shapeU1", "shapeU2", "shapeU3", "shapeU4", "true_res", "columns", "rows"),
     [
         (
             (3, 3),
@@ -201,7 +201,7 @@ def test_cp_to_tensor(shapeU1, shapeU2, shapeU3, shapeU4, true_res, columns, row
         matrices.insert(i, U_i)
 
 
-@pytest.mark.parametrize("shape, expected", [((2, 2), [[-2, -2], [6, 10]])])
+@pytest.mark.parametrize(("shape", "expected"), [((2, 2), [[-2, -2], [6, 10]])])
 def test_cp_to_tensor_with_weights(shape, expected):
     A = ivy.reshape(ivy.arange(1, 5, dtype=float), shape)
     B = ivy.reshape(ivy.arange(5, 9, dtype=float), shape)
@@ -222,7 +222,7 @@ def test_cp_to_tensor_with_weights(shape, expected):
 
 
 @pytest.mark.parametrize(
-    "shapeU1, shapeU2, shapeU3, shapeU4", [((3, 3), (4, 3), (2, 3), (2, 3))]
+    ("shapeU1", "shapeU2", "shapeU3", "shapeU4"), [((3, 3), (4, 3), (2, 3), (2, 3))]
 )
 def test_cp_to_unfolded(shapeU1, shapeU2, shapeU3, shapeU4):
     U1 = ivy.reshape(ivy.arange(1, 10, dtype=float), shapeU1)
@@ -243,7 +243,7 @@ def test_cp_to_unfolded(shapeU1, shapeU2, shapeU3, shapeU4):
 
 
 @pytest.mark.parametrize(
-    "shapeU1, shapeU2, shapeU3, shapeU4", [((3, 3), (4, 3), (2, 3), (2, 3))]
+    ("shapeU1", "shapeU2", "shapeU3", "shapeU4"), [((3, 3), (4, 3), (2, 3), (2, 3))]
 )
 def test_cp_to_vec(shapeU1, shapeU2, shapeU3, shapeU4):
     """Test for cp_to_vec."""
@@ -267,7 +267,7 @@ def test_cp_to_vec(shapeU1, shapeU2, shapeU3, shapeU4):
 
 
 @pytest.mark.parametrize(
-    "shape, rank",
+    ("shape", "rank"),
     [
         (
             (10, 10, 10, 4),
@@ -307,7 +307,7 @@ def test_validate_cp_rank(size):
 
 
 @pytest.mark.parametrize(
-    "true_shape, true_rank",
+    ("true_shape", "true_rank"),
     [
         (
             (3, 4, 5),

--- a/ivy_tests/test_ivy/test_misc/test_factorized_tensor/test_parafac2_tensor.py
+++ b/ivy_tests/test_ivy/test_misc/test_factorized_tensor/test_parafac2_tensor.py
@@ -5,7 +5,7 @@ import pytest
 
 
 @pytest.mark.parametrize(
-    "weights, factors, projections, true_res",
+    ("weights", "factors", "projections", "true_res"),
     [
         (
             (2, 3),
@@ -29,7 +29,7 @@ def test_apply_parafac2_projections(weights, factors, projections, true_res):
 
 
 @pytest.mark.parametrize(
-    "shape, rank",
+    ("shape", "rank"),
     [
         (
             [(4, 5)] * 3,
@@ -54,7 +54,7 @@ def test_parafac2_normalise(shape, rank):
 
 
 @pytest.mark.parametrize(
-    "weights, factors, projections, true_res",
+    ("weights", "factors", "projections", "true_res"),
     [
         (
             (2, 3),
@@ -82,7 +82,7 @@ def test_parafac2_to_slices(weights, factors, projections, true_res):
 
 
 @pytest.mark.parametrize(
-    "weights, factors, projections, true_res",
+    ("weights", "factors", "projections", "true_res"),
     [
         (
             (2, 3),
@@ -103,7 +103,7 @@ def test_parafac2_to_tensor(weights, factors, projections, true_res):
 
 
 @pytest.mark.parametrize(
-    "shape, rank",
+    ("shape", "rank"),
     [
         (
             [(4, 5)] * 3,
@@ -122,7 +122,7 @@ def test_parafac2_to_unfolded(shape, rank):
 
 
 @pytest.mark.parametrize(
-    "shape, rank",
+    ("shape", "rank"),
     [
         (
             [(4, 5)] * 3,
@@ -140,7 +140,7 @@ def test_parafac2_to_vec(shape, rank):
 
 
 @pytest.mark.parametrize(
-    "true_shape, true_rank",
+    ("true_shape", "true_rank"),
     [
         (
             [(4, 5)] * 3,

--- a/ivy_tests/test_ivy/test_misc/test_factorized_tensor/test_tr_tensor.py
+++ b/ivy_tests/test_ivy/test_misc/test_factorized_tensor/test_tr_tensor.py
@@ -5,7 +5,7 @@ import pytest
 
 
 @pytest.mark.parametrize(
-    "shape1, shape2, shape3",
+    ("shape1", "shape2", "shape3"),
     [
         (
             (2, 4, 3),
@@ -30,7 +30,7 @@ def test_tr_to_tensor(shape1, shape2, shape3):
 
 
 @pytest.mark.parametrize(
-    "rank1, rank2",
+    ("rank1", "rank2"),
     [((2, 3, 4, 2), (2, 3, 4, 2, 3))],
 )
 def test_validate_tr_rank(rank1, rank2):
@@ -60,7 +60,7 @@ def test_validate_tr_rank(rank1, rank2):
 
 
 @pytest.mark.parametrize(
-    "true_shape, true_rank",
+    ("true_shape", "true_rank"),
     [
         (
             (6, 4, 5),

--- a/ivy_tests/test_ivy/test_misc/test_factorized_tensor/test_tt_tensor.py
+++ b/ivy_tests/test_ivy/test_misc/test_factorized_tensor/test_tt_tensor.py
@@ -42,7 +42,7 @@ def test_pad_tt_rank(n_pad):
 
 
 @pytest.mark.parametrize(
-    "shape, rank",
+    ("shape", "rank"),
     [((4, 5, 4, 8, 5), (1, 3, 2, 2, 4, 1))],
 )
 def test_tt_n_param(shape, rank):
@@ -53,7 +53,7 @@ def test_tt_n_param(shape, rank):
 
 
 @pytest.mark.parametrize(
-    "n1, n2, n3, shape1, shape2, shape3",
+    ("n1", "n2", "n3", "shape1", "shape2", "shape3"),
     [(3, 4, 2, (1, 3, 2), (2, 4, 2), (2, 2, 1))],
 )
 def test_tt_to_tensor(n1, n2, n3, shape1, shape2, shape3):
@@ -109,7 +109,7 @@ def test_validate_tt_rank(coef):
 
 
 @pytest.mark.parametrize(
-    "true_shape, true_rank",
+    ("true_shape", "true_rank"),
     [
         (
             (3, 4, 5),

--- a/ivy_tests/test_ivy/test_misc/test_factorized_tensor/test_tucker_tensor.py
+++ b/ivy_tests/test_ivy/test_misc/test_factorized_tensor/test_tucker_tensor.py
@@ -4,7 +4,7 @@ import numpy as np
 import pytest
 
 
-@pytest.mark.parametrize("shape, rank", [((5, 4, 6), (3, 2, 3))])
+@pytest.mark.parametrize(("shape", "rank"), [((5, 4, 6), (3, 2, 3))])
 def test_n_param_tucker(shape, rank):
     tucker_tensor = ivy.random_tucker(shape, rank)
     true_n_param = ivy.prod(ivy.shape(tucker_tensor[0])) + ivy.sum(
@@ -14,7 +14,7 @@ def test_n_param_tucker(shape, rank):
     assert np.allclose(n_param, true_n_param)
 
 
-@pytest.mark.parametrize("shape, rank", [((3, 4, 5), 4)])
+@pytest.mark.parametrize(("shape", "rank"), [((3, 4, 5), 4)])
 def test_tucker_copy(shape, rank):
     tucker_tensor = ivy.random_tucker(shape, rank)
     core, factors = tucker_tensor
@@ -28,7 +28,7 @@ def test_tucker_copy(shape, rank):
     )
 
 
-@pytest.mark.parametrize("shape, ranks", [((5, 4, 6), (3, 2, 3))])
+@pytest.mark.parametrize(("shape", "ranks"), [((5, 4, 6), (3, 2, 3))])
 def test_tucker_mode_dot(shape, ranks):
     tucker_ten = ivy.random_tucker(shape, ranks, full=False)
     full_tensor = ivy.TuckerTensor.tucker_to_tensor(tucker_ten)
@@ -57,7 +57,7 @@ def test_tucker_mode_dot(shape, ranks):
     assert np.allclose(true_res, res)
 
 
-@pytest.mark.parametrize("shape, rank", [((3, 4, 5), (3, 2, 4))])
+@pytest.mark.parametrize(("shape", "rank"), [((3, 4, 5), (3, 2, 4))])
 def test_tucker_normalize(shape, rank):
     tucker_ten = ivy.random_tucker(shape, rank)
     core, factors = ivy.TuckerTensor.tucker_normalize(tucker_ten)
@@ -71,7 +71,7 @@ def test_tucker_normalize(shape, rank):
 
 
 @pytest.mark.parametrize(
-    "X, ranks, true_res",
+    ("X", "ranks", "true_res"),
     [
         (
             [
@@ -107,7 +107,7 @@ def test_tucker_to_tensor(X, ranks, true_res):
     assert np.allclose(true_res, res)
 
 
-@pytest.mark.parametrize("shape, ranks", [((4, 3, 5, 2), (2, 2, 3, 4))])
+@pytest.mark.parametrize(("shape", "ranks"), [((4, 3, 5, 2), (2, 2, 3, 4))])
 def test_tucker_to_unfolded(shape, ranks):
     G = ivy.random_uniform(shape=shape)
     U = [ivy.random_uniform(shape=(ranks[i], G.shape[i])) for i in range(4)]
@@ -126,7 +126,7 @@ def test_tucker_to_unfolded(shape, ranks):
         )
 
 
-@pytest.mark.parametrize("shape, ranks", [((4, 3, 5, 2), (2, 2, 3, 4))])
+@pytest.mark.parametrize(("shape", "ranks"), [((4, 3, 5, 2), (2, 2, 3, 4))])
 def test_tucker_to_vec(shape, ranks):
     G = ivy.random_uniform(shape=shape)
     ranks = [2, 2, 3, 4]
@@ -191,7 +191,7 @@ def test_validate_tucker_rank(tol):
 
 # These tests have been adapted from TensorLy
 # https://github.com/tensorly/tensorly/blob/main/tensorly/tests/test_tucker_tensor.py
-@pytest.mark.parametrize("true_shape, true_rank", [((3, 4, 5), (3, 2, 4))])
+@pytest.mark.parametrize(("true_shape", "true_rank"), [((3, 4, 5), (3, 2, 4))])
 def test_validate_tucker_tensor(true_shape, true_rank):
     core, factors = ivy.random_tucker(true_shape, true_rank)
 

--- a/ivy_tests/test_ivy/test_misc/test_handle_exceptions.py
+++ b/ivy_tests/test_ivy/test_misc/test_handle_exceptions.py
@@ -30,7 +30,7 @@ def func(e):
 
 @pytest.mark.parametrize(
     "e",
-    (
+    [
         IvyError,
         IvyNotImplementedException,
         IvyBroadcastShapeError,
@@ -43,7 +43,7 @@ def func(e):
         IvyDeviceError,
         IvyInvalidBackendException,
         IvyDtypePromotionError,
-    ),
+    ],
 )
 def test_ivy_errors_raising(e):
     with pytest.raises(e):
@@ -55,7 +55,7 @@ def test_no_exception():
 
 
 @pytest.mark.parametrize(
-    "e, to_be_raised",
+    ("e", "to_be_raised"),
     _non_ivy_exceptions_mapping.items(),
 )
 def test_non_ivy_errors_mapping(e, to_be_raised):


### PR DESCRIPTION
# PR Description
The consistent style for `pytest.mark.parametrize` arguments enhances code clarity and readability, making it easier for developers to understand and maintain the codebase.
Following are the best practices that are recommended by `flake8-pytest-style`

https://docs.astral.sh/ruff/rules/pytest-parametrize-values-wrong-type/
https://docs.astral.sh/ruff/rules/pytest-parametrize-names-wrong-type/

I made changes all over the codebase (wherever required) according to these 2 rules, to increase readability and to adhere to best practices.

## Related Issue
Closes #27175

## Checklist

- [ ] Did you add a function?
- [ ] Did you add the tests?
- [ ] Did you run your tests and are your tests passing?
- [x] Did pre-commit not fail on any check?
- [ ] Did you follow the steps we provided?


### Socials