### PR TITLE
fix: Removed un-necessary trailing comma on bare `tuple`.

### DIFF
--- a/ivy/functional/frontends/torch/nn/functional/vision_functions.py
+++ b/ivy/functional/frontends/torch/nn/functional/vision_functions.py
@@ -461,7 +461,7 @@ def pixel_unshuffle(input, downscale_factor):
             f"pixel_unshuffle expects 4D input, but got input with sizes {input_shape}"
         ),
         as_array=False,
-    ),
+    )
 
     b = input_shape[0]
     c = input_shape[1]

--- a/ivy_tests/test_ivy/test_misc/test_assertions.py
+++ b/ivy_tests/test_ivy/test_misc/test_assertions.py
@@ -838,7 +838,6 @@ def test_check_true(expression):
         (ivy.array([1, 2, 3]), ivy.array([0, 1, 0], dtype=ivy.int32), 2.0),
         (ivy.array([1, 2, 3]), ivy.array([0, 1, 0], dtype=ivy.int32), 0),
         (ivy.array([1, 2, 3]), ivy.array([0, 1, 0], dtype=ivy.int32), -2),
-        (ivy.array([1, 2, 3]), ivy.array([0, 1, 0], dtype=ivy.int32), 0),
         (ivy.array([1, 2, 3]), ivy.array([0.0, 1.0, 0.0], dtype=ivy.float16), 0),
         (ivy.array([1, 2]), ivy.array([0, 1, 0], dtype=ivy.int32), 0),
         (ivy.array([1, 2, 3]), ivy.array([0, 1], dtype=ivy.int32), 0),


### PR DESCRIPTION
# PR Description
In the file [`ivy\functional\frontends\torch\nn\functional\vision_functions.py`](https://github.com/unifyai/ivy/blob/main/ivy/functional/frontends/torch/nn/functional/vision_functions.py)
in the following function:
https://github.com/unifyai/ivy/blob/567093e891fd4da8a9d5031dbb4c851310b7e182/ivy/functional/frontends/torch/nn/functional/vision_functions.py#L454
There is a un-necessary Trailing comma on bare tuple
https://github.com/unifyai/ivy/blob/567093e891fd4da8a9d5031dbb4c851310b7e182/ivy/functional/frontends/torch/nn/functional/vision_functions.py#L464
The presence of a misplaced comma may cause Python to interpret the value as a tuple, which may lead to unexpected behaviour.
So, i removed it.

Also, the following test case is repeated
https://github.com/unifyai/ivy/blob/567093e891fd4da8a9d5031dbb4c851310b7e182/ivy_tests/test_ivy/test_misc/test_assertions.py#L839
https://github.com/unifyai/ivy/blob/567093e891fd4da8a9d5031dbb4c851310b7e182/ivy_tests/test_ivy/test_misc/test_assertions.py#L841
So, i removed one of them.

## Related Issue
Closes #27231 

## Checklist

- [ ] Did you add a function?
- [ ] Did you add the tests?
- [ ] Did you run your tests and are your tests passing?
- [x] Did pre-commit not fail on any check?
- [ ] Did you follow the steps we provided?


### Socials
https://twitter.com/Sai_Suraj_27