### PR TITLE
fix: Raised `exception` statements that are Unraised

### DIFF
--- a/ivy/functional/backends/torch/elementwise.py
+++ b/ivy/functional/backends/torch/elementwise.py
@@ -647,7 +647,7 @@ def trapz(
         return torch.trapezoid(y, dx=dx, dim=axis)
     else:
         if dx is not None:
-            TypeError(
+            raise TypeError(
                 "trapezoid() received an invalid combination of arguments - got "
                 "(Tensor, Tensor, int), but expected one of: *(Tensor "
                 "y, Tensor x, *, int dim) * (Tensor y, *, Number dx, int dim)"

--- a/ivy/functional/frontends/tensorflow/ragged/ragged.py
+++ b/ivy/functional/frontends/tensorflow/ragged/ragged.py
@@ -25,12 +25,12 @@ class RaggedTensor:
 
         if values.shape[0] != row_splits[-1] or row_splits[0] != 0:
             if values.shape[0] != row_splits[-1]:
-                ivy.utils.exceptions.IvyException(
+                raise ivy.utils.exceptions.IvyException(
                     "first dimension of shape of values should be equal to the"
                     " last dimension of row_splits"
                 )
             else:
-                ivy.utils.exceptions.IvyException(
+                raise ivy.utils.exceptions.IvyException(
                     "first value of row_splits should be equal to zero."
                 )
         data = [
@@ -49,7 +49,7 @@ class RaggedTensor:
     ):
         # TODO : modify this, if necessary, to accept raggedTensor inputs too
         if sum(row_lengths) != values.shape[0]:
-            ivy.utils.exceptions.IvyException(
+            raise ivy.utils.exceptions.IvyException(
                 "first dimension of values should be equal to sum(row_lengths) "
             )
         data = []


### PR DESCRIPTION
# PR Description
In few places I found that an `exception` is created but it is not `raised` or `returned` for subsequent use elsewhere.
Like in the following cases:
https://github.com/unifyai/ivy/blob/3260ec4308298bed5149e5abd92add5bf923a0f1/ivy/functional/backends/torch/elementwise.py#L650
https://github.com/unifyai/ivy/blob/3260ec4308298bed5149e5abd92add5bf923a0f1/ivy/functional/frontends/tensorflow/ragged/ragged.py#L28
https://github.com/unifyai/ivy/blob/3260ec4308298bed5149e5abd92add5bf923a0f1/ivy/functional/frontends/tensorflow/ragged/ragged.py#L33
https://github.com/unifyai/ivy/blob/3260ec4308298bed5149e5abd92add5bf923a0f1/ivy/functional/frontends/tensorflow/ragged/ragged.py#L52
I think at all these places the exceptions should be `raised`.

## Related Issue
Closes #27276 

## Checklist

- [ ] Did you add a function?
- [ ] Did you add the tests?
- [ ] Did you run your tests and are your tests passing?
- [x] Did pre-commit not fail on any check?
- [ ] Did you follow the steps we provided?


### Socials
https://twitter.com/Sai_Suraj_27