### PR TITLE
feat: Add checks to handle `tf.TensorArrays` used extensively by `tf.keras.LSTM`

### DIFF
--- a/ivy/data_classes/array/array.py
+++ b/ivy/data_classes/array/array.py
@@ -262,6 +262,9 @@ class Array(
     def size(self) -> Optional[int]:
         """Number of elements in the array."""
         if self._size is None:
+            if hasattr(self._data, "size") and callable(self._data.size):
+                self._size = self._data.size()
+                return self._size
             self._size = (
                 functools.reduce(mul, self._data.shape)
                 if len(self._data.shape) > 0

--- a/ivy/functional/backends/tensorflow/creation.py
+++ b/ivy/functional/backends/tensorflow/creation.py
@@ -350,14 +350,20 @@ array = asarray
 
 
 def copy_array(
-    x: Union[tf.Tensor, tf.Variable],
+    x: Union[tf.Tensor, tf.Variable, tf.TensorArray],
     *,
     to_ivy_array: bool = True,
     out: Optional[Union[tf.Tensor, tf.Variable]] = None,
 ) -> Union[tf.Tensor, tf.Variable]:
+    if isinstance(x, tf.TensorArray):
+        x_wrapped = x.stack()
+        y = tf.TensorArray(x.dtype, x.size())
+        x = y.unstack(ivy.copy_array(x_wrapped))
+    else:
+        x = tf.identity(x)
     if to_ivy_array:
-        return ivy.to_ivy(tf.identity(x))
-    return tf.identity(x)
+        return ivy.to_ivy(x)
+    return x
 
 
 def one_hot(

--- a/ivy/functional/backends/tensorflow/device.py
+++ b/ivy/functional/backends/tensorflow/device.py
@@ -24,11 +24,14 @@ def _same_device(dev_a, dev_b):
 
 
 def dev(
-    x: Union[tf.Tensor, tf.Variable],
+    x: Union[tf.Tensor, tf.Variable, tf.TensorArray],
     /,
     *,
     as_native: bool = False,
 ) -> Union[ivy.Device, str]:
+    if isinstance(x, tf.TensorArray):
+        # Read the underlying tensor being wrapped to get the device.
+        x = x.stack()
     dv = x.device
     if as_native:
         return dv

--- a/ivy/functional/backends/tensorflow/general.py
+++ b/ivy/functional/backends/tensorflow/general.py
@@ -24,7 +24,7 @@ _round = round
 
 
 def is_native_array(x, /, *, exclusive=False):
-    if isinstance(x, (tf.Tensor, tf.Variable)):
+    if isinstance(x, (tf.Tensor, tf.Variable, tf.TensorArray)):
         if exclusive and isinstance(x, tf.Variable):
             return False
         return True


### PR DESCRIPTION
Add checks to handle `tf.TensorArrays` used extensively by `tf.keras.LSTM` to some general functions like `is_native_array`, `copy_array`, `dev` etc.


<!--
This template will help you to have a meaningful PR, please follow it and do not leave it blank.
-->

# PR Description

<!--
If there is no related issue, please add a short description about your PR.
-->

## Related Issue

<!--
Please use this format to link other issues with their numbers: Close #123
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes #

## Checklist

- [ ] Did you add a function?
- [ ] Did you add the tests?
- [ ] Did you run your tests and are your tests passing?
- [ ] Did pre-commit not fail on any check?
- [ ] Did you follow the steps we provided?

<!--
Please mark your PR as a draft if you realise after the fact that your tests are not passing or
that your pre-commit check has some failures.

Here are some relevant resources regarding tests and pre-commit:

https://unify.ai/docs/ivy/overview/deep_dive/ivy_tests.html
https://unify.ai/docs/ivy/overview/deep_dive/formatting.html#pre-commit

-->

### Socials

<!--
If you have Twitter, please provide it here otherwise just ignore this.
-->
