### PR TITLE
feat: Add Paddle signal module with istft function

### DIFF
--- a/ivy/functional/frontends/paddle/signal.py
+++ b/ivy/functional/frontends/paddle/signal.py
@@ -1,0 +1,41 @@
+import ivy
+from ivy.functional.frontends.tensorflow.func_wrapper import to_ivy_arrays_and_back
+from ivy.func_wrapper import with_supported_dtypes
+
+
+# istft
+@with_supported_dtypes(
+    {
+        "2.5.1 and below": (
+            "complex64",
+            "complex128",
+        )
+    },
+    "paddle",
+)
+@to_ivy_arrays_and_back
+def istft(
+    stft_matrix,
+    n_fft,
+    hop_length=None,
+    win_length=None,
+    window=None,
+    center=True,
+    normalized=False,
+    onesided=True,
+    length=None,
+    name=None,
+):
+    stft_matrix = ivy.asarray(stft_matrix)
+    return ivy.istft(
+        stft_matrix,
+        n_fft,
+        hop_length=hop_length,
+        win_length=win_length,
+        window=window,
+        center=center,
+        normalized=normalized,
+        onesided=onesided,
+        length=length,
+        name=name,
+    )

--- a/ivy_tests/test_ivy/test_frontends/test_paddle/test_signal.py
+++ b/ivy_tests/test_ivy/test_frontends/test_paddle/test_signal.py
@@ -1,0 +1,72 @@
+# global
+from hypothesis import strategies as st
+
+# local
+import ivy_tests.test_ivy.helpers as helpers
+from ivy_tests.test_ivy.helpers import handle_frontend_test
+
+
+# --- Helpers --- #
+# --------------- #
+
+
+@st.composite
+def _valid_istft(draw):
+    # Generating a complex dtype and corresponding STFT matrix values
+    dtype, stft_matrix = draw(
+        helpers.dtype_and_values(
+            available_dtypes=["complex64", "complex128"],
+            max_value=65280,
+            min_value=-65280,
+            min_num_dims=2,  # STFT matrix usually has at least 2 dimensions
+            min_dim_size=2,
+            shared_dtype=True,
+        )
+    )
+    # Randomly generating n_fft and hop_length
+    n_fft = draw(helpers.ints(min_value=16, max_value=100))
+    hop_length = draw(helpers.ints(min_value=1, max_value=50))
+
+    # Return the generated parameters
+    return dtype, stft_matrix, n_fft, hop_length
+
+
+# --- Main --- #
+# ------------ #
+
+
+# Test function for istft
+@handle_frontend_test(
+    fn_tree="paddle.signal.istft",  # Assuming istft is under paddle.signal namespace
+    dtype_x_and_args=_valid_istft(),
+    test_with_out=st.just(False),
+)
+def test_paddle_istft(
+    *,
+    dtype_x_and_args,
+    frontend,
+    test_flags,
+    fn_tree,
+    backend_fw,
+    on_device,
+):
+    input_dtype, stft_matrix, n_fft, hop_length = dtype_x_and_args
+    helpers.test_frontend_function(
+        input_dtypes=input_dtype,
+        backend_to_test=backend_fw,
+        frontend=frontend,
+        test_flags=test_flags,
+        fn_tree=fn_tree,
+        on_device=on_device,
+        stft_matrix=stft_matrix[0],
+        n_fft=n_fft,
+        hop_length=hop_length,
+        win_length=None,
+        window=None,
+        center=True,
+        normalized=False,
+        onesided=True,
+        length=None,  # Optionally, you can add a strategy to generate this
+        atol=1e-02,
+        rtol=1e-02,
+    )


### PR DESCRIPTION
Fixes https://github.com/unifyai/ivy/issues/27280


@vedpatwardhan @NripeshN, istft is not implemented in ivy backend. Could we maybe implement it?
`FAILED ivy_tests/test_ivy/test_frontends/test_paddle/test_signal.py::test_paddle_istft[cpu-numpy-False-False] - AttributeError: module 'ivy.functional.backends.numpy' has no attribute 'istft'
FAILED ivy_tests/test_ivy/test_frontends/test_paddle/test_signal.py::test_paddle_istft[cpu-jax-False-False] - AttributeError: module 'ivy.functional.backends.jax' has no attribute 'istft'
FAILED ivy_tests/test_ivy/test_frontends/test_paddle/test_signal.py::test_paddle_istft[cpu-tensorflow-False-False] - hypothesis.errors.InvalidArgument: Cannot sample from a length-zero sequence.
FAILED ivy_tests/test_ivy/test_frontends/test_paddle/test_signal.py::test_paddle_istft[cpu-torch-False-False] - AttributeError: module 'ivy.functional.backends.torch' has no attribute 'istft'
FAILED ivy_tests/test_ivy/test_frontends/test_paddle/test_signal.py::test_paddle_istft[cpu-paddle-False-False] - AttributeError: module 'ivy.functional.backends.paddle' has no attribute 'istft'`