### PR TITLE
Updated a Minor Grammar Issue in building_blocks.rst

### DIFF
--- a/docs/overview/design/building_blocks.rst
+++ b/docs/overview/design/building_blocks.rst
@@ -11,7 +11,7 @@ These are the 4 parts labelled as (a) in the image below:
 Backend Functional APIs ✅
 --------------------------
 
-The first important point to make is that, Ivy does not implement it’s own C++ or CUDA backend.
+The first important point to make is that, Ivy does not implement its own C++ or CUDA backend.
 Instead, Ivy **wraps** the functional APIs of existing frameworks, bringing them into syntactic and semantic alignment.
 Let’s take the function :func:`ivy.stack` as an example.
 


### PR DESCRIPTION
The sentence is correct in terms of its meaning, but there is a minor issue with the use of the apostrophe in "it’s."  

The correct form should be "its" without an apostrophe. Here's the corrected version: "The first important point to make is that Ivy does not implement its own C++ or CUDA backend."
