### PR TITLE
refactor: Refactored few files to make the code better.

### DIFF
--- a/ivy/func_wrapper.py
+++ b/ivy/func_wrapper.py
@@ -46,7 +46,7 @@ FN_DECORATORS = [
 casting_modes_dict = {
     "uint": lambda: ivy.valid_uint_dtypes,
     "int": lambda: sorted(
-        tuple(set(ivy.valid_int_dtypes).difference(set(ivy.valid_uint_dtypes)))
+        set(ivy.valid_int_dtypes).difference(set(ivy.valid_uint_dtypes))
     ),
     "float": lambda: ivy.valid_float_dtypes,
     "complex": lambda: ivy.valid_complex_dtypes,

--- a/ivy/functional/backends/jax/experimental/creation.py
+++ b/ivy/functional/backends/jax/experimental/creation.py
@@ -156,9 +156,9 @@ def mel_weight_matrix(
         dtype=jnp.float32,
     )
     mel_edges = jnp.stack([mel_edges[i : i + 3] for i in range(num_mel_bins)])
-    lower_edge_mel, center_mel, upper_edge_mel = [
+    lower_edge_mel, center_mel, upper_edge_mel = (
         t.reshape((1, num_mel_bins)) for t in jnp.split(mel_edges, 3, axis=1)
-    ]
+    )
     lower_slopes = (spec_bin_mels - lower_edge_mel) / (center_mel - lower_edge_mel)
     upper_slopes = (upper_edge_mel - spec_bin_mels) / (upper_edge_mel - center_mel)
     mel_weights = jnp.maximum(zero, jnp.minimum(lower_slopes, upper_slopes))

--- a/ivy/functional/backends/numpy/experimental/creation.py
+++ b/ivy/functional/backends/numpy/experimental/creation.py
@@ -194,9 +194,9 @@ def mel_weight_matrix(
         dtype=np.float32,
     )
     mel_edges = np.stack([mel_edges[i : i + 3] for i in range(num_mel_bins)])
-    lower_edge_mel, center_mel, upper_edge_mel = [
+    lower_edge_mel, center_mel, upper_edge_mel = (
         t.reshape((1, num_mel_bins)) for t in np.split(mel_edges, 3, axis=1)
-    ]
+    )
     lower_slopes = (spec_bin_mels - lower_edge_mel) / (center_mel - lower_edge_mel)
     upper_slopes = (upper_edge_mel - spec_bin_mels) / (upper_edge_mel - center_mel)
     mel_weights = np.maximum(zero, np.minimum(lower_slopes, upper_slopes))

--- a/ivy/functional/backends/paddle/experimental/norms.py
+++ b/ivy/functional/backends/paddle/experimental/norms.py
@@ -42,9 +42,9 @@ def batch_norm(
     out: Optional[Tuple[paddle.Tensor, paddle.Tensor, paddle.Tensor]] = None,
 ) -> Tuple[paddle.Tensor, paddle.Tensor, paddle.Tensor]:
     if x.dtype not in [paddle.float32, paddle.float64]:
-        x, mean, variance, scale, offset = [
+        x, mean, variance, scale, offset = (
             t.cast("float32") for t in [x, mean, variance, scale, offset]
-        ]
+        )
     runningmean = mean
     runningvariance = variance
     data_formats = ["NC", "NCL", "NCHW", "NCDHW", "NLC", "NHWC", "NDHWC"]

--- a/ivy/functional/backends/paddle/set.py
+++ b/ivy/functional/backends/paddle/set.py
@@ -67,7 +67,7 @@ def unique_all(
             [
                 i[0]
                 for i in sorted(
-                    list(enumerate(values_.numpy().tolist())), key=lambda x: tuple(x[1])
+                    enumerate(values_.numpy().tolist()), key=lambda x: tuple(x[1])
                 )
             ]
         )

--- a/ivy/functional/backends/tensorflow/set.py
+++ b/ivy/functional/backends/tensorflow/set.py
@@ -59,7 +59,7 @@ def unique_all(
         values_ = tf.experimental.numpy.moveaxis(values, axis, 0)
         values_ = tf.reshape(values_, (values_.shape[0], -1))
         sort_idx = tf.stack(
-            [i[0] for i in sorted(list(enumerate(values_)), key=lambda x: tuple(x[1]))]
+            [i[0] for i in sorted(enumerate(values_), key=lambda x: tuple(x[1]))]
         )
         sort_idx = tf.cast(sort_idx, tf.int32)
         values = tf.gather(values, sort_idx, axis=axis)

--- a/ivy/functional/backends/torch/experimental/creation.py
+++ b/ivy/functional/backends/torch/experimental/creation.py
@@ -238,9 +238,9 @@ def mel_weight_matrix(
     )
     # create overlapping frames of size 3
     mel_edges = mel_edges.unfold(0, size=3, step=1)
-    lower_edge_mel, center_mel, upper_edge_mel = [
+    lower_edge_mel, center_mel, upper_edge_mel = (
         t.reshape((1, num_mel_bins)) for t in mel_edges.split(1, dim=1)
-    ]
+    )
     lower_slopes = (spec_bin_mels - lower_edge_mel) / (center_mel - lower_edge_mel)
     upper_slopes = (upper_edge_mel - spec_bin_mels) / (upper_edge_mel - center_mel)
     mel_weights = torch.maximum(zero, torch.minimum(lower_slopes, upper_slopes))

--- a/ivy/functional/backends/torch/layers.py
+++ b/ivy/functional/backends/torch/layers.py
@@ -57,7 +57,7 @@ def multi_head_attention(
     )[1]
     num_dims = query.ndim
     if num_dims == 3 and batch_first:
-        query, key, value = [torch.swapaxes(x, 0, 1) for x in [query, key, value]]
+        query, key, value = (torch.swapaxes(x, 0, 1) for x in [query, key, value])
     ret = torch.nn.functional.multi_head_attention_forward(
         query,
         key,

--- a/ivy/functional/backends/torch/set.py
+++ b/ivy/functional/backends/torch/set.py
@@ -63,7 +63,7 @@ def unique_all(
         values_ = torch.moveaxis(values, axis, 0)
         values_ = torch.reshape(values_, (values_.shape[0], -1))
         sort_idx = torch.tensor(
-            [i[0] for i in sorted(list(enumerate(values_)), key=lambda x: tuple(x[1]))]
+            [i[0] for i in sorted(enumerate(values_), key=lambda x: tuple(x[1]))]
         )
     ivy_torch = ivy.current_backend()
     values = ivy_torch.gather(values, sort_idx, axis=axis)

--- a/ivy/functional/frontends/jax/numpy/mathematical_functions.py
+++ b/ivy/functional/frontends/jax/numpy/mathematical_functions.py
@@ -322,7 +322,7 @@ def einsum_path(subscripts, *operands, optimize="greedy"):
     # Build contraction tuple (positions, gemm, einsum_str, remaining)
     for cnum, contract_inds in enumerate(path):
         # Make sure we remove inds from right to left
-        contract_inds = tuple(sorted(list(contract_inds), reverse=True))
+        contract_inds = tuple(sorted(contract_inds, reverse=True))
 
         contract = find_contraction(contract_inds, input_sets, output_set)
         out_inds, input_sets, idx_removed, idx_contract = contract

--- a/ivy/functional/frontends/numpy/indexing_routines/inserting_data_into_arrays.py
+++ b/ivy/functional/frontends/numpy/indexing_routines/inserting_data_into_arrays.py
@@ -61,7 +61,7 @@ class AxisConcatenator:
                 if "," in item:
                     vec = item.split(",")
                     try:
-                        axis, ndmin = [int(x) for x in vec[:2]]
+                        axis, ndmin = (int(x) for x in vec[:2])
                         if len(vec) == 3:
                             trans1d = int(vec[2])
                         continue

--- a/ivy/functional/frontends/tensorflow/math.py
+++ b/ivy/functional/frontends/tensorflow/math.py
@@ -845,7 +845,7 @@ def xlogy(x, y, name=None):
 
 @to_ivy_arrays_and_back
 def zero_fraction(value, name="zero_fraction"):
-    zero = ivy.zeros(tuple(list(value.shape)), dtype=ivy.float32)
+    zero = ivy.zeros(tuple(value.shape), dtype=ivy.float32)
     x = ivy.array(value, dtype=ivy.float32)
     count_zero = ivy.sum(ivy.equal(x, zero))
     count_nonzero = ivy.sum(ivy.not_equal(x, zero))

--- a/ivy/functional/frontends/torch/nn/functional/pooling_functions.py
+++ b/ivy/functional/frontends/torch/nn/functional/pooling_functions.py
@@ -97,7 +97,7 @@ def avg_pool1d(
     kernel_size = _broadcast_pooling_helper(kernel_size, "1d", name="kernel_size")
     padding = _broadcast_pooling_helper(padding, "1d", name="padding")
     if all(
-        [pad == ivy.ceil((kernel - 1) / 2) for kernel, pad in zip(kernel_size, padding)]
+        pad == ivy.ceil((kernel - 1) / 2) for kernel, pad in zip(kernel_size, padding)
     ):
         padding = "SAME"
     else:
@@ -130,7 +130,7 @@ def avg_pool2d(
     kernel_size = _broadcast_pooling_helper(kernel_size, "2d", name="kernel_size")
     padding = _broadcast_pooling_helper(padding, "2d", name="padding")
     if all(
-        [pad == ivy.ceil((kernel - 1) / 2) for kernel, pad in zip(kernel_size, padding)]
+        pad == ivy.ceil((kernel - 1) / 2) for kernel, pad in zip(kernel_size, padding)
     ):
         padding = "SAME"
     else:
@@ -164,7 +164,7 @@ def avg_pool3d(
     kernel_size = _broadcast_pooling_helper(kernel_size, "3d", name="kernel_size")
     padding = _broadcast_pooling_helper(padding, "3d", name="padding")
     if all(
-        [pad == ivy.ceil((kernel - 1) / 2) for kernel, pad in zip(kernel_size, padding)]
+        pad == ivy.ceil((kernel - 1) / 2) for kernel, pad in zip(kernel_size, padding)
     ):
         padding = "SAME"
     else:

--- a/ivy/functional/ivy/layers.py
+++ b/ivy/functional/ivy/layers.py
@@ -856,9 +856,9 @@ def multi_head_attention(
     if key is None and value is None:
         key = value = query
     if num_dims == 2:
-        query, key, value = [ivy.expand_dims(x, axis=0) for x in [query, key, value]]
+        query, key, value = (ivy.expand_dims(x, axis=0) for x in [query, key, value])
     elif not batch_first:
-        query, key, value = [ivy.swapaxes(x, 0, 1) for x in [query, key, value]]
+        query, key, value = (ivy.swapaxes(x, 0, 1) for x in [query, key, value])
 
     # project query, key and value
     if ivy.exists(in_proj_weights):

--- a/ivy/stateful/converters.py
+++ b/ivy/stateful/converters.py
@@ -466,7 +466,7 @@ class ModuleConverters:
                         name=kc, shape=x.shape, dtype=x.dtype, trainable=True
                     )
                 )
-                model_weights = list()
+                model_weights = []
                 self._ivy_module.v.cont_map(
                     lambda x, kc: model_weights.append(ivy.to_numpy(x))
                 )

--- a/ivy_tests/test_ivy/test_frontends/test_torch/test_nn/test_functional/test_layer_functions.py
+++ b/ivy_tests/test_ivy/test_frontends/test_torch/test_nn/test_functional/test_layer_functions.py
@@ -120,9 +120,9 @@ def _lstm_helper(draw):
             )
         )
         batch_sizes = np.array(draw(st.permutations(batch_sizes)))
-        input, batch_sizes = [
+        input, batch_sizes = (
             ivy.to_numpy(p) for p in _pack_padded_sequence(input, batch_sizes)
-        ]
+        )
     else:
         batch_sizes = None
 

--- a/ivy_tests/test_ivy/test_functional/test_core/test_device.py
+++ b/ivy_tests/test_ivy/test_functional/test_core/test_device.py
@@ -289,7 +289,7 @@ def test_function_supported_devices(
         res = ivy_backend.function_supported_devices(func)
         exp = set(expected)
 
-        assert sorted(tuple(exp)) == sorted(res)
+        assert sorted(exp) == sorted(res)
 
 
 # function_unsupported_devices
@@ -308,7 +308,7 @@ def test_function_unsupported_devices(
         res = ivy_backend.function_unsupported_devices(func)
         exp = set(expected)
 
-        assert sorted(tuple(exp)) == sorted(res)
+        assert sorted(exp) == sorted(res)
 
 
 @handle_test(

--- a/ivy_tests/test_ivy/test_functional/test_core/test_dtype.py
+++ b/ivy_tests/test_ivy/test_functional/test_core/test_dtype.py
@@ -655,7 +655,7 @@ def test_function_supported_dtypes(*, func, backend_fw):
         exp = set(ivy_backend.all_dtypes).difference(
             set(func.test_unsupported_dtypes[backend_fw])
         )
-        assert set(tuple(exp)) == set(res)
+        assert set(exp) == set(res)
 
 
 # function_unsupported_dtypes
@@ -667,7 +667,7 @@ def test_function_unsupported_dtypes(*, func, backend_fw):
     with BackendHandler.update_backend(backend_fw) as ivy_backend:
         res = ivy_backend.function_unsupported_dtypes(func)
         exp = func.test_unsupported_dtypes[backend_fw]
-        assert set(tuple(exp)) == set(res)
+        assert set(exp) == set(res)
 
 
 # iinfo

--- a/ivy_tests/test_ivy/test_functional/test_nn/test_layers.py
+++ b/ivy_tests/test_ivy/test_functional/test_nn/test_layers.py
@@ -307,7 +307,7 @@ def _mha_helper(draw, same_pre_embed_dim=False, batch_second=False):
     average_attention_weights = draw(st.booleans())
 
     if len(q.shape) == 3 and not batch_first:
-        q, k, v = [np.swapaxes(x, 0, 1) if x is not None else x for x in [q, k, v]]
+        q, k, v = (np.swapaxes(x, 0, 1) if x is not None else x for x in [q, k, v])
 
     ret = (
         q,

--- a/ivy_tests/test_ivy/test_misc/test_backend_utils/test_backend_handler.py
+++ b/ivy_tests/test_ivy/test_misc/test_backend_utils/test_backend_handler.py
@@ -127,7 +127,7 @@ def test_dynamic_backend_all_combos(middle_backend, end_backend):
     assert isinstance(a.data, ivy.NativeArray)
     assert isinstance(ivy_cont["b"].data, ivy.NativeArray)
 
-    if set(["numpy", "jax"]).intersection([middle_backend, end_backend]):
+    if {"numpy", "jax"}.intersection([middle_backend, end_backend]):
         # these frameworks don't support native variables
         assert isinstance(var_cont["b"].data, ivy.NativeArray)
     else:


### PR DESCRIPTION
# PR Description
The following optimizations can be made to make the code better:
It's unnecessary to double-cast or double-process iterables by wrapping the listed functions within an additional `list`, `set`, `sorted`, or `tuple` call. Doing so is redundant and can be confusing for readers.

There is no reason to use a `list comprehension` if the result is `immediately unpacked`. Instead, use a `generator` expression, which is more efficient as it avoids allocating an intermediary list.

I used [`ruff`](https://docs.astral.sh/ruff/) linter to identify and fix these.


## Related Issue
Closes #27217

## Checklist

- [ ] Did you add a function?
- [ ] Did you add the tests?
- [ ] Did you run your tests and are your tests passing?
- [x] Did pre-commit not fail on any check?
- [ ] Did you follow the steps we provided?

### Socials
https://twitter.com/Sai_Suraj_27