### PR TITLE
fix: Removed useless statements in few files.

### DIFF
--- a/ivy/__init__.py
+++ b/ivy/__init__.py
@@ -480,8 +480,7 @@ class Shape(Sequence):
             shape is not None for shape in self._shape
         )
 
-    property
-
+    @property
     def num_elements(self):
         if not self.is_fully_defined():
             return None

--- a/ivy/functional/backends/tensorflow/experimental/elementwise.py
+++ b/ivy/functional/backends/tensorflow/experimental/elementwise.py
@@ -297,7 +297,6 @@ def gradient(
     edge_order: int = 1,
 ) -> Union[tf.Tensor, List[tf.Tensor]]:
     # https://github.com/numpy/numpy/blob/v1.24.3/numpy/lib/function_base.py#L969-L1312
-    x.device
     x = tf.experimental.numpy.asanyarray(x)
     N = x.ndim  # number of dimensions
     if axis is None:

--- a/ivy_tests/test_ivy/test_misc/test_factorized_tensor/test_parafac2_tensor.py
+++ b/ivy_tests/test_ivy/test_misc/test_factorized_tensor/test_parafac2_tensor.py
@@ -98,7 +98,6 @@ def test_parafac2_to_tensor(weights, factors, projections, true_res):
     projections = [ivy.array(p) for p in projections]
     true_res = ivy.array(true_res)
     res = ivy.Parafac2Tensor.parafac2_to_tensor((weights, factors, projections))
-    (true_res, res)
     assert np.allclose(res, true_res)
 
 


### PR DESCRIPTION
# PR Description
In few files there are few useless code/statements that have no effect. So, they should be removed or properly assigned. I detected these using the [`Ruff`](https://docs.astral.sh/ruff/rules/useless-expression/) linter.
Like, in the following places:
https://github.com/unifyai/ivy/blob/8d0ad8159312695e7eba129cfb787a1ad947eddd/ivy/__init__.py#L483
https://github.com/unifyai/ivy/blob/8d0ad8159312695e7eba129cfb787a1ad947eddd/ivy/functional/backends/tensorflow/experimental/elementwise.py#L300
https://github.com/unifyai/ivy/blob/8d0ad8159312695e7eba129cfb787a1ad947eddd/ivy_tests/test_ivy/test_misc/test_factorized_tensor/test_parafac2_tensor.py#L101


## Related Issue
Closes #27208

## Checklist

- [ ] Did you add a function?
- [ ] Did you add the tests?
- [ ] Did you run your tests and are your tests passing?
- [x] Did pre-commit not fail on any check?
- [ ] Did you follow the steps we provided?


### Socials
https://twitter.com/Sai_Suraj_27