### PR TITLE
fix: Fixed passing `positional only` arguments in few functions

### DIFF
--- a/ivy/functional/frontends/jax/numpy/statistical.py
+++ b/ivy/functional/frontends/jax/numpy/statistical.py
@@ -33,7 +33,7 @@ def average(a, axis=None, weights=None, returned=False, keepdims=False):
         ret = ivy.mean(a, axis=axis, keepdims=keepdims)
         if axis is None:
             fill_value = int(a.size) if ivy.is_int_dtype(ret) else float(a.size)
-            weights_sum = ivy.full(shape=(), fill_value=fill_value, dtype=ret.dtype)
+            weights_sum = ivy.full((), fill_value, dtype=ret.dtype)
         else:
             if isinstance(axis, tuple):
                 # prod with axis has dtype Sequence[int]

--- a/ivy/functional/frontends/mindspore/ops/function/nn_func.py
+++ b/ivy/functional/frontends/mindspore/ops/function/nn_func.py
@@ -336,7 +336,7 @@ def interpolate(
 ):
     return ivy.interpolate(
         input,
-        size=size,
+        size,
         scale_factor=scale_factor,
         mode=mode,
         align_corners=align_corners,

--- a/ivy/functional/frontends/mxnet/numpy/random.py
+++ b/ivy/functional/frontends/mxnet/numpy/random.py
@@ -62,7 +62,7 @@ def rand(*size, **kwargs):
 
 @to_ivy_arrays_and_back
 def randint(low, high=None, size=None, dtype=None, device=None, out=None):
-    return ivy.randint(low, high=high, shape=size, device=device, dtype=dtype, out=out)
+    return ivy.randint(low, high, shape=size, device=device, dtype=dtype, out=out)
 
 
 @to_ivy_arrays_and_back

--- a/ivy/functional/frontends/scipy/spatial/distance.py
+++ b/ivy/functional/frontends/scipy/spatial/distance.py
@@ -29,7 +29,7 @@ def _validate_weights(w, dtype="float64"):
 # euclidean
 @to_ivy_arrays_and_back
 def euclidean(u, v, /, *, w=None):
-    return minkowski(u, v, p=2, w=w)
+    return minkowski(u, v, 2, w=w)
 
 
 # Functions #

--- a/ivy/functional/frontends/torch/nn/functional/non_linear_activation_functions.py
+++ b/ivy/functional/frontends/torch/nn/functional/non_linear_activation_functions.py
@@ -67,7 +67,7 @@ def glu(input, dim=-1):
 def gumbel_softmax(logits, tau=1, hard=False, eps=1e-10, dim=-1):
     gumbels = -ivy.empty_like(logits).exponential().log()
     gumbels = (logits + gumbels) / tau
-    y_soft = ivy.softmax(x=gumbels, axis=dim)
+    y_soft = ivy.softmax(gumbels, axis=dim)
 
     if hard:
         indices = y_soft.max(axis=dim, keepdims=True)[1]


### PR DESCRIPTION
# PR Description
In some files while calling some of the functions, `position only arguments` (those to the left of `/` in the function signature) are passed as `keyword arguments`.
https://github.com/unifyai/ivy/blob/3678f56e2d60be5ab5065905a6eb2f4eb008c27c/ivy/functional/frontends/jax/numpy/statistical.py#L36
https://github.com/unifyai/ivy/blob/3678f56e2d60be5ab5065905a6eb2f4eb008c27c/ivy/functional/frontends/mindspore/ops/function/nn_func.py#L339
https://github.com/unifyai/ivy/blob/3678f56e2d60be5ab5065905a6eb2f4eb008c27c/ivy/functional/frontends/torch/nn/functional/non_linear_activation_functions.py#L70
https://github.com/unifyai/ivy/blob/3678f56e2d60be5ab5065905a6eb2f4eb008c27c/ivy/functional/frontends/mxnet/numpy/random.py#L65
https://github.com/unifyai/ivy/blob/3678f56e2d60be5ab5065905a6eb2f4eb008c27c/ivy/functional/frontends/scipy/spatial/distance.py#L32


## Related Issue
Closes #27244

## Checklist

- [ ] Did you add a function?
- [ ] Did you add the tests?
- [ ] Did you run your tests and are your tests passing?
- [x] Did pre-commit not fail on any check?
- [ ] Did you follow the steps we provided?


### Socials
https://twitter.com/Sai_Suraj_27