### PR TITLE
fix: Remove duplicate `union members`

### DIFF
--- a/ivy/data_classes/container/data_type.py
+++ b/ivy/data_classes/container/data_type.py
@@ -156,7 +156,7 @@ class _ContainerWithDataTypes(ContainerBase):
 
     @staticmethod
     def _static_broadcast_arrays(
-        *arrays: Union[ivy.Container, ivy.Array, ivy.NativeArray, ivy.Container],
+        *arrays: Union[ivy.Container, ivy.Array, ivy.NativeArray],
         key_chains: Optional[Union[List[str], Dict[str, str], ivy.Container]] = None,
         to_apply: Union[bool, ivy.Container] = True,
         prune_unapplied: Union[bool, ivy.Container] = False,
@@ -232,7 +232,7 @@ class _ContainerWithDataTypes(ContainerBase):
 
     def broadcast_arrays(
         self: ivy.Container,
-        *arrays: Union[ivy.Container, ivy.Array, ivy.NativeArray, ivy.Container],
+        *arrays: Union[ivy.Container, ivy.Array, ivy.NativeArray],
         key_chains: Optional[Union[List[str], Dict[str, str], ivy.Container]] = None,
         to_apply: Union[bool, ivy.Container] = True,
         prune_unapplied: Union[bool, ivy.Container] = False,

--- a/ivy/data_classes/container/elementwise.py
+++ b/ivy/data_classes/container/elementwise.py
@@ -9,7 +9,7 @@ from ivy.data_classes.container.base import ContainerBase
 class _ContainerWithElementwise(ContainerBase):
     @staticmethod
     def _static_abs(
-        x: Union[ivy.Container, ivy.Array, ivy.NativeArray, ivy.Container],
+        x: Union[ivy.Container, ivy.Array, ivy.NativeArray],
         /,
         *,
         key_chains: Optional[Union[List[str], Dict[str, str], ivy.Container]] = None,

--- a/ivy/functional/backends/mxnet/data_type.py
+++ b/ivy/functional/backends/mxnet/data_type.py
@@ -129,9 +129,7 @@ def iinfo(type: Union[str, mx.ndarray.NDArray, np.dtype], /) -> np.iinfo:
     return np.iinfo(ivy.as_native_dtype(type))
 
 
-def result_type(
-    *arrays_and_dtypes: Union[(None, mx.ndarray.NDArray, None)]
-) -> ivy.Dtype:
+def result_type(*arrays_and_dtypes: Union[(None, mx.ndarray.NDArray)]) -> ivy.Dtype:
     raise IvyNotImplementedException()
 
 

--- a/ivy/functional/backends/tensorflow/sub_backends/tf_probability/experimental/random.py
+++ b/ivy/functional/backends/tensorflow/sub_backends/tf_probability/experimental/random.py
@@ -20,7 +20,7 @@ def beta(
     *,
     shape: Optional[Union[ivy.NativeShape, Sequence[int]]] = None,
     device: Optional[str] = None,
-    dtype: Optional[Union[ivy.Dtype, ivy.Dtype]] = None,
+    dtype: Optional[Union[ivy.Dtype]] = None,
     seed: Optional[int] = None,
     out: Optional[Union[tf.Tensor, tf.Variable]] = None,
 ) -> Union[tf.Tensor, tf.Variable]:


### PR DESCRIPTION
# PR Description
At some of the places Duplicate union members are present, they can be removed to reduce redundancy.
Like in the following places:
https://github.com/unifyai/ivy/blob/6e1f438cbe6d3cf7077f805648920074a8f15792/ivy/data_classes/container/data_type.py#L159
https://github.com/unifyai/ivy/blob/6e1f438cbe6d3cf7077f805648920074a8f15792/ivy/data_classes/container/data_type.py#L235
https://github.com/unifyai/ivy/blob/6e1f438cbe6d3cf7077f805648920074a8f15792/ivy/data_classes/container/elementwise.py#L12
https://github.com/unifyai/ivy/blob/6e1f438cbe6d3cf7077f805648920074a8f15792/ivy/functional/backends/mxnet/data_type.py#L133
https://github.com/unifyai/ivy/blob/6e1f438cbe6d3cf7077f805648920074a8f15792/ivy/functional/backends/tensorflow/sub_backends/tf_probability/experimental/random.py#L23

I removed all of these duplicates to avoid redundancy.

## Related Issue
Closes #27202

## Checklist

- [ ] Did you add a function?
- [ ] Did you add the tests?
- [ ] Did you run your tests and are your tests passing?
- [x] Did pre-commit not fail on any check?
- [ ] Did you follow the steps we provided?

### Socials
https://twitter.com/Sai_Suraj_27