### PR TITLE
Fix: torch pointwise operations

### DIFF
--- a/ivy_tests/test_ivy/test_frontends/test_torch/test_pointwise_ops.py
+++ b/ivy_tests/test_ivy/test_frontends/test_torch/test_pointwise_ops.py
@@ -5,7 +5,7 @@ from hypothesis import strategies as st, assume
 # local
 import ivy
 import ivy_tests.test_ivy.helpers as helpers
-from ivy_tests.array_api_testing.test_array_api.array_api_tests import (
+from ivy_tests.test_ivy.helpers import (
     hypothesis_helpers as hh,
 )
 from ivy_tests.test_ivy.helpers import handle_frontend_test


### PR DESCRIPTION
Fixed import issue with hypothesis_helpers. All tests pass for most functions except for jax always and paddle sometimes. 
Getting the following error:
E       KeyError: 'cpu'
E       
E       You can reproduce this example by temporarily adding @reproduce_failure('6.88.3', b'AA==') as a decorator on your test case

This is a task in the priority dashboard

@vedpatwardhan 