### PR TITLE
Revert back recent changes made to avg_pool functions

### DIFF
--- a/ivy/functional/frontends/torch/nn/functional/pooling_functions.py
+++ b/ivy/functional/frontends/torch/nn/functional/pooling_functions.py
@@ -94,11 +94,19 @@ def avg_pool1d(
     ceil_mode=False,
     count_include_pad=True,
 ):
+    kernel_size = _broadcast_pooling_helper(kernel_size, "1d", name="kernel_size")
+    padding = _broadcast_pooling_helper(padding, "1d", name="padding")
+    if all(
+        [pad == ivy.ceil((kernel - 1) / 2) for kernel, pad in zip(kernel_size, padding)]
+    ):
+        padding = "SAME"
+    else:
+        padding = "VALID"
     return ivy.avg_pool1d(
         input,
         kernel_size,
         stride if stride is not None else kernel_size,
-        [(pad, pad) for pad in padding],
+        padding,
         data_format="NCW",
         count_include_pad=count_include_pad,
         ceil_mode=ceil_mode,
@@ -119,11 +127,19 @@ def avg_pool2d(
     count_include_pad=True,
     divisor_override=None,
 ):
+    kernel_size = _broadcast_pooling_helper(kernel_size, "2d", name="kernel_size")
+    padding = _broadcast_pooling_helper(padding, "2d", name="padding")
+    if all(
+        [pad == ivy.ceil((kernel - 1) / 2) for kernel, pad in zip(kernel_size, padding)]
+    ):
+        padding = "SAME"
+    else:
+        padding = "VALID"
     return ivy.avg_pool2d(
         input,
         kernel_size,
         stride if stride is not None else kernel_size,
-        [(pad, pad) for pad in padding],
+        padding,
         data_format="NCHW",
         ceil_mode=ceil_mode,
         count_include_pad=count_include_pad,
@@ -145,11 +161,19 @@ def avg_pool3d(
     count_include_pad=True,
     divisor_override=None,
 ):
+    kernel_size = _broadcast_pooling_helper(kernel_size, "3d", name="kernel_size")
+    padding = _broadcast_pooling_helper(padding, "3d", name="padding")
+    if all(
+        [pad == ivy.ceil((kernel - 1) / 2) for kernel, pad in zip(kernel_size, padding)]
+    ):
+        padding = "SAME"
+    else:
+        padding = "VALID"
     return ivy.avg_pool3d(
         input,
         kernel_size,
         stride if stride is not None else kernel_size,
-        [(pad, pad) for pad in padding],
+        padding,
         data_format="NCDHW",
         ceil_mode=ceil_mode,
         count_include_pad=count_include_pad,


### PR DESCRIPTION
Revert back recent changes made to avg_pool functions on a priority basis. Need to fix these later once the KLA demo is done


<!--
This template will help you to have a meaningful PR, please follow it and do not leave it blank.
-->

# PR Description

<!--
If there is no related issue, please add a short description about your PR.
-->

## Related Issue

<!--
Please use this format to link other issues with their numbers: Close #123
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes #

## Checklist

- [ ] Did you add a function?
- [ ] Did you add the tests?
- [ ] Did you run your tests and are your tests passing?
- [ ] Did pre-commit not fail on any check?
- [ ] Did you follow the steps we provided?

<!--
Please mark your PR as a draft if you realise after the fact that your tests are not passing or
that your pre-commit check has some failures.

Here are some relevant resources regarding tests and pre-commit:

https://unify.ai/docs/ivy/overview/deep_dive/ivy_tests.html
https://unify.ai/docs/ivy/overview/deep_dive/formatting.html#pre-commit

-->

### Socials

<!--
If you have Twitter, please provide it here otherwise just ignore this.
-->
