### PR TITLE
fix: Removed duplicate Data Type Attributes in `class SupportedDtypes`

### DIFF
--- a/ivy_tests/test_ivy/test_frontends/config/base.py
+++ b/ivy_tests/test_ivy/test_frontends/config/base.py
@@ -25,9 +25,6 @@ class SupportedDtypes:
     valid_uint_dtypes: List[str]
     invalid_uint_dtypes: List[str]
 
-    valid_uint_dtypes: List[str]
-    invalid_uint_dtypes: List[str]
-
     valid_float_dtypes: List[str]
     invalid_float_dtypes: List[str]
 


### PR DESCRIPTION
# PR Description
In the file: [`ivy_tests\test_ivy\test_frontends\config\base.py`](https://github.com/unifyai/ivy/blob/main/ivy_tests/test_ivy/test_frontends/config/base.py)

The following lines are repeated (duplicated):
https://github.com/unifyai/ivy/blob/82986f40c8f2e72dbfd5aee902dc34cb478348d9/ivy_tests/test_ivy/test_frontends/config/base.py#L28
https://github.com/unifyai/ivy/blob/82986f40c8f2e72dbfd5aee902dc34cb478348d9/ivy_tests/test_ivy/test_frontends/config/base.py#L29
So, I removed them.

## Related Issue
Closes #27213

## Checklist

- [ ] Did you add a function?
- [ ] Did you add the tests?
- [ ] Did you run your tests and are your tests passing?
- [x] Did pre-commit not fail on any check?
- [ ] Did you follow the steps we provided?

### Socials
https://twitter.com/Sai_Suraj_27