### PR TITLE
fix: Fixed key-word arguments in `torch_frontend.quantile()` function call.

### DIFF
--- a/ivy/functional/frontends/torch/tensor.py
+++ b/ivy/functional/frontends/torch/tensor.py
@@ -1960,7 +1960,7 @@ class Tensor:
     )
     def quantile(self, q, dim=None, keepdim=False, *, interpolation="linear", out=None):
         return torch_frontend.quantile(
-            self, q, axis=dim, keepdims=keepdim, interpolation=interpolation, out=out
+            self, q, dim=dim, keepdim=keepdim, interpolation=interpolation, out=out
         )
 
     @with_unsupported_dtypes(


### PR DESCRIPTION
# PR Description
In the following file [`ivy\functional\frontends\torch\tensor.py`](https://github.com/unifyai/ivy/blob/main/ivy/functional/frontends/torch/tensor.py), the arguments are wrongly passed in this function call 
https://github.com/unifyai/ivy/blob/365cfd9b20cc78b009e704bdf0d9de11bb89ba70/ivy/functional/frontends/torch/tensor.py#L1962-L1964
From the definition of the `quantile` function:
https://github.com/unifyai/ivy/blob/365cfd9b20cc78b009e704bdf0d9de11bb89ba70/ivy/functional/frontends/torch/reduction_ops.py#L290
The key-word arguments should be `dim, keepdim` but they were passed as `axis, keepdims`:

So, I fixed them.

## Related Issue
Closes #27248

## Checklist

- [ ] Did you add a function?
- [ ] Did you add the tests?
- [ ] Did you run your tests and are your tests passing?
- [x] Did pre-commit not fail on any check?
- [ ] Did you follow the steps we provided?


### Socials
https://twitter.com/Sai_Suraj_27