### PR TITLE
feat: Updated `TensorFlow` version mapping from `2.14.0` to `2.15.0`

### DIFF
--- a/ivy/functional/backends/tensorflow/__init__.py
+++ b/ivy/functional/backends/tensorflow/__init__.py
@@ -128,7 +128,7 @@ native_bool = tf.bool
 
 # update these to add new dtypes
 valid_dtypes = {
-    "2.14.0 and below": (
+    "2.15.0 and below": (
         ivy.int8,
         ivy.int16,
         ivy.int32,
@@ -147,7 +147,7 @@ valid_dtypes = {
     )
 }
 valid_numeric_dtypes = {
-    "2.14.0 and below": (
+    "2.15.0 and below": (
         ivy.int8,
         ivy.int16,
         ivy.int32,
@@ -165,7 +165,7 @@ valid_numeric_dtypes = {
     )
 }
 valid_int_dtypes = {
-    "2.14.0 and below": (
+    "2.15.0 and below": (
         ivy.int8,
         ivy.int16,
         ivy.int32,
@@ -177,12 +177,12 @@ valid_int_dtypes = {
     )
 }
 valid_float_dtypes = {
-    "2.14.0 and below": (ivy.bfloat16, ivy.float16, ivy.float32, ivy.float64)
+    "2.15.0 and below": (ivy.bfloat16, ivy.float16, ivy.float32, ivy.float64)
 }
 valid_uint_dtypes = {
-    "2.14.0 and below": (ivy.uint8, ivy.uint16, ivy.uint32, ivy.uint64)
+    "2.15.0 and below": (ivy.uint8, ivy.uint16, ivy.uint32, ivy.uint64)
 }
-valid_complex_dtypes = {"2.14.0 and below": (ivy.complex64, ivy.complex128)}
+valid_complex_dtypes = {"2.15.0 and below": (ivy.complex64, ivy.complex128)}
 
 # leave these untouched
 valid_dtypes = _dtype_from_version(valid_dtypes, backend_version)
@@ -194,12 +194,12 @@ valid_complex_dtypes = _dtype_from_version(valid_complex_dtypes, backend_version
 
 # invalid data types
 # update these to add new dtypes
-invalid_dtypes = {"2.14.0 and below": ()}
-invalid_numeric_dtypes = {"2.14.0 and below": ()}
-invalid_int_dtypes = {"2.14.0 and below": ()}
-invalid_float_dtypes = {"2.14.0 and below": ()}
-invalid_uint_dtypes = {"2.14.0 and below": ()}
-invalid_complex_dtypes = {"2.14.0 and below": ()}
+invalid_dtypes = {"2.15.0 and below": ()}
+invalid_numeric_dtypes = {"2.15.0 and below": ()}
+invalid_int_dtypes = {"2.15.0 and below": ()}
+invalid_float_dtypes = {"2.15.0 and below": ()}
+invalid_uint_dtypes = {"2.15.0 and below": ()}
+invalid_complex_dtypes = {"2.15.0 and below": ()}
 
 # leave these untouched
 invalid_dtypes = _dtype_from_version(invalid_dtypes, backend_version)

--- a/ivy/functional/backends/tensorflow/activations.py
+++ b/ivy/functional/backends/tensorflow/activations.py
@@ -68,7 +68,7 @@ def softmax(
 
 @with_supported_dtypes(
     {
-        "2.14.0 and below": (
+        "2.15.0 and below": (
             "float16",
             "bfloat16",
             "float32",
@@ -102,7 +102,7 @@ def softplus(
 # Softsign
 @with_supported_dtypes(
     {
-        "2.14.0 and below": (
+        "2.15.0 and below": (
             "float16",
             "bfloat16",
             "float32",
@@ -148,7 +148,7 @@ def mish(
     return tf.multiply(x, tf.math.tanh(x_norm))
 
 
-@with_unsupported_dtypes({"2.14.0 and below": ("complex",)}, backend_version)
+@with_unsupported_dtypes({"2.15.0 and below": ("complex",)}, backend_version)
 def hardswish(
     x: Tensor,
     /,

--- a/ivy/functional/backends/tensorflow/creation.py
+++ b/ivy/functional/backends/tensorflow/creation.py
@@ -26,7 +26,7 @@ from . import backend_version
 
 @with_unsupported_dtypes(
     {
-        "2.14.0 and below": (
+        "2.15.0 and below": (
             "float16",
             "bfloat16",
             "complex",
@@ -119,7 +119,7 @@ def empty_like(
     return tf.experimental.numpy.empty_like(x, dtype=dtype)
 
 
-@with_unsupported_dtypes({"2.14.0 and below": ("uint16",)}, backend_version)
+@with_unsupported_dtypes({"2.15.0 and below": ("uint16",)}, backend_version)
 def eye(
     n_rows: int,
     n_cols: Optional[int] = None,
@@ -253,7 +253,7 @@ def linspace(
     return tf.cast(ans, dtype)
 
 
-@with_unsupported_dtypes({"2.14.0 and below": ("bool",)}, backend_version)
+@with_unsupported_dtypes({"2.15.0 and below": ("bool",)}, backend_version)
 def meshgrid(
     *arrays: Union[tf.Tensor, tf.Variable],
     sparse: bool = False,
@@ -297,7 +297,7 @@ def ones_like(
     return tf.ones_like(x, dtype=dtype)
 
 
-@with_unsupported_dtypes({"2.14.0 and below": ("bool",)}, backend_version)
+@with_unsupported_dtypes({"2.15.0 and below": ("bool",)}, backend_version)
 def tril(
     x: Union[tf.Tensor, tf.Variable],
     /,
@@ -310,7 +310,7 @@ def tril(
     return tf.experimental.numpy.tril(x, k)
 
 
-@with_unsupported_dtypes({"2.14.0 and below": ("bool",)}, backend_version)
+@with_unsupported_dtypes({"2.15.0 and below": ("bool",)}, backend_version)
 def triu(
     x: Union[tf.Tensor, tf.Variable],
     /,
@@ -383,7 +383,7 @@ def one_hot(
     )
 
 
-@with_unsupported_dtypes({"2.14.0 and below": ("uint32", "uint64")}, backend_version)
+@with_unsupported_dtypes({"2.15.0 and below": ("uint32", "uint64")}, backend_version)
 def frombuffer(
     buffer: bytes,
     dtype: Optional[tf.DType] = float,

--- a/ivy/functional/backends/tensorflow/data_type.py
+++ b/ivy/functional/backends/tensorflow/data_type.py
@@ -164,7 +164,7 @@ def iinfo(type: Union[DType, str, tf.Tensor, tf.Variable, np.ndarray], /) -> np.
     return tf.experimental.numpy.iinfo(ivy.as_ivy_dtype(type))
 
 
-@with_unsupported_dtypes({"2.14.0 and below": ("bfloat16",)}, backend_version)
+@with_unsupported_dtypes({"2.15.0 and below": ("bfloat16",)}, backend_version)
 def result_type(
     *arrays_and_dtypes: Union[tf.Tensor, tf.Variable, tf.DType],
 ) -> ivy.Dtype:

--- a/ivy/functional/backends/tensorflow/elementwise.py
+++ b/ivy/functional/backends/tensorflow/elementwise.py
@@ -83,7 +83,7 @@ def atan(
     return tf.math.atan(x)
 
 
-@with_unsupported_dtypes({"2.14.0 and below": ("complex",)}, backend_version)
+@with_unsupported_dtypes({"2.15.0 and below": ("complex",)}, backend_version)
 def atan2(
     x1: Union[tf.Tensor, tf.Variable],
     x2: Union[tf.Tensor, tf.Variable],
@@ -104,7 +104,7 @@ def atanh(
     return tf.math.atanh(x)
 
 
-@with_unsupported_dtypes({"2.14.0 and below": ("complex",)}, backend_version)
+@with_unsupported_dtypes({"2.15.0 and below": ("complex",)}, backend_version)
 def bitwise_and(
     x1: Union[int, tf.Tensor, tf.Variable],
     x2: Union[int, tf.Tensor, tf.Variable],
@@ -119,7 +119,7 @@ def bitwise_and(
         return tf.bitwise.bitwise_and(x1, x2)
 
 
-@with_unsupported_dtypes({"2.14.0 and below": ("complex",)}, backend_version)
+@with_unsupported_dtypes({"2.15.0 and below": ("complex",)}, backend_version)
 def bitwise_invert(
     x: Union[int, tf.Tensor, tf.Variable],
     /,
@@ -132,7 +132,7 @@ def bitwise_invert(
         return tf.bitwise.invert(x)
 
 
-@with_unsupported_dtypes({"2.14.0 and below": ("complex",)}, backend_version)
+@with_unsupported_dtypes({"2.15.0 and below": ("complex",)}, backend_version)
 def bitwise_left_shift(
     x1: Union[int, tf.Tensor, tf.Variable],
     x2: Union[int, tf.Tensor, tf.Variable],
@@ -144,7 +144,7 @@ def bitwise_left_shift(
     return tf.bitwise.left_shift(x1, x2)
 
 
-@with_unsupported_dtypes({"2.14.0 and below": ("complex",)}, backend_version)
+@with_unsupported_dtypes({"2.15.0 and below": ("complex",)}, backend_version)
 def bitwise_or(
     x1: Union[int, tf.Tensor, tf.Variable],
     x2: Union[int, tf.Tensor, tf.Variable],
@@ -159,7 +159,7 @@ def bitwise_or(
         return tf.bitwise.bitwise_or(x1, x2)
 
 
-@with_unsupported_dtypes({"2.14.0 and below": ("complex",)}, backend_version)
+@with_unsupported_dtypes({"2.15.0 and below": ("complex",)}, backend_version)
 def bitwise_right_shift(
     x1: Union[int, tf.Tensor, tf.Variable],
     x2: Union[int, tf.Tensor, tf.Variable],
@@ -171,7 +171,7 @@ def bitwise_right_shift(
     return tf.bitwise.right_shift(x1, x2)
 
 
-@with_unsupported_dtypes({"2.14.0 and below": ("complex",)}, backend_version)
+@with_unsupported_dtypes({"2.15.0 and below": ("complex",)}, backend_version)
 def bitwise_xor(
     x1: Union[int, tf.Tensor, tf.Variable],
     x2: Union[int, tf.Tensor, tf.Variable],
@@ -186,7 +186,7 @@ def bitwise_xor(
         return tf.bitwise.bitwise_xor(x1, x2)
 
 
-@with_unsupported_dtypes({"2.14.0 and below": ("complex",)}, backend_version)
+@with_unsupported_dtypes({"2.15.0 and below": ("complex",)}, backend_version)
 def ceil(
     x: Union[tf.Tensor, tf.Variable],
     /,
@@ -208,7 +208,7 @@ def cos(
     return tf.cos(x)
 
 
-@with_unsupported_dtypes({"2.14.0 and below": ("float16",)}, backend_version)
+@with_unsupported_dtypes({"2.15.0 and below": ("float16",)}, backend_version)
 def cosh(
     x: Union[tf.Tensor, tf.Variable],
     /,
@@ -263,7 +263,7 @@ def exp2(
     return tf.math.pow(2, x, name=None)
 
 
-@with_supported_dtypes({"2.14.0 and below": ("float", "complex")}, backend_version)
+@with_supported_dtypes({"2.15.0 and below": ("float", "complex")}, backend_version)
 def expm1(
     x: Union[tf.Tensor, tf.Variable],
     /,
@@ -273,7 +273,7 @@ def expm1(
     return tf.math.expm1(x)
 
 
-@with_unsupported_dtypes({"2.14.0 and below": ("complex",)}, backend_version)
+@with_unsupported_dtypes({"2.15.0 and below": ("complex",)}, backend_version)
 def floor(
     x: Union[tf.Tensor, tf.Variable],
     /,
@@ -286,7 +286,7 @@ def floor(
         return tf.math.floor(x)
 
 
-@with_unsupported_dtypes({"2.14.0 and below": ("complex",)}, backend_version)
+@with_unsupported_dtypes({"2.15.0 and below": ("complex",)}, backend_version)
 def floor_divide(
     x1: Union[float, tf.Tensor, tf.Variable],
     x2: Union[float, tf.Tensor, tf.Variable],
@@ -298,7 +298,7 @@ def floor_divide(
     return tf.experimental.numpy.floor_divide(x1, x2)
 
 
-@with_supported_dtypes({"2.14.0 and below": ("float",)}, backend_version)
+@with_supported_dtypes({"2.15.0 and below": ("float",)}, backend_version)
 def fmin(
     x1: Union[tf.Tensor, tf.Variable],
     x2: Union[tf.Tensor, tf.Variable],
@@ -313,7 +313,7 @@ def fmin(
     return ret
 
 
-@with_unsupported_dtypes({"2.14.0 and below": ("complex",)}, backend_version)
+@with_unsupported_dtypes({"2.15.0 and below": ("complex",)}, backend_version)
 def greater(
     x1: Union[float, tf.Tensor, tf.Variable],
     x2: Union[float, tf.Tensor, tf.Variable],
@@ -325,7 +325,7 @@ def greater(
     return tf.experimental.numpy.greater(x1, x2)
 
 
-@with_unsupported_dtypes({"2.14.0 and below": ("complex",)}, backend_version)
+@with_unsupported_dtypes({"2.15.0 and below": ("complex",)}, backend_version)
 def greater_equal(
     x1: Union[float, tf.Tensor, tf.Variable],
     x2: Union[float, tf.Tensor, tf.Variable],
@@ -374,7 +374,7 @@ def isinf(
     return tf.zeros_like(x, tf.bool)
 
 
-@with_unsupported_dtypes({"2.14.0 and below": ("complex", "bool")}, backend_version)
+@with_unsupported_dtypes({"2.15.0 and below": ("complex", "bool")}, backend_version)
 def isnan(
     x: Union[tf.Tensor, tf.Variable],
     /,
@@ -387,7 +387,7 @@ def isnan(
         return tf.math.is_nan(x)
 
 
-@with_unsupported_dtypes({"2.14.0 and below": ("unsigned",)}, backend_version)
+@with_unsupported_dtypes({"2.15.0 and below": ("unsigned",)}, backend_version)
 def lcm(
     x1: Union[tf.Tensor, tf.Variable],
     x2: Union[tf.Tensor, tf.Variable],
@@ -401,7 +401,7 @@ def lcm(
 
 @with_unsupported_dtypes(
     {
-        "2.14.0 and below": (
+        "2.15.0 and below": (
             "bool",
             "complex",
         )
@@ -419,7 +419,7 @@ def less(
     return tf.math.less(x1, x2)
 
 
-@with_unsupported_dtypes({"2.14.0 and below": ("complex",)}, backend_version)
+@with_unsupported_dtypes({"2.15.0 and below": ("complex",)}, backend_version)
 def less_equal(
     x1: Union[float, tf.Tensor, tf.Variable],
     x2: Union[float, tf.Tensor, tf.Variable],
@@ -467,7 +467,7 @@ def log2(
     return tf.math.log(x) / tf.math.log(tf.constant(2.0, x.dtype))
 
 
-@with_unsupported_dtypes({"2.14.0 and below": ("float16", "bfloat16")}, backend_version)
+@with_unsupported_dtypes({"2.15.0 and below": ("float16", "bfloat16")}, backend_version)
 def logaddexp(
     x1: Union[tf.Tensor, tf.Variable],
     x2: Union[tf.Tensor, tf.Variable],
@@ -479,7 +479,7 @@ def logaddexp(
     return tf.experimental.numpy.logaddexp(x1, x2)
 
 
-@with_unsupported_dtypes({"2.14.0 and below": ("float16",)}, backend_version)
+@with_unsupported_dtypes({"2.15.0 and below": ("float16",)}, backend_version)
 def real(
     x: Union[tf.Tensor, tf.Variable],
     /,
@@ -491,7 +491,7 @@ def real(
 
 @with_unsupported_dtypes(
     {
-        "2.14.0 and below": (
+        "2.15.0 and below": (
             "uint8",
             "uint16",
             "uint32",
@@ -563,7 +563,7 @@ def logical_xor(
     return tf.math.logical_xor(tf.cast(x1, tf.bool), tf.cast(x2, tf.bool))
 
 
-@with_unsupported_dtypes({"2.14.0 and below": ("bool",)}, backend_version)
+@with_unsupported_dtypes({"2.15.0 and below": ("bool",)}, backend_version)
 def multiply(
     x1: Union[float, tf.Tensor, tf.Variable],
     x2: Union[float, tf.Tensor, tf.Variable],
@@ -575,7 +575,7 @@ def multiply(
     return tf.math.multiply(x1, x2)
 
 
-@with_unsupported_dtypes({"2.14.0 and below": ("bool", "unsigned")}, backend_version)
+@with_unsupported_dtypes({"2.15.0 and below": ("bool", "unsigned")}, backend_version)
 def negative(
     x: Union[float, tf.Tensor, tf.Variable],
     /,
@@ -605,7 +605,7 @@ def positive(
     return tf.experimental.numpy.positive(x)
 
 
-@with_unsupported_dtypes({"2.14.0 and below": ("bool", "unsigned")}, backend_version)
+@with_unsupported_dtypes({"2.15.0 and below": ("bool", "unsigned")}, backend_version)
 def pow(
     x1: Union[tf.Tensor, tf.Variable],
     x2: Union[int, float, tf.Tensor, tf.Variable],
@@ -630,7 +630,7 @@ def pow(
     return tf.experimental.numpy.power(x1, x2)
 
 
-@with_unsupported_dtypes({"2.14.0 and below": ("bfloat16", "complex")}, backend_version)
+@with_unsupported_dtypes({"2.15.0 and below": ("bfloat16", "complex")}, backend_version)
 def remainder(
     x1: Union[float, tf.Tensor, tf.Variable],
     x2: Union[float, tf.Tensor, tf.Variable],
@@ -649,7 +649,7 @@ def remainder(
     return tf.experimental.numpy.remainder(x1, x2)
 
 
-@with_unsupported_dtypes({"2.14.0 and below": ("bfloat16", "complex")}, backend_version)
+@with_unsupported_dtypes({"2.15.0 and below": ("bfloat16", "complex")}, backend_version)
 def round(
     x: Union[tf.Tensor, tf.Variable],
     /,
@@ -670,7 +670,7 @@ def round(
         return tf.cast(tf.round(x * factor) / factor_deno, ret_dtype)
 
 
-@with_unsupported_dtypes({"2.14.0 and below": ("bool", "unsigned")}, backend_version)
+@with_unsupported_dtypes({"2.15.0 and below": ("bool", "unsigned")}, backend_version)
 def sign(
     x: Union[tf.Tensor, tf.Variable],
     /,
@@ -765,7 +765,7 @@ def trapz(
     # TODO: Implement purely in tensorflow
 
 
-@with_unsupported_dtypes({"2.14.0 and below": ("complex",)}, backend_version)
+@with_unsupported_dtypes({"2.15.0 and below": ("complex",)}, backend_version)
 def trunc(
     x: Union[tf.Tensor, tf.Variable],
     /,
@@ -792,7 +792,7 @@ def trunc(
 # ------#
 
 
-@with_unsupported_dtypes({"2.14.0 and below": ("complex",)}, backend_version)
+@with_unsupported_dtypes({"2.15.0 and below": ("complex",)}, backend_version)
 def erf(
     x: Union[tf.Tensor, tf.Variable],
     /,
@@ -802,7 +802,7 @@ def erf(
     return tf.math.erf(x)
 
 
-@with_unsupported_dtypes({"2.14.0 and below": ("complex", "bool")}, backend_version)
+@with_unsupported_dtypes({"2.15.0 and below": ("complex", "bool")}, backend_version)
 def maximum(
     x1: Union[tf.Tensor, tf.Variable],
     x2: Union[tf.Tensor, tf.Variable],
@@ -815,7 +815,7 @@ def maximum(
     return tf.math.maximum(x1, x2)
 
 
-@with_unsupported_dtypes({"2.14.0 and below": ("complex", "bool")}, backend_version)
+@with_unsupported_dtypes({"2.15.0 and below": ("complex", "bool")}, backend_version)
 def minimum(
     x1: Union[tf.Tensor, tf.Variable],
     x2: Union[tf.Tensor, tf.Variable],
@@ -830,7 +830,7 @@ def minimum(
 
 @with_unsupported_dtypes(
     {
-        "2.14.0 and below": (
+        "2.15.0 and below": (
             "uint8",
             "uint16",
             "uint32",
@@ -852,7 +852,7 @@ def reciprocal(
     return tf.math.reciprocal(x)
 
 
-@with_unsupported_dtypes({"2.14.0 and below": ("bfloat16",)}, backend_version)
+@with_unsupported_dtypes({"2.15.0 and below": ("bfloat16",)}, backend_version)
 def deg2rad(
     x: Union[tf.Tensor, tf.Variable],
     /,
@@ -881,7 +881,7 @@ def isreal(
 
 
 @with_unsupported_dtypes(
-    {"2.14.0 and below": ("uint8", "uint16", "uint32", "uint64", "complex", "bool")},
+    {"2.15.0 and below": ("uint8", "uint16", "uint32", "uint64", "complex", "bool")},
     backend_version,
 )
 def fmod(
@@ -898,7 +898,7 @@ def fmod(
 
 
 @with_unsupported_dtypes(
-    {"2.14.0 and below": ("uint8", "uint16", "uint32", "uint64")}, backend_version
+    {"2.15.0 and below": ("uint8", "uint16", "uint32", "uint64")}, backend_version
 )
 def gcd(
     x1: Union[tf.Tensor, tf.Variable, int, list, tuple],
@@ -916,7 +916,7 @@ gcd.support_native_out = False
 
 @with_unsupported_dtypes(
     {
-        "2.14.0 and below": (
+        "2.15.0 and below": (
             "uint8",
             "uint16",
             "uint32",
@@ -942,7 +942,7 @@ def angle(
 
 @with_unsupported_dtypes(
     {
-        "2.14.0 and below": (
+        "2.15.0 and below": (
             "uint8",
             "uint16",
             "uint32",

--- a/ivy/functional/backends/tensorflow/experimental/activations.py
+++ b/ivy/functional/backends/tensorflow/experimental/activations.py
@@ -26,7 +26,7 @@ def logit(
     return tf.cast(tf.math.log(x / (1 - x)), x_dtype)
 
 
-@with_unsupported_dtypes({"2.14.0 and below": ("complex", "bool")}, backend_version)
+@with_unsupported_dtypes({"2.15.0 and below": ("complex", "bool")}, backend_version)
 def thresholded_relu(
     x: Tensor,
     /,
@@ -42,7 +42,7 @@ def relu6(x: Tensor, /, *, complex_mode="jax", out: Optional[Tensor] = None) -> 
     return tf.nn.relu6(x)
 
 
-@with_supported_dtypes({"2.14.0 and below": ("float",)}, backend_version)
+@with_supported_dtypes({"2.15.0 and below": ("float",)}, backend_version)
 def logsigmoid(
     input: Tensor, /, *, complex_mode="jax", out: Optional[Tensor] = None
 ) -> Tensor:
@@ -51,7 +51,7 @@ def logsigmoid(
     return tf.math.log_sigmoid(input)
 
 
-@with_supported_dtypes({"2.14.0 and below": ("float",)}, backend_version)
+@with_supported_dtypes({"2.15.0 and below": ("float",)}, backend_version)
 def selu(x: Tensor, /, *, out: Optional[Tensor] = None) -> Tensor:
     ret = tf.nn.selu(x)
     if ivy.exists(out):
@@ -59,7 +59,7 @@ def selu(x: Tensor, /, *, out: Optional[Tensor] = None) -> Tensor:
     return ivy.astype(ret, x.dtype)
 
 
-@with_unsupported_dtypes({"2.14.0 and below": ("complex",)}, backend_version)
+@with_unsupported_dtypes({"2.15.0 and below": ("complex",)}, backend_version)
 def silu(
     x: Tensor,
     /,
@@ -72,7 +72,7 @@ def silu(
     return ivy.astype(ret, x.dtype)
 
 
-@with_supported_dtypes({"2.14.0 and below": ("float",)}, backend_version)
+@with_supported_dtypes({"2.15.0 and below": ("float",)}, backend_version)
 def elu(x: Tensor, /, *, alpha: float = 1.0, out: Optional[Tensor] = None) -> Tensor:
     alpha = tf.cast(alpha, x.dtype)
     ret = tf.cast(tf.where(x > 0, x, tf.multiply(alpha, tf.math.expm1(x))), x.dtype)
@@ -81,7 +81,7 @@ def elu(x: Tensor, /, *, alpha: float = 1.0, out: Optional[Tensor] = None) -> Te
     return ivy.astype(ret, x.dtype)
 
 
-@with_supported_dtypes({"2.14.0 and below": ("float",)}, backend_version)
+@with_supported_dtypes({"2.15.0 and below": ("float",)}, backend_version)
 def hardtanh(
     x: Tensor,
     /,
@@ -100,7 +100,7 @@ def hardtanh(
     return ivy.astype(ret, x.dtype)
 
 
-@with_supported_dtypes({"2.14.0 and below": ("float",)}, backend_version)
+@with_supported_dtypes({"2.15.0 and below": ("float",)}, backend_version)
 def tanhshrink(
     x: Tensor,
     /,
@@ -113,7 +113,7 @@ def tanhshrink(
     return ivy.astype(ret, x.dtype)
 
 
-@with_supported_dtypes({"2.14.0 and below": ("float",)}, backend_version)
+@with_supported_dtypes({"2.15.0 and below": ("float",)}, backend_version)
 def threshold(
     x: Tensor,
     /,
@@ -128,7 +128,7 @@ def threshold(
     return ivy.astype(ret, x.dtype)
 
 
-@with_supported_dtypes({"2.14.0 and below": ("float",)}, backend_version)
+@with_supported_dtypes({"2.15.0 and below": ("float",)}, backend_version)
 def softshrink(
     x: Tensor,
     /,
@@ -146,7 +146,7 @@ def softshrink(
     return ivy.astype(ret, x.dtype)
 
 
-@with_unsupported_dtypes({"2.14.0 and below": ("complex",)}, backend_version)
+@with_unsupported_dtypes({"2.15.0 and below": ("complex",)}, backend_version)
 def celu(
     x: Tensor,
     /,
@@ -158,7 +158,7 @@ def celu(
     return tf.math.maximum(0, x) + alpha * tf.math.expm1(tf.math.minimum(0, x) / alpha)
 
 
-@with_unsupported_dtypes({"2.14.0 and below": ("uint16",)}, backend_version)
+@with_unsupported_dtypes({"2.15.0 and below": ("uint16",)}, backend_version)
 def scaled_tanh(
     x: Tensor,
     /,
@@ -170,7 +170,7 @@ def scaled_tanh(
     return alpha * tf.nn.tanh(beta * x)
 
 
-@with_supported_dtypes({"2.14.0 and below": ("float",)}, backend_version)
+@with_supported_dtypes({"2.15.0 and below": ("float",)}, backend_version)
 def hardshrink(
     x: Tensor,
     /,

--- a/ivy/functional/backends/tensorflow/experimental/creation.py
+++ b/ivy/functional/backends/tensorflow/experimental/creation.py
@@ -13,7 +13,7 @@ from .. import backend_version
 
 
 @with_unsupported_device_and_dtypes(
-    {"2.14.0 and below": {"cpu": ("bfloat16",)}},
+    {"2.15.0 and below": {"cpu": ("bfloat16",)}},
     backend_version,
 )
 def kaiser_window(
@@ -130,7 +130,7 @@ def unsorted_segment_sum(
     return tf.math.unsorted_segment_sum(data, segment_ids, num_segments)
 
 
-@with_unsupported_dtypes({"2.14.0 and below": ("bool",)}, backend_version)
+@with_unsupported_dtypes({"2.15.0 and below": ("bool",)}, backend_version)
 def trilu(
     x: Union[tf.Tensor, tf.Variable],
     /,

--- a/ivy/functional/backends/tensorflow/experimental/elementwise.py
+++ b/ivy/functional/backends/tensorflow/experimental/elementwise.py
@@ -54,7 +54,7 @@ def amin(
 
 
 @with_supported_dtypes(
-    {"2.14.0 and below": ("float16", "float32", "float64")},
+    {"2.15.0 and below": ("float16", "float32", "float64")},
     backend_version,
 )
 def lgamma(
@@ -77,7 +77,7 @@ def sinc(
 
 
 @with_supported_dtypes(
-    {"2.14.0 and below": ("bfloat16", "float16", "float32", "float64")}, backend_version
+    {"2.15.0 and below": ("bfloat16", "float16", "float32", "float64")}, backend_version
 )
 def fmax(
     x1: Union[tf.Tensor, tf.Variable],
@@ -93,7 +93,7 @@ def fmax(
 
 
 @with_unsupported_dtypes(
-    {"2.14.0 and below": ("uint8", "uint16", "uint32", "uint64")}, backend_version
+    {"2.15.0 and below": ("uint8", "uint16", "uint32", "uint64")}, backend_version
 )
 def float_power(
     x1: Union[tf.Tensor, tf.Variable, float, list, tuple],
@@ -145,7 +145,7 @@ def count_nonzero(
     )
 
 
-@with_unsupported_dtypes({"2.14.0 and below": ("complex",)}, backend_version)
+@with_unsupported_dtypes({"2.15.0 and below": ("complex",)}, backend_version)
 def nansum(
     x: Union[tf.Tensor, tf.Variable],
     /,
@@ -208,7 +208,7 @@ def allclose(
     )
 
 
-@with_unsupported_dtypes({"2.14.0 and below": ("bfloat16",)}, backend_version)
+@with_unsupported_dtypes({"2.15.0 and below": ("bfloat16",)}, backend_version)
 def fix(
     x: Union[tf.Tensor, tf.Variable],
     /,
@@ -218,7 +218,7 @@ def fix(
     return tf.cast(tf.where(x > 0, tf.math.floor(x), tf.math.ceil(x)), x.dtype)
 
 
-@with_unsupported_dtypes({"2.14.0 and below": ("bflaot16", "float16")}, backend_version)
+@with_unsupported_dtypes({"2.15.0 and below": ("bflaot16", "float16")}, backend_version)
 def nextafter(
     x1: Union[tf.Tensor, tf.Variable],
     x2: Union[tf.Tensor, tf.Variable],
@@ -230,7 +230,7 @@ def nextafter(
 
 
 @with_unsupported_dtypes(
-    {"2.14.0 and below": ("uint8", "uint16", "uint32", "uint64")}, backend_version
+    {"2.15.0 and below": ("uint8", "uint16", "uint32", "uint64")}, backend_version
 )
 def diff(
     x: Union[tf.Tensor, tf.Variable, list, tuple],
@@ -253,7 +253,7 @@ def diff(
 
 @with_supported_dtypes(
     {
-        "2.14.0 and below": (
+        "2.15.0 and below": (
             "float32",
             "float64",
         )
@@ -469,7 +469,7 @@ def gradient(
 
 @with_supported_dtypes(
     {
-        "2.14.0 and below": (
+        "2.15.0 and below": (
             "float16",
             "float32",
             "float64",
@@ -499,7 +499,7 @@ def conj(
     return tf.math.conj(x)
 
 
-@with_unsupported_dtypes({"2.14.0 and below": ("unsigned",)}, backend_version)
+@with_unsupported_dtypes({"2.15.0 and below": ("unsigned",)}, backend_version)
 def ldexp(
     x1: Union[tf.Tensor, tf.Variable],
     x2: Union[tf.Tensor, tf.Variable, int],
@@ -520,7 +520,7 @@ def ldexp(
     return tf.cast(ret, out_dtype)
 
 
-@with_unsupported_dtypes({"2.14.0 and below": ("unsigned",)}, backend_version)
+@with_unsupported_dtypes({"2.15.0 and below": ("unsigned",)}, backend_version)
 def frexp(
     x: Union[tf.Tensor, tf.Variable],
     /,

--- a/ivy/functional/backends/tensorflow/experimental/layers.py
+++ b/ivy/functional/backends/tensorflow/experimental/layers.py
@@ -173,7 +173,7 @@ def max_pool2d(
 
 
 @with_unsupported_dtypes(
-    {"2.14.0 and below": ("bfloat16", "float64", "float16")}, backend_version
+    {"2.15.0 and below": ("bfloat16", "float64", "float16")}, backend_version
 )
 def max_pool3d(
     x: Union[tf.Tensor, tf.Variable],
@@ -279,7 +279,7 @@ def _handle_manual_pad_avg_pool(x, kernel, strides, padding, ceil_mode, dims):
     return padding, pad_specific, c
 
 
-@with_unsupported_dtypes({"2.14.0 and below": ("bfloat16", "float64")}, backend_version)
+@with_unsupported_dtypes({"2.15.0 and below": ("bfloat16", "float64")}, backend_version)
 def avg_pool1d(
     x: Union[tf.Tensor, tf.Variable],
     kernel: Union[int, Tuple[int]],
@@ -351,7 +351,7 @@ def avg_pool1d(
 
 
 @with_unsupported_dtypes(
-    {"2.14.0 and below": ("bfloat16", "float64", "float16")}, backend_version
+    {"2.15.0 and below": ("bfloat16", "float64", "float16")}, backend_version
 )
 def avg_pool2d(
     x: Union[tf.Tensor, tf.Variable],
@@ -443,7 +443,7 @@ def avg_pool2d(
 
 
 @with_unsupported_dtypes(
-    {"2.14.0 and below": ("bfloat16", "float64", "float16")}, backend_version
+    {"2.15.0 and below": ("bfloat16", "float64", "float16")}, backend_version
 )
 def avg_pool3d(
     x: Union[tf.Tensor, tf.Variable],
@@ -548,7 +548,7 @@ def avg_pool3d(
 
 
 @with_unsupported_dtypes(
-    {"2.14.0 and below": ("bfloat16", "float64", "float16")}, backend_version
+    {"2.15.0 and below": ("bfloat16", "float64", "float16")}, backend_version
 )
 def pool(
     x: Union[tf.Tensor, tf.Variable],
@@ -574,7 +574,7 @@ def pool(
     )
 
 
-@with_supported_dtypes({"2.14.0 and below": ("float32", "float64")}, backend_version)
+@with_supported_dtypes({"2.15.0 and below": ("float32", "float64")}, backend_version)
 def dct(
     x: Union[tf.Tensor, tf.Variable],
     /,
@@ -649,7 +649,7 @@ def _ifft_norm(
 
 
 @with_supported_dtypes(
-    {"2.14.0 and below": ("complex", "float32", "float64")}, backend_version
+    {"2.15.0 and below": ("complex", "float32", "float64")}, backend_version
 )
 def fft(
     x: Union[tf.Tensor, tf.Variable],
@@ -712,7 +712,7 @@ def fft(
     return ret
 
 
-@with_unsupported_dtypes({"2.14.0 and below": ("complex",)}, backend_version)
+@with_unsupported_dtypes({"2.15.0 and below": ("complex",)}, backend_version)
 def dropout(
     x: Union[tf.Tensor, tf.Variable],
     prob: float,
@@ -854,7 +854,7 @@ def ifft(
     return ret
 
 
-@with_unsupported_dtypes({"2.14.0 and below": ("complex",)}, backend_version)
+@with_unsupported_dtypes({"2.15.0 and below": ("complex",)}, backend_version)
 def embedding(
     weights: Union[tf.Tensor, tf.Variable],
     indices: Union[tf.Tensor, tf.Variable],
@@ -1052,7 +1052,7 @@ def _fft2_helper(x, shape, axes):
     return x
 
 
-@with_supported_dtypes({"2.14.0 and below": ("complex",)}, backend_version)
+@with_supported_dtypes({"2.15.0 and below": ("complex",)}, backend_version)
 def fft2(
     x: Union[tf.Tensor, tf.Variable],
     *,
@@ -1523,7 +1523,7 @@ def rfftn(
 
 
 # stft
-@with_supported_dtypes({"2.14.0 and below": ("complex",)}, backend_version)
+@with_supported_dtypes({"2.15.0 and below": ("complex",)}, backend_version)
 def stft(
     signals: Union[tf.Tensor, tf.Variable],
     frame_length: int,

--- a/ivy/functional/backends/tensorflow/experimental/linear_algebra.py
+++ b/ivy/functional/backends/tensorflow/experimental/linear_algebra.py
@@ -12,7 +12,7 @@ from .. import backend_version
 
 
 @with_unsupported_dtypes(
-    {"2.14.0 and below": ("int", "float16", "bfloat16")}, backend_version
+    {"2.15.0 and below": ("int", "float16", "bfloat16")}, backend_version
 )
 def eigh_tridiagonal(
     alpha: Union[tf.Tensor, tf.Variable],
@@ -96,7 +96,7 @@ def matrix_exp(
 
 @with_supported_dtypes(
     {
-        "2.14.0 and below": (
+        "2.15.0 and below": (
             "complex",
             "float32",
             "float64",
@@ -115,7 +115,7 @@ def eig(
 
 @with_supported_dtypes(
     {
-        "2.14.0 and below": (
+        "2.15.0 and below": (
             "complex",
             "float32",
             "float64",
@@ -162,7 +162,7 @@ def solve_triangular(
 
 @with_supported_dtypes(
     {
-        "2.14.0 and below": (
+        "2.15.0 and below": (
             "bfloat16",
             "float16",
             "float32",
@@ -241,7 +241,7 @@ def lu_factor(
 
 @with_supported_dtypes(
     {
-        "2.14.0 and below": (
+        "2.15.0 and below": (
             "bfloat16",
             "float16",
             "float32",

--- a/ivy/functional/backends/tensorflow/experimental/losses.py
+++ b/ivy/functional/backends/tensorflow/experimental/losses.py
@@ -8,7 +8,7 @@ from ivy.func_wrapper import (
 from . import backend_version
 
 
-@with_unsupported_dtypes({"2.14.0 and below": "bool"}, backend_version)
+@with_unsupported_dtypes({"2.15.0 and below": "bool"}, backend_version)
 def huber_loss(
     input: tf.Tensor,
     target: tf.Tensor,
@@ -30,7 +30,7 @@ def huber_loss(
         return loss
 
 
-@with_unsupported_dtypes({"2.14.0 and below": "bool"}, backend_version)
+@with_unsupported_dtypes({"2.15.0 and below": "bool"}, backend_version)
 def smooth_l1_loss(
     input: tf.Tensor,
     target: tf.Tensor,
@@ -50,7 +50,7 @@ def smooth_l1_loss(
         return loss
 
 
-@with_unsupported_dtypes({"2.14.0 and below": "bool"}, backend_version)
+@with_unsupported_dtypes({"2.15.0 and below": "bool"}, backend_version)
 def soft_margin_loss(
     input: tf.Tensor,
     target: tf.Tensor,
@@ -118,7 +118,7 @@ def _validate_poisson_nll_params(
 
 @with_supported_device_and_dtypes(
     {
-        "2.14.0 and below": {
+        "2.15.0 and below": {
             "cpu": ("float32", "float64"),
             "gpu": ("float32", "float64"),
         }

--- a/ivy/functional/backends/tensorflow/experimental/manipulation.py
+++ b/ivy/functional/backends/tensorflow/experimental/manipulation.py
@@ -34,7 +34,7 @@ def moveaxis(
     return tf.experimental.numpy.moveaxis(a, source, destination)
 
 
-@with_unsupported_dtypes({"2.14.0 and below": ("bfloat16",)}, backend_version)
+@with_unsupported_dtypes({"2.15.0 and below": ("bfloat16",)}, backend_version)
 def heaviside(
     x1: Union[tf.Tensor, tf.Variable],
     x2: Union[tf.Tensor, tf.Variable],
@@ -85,7 +85,7 @@ def rot90(
     return tf.experimental.numpy.rot90(m, k, axes)
 
 
-@with_unsupported_dtypes({"2.14.0 and below": ("unsigned", "complex")}, backend_version)
+@with_unsupported_dtypes({"2.15.0 and below": ("unsigned", "complex")}, backend_version)
 def top_k(
     x: tf.Tensor,
     k: int,
@@ -127,7 +127,7 @@ def fliplr(
     return tf.experimental.numpy.fliplr(m)
 
 
-@with_unsupported_dtypes({"2.14.0 and below": ("bfloat16",)}, backend_version)
+@with_unsupported_dtypes({"2.15.0 and below": ("bfloat16",)}, backend_version)
 def i0(
     x: Union[tf.Tensor, tf.Variable],
     /,

--- a/ivy/functional/backends/tensorflow/experimental/norms.py
+++ b/ivy/functional/backends/tensorflow/experimental/norms.py
@@ -5,7 +5,7 @@ from . import backend_version
 import math
 
 
-@with_unsupported_dtypes({"2.14.0 and below": "uint8"}, backend_version)
+@with_unsupported_dtypes({"2.15.0 and below": "uint8"}, backend_version)
 def l1_normalize(
     x: Union[tf.Tensor, tf.Variable],
     /,
@@ -30,7 +30,7 @@ def l2_normalize(
     return tf.math.divide(x, denorm)
 
 
-@with_supported_dtypes({"2.14.0 and below": ("float32", "float16")}, backend_version)
+@with_supported_dtypes({"2.15.0 and below": ("float32", "float16")}, backend_version)
 def local_response_norm(
     x: Union[tf.Tensor, tf.Variable],
     size,
@@ -66,7 +66,7 @@ def local_response_norm(
 local_response_norm.partial_mixed_handler = lambda x, size, **kwargs: size % 2 != 0
 
 
-@with_unsupported_dtypes({"2.14.0 and below": ("float16", "bfloat16")}, backend_version)
+@with_unsupported_dtypes({"2.15.0 and below": ("float16", "bfloat16")}, backend_version)
 def batch_norm(
     x: Union[tf.Tensor, tf.Variable],
     mean: Union[tf.Tensor, tf.Variable],

--- a/ivy/functional/backends/tensorflow/experimental/random.py
+++ b/ivy/functional/backends/tensorflow/experimental/random.py
@@ -15,7 +15,7 @@ from ivy.functional.ivy.random import (
 # dirichlet
 @with_unsupported_dtypes(
     {
-        "2.14.0 and below": (
+        "2.15.0 and below": (
             "blfoat16",
             "float16",
         )
@@ -65,7 +65,7 @@ def gamma(
     # TODO: Implement purely in tensorflow
 
 
-@with_unsupported_dtypes({"2.14.0 and below": ("bfloat16",)}, backend_version)
+@with_unsupported_dtypes({"2.15.0 and below": ("bfloat16",)}, backend_version)
 def poisson(
     lam: Union[float, tf.Tensor, tf.Variable],
     *,

--- a/ivy/functional/backends/tensorflow/experimental/searching.py
+++ b/ivy/functional/backends/tensorflow/experimental/searching.py
@@ -9,7 +9,7 @@ from . import backend_version
 
 @with_supported_dtypes(
     {
-        "2.14.0 and below": (
+        "2.15.0 and below": (
             "int32",
             "int64",
         )

--- a/ivy/functional/backends/tensorflow/experimental/statistical.py
+++ b/ivy/functional/backends/tensorflow/experimental/statistical.py
@@ -34,7 +34,7 @@ def histogram(
 
 @with_supported_dtypes(
     {
-        "2.14.0 and below": (
+        "2.15.0 and below": (
             "float",
             "complex",
         )
@@ -275,7 +275,7 @@ def nanmedian(
 
 @with_supported_device_and_dtypes(
     {
-        "2.14.0 and below": {
+        "2.15.0 and below": {
             "cpu": (
                 "int64",
                 "int32",
@@ -310,7 +310,7 @@ def bincount(
 
 @with_supported_device_and_dtypes(
     {
-        "2.14.0 and below": {
+        "2.15.0 and below": {
             "cpu": ("float32", "float64"),
             "gpu": ("bfloat16", "float16", "float32", "float64"),
         }
@@ -323,7 +323,7 @@ def igamma(
     return tf.math.igamma(a, x)
 
 
-@with_unsupported_dtypes({"2.14.0 and below": ("float16", "bfloat16")}, backend_version)
+@with_unsupported_dtypes({"2.15.0 and below": ("float16", "bfloat16")}, backend_version)
 def cov(
     x1: tf.Tensor,
     x2: tf.Tensor = None,
@@ -426,7 +426,7 @@ def cov(
 
 
 @with_unsupported_dtypes(
-    {"2.14.0 and below": ("bool",)},
+    {"2.15.0 and below": ("bool",)},
     backend_version,
 )
 def cummax(
@@ -555,7 +555,7 @@ def __get_index(lst, indices=None, prefix=None):
 
 
 @with_unsupported_dtypes(
-    {"2.14.0 and below": ("bfloat16", "complex")},
+    {"2.15.0 and below": ("bfloat16", "complex")},
     backend_version,
 )
 def cummin(

--- a/ivy/functional/backends/tensorflow/general.py
+++ b/ivy/functional/backends/tensorflow/general.py
@@ -345,7 +345,7 @@ def scatter_flat(
 scatter_flat.support_native_out = True
 
 
-@with_unsupported_dtypes({"2.14.0 and below": ("bfloat16", "complex")}, backend_version)
+@with_unsupported_dtypes({"2.15.0 and below": ("bfloat16", "complex")}, backend_version)
 def scatter_nd(
     indices: Union[tf.Tensor, tf.Variable],
     updates: Union[tf.Tensor, tf.Variable],
@@ -505,7 +505,7 @@ def vmap(
     return _vmap
 
 
-@with_unsupported_dtypes({"2.14.0 and below": ("bfloat16", "complex")}, backend_version)
+@with_unsupported_dtypes({"2.15.0 and below": ("bfloat16", "complex")}, backend_version)
 def isin(
     elements: tf.Tensor,
     test_elements: tf.Tensor,

--- a/ivy/functional/backends/tensorflow/layers.py
+++ b/ivy/functional/backends/tensorflow/layers.py
@@ -81,7 +81,7 @@ def _output_shape(
     return output_shape
 
 
-@with_unsupported_dtypes({"2.14.0 and below": ("bfloat16", "complex")}, backend_version)
+@with_unsupported_dtypes({"2.15.0 and below": ("bfloat16", "complex")}, backend_version)
 def conv1d(
     x: Union[tf.Tensor, tf.Variable],
     filters: Union[tf.Tensor, tf.Variable],
@@ -109,7 +109,7 @@ def conv1d(
     return res
 
 
-@with_unsupported_dtypes({"2.14.0 and below": ("bfloat16", "complex")}, backend_version)
+@with_unsupported_dtypes({"2.15.0 and below": ("bfloat16", "complex")}, backend_version)
 def conv1d_transpose(
     x: Union[tf.Tensor, tf.Variable],
     filters: Union[tf.Tensor, tf.Variable],
@@ -145,7 +145,7 @@ def conv1d_transpose(
     return res
 
 
-@with_supported_dtypes({"2.14.0 and below": ("float", "int32")}, backend_version)
+@with_supported_dtypes({"2.15.0 and below": ("float", "int32")}, backend_version)
 def conv2d(
     x: Union[tf.Tensor, tf.Variable],
     filters: Union[tf.Tensor, tf.Variable],
@@ -185,7 +185,7 @@ def conv2d(
     return res
 
 
-@with_unsupported_dtypes({"2.14.0 and below": ("bfloat16", "complex")}, backend_version)
+@with_unsupported_dtypes({"2.15.0 and below": ("bfloat16", "complex")}, backend_version)
 def conv2d_transpose(
     x: Union[tf.Tensor, tf.Variable],
     filters: Union[tf.Tensor, tf.Variable],
@@ -220,7 +220,7 @@ def conv2d_transpose(
     return res
 
 
-@with_unsupported_dtypes({"2.14.0 and below": ("bfloat16", "complex")}, backend_version)
+@with_unsupported_dtypes({"2.15.0 and below": ("bfloat16", "complex")}, backend_version)
 def depthwise_conv2d(
     x: Union[tf.Tensor, tf.Variable],
     filters: Union[tf.Tensor, tf.Variable],
@@ -246,7 +246,7 @@ def depthwise_conv2d(
     return res
 
 
-@with_unsupported_dtypes({"2.14.0 and below": ("bfloat16", "complex")}, backend_version)
+@with_unsupported_dtypes({"2.15.0 and below": ("bfloat16", "complex")}, backend_version)
 def conv3d(
     x: Union[tf.Tensor, tf.Variable],
     filters: Union[tf.Tensor, tf.Variable],
@@ -278,7 +278,7 @@ def conv3d(
     return res
 
 
-@with_unsupported_dtypes({"2.14.0 and below": ("bfloat16", "complex")}, backend_version)
+@with_unsupported_dtypes({"2.15.0 and below": ("bfloat16", "complex")}, backend_version)
 def conv3d_transpose(
     x: Tensor,
     filters: Tensor,
@@ -317,7 +317,7 @@ def conv3d_transpose(
     return res
 
 
-@with_unsupported_dtypes({"2.14.0 and below": ("bfloat16", "complex")}, backend_version)
+@with_unsupported_dtypes({"2.15.0 and below": ("bfloat16", "complex")}, backend_version)
 def conv_general_dilated(
     x: Union[tf.Tensor, tf.Variable],
     filters: Union[tf.Tensor, tf.Variable],
@@ -430,7 +430,7 @@ def conv_general_dilated(
     return res
 
 
-@with_unsupported_dtypes({"2.14.0 and below": ("bfloat16", "complex")}, backend_version)
+@with_unsupported_dtypes({"2.15.0 and below": ("bfloat16", "complex")}, backend_version)
 def conv_general_transpose(
     x: Union[tf.Tensor, tf.Variable],
     filters: Union[tf.Tensor, tf.Variable],

--- a/ivy/functional/backends/tensorflow/linear_algebra.py
+++ b/ivy/functional/backends/tensorflow/linear_algebra.py
@@ -17,7 +17,7 @@ from . import backend_version
 # -------------------#
 
 
-@with_unsupported_dtypes({"2.14.0 and below": ("float16", "bfloat16")}, backend_version)
+@with_unsupported_dtypes({"2.15.0 and below": ("float16", "bfloat16")}, backend_version)
 def cholesky(
     x: Union[tf.Tensor, tf.Variable],
     /,
@@ -35,7 +35,7 @@ def cholesky(
 
 @with_unsupported_dtypes(
     {
-        "2.14.0 and below": (
+        "2.15.0 and below": (
             "complex",
             "float16",
         )
@@ -61,7 +61,7 @@ def cross(
 
 @with_unsupported_dtypes(
     {
-        "2.14.0 and below": (
+        "2.15.0 and below": (
             "float16",
             "bfloat16",
         )
@@ -77,7 +77,7 @@ def det(
     return tf.linalg.det(x)
 
 
-@with_unsupported_dtypes({"2.14.0 and below": ("complex",)}, backend_version)
+@with_unsupported_dtypes({"2.15.0 and below": ("complex",)}, backend_version)
 def diagonal(
     x: Union[tf.Tensor, tf.Variable],
     /,
@@ -90,7 +90,7 @@ def diagonal(
     return tf.experimental.numpy.diagonal(x, offset, axis1=axis1, axis2=axis2)
 
 
-@with_unsupported_dtypes({"2.14.0 and below": ("float16", "bfloat16")}, backend_version)
+@with_unsupported_dtypes({"2.15.0 and below": ("float16", "bfloat16")}, backend_version)
 def eig(
     x: Union[tf.Tensor, tf.Variable],
     /,
@@ -108,7 +108,7 @@ def eig(
     return result_tuple(eigenvalues, eigenvectors)
 
 
-@with_unsupported_dtypes({"2.14.0 and below": ("float16", "bfloat16")}, backend_version)
+@with_unsupported_dtypes({"2.15.0 and below": ("float16", "bfloat16")}, backend_version)
 def eigh(
     x: Union[tf.Tensor, tf.Variable],
     /,
@@ -135,7 +135,7 @@ def eigh(
     return result_tuple(eigenvalues, eigenvectors)
 
 
-@with_unsupported_dtypes({"2.14.0 and below": ("float16", "bfloat16")}, backend_version)
+@with_unsupported_dtypes({"2.15.0 and below": ("float16", "bfloat16")}, backend_version)
 def eigvalsh(
     x: Union[tf.Tensor, tf.Variable],
     /,
@@ -156,7 +156,7 @@ def eigvalsh(
 
 @with_unsupported_dtypes(
     {
-        "2.14.0 and below": (
+        "2.15.0 and below": (
             "int8",
             "uint8",
             "int16",
@@ -182,7 +182,7 @@ def inner(
 
 @with_unsupported_dtypes(
     {
-        "2.14.0 and below": (
+        "2.15.0 and below": (
             "float16",
             "bfloat16",
         )
@@ -200,7 +200,7 @@ def inv(
 
 
 @with_unsupported_dtypes(
-    {"2.14.0 and below": ("float16", "bfloat16", "bool")}, backend_version
+    {"2.15.0 and below": ("float16", "bfloat16", "bool")}, backend_version
 )
 def matmul(
     x1: Union[tf.Tensor, tf.Variable],
@@ -279,7 +279,7 @@ def matmul(
 
 
 @with_supported_dtypes(
-    {"2.14.0 and below": ("float32", "float64", "complex")}, backend_version
+    {"2.15.0 and below": ("float32", "float64", "complex")}, backend_version
 )
 def matrix_norm(
     x: Union[tf.Tensor, tf.Variable],
@@ -323,7 +323,7 @@ def matrix_norm(
     return ret
 
 
-@with_unsupported_dtypes({"2.14.0 and below": ("float16", "bfloat16")}, backend_version)
+@with_unsupported_dtypes({"2.15.0 and below": ("float16", "bfloat16")}, backend_version)
 def matrix_power(
     x: Union[tf.Tensor, tf.Variable],
     n: int,
@@ -356,7 +356,7 @@ def matrix_power(
 
 
 @with_unsupported_dtypes(
-    {"2.14.0 and below": ("bfloat16", "float16", "complex")},
+    {"2.15.0 and below": ("bfloat16", "float16", "complex")},
     backend_version,
 )
 # noinspection PyPep8Naming
@@ -394,7 +394,7 @@ def matrix_rank(
 
 @with_unsupported_dtypes(
     {
-        "2.14.0 and below": (
+        "2.15.0 and below": (
             "float16",
             "int8",
             "int16",
@@ -421,7 +421,7 @@ def matrix_transpose(
 
 
 # noinspection PyUnusedLocal,PyShadowingBuiltins
-@with_unsupported_dtypes({"2.14.0 and below": ("complex",)}, backend_version)
+@with_unsupported_dtypes({"2.15.0 and below": ("complex",)}, backend_version)
 def outer(
     x1: Union[tf.Tensor, tf.Variable],
     x2: Union[tf.Tensor, tf.Variable],
@@ -434,7 +434,7 @@ def outer(
 
 
 @with_unsupported_dtypes(
-    {"2.14.0 and below": ("bfloat16", "float16", "complex")},
+    {"2.15.0 and below": ("bfloat16", "float16", "complex")},
     backend_version,
 )
 def pinv(
@@ -452,7 +452,7 @@ def pinv(
     return ret
 
 
-@with_unsupported_dtypes({"2.14.0 and below": ("float16", "bfloat16")}, backend_version)
+@with_unsupported_dtypes({"2.15.0 and below": ("float16", "bfloat16")}, backend_version)
 def qr(
     x: Union[tf.Tensor, tf.Variable],
     /,
@@ -477,7 +477,7 @@ def qr(
     return ret
 
 
-@with_unsupported_dtypes({"2.14.0 and below": ("float16", "bfloat16")}, backend_version)
+@with_unsupported_dtypes({"2.15.0 and below": ("float16", "bfloat16")}, backend_version)
 def slogdet(
     x: Union[tf.Tensor, tf.Variable],
     /,
@@ -488,7 +488,7 @@ def slogdet(
 
 
 @with_unsupported_dtypes(
-    {"2.14.0 and below": ("bfloat16", "float16", "complex")},
+    {"2.15.0 and below": ("bfloat16", "float16", "complex")},
     backend_version,
 )
 def solve(
@@ -531,7 +531,7 @@ def solve(
 
 
 @with_unsupported_dtypes(
-    {"2.14.0 and below": ("bfloat16", "float16", "complex")},
+    {"2.15.0 and below": ("bfloat16", "float16", "complex")},
     backend_version,
 )
 def svd(
@@ -559,7 +559,7 @@ def svd(
         return results(D)
 
 
-@with_unsupported_dtypes({"2.14.0 and below": ("float16", "bfloat16")}, backend_version)
+@with_unsupported_dtypes({"2.15.0 and below": ("float16", "bfloat16")}, backend_version)
 def svdvals(
     x: Union[tf.Tensor, tf.Variable],
     /,
@@ -572,7 +572,7 @@ def svdvals(
     return ret
 
 
-@with_supported_dtypes({"2.14.0 and below": ("float32",)}, backend_version)
+@with_supported_dtypes({"2.15.0 and below": ("float32",)}, backend_version)
 def tensordot(
     x1: Union[tf.Tensor, tf.Variable],
     x2: Union[tf.Tensor, tf.Variable],
@@ -587,7 +587,7 @@ def tensordot(
 
 
 @with_unsupported_dtypes(
-    {"2.14.0 and below": ("bfloat16", "float16", "complex")},
+    {"2.15.0 and below": ("bfloat16", "float16", "complex")},
     backend_version,
 )
 def trace(
@@ -606,7 +606,7 @@ def trace(
 
 
 @with_unsupported_dtypes(
-    {"2.14.0 and below": ("int16", "int8", "bool", "unsigned")}, backend_version
+    {"2.15.0 and below": ("int16", "int8", "bool", "unsigned")}, backend_version
 )
 def vecdot(
     x1: Union[tf.Tensor, tf.Variable],
@@ -622,7 +622,7 @@ def vecdot(
 
 @with_unsupported_dtypes(
     {
-        "2.14.0 and below": (
+        "2.15.0 and below": (
             "float16",
             "bfloat16",
             "integer",
@@ -657,7 +657,7 @@ def vector_norm(
 # ----- #
 
 
-@with_unsupported_dtypes({"2.14.0 and below": ("complex",)}, backend_version)
+@with_unsupported_dtypes({"2.15.0 and below": ("complex",)}, backend_version)
 def diag(
     x: Union[tf.Tensor, tf.Variable],
     /,
@@ -669,7 +669,7 @@ def diag(
 
 
 @with_unsupported_dtypes(
-    {"2.14.0 and below": ("bfloat16", "float16", "complex", "unsigned")},
+    {"2.15.0 and below": ("bfloat16", "float16", "complex", "unsigned")},
     backend_version,
 )
 def vander(
@@ -685,7 +685,7 @@ def vander(
 
 @with_unsupported_dtypes(
     {
-        "2.14.0 and below": (
+        "2.15.0 and below": (
             "int8",
             "int16",
             "int32",

--- a/ivy/functional/backends/tensorflow/manipulation.py
+++ b/ivy/functional/backends/tensorflow/manipulation.py
@@ -105,7 +105,7 @@ def permute_dims(
     return tf.transpose(x, perm=axes)
 
 
-@with_unsupported_dtypes({"2.14.0 and below": ("bool",)}, backend_version)
+@with_unsupported_dtypes({"2.15.0 and below": ("bool",)}, backend_version)
 def reshape(
     x: Union[tf.Tensor, tf.Variable],
     /,
@@ -185,7 +185,7 @@ def squeeze(
     return ret
 
 
-@with_unsupported_dtypes({"2.14.0 and below": ("bfloat16",)}, backend_version)
+@with_unsupported_dtypes({"2.15.0 and below": ("bfloat16",)}, backend_version)
 def stack(
     arrays: Union[Tuple[tf.Tensor], List[tf.Tensor]],
     /,
@@ -252,7 +252,7 @@ def repeat(
 
 @with_unsupported_dtypes(
     {
-        "2.14.0 and below": (
+        "2.15.0 and below": (
             "uint8",
             "uint16",
             "uint32",
@@ -323,7 +323,7 @@ def swapaxes(
     return tf.transpose(x, config)
 
 
-@with_unsupported_dtypes({"2.14.0 and below": ("complex",)}, backend_version)
+@with_unsupported_dtypes({"2.15.0 and below": ("complex",)}, backend_version)
 def clip(
     x: Union[tf.Tensor, tf.Variable],
     /,

--- a/ivy/functional/backends/tensorflow/random.py
+++ b/ivy/functional/backends/tensorflow/random.py
@@ -27,7 +27,7 @@ from . import backend_version
 
 
 @with_supported_dtypes(
-    {"2.14.0 and below": ("float", "int32", "int64")}, backend_version
+    {"2.15.0 and below": ("float", "int32", "int64")}, backend_version
 )
 def random_uniform(
     *,
@@ -66,7 +66,7 @@ def random_normal(
     return tf.random.normal(shape, mean, std, dtype=dtype, seed=seed)
 
 
-@with_unsupported_dtypes({"2.14.0 and below": ("bfloat16",)}, backend_version)
+@with_unsupported_dtypes({"2.15.0 and below": ("bfloat16",)}, backend_version)
 def multinomial(
     population_size: int,
     num_samples: int,

--- a/ivy/functional/backends/tensorflow/searching.py
+++ b/ivy/functional/backends/tensorflow/searching.py
@@ -12,7 +12,7 @@ from . import backend_version
 # ------------------ #
 
 
-@with_unsupported_dtypes({"2.14.0 and below": ("complex",)}, backend_version)
+@with_unsupported_dtypes({"2.15.0 and below": ("complex",)}, backend_version)
 def argmax(
     x: Union[tf.Tensor, tf.Variable],
     /,

--- a/ivy/functional/backends/tensorflow/set.py
+++ b/ivy/functional/backends/tensorflow/set.py
@@ -6,7 +6,7 @@ from ivy.func_wrapper import with_unsupported_dtypes
 from . import backend_version
 
 
-@with_unsupported_dtypes({"2.14.0 and below": ("complex",)}, backend_version)
+@with_unsupported_dtypes({"2.15.0 and below": ("complex",)}, backend_version)
 def unique_all(
     x: Union[tf.Tensor, tf.Variable],
     /,
@@ -78,7 +78,7 @@ def unique_all(
     )
 
 
-@with_unsupported_dtypes({"2.14.0 and below": ("complex",)}, backend_version)
+@with_unsupported_dtypes({"2.15.0 and below": ("complex",)}, backend_version)
 def unique_counts(
     x: Union[tf.Tensor, tf.Variable],
     /,
@@ -90,7 +90,7 @@ def unique_counts(
     return Results(v, c)
 
 
-@with_unsupported_dtypes({"2.14.0 and below": ("complex",)}, backend_version)
+@with_unsupported_dtypes({"2.15.0 and below": ("complex",)}, backend_version)
 def unique_inverse(
     x: Union[tf.Tensor, tf.Variable],
     /,
@@ -113,7 +113,7 @@ def unique_inverse(
     return Results(values, inverse_indices)
 
 
-@with_unsupported_dtypes({"2.14.0 and below": ("complex",)}, backend_version)
+@with_unsupported_dtypes({"2.15.0 and below": ("complex",)}, backend_version)
 def unique_values(
     x: Union[tf.Tensor, tf.Variable],
     /,

--- a/ivy/functional/backends/tensorflow/sorting.py
+++ b/ivy/functional/backends/tensorflow/sorting.py
@@ -8,7 +8,7 @@ from ivy.func_wrapper import with_unsupported_dtypes
 from . import backend_version
 
 
-@with_unsupported_dtypes({"2.14.0 and below": ("complex", "bool")}, backend_version)
+@with_unsupported_dtypes({"2.15.0 and below": ("complex", "bool")}, backend_version)
 def argsort(
     x: Union[tf.Tensor, tf.Variable],
     /,
@@ -24,7 +24,7 @@ def argsort(
     return tf.cast(ret, dtype=tf.int64)
 
 
-@with_unsupported_dtypes({"2.14.0 and below": ("complex", "bool")}, backend_version)
+@with_unsupported_dtypes({"2.15.0 and below": ("complex", "bool")}, backend_version)
 def sort(
     x: Union[tf.Tensor, tf.Variable],
     /,
@@ -43,7 +43,7 @@ def sort(
 
 
 # msort
-@with_unsupported_dtypes({"2.14.0 and below": ("complex", "bool")}, backend_version)
+@with_unsupported_dtypes({"2.15.0 and below": ("complex", "bool")}, backend_version)
 def msort(
     a: Union[tf.Tensor, tf.Variable, list, tuple],
     /,
@@ -53,7 +53,7 @@ def msort(
     return tf.sort(a, axis=0)
 
 
-@with_unsupported_dtypes({"2.14.0 and below": ("complex",)}, backend_version)
+@with_unsupported_dtypes({"2.15.0 and below": ("complex",)}, backend_version)
 def searchsorted(
     x: Union[tf.Tensor, tf.Variable],
     v: Union[tf.Tensor, tf.Variable],

--- a/ivy/functional/backends/tensorflow/statistical.py
+++ b/ivy/functional/backends/tensorflow/statistical.py
@@ -12,7 +12,7 @@ from ivy.utils.einsum_parser import legalise_einsum_expr
 # -------------------#
 
 
-@with_unsupported_dtypes({"2.14.0 and below": ("complex",)}, backend_version)
+@with_unsupported_dtypes({"2.15.0 and below": ("complex",)}, backend_version)
 def min(
     x: Union[tf.Tensor, tf.Variable],
     /,
@@ -51,7 +51,7 @@ def max(
     return tf.math.reduce_max(x, axis=axis, keepdims=keepdims)
 
 
-@with_unsupported_dtypes({"2.14.0 and below": ("bool",)}, backend_version)
+@with_unsupported_dtypes({"2.15.0 and below": ("bool",)}, backend_version)
 def mean(
     x: Union[tf.Tensor, tf.Variable],
     /,
@@ -163,7 +163,7 @@ def var(
 # ------#
 
 
-@with_unsupported_dtypes({"2.14.0 and below": "bfloat16"}, backend_version)
+@with_unsupported_dtypes({"2.15.0 and below": "bfloat16"}, backend_version)
 def cumprod(
     x: Union[tf.Tensor, tf.Variable],
     /,
@@ -208,7 +208,7 @@ def cumsum(
 
 
 @with_unsupported_dtypes(
-    {"2.14.0 and below": ("unsigned", "int8", "int16")},
+    {"2.15.0 and below": ("unsigned", "int8", "int16")},
     backend_version,
 )
 def einsum(

--- a/ivy/functional/backends/tensorflow/sub_backends/tf_probability/experimental/random.py
+++ b/ivy/functional/backends/tensorflow/sub_backends/tf_probability/experimental/random.py
@@ -81,7 +81,7 @@ def bernoulli(
 # dirichlet
 @with_unsupported_dtypes(
     {
-        "2.14.0 and below": (
+        "2.15.0 and below": (
             "blfoat16",
             "float16",
         )

--- a/ivy/functional/backends/tensorflow/sub_backends/tf_probability/experimental/statistical.py
+++ b/ivy/functional/backends/tensorflow/sub_backends/tf_probability/experimental/statistical.py
@@ -75,7 +75,7 @@ def histogram(
 
 @with_supported_dtypes(
     {
-        "2.14.0 and below": (
+        "2.15.0 and below": (
             "float",
             "complex",
         )

--- a/ivy/functional/backends/torch/experimental/losses.py
+++ b/ivy/functional/backends/torch/experimental/losses.py
@@ -124,7 +124,7 @@ def kl_div(
 
 @with_supported_device_and_dtypes(
     {
-        "2.14.0 and below": {
+        "2.15.0 and below": {
             "cpu": (
                 "float32",
                 "float64",

--- a/ivy/functional/frontends/__init__.py
+++ b/ivy/functional/frontends/__init__.py
@@ -3,7 +3,7 @@ import importlib
 
 versions = {
     "torch": "2.1.0",
-    "tensorflow": "2.14.0",
+    "tensorflow": "2.15.0",
     "numpy": "1.25.2",
     "jax": "0.4.14",
     "scipy": "1.10.1",

--- a/ivy/functional/frontends/jax/numpy/dtype.py
+++ b/ivy/functional/frontends/jax/numpy/dtype.py
@@ -73,7 +73,7 @@ def can_cast(from_, to, casting="safe"):
 
 
 @with_supported_dtypes(
-    {"2.14.0 and below": ("float16", "float32", "float64")},
+    {"2.15.0 and below": ("float16", "float32", "float64")},
     "jax",
 )
 @to_ivy_arrays_and_back
@@ -82,7 +82,7 @@ def finfo(dtype):
 
 
 @with_supported_dtypes(
-    {"2.14.0 and below": ("integer",)},
+    {"2.15.0 and below": ("integer",)},
     "jax",
 )
 @to_ivy_arrays_and_back

--- a/ivy/functional/frontends/tensorflow/compat/v1/nn.py
+++ b/ivy/functional/frontends/tensorflow/compat/v1/nn.py
@@ -5,7 +5,7 @@ from ivy.func_wrapper import with_supported_dtypes, with_unsupported_dtypes
 import ivy.functional.frontends.tensorflow.nn as tf_nn
 
 
-@with_unsupported_dtypes({"2.14.0 and below": ("float16",)}, "tensorflow")
+@with_unsupported_dtypes({"2.15.0 and below": ("float16",)}, "tensorflow")
 def depthwise_conv2d(
     input,
     filter,
@@ -30,7 +30,7 @@ def depthwise_conv2d(
 
 # should have float16 as well but sqrt doesn't support it
 @to_ivy_arrays_and_back
-@with_supported_dtypes({"2.14.0 and below": ("float32",)}, "tensorflow")
+@with_supported_dtypes({"2.15.0 and below": ("float32",)}, "tensorflow")
 def fused_batch_norm(
     x,
     scale,
@@ -105,7 +105,7 @@ def fused_batch_norm(
 
 @to_ivy_arrays_and_back
 @with_unsupported_dtypes(
-    {"2.14.0 and below": ("float16",)},
+    {"2.15.0 and below": ("float16",)},
     "tensorflow",
 )
 def max_pool(value, ksize, strides, padding, data_format="NHWC", name=None, input=None):
@@ -124,7 +124,7 @@ def max_pool(value, ksize, strides, padding, data_format="NHWC", name=None, inpu
 
 @with_unsupported_dtypes(
     {
-        "2.14.0 and below": (
+        "2.15.0 and below": (
             "float16",
             "bfloat16",
         )

--- a/ivy/functional/frontends/tensorflow/general_functions.py
+++ b/ivy/functional/frontends/tensorflow/general_functions.py
@@ -62,7 +62,7 @@ def boolean_mask(tensor, mask, axis=None, name=None):
         return ivy.get_item(tensor, mask)
 
 
-@with_supported_dtypes({"2.14.0 and below": ("float32",)}, "tensorflow")
+@with_supported_dtypes({"2.15.0 and below": ("float32",)}, "tensorflow")
 @to_ivy_arrays_and_back
 def clip_by_global_norm(t_list, clip_norm, use_norm=None):
     if use_norm is not None:
@@ -76,7 +76,7 @@ def clip_by_global_norm(t_list, clip_norm, use_norm=None):
     ], global_norm
 
 
-@with_supported_dtypes({"2.14.0 and below": ("float", "complex")}, "tensorflow")
+@with_supported_dtypes({"2.15.0 and below": ("float", "complex")}, "tensorflow")
 @to_ivy_arrays_and_back
 def clip_by_norm(t, clip_norm, axes=None):
     t, clip_norm = check_tensorflow_casting(t, clip_norm)
@@ -95,7 +95,7 @@ def clip_by_norm(t, clip_norm, axes=None):
 
 
 @to_ivy_arrays_and_back
-@with_unsupported_dtypes({"2.14.0 and below": ("float16",)}, "tensorflow")
+@with_unsupported_dtypes({"2.15.0 and below": ("float16",)}, "tensorflow")
 def clip_by_value(t, clip_value_min, clip_value_max):
     ivy.utils.assertions.check_all_or_any_fn(
         clip_value_min,
@@ -170,7 +170,7 @@ def expand_dims(input, axis, name=None):
     return ivy.expand_dims(input, axis=axis)
 
 
-@with_unsupported_dtypes({"2.14.0 and below": ("float16", "bfloat16")}, "tensorflow")
+@with_unsupported_dtypes({"2.15.0 and below": ("float16", "bfloat16")}, "tensorflow")
 @handle_tf_dtype
 @to_ivy_arrays_and_back
 def eye(num_rows, num_columns=None, batch_shape=None, dtype=ivy.float32, name=None):
@@ -299,7 +299,7 @@ def no_op(name=None):
     return
 
 
-@with_supported_dtypes({"2.14.0 and below": ("float32", "float64")}, "tensorflow")
+@with_supported_dtypes({"2.15.0 and below": ("float32", "float64")}, "tensorflow")
 @to_ivy_arrays_and_back
 def norm(tensor, ord="euclidean", axis=None, keepdims=None, name=None):
     return tf_frontend.linalg.norm(
@@ -321,7 +321,7 @@ def one_hot(
     return ivy.one_hot(indices, depth)
 
 
-@with_unsupported_dtypes({"2.14.0 and below": ("float16", "bfloat16")}, "tensorflow")
+@with_unsupported_dtypes({"2.15.0 and below": ("float16", "bfloat16")}, "tensorflow")
 @handle_tf_dtype
 @to_ivy_arrays_and_back
 def ones(shape, dtype=ivy.float32, name=None):
@@ -340,7 +340,7 @@ def pad(tensor, paddings, mode="CONSTANT", constant_values=0, name=None):
     return ivy.pad(tensor, paddings, mode=mode.lower(), constant_values=constant_values)
 
 
-@with_unsupported_dtypes({"2.14.0 and below": ("float16", "bfloat16")}, "tensorflow")
+@with_unsupported_dtypes({"2.15.0 and below": ("float16", "bfloat16")}, "tensorflow")
 @handle_tf_dtype
 @to_ivy_arrays_and_back
 def range(start, limit=None, delta=1, dtype=None, name=None):
@@ -352,7 +352,7 @@ def rank(input, **kwargs):
     return ivy.astype(ivy.array(input.ndim), ivy.int32)
 
 
-@with_unsupported_dtypes({"2.14.0 and below": ("unsigned", "integer")}, "tensorflow")
+@with_unsupported_dtypes({"2.15.0 and below": ("unsigned", "integer")}, "tensorflow")
 @to_ivy_arrays_and_back
 def realdiv(x, y, name=None):
     x, y = check_tensorflow_casting(x, y)
@@ -410,7 +410,7 @@ def searchsorted(sorted_sequence, values, side="left", out_type="int32"):
 
 
 @with_supported_dtypes(
-    {"2.14.0 and below": ("int8", "int16", "int32", "int64")}, "tensorflow"
+    {"2.15.0 and below": ("int8", "int16", "int32", "int64")}, "tensorflow"
 )
 @to_ivy_arrays_and_back
 def sequence_mask(lengths, maxlen=None, dtype=ivy.bool, name=None):
@@ -483,7 +483,7 @@ def sort(values, axis=-1, direction="ASCENDING", name=None):
 
 
 @with_unsupported_dtypes(
-    {"2.14.0 and below": ("uint8", "uint16", "uint32", "uint64", "int16")}, "tensorflow"
+    {"2.15.0 and below": ("uint8", "uint16", "uint32", "uint64", "int16")}, "tensorflow"
 )
 @to_ivy_arrays_and_back
 def split(value, num_or_size_splits, axis=0, num=None, name=None):
@@ -620,7 +620,7 @@ def tensor_scatter_nd_add(tensor, indices, updates, name=None):
     return ivy.add(tensor, scatter_tensor)
 
 
-@with_unsupported_dtypes({"2.14.0 and below": ("uint16",)}, "tensorflow")
+@with_unsupported_dtypes({"2.15.0 and below": ("uint16",)}, "tensorflow")
 @to_ivy_arrays_and_back
 def tile(input, multiples, name=None):
     return ivy.tile(input, multiples)
@@ -636,14 +636,14 @@ def transpose(a, perm=None, conjugate=False, name="transpose"):
     return ivy.permute_dims(a, axes=perm)
 
 
-@with_unsupported_dtypes({"2.14.0 and below": ("float16", "bfloat16")}, "tensorflow")
+@with_unsupported_dtypes({"2.15.0 and below": ("float16", "bfloat16")}, "tensorflow")
 @to_ivy_arrays_and_back
 def truncatediv(x, y, name=None):
     return x.trunc_divide(y)
 
 
 @with_unsupported_dtypes(
-    {"2.14.0 and below": ("int16", "int8", "uint8", " uint16")}, "tensorflow"
+    {"2.15.0 and below": ("int16", "int8", "uint8", " uint16")}, "tensorflow"
 )
 @to_ivy_arrays_and_back
 def truncatemod(x, y):
@@ -704,7 +704,7 @@ def unravel_index(indices, dims, out=None, name=None):
     return ivy.unravel_index(indices, dims, out=out)
 
 
-@with_unsupported_dtypes({"2.14.0 and below": ("float16", "bfloat16")}, "tensorflow")
+@with_unsupported_dtypes({"2.15.0 and below": ("float16", "bfloat16")}, "tensorflow")
 @to_ivy_arrays_and_back
 def unstack(value: ivy.Array, axis=0, num=None, name=None):
     return ivy.unstack(value, axis=axis)
@@ -739,7 +739,7 @@ def zeros(shape, dtype=ivy.float32, name=None):
     return ivy.zeros(shape=shape, dtype=dtype)
 
 
-@with_unsupported_dtypes({"2.14.0 and below": ("float16", "bfloat16")}, "tensorflow")
+@with_unsupported_dtypes({"2.15.0 and below": ("float16", "bfloat16")}, "tensorflow")
 @to_ivy_arrays_and_back
 def zeros_initializer(shape, dtype=None, name=None):
     # todo internal: fix behaviour

--- a/ivy/functional/frontends/tensorflow/image/cropping.py
+++ b/ivy/functional/frontends/tensorflow/image/cropping.py
@@ -7,7 +7,7 @@ from ivy.functional.frontends.tensorflow.func_wrapper import to_ivy_arrays_and_b
 from ivy.func_wrapper import with_supported_dtypes
 
 
-@with_supported_dtypes({"2.14.0 and below": ("float",)}, "tensorflow")
+@with_supported_dtypes({"2.15.0 and below": ("float",)}, "tensorflow")
 @to_ivy_arrays_and_back
 def extract_patches(images, sizes, strides, rates, padding):
     depth = images.shape[-1]

--- a/ivy/functional/frontends/tensorflow/keras/activations.py
+++ b/ivy/functional/frontends/tensorflow/keras/activations.py
@@ -17,7 +17,7 @@ ACTIVATION_FUNCTIONS = [
 
 
 @with_supported_dtypes(
-    {"2.14.0 and below": ("float16", "float32", "float64")},
+    {"2.15.0 and below": ("float16", "float32", "float64")},
     "tensorflow",
 )
 def deserialize(name, custom_objects=None):
@@ -47,7 +47,7 @@ def deserialize(name, custom_objects=None):
 
 
 @with_supported_dtypes(
-    {"2.14.0 and below": ("bfloat16", "float16", "float32", "float64")},
+    {"2.15.0 and below": ("bfloat16", "float16", "float32", "float64")},
     "tensorflow",
 )
 @to_ivy_arrays_and_back
@@ -103,7 +103,7 @@ def relu(x, alpha=0.0, max_value=None, threshold=0.0):
 
 
 @with_supported_dtypes(
-    {"2.14.0 and below": ("float16", "float32", "float64")},
+    {"2.15.0 and below": ("float16", "float32", "float64")},
     "tensorflow",
 )
 @to_ivy_arrays_and_back
@@ -112,7 +112,7 @@ def selu(x):
 
 
 @with_supported_dtypes(
-    {"2.14.0 and below": ("float16", "float32", "float64")},
+    {"2.15.0 and below": ("float16", "float32", "float64")},
     "tensorflow",
 )
 def serialize(activation, use_legacy_format=False, custom_objects=None):

--- a/ivy/functional/frontends/tensorflow/linalg.py
+++ b/ivy/functional/frontends/tensorflow/linalg.py
@@ -38,7 +38,7 @@ def cholesky(input, name=None):
 
 
 @to_ivy_arrays_and_back
-@with_unsupported_dtypes({"2.14.0 and below": ("float16", "bfloat16")}, "tensorflow")
+@with_unsupported_dtypes({"2.15.0 and below": ("float16", "bfloat16")}, "tensorflow")
 def cholesky_solve(chol, rhs, name=None):
     chol, rhs = check_tensorflow_casting(chol, rhs)
     y = ivy.solve(chol, rhs)
@@ -107,7 +107,7 @@ def eigh(tensor, name=None):
 
 @to_ivy_arrays_and_back
 @with_supported_dtypes(
-    {"2.14.0 and below": ("float32", "float64", "complex64", "complex128")},
+    {"2.15.0 and below": ("float32", "float64", "complex64", "complex128")},
     "tensorflow",
 )
 def eigvals(tensor, name=None):
@@ -130,12 +130,12 @@ def expm(input, name=None):
 
 @handle_tf_dtype
 @to_ivy_arrays_and_back
-@with_unsupported_dtypes({"2.14.0 and below": ("float16", "bfloat16")}, "tensorflow")
+@with_unsupported_dtypes({"2.15.0 and below": ("float16", "bfloat16")}, "tensorflow")
 def eye(num_rows, num_columns=None, batch_shape=None, dtype=ivy.float32, name=None):
     return ivy.eye(num_rows, num_columns, batch_shape=batch_shape, dtype=dtype)
 
 
-@with_supported_dtypes({"2.14.0 and below": ("float32", "float64")}, "tensorflow")
+@with_supported_dtypes({"2.15.0 and below": ("float32", "float64")}, "tensorflow")
 @to_ivy_arrays_and_back
 def global_norm(t_list, name=None):
     l2_norms = [ivy.sqrt(ivy.sum(ivy.square(t))) ** 2 for t in t_list if t is not None]
@@ -145,7 +145,7 @@ def global_norm(t_list, name=None):
 @to_ivy_arrays_and_back
 @with_supported_dtypes(
     {
-        "2.14.0 and below": (
+        "2.15.0 and below": (
             "float32",
             "float64",
             "complex64",
@@ -159,7 +159,7 @@ def inv(input, adjoint=False, name=None):
 
 
 @to_ivy_arrays_and_back
-@with_supported_dtypes({"2.14.0 and below": ("float32", "float64")}, "tensorflow")
+@with_supported_dtypes({"2.15.0 and below": ("float32", "float64")}, "tensorflow")
 def l2_normalize(x, axis=None, epsilon=1e-12, name=None):
     square_sum = ivy.sum(ivy.square(x), axis=axis, keepdims=True)
     x_inv_norm = ivy.reciprocal(ivy.sqrt(ivy.maximum(square_sum, epsilon)))
@@ -168,7 +168,7 @@ def l2_normalize(x, axis=None, epsilon=1e-12, name=None):
 
 @to_ivy_arrays_and_back
 @with_supported_dtypes(
-    {"2.14.0 and below": ("float16", "float32", "float64", "complex64", "complex128")},
+    {"2.15.0 and below": ("float16", "float32", "float64", "complex64", "complex128")},
     "tensorflow",
 )
 def logdet(matrix, name=None):
@@ -185,7 +185,7 @@ def lu_matrix_inverse(lower_upper, perm, validate_args=False, name=None):
 @to_ivy_arrays_and_back
 @with_supported_dtypes(
     {
-        "2.14.0 and below": (
+        "2.15.0 and below": (
             "float16",
             "float32",
             "float64",
@@ -244,7 +244,7 @@ def matrix_transpose(a, name="matrix_transpose", conjugate=False):
     return ivy.matrix_transpose(a)
 
 
-@with_supported_dtypes({"2.14.0 and below": ("float32", "float64")}, "tensorflow")
+@with_supported_dtypes({"2.15.0 and below": ("float32", "float64")}, "tensorflow")
 @to_ivy_arrays_and_back
 def norm(tensor, ord="euclidean", axis=None, keepdims=None, name=None):
     keepdims = keepdims or False
@@ -257,7 +257,7 @@ def norm(tensor, ord="euclidean", axis=None, keepdims=None, name=None):
 
 
 @to_ivy_arrays_and_back
-@with_supported_dtypes({"2.14.0 and below": ("float32", "float64")}, "tensorflow")
+@with_supported_dtypes({"2.15.0 and below": ("float32", "float64")}, "tensorflow")
 def normalize(tensor, ord="euclidean", axis=None, name=None):
     tensor = tf_frontend.convert_to_tensor(
         tensor, dtype=ivy.dtype(tensor), dtype_hint="Any"
@@ -280,7 +280,7 @@ def qr(input, /, *, full_matrices=False, name=None):
 @to_ivy_arrays_and_back
 @with_supported_dtypes(
     {
-        "2.14.0 and below": (
+        "2.15.0 and below": (
             "bfloat16",
             "half",
             "float32",
@@ -350,7 +350,7 @@ def slogdet(input, name=None):
 
 
 @to_ivy_arrays_and_back
-@with_unsupported_dtypes({"2.14.0 and below": ("float16", "bfloat16")}, "tensorflow")
+@with_unsupported_dtypes({"2.15.0 and below": ("float16", "bfloat16")}, "tensorflow")
 def solve(matrix, rhs, /, *, adjoint=False, name=None):
     matrix, rhs = check_tensorflow_casting(matrix, rhs)
     return ivy.solve(matrix, rhs, adjoint=adjoint)
@@ -364,7 +364,7 @@ def svd(a, /, *, full_matrices=False, compute_uv=True, name=None):
 @to_ivy_arrays_and_back
 @with_supported_dtypes(
     {
-        "2.14.0 and below": (
+        "2.15.0 and below": (
             "bfloat16",
             "half",
             "float32",
@@ -388,7 +388,7 @@ def tensor_diag(diagonal, /, *, name=None):
 @to_ivy_arrays_and_back
 @with_supported_dtypes(
     {
-        "2.14.0 and below": (
+        "2.15.0 and below": (
             "float32",
             "float64",
             "int32",
@@ -424,7 +424,7 @@ def tensor_diag_part(input, name=None):
 
 @to_ivy_arrays_and_back
 @with_supported_dtypes(
-    {"2.14.0 and below": ("float32", "float64", "int32")}, "tensorflow"
+    {"2.15.0 and below": ("float32", "float64", "int32")}, "tensorflow"
 )
 def tensordot(a, b, axes, name=None):
     a, b = check_tensorflow_casting(a, b)
@@ -436,7 +436,7 @@ def tensordot(a, b, axes, name=None):
 @to_ivy_arrays_and_back
 @with_unsupported_dtypes(
     {
-        "2.14.0 and below": (
+        "2.15.0 and below": (
             "float16",
             "bfloat16",
             "int8",

--- a/ivy/functional/frontends/tensorflow/math.py
+++ b/ivy/functional/frontends/tensorflow/math.py
@@ -17,7 +17,7 @@ from ivy.functional.frontends.tensorflow.func_wrapper import (
     {
         "1.2.0": ("float16", "complex64", "complex128"),
         "1.8.0 and below": ("float16",),
-        "2.14.0 and below": ("int8", "int16", "uint8", "uint16", "uint32", "uint64"),
+        "2.15.0 and below": ("int8", "int16", "uint8", "uint16", "uint32", "uint64"),
     },
     "tensorflow",
 )
@@ -105,7 +105,7 @@ def atanh(x, name="atanh"):
 
 
 @with_supported_dtypes(
-    {"2.14.0 and below": ("int32",)},
+    {"2.15.0 and below": ("int32",)},
     "tensorflow",
 )
 @to_ivy_arrays_and_back
@@ -297,7 +297,7 @@ def greater_equal(x, y, name=None):
 
 @with_supported_device_and_dtypes(
     {
-        "2.14.0 and below": {
+        "2.15.0 and below": {
             "cpu": ("float32", "float64"),
             "gpu": ("bfloat16", "float16", "float32", "float64"),
         }
@@ -310,7 +310,7 @@ def igamma(a, x, name=None):
 
 
 @with_supported_dtypes(
-    {"2.14.0 and below": ("float16", "float32", "float64", "complex64", "complex128")},
+    {"2.15.0 and below": ("float16", "float32", "float64", "complex64", "complex128")},
     "tensorflow",
 )
 @to_ivy_arrays_and_back
@@ -326,7 +326,7 @@ def in_top_k(target, pred, k, name=None):
 
 @with_supported_dtypes(
     {
-        "2.14.0 and below": ("int32", "int64"),
+        "2.15.0 and below": ("int32", "int64"),
     },
     "tensorflow",
 )
@@ -337,7 +337,7 @@ def invert_permutation(x, name=None):
 
 @with_supported_dtypes(
     {
-        "2.14.0 and below": ("bfloat16", "half", "float32", "float64"),
+        "2.15.0 and below": ("bfloat16", "half", "float32", "float64"),
     },
     "tensorflow",
 )
@@ -375,7 +375,7 @@ def is_strictly_increasing(x, name="is_strictly_increasing"):
 
 
 @to_ivy_arrays_and_back
-@with_supported_dtypes({"2.14.0 and below": ("float32", "float64")}, "tensorflow")
+@with_supported_dtypes({"2.15.0 and below": ("float32", "float64")}, "tensorflow")
 def l2_normalize(x, axis=None, epsilon=1e-12, name=None):
     square_sum = ivy.sum(ivy.square(x), axis=axis, keepdims=True)
     x_inv_norm = ivy.reciprocal(ivy.sqrt(ivy.maximum(square_sum, epsilon)))
@@ -396,7 +396,7 @@ def less_equal(x, y, name="LessEqual"):
 
 # lgamma
 @to_ivy_arrays_and_back
-@with_supported_dtypes({"2.14.0 and below": ("float32", "float64")}, "tensorflow")
+@with_supported_dtypes({"2.15.0 and below": ("float32", "float64")}, "tensorflow")
 def lgamma(x, name=None):
     return ivy.lgamma(x)
 
@@ -609,7 +609,7 @@ def reduce_variance(input_tensor, axis=None, keepdims=False, name="reduce_varian
 
 @with_supported_device_and_dtypes(
     {
-        "2.14.0 and below": {
+        "2.15.0 and below": {
             "cpu": ("float32", "float64"),
             "gpu": ("bfloat16", "float16", "float32", "float64"),
         }
@@ -644,7 +644,7 @@ def sigmoid(x, name=None):
 
 @with_supported_dtypes(
     {
-        "2.14.0 and below": (
+        "2.15.0 and below": (
             "bfloat16",
             "float16",
             "float32",
@@ -676,7 +676,7 @@ def softplus(features, name=None):
 
 
 @with_supported_dtypes(
-    {"2.14.0 and below": ("bfloat32", "float32", "float64")}, "tensorflow"
+    {"2.15.0 and below": ("bfloat32", "float32", "float64")}, "tensorflow"
 )
 @to_ivy_arrays_and_back
 def softsign(features, name=None):
@@ -695,7 +695,7 @@ def square(x, name=None):
 
 @with_supported_dtypes(
     {
-        "2.14.0 and below": (
+        "2.15.0 and below": (
             "bfloat16",
             "float16",
             "float32",
@@ -730,7 +730,7 @@ def tan(x, name=None):
 
 
 @with_supported_dtypes(
-    {"2.14.0 and below": ("float16", "float32", "float64", "complex64", "complex128")},
+    {"2.15.0 and below": ("float16", "float32", "float64", "complex64", "complex128")},
     "tensorflow",
 )
 @to_ivy_arrays_and_back
@@ -820,7 +820,7 @@ def unsorted_segment_sum(data, segment_ids, num_segments, name="unsorted_segment
 
 
 @with_supported_dtypes(
-    {"2.14.0 and below": ("float32", "float64", "complex64", "complex128")},
+    {"2.15.0 and below": ("float32", "float64", "complex64", "complex128")},
     "tensorflow",
 )
 @to_ivy_arrays_and_back
@@ -832,7 +832,7 @@ def xdivy(x, y, name=None):
 
 
 @to_ivy_arrays_and_back
-@with_supported_dtypes({"2.14.0 and below": ("float32", "float64")}, "tensorflow")
+@with_supported_dtypes({"2.15.0 and below": ("float32", "float64")}, "tensorflow")
 def xlog1py(x, y, name=None):
     x, y = check_tensorflow_casting(x, y)
     return x * ivy.log1p(y)
@@ -855,7 +855,7 @@ def zero_fraction(value, name="zero_fraction"):
 @to_ivy_arrays_and_back
 @with_supported_dtypes(
     {
-        "2.14.0 and below": ("float32", "float64"),
+        "2.15.0 and below": ("float32", "float64"),
     },
     "tensorflow",
 )

--- a/ivy/functional/frontends/tensorflow/nn.py
+++ b/ivy/functional/frontends/tensorflow/nn.py
@@ -210,7 +210,7 @@ def conv3d(
     )
 
 
-@with_unsupported_dtypes({"2.14.0 and below": ("bfloat16",)}, "tensorflow")
+@with_unsupported_dtypes({"2.15.0 and below": ("bfloat16",)}, "tensorflow")
 @to_ivy_arrays_and_back
 def conv3d_transpose(
     input,
@@ -292,7 +292,7 @@ def ctc_unique_labels(labels, name=None):
     return unique_pad, ctc_labels[2]
 
 
-@with_unsupported_dtypes({"2.14.0 and below": ("bfloat16",)}, "tensorflow")
+@with_unsupported_dtypes({"2.15.0 and below": ("bfloat16",)}, "tensorflow")
 @to_ivy_arrays_and_back
 def depthwise_conv2d(
     input,
@@ -336,13 +336,13 @@ def gelu(features, approximate=False, name=None):
     return ivy.gelu(features, approximate=approximate)
 
 
-@with_unsupported_dtypes({"2.14.0 and below": "float16"}, "tensorflow")
+@with_unsupported_dtypes({"2.15.0 and below": "float16"}, "tensorflow")
 @to_ivy_arrays_and_back
 def leaky_relu(features, alpha=0.2, name=None):
     return ivy.leaky_relu(features, alpha=alpha)
 
 
-@with_supported_dtypes({"2.14.0 and below": ("float32", "float16")}, "tensorflow")
+@with_supported_dtypes({"2.15.0 and below": ("float32", "float16")}, "tensorflow")
 @to_ivy_arrays_and_back
 def local_response_normalization(
     input, depth_radius=5, bias=1.0, alpha=1.0, beta=0.5, name=None
@@ -367,7 +367,7 @@ def max_pool2d(input, ksize, strides, padding, data_format="NHWC", name=None):
     return ivy.max_pool2d(input, ksize, strides, padding, data_format=data_format)
 
 
-@with_supported_dtypes({"2.14.0 and below": ("float32",)}, "tensorflow")
+@with_supported_dtypes({"2.15.0 and below": ("float32",)}, "tensorflow")
 @to_ivy_arrays_and_back
 def max_pool3d(input, ksize, strides, padding, data_format="NDHWC", name=None):
     return ivy.max_pool3d(input, ksize, strides, padding, data_format=data_format)
@@ -382,7 +382,7 @@ def moments(x, axes, shift=None, keepdims=False, name=None):
 
 @with_unsupported_dtypes(
     {
-        "2.14.0 and below": (
+        "2.15.0 and below": (
             "int8",
             "int16",
             "int32",
@@ -431,19 +431,19 @@ def pool(
     )
 
 
-@with_unsupported_dtypes({"2.14.0 and below": ("complex",)}, "tensorflow")
+@with_unsupported_dtypes({"2.15.0 and below": ("complex",)}, "tensorflow")
 @to_ivy_arrays_and_back
 def relu(features, name=None):
     return ivy.relu(features)
 
 
-@with_unsupported_dtypes({"2.14.0 and below": ("complex",)}, "tensorflow")
+@with_unsupported_dtypes({"2.15.0 and below": ("complex",)}, "tensorflow")
 @to_ivy_arrays_and_back
 def relu6(features, name=None):
     return ivy.relu6(features)
 
 
-@with_unsupported_dtypes({"2.14.0 and below": ("bfloat16",)}, "tensorflow")
+@with_unsupported_dtypes({"2.15.0 and below": ("bfloat16",)}, "tensorflow")
 @to_ivy_arrays_and_back
 def separable_conv2d(
     input,
@@ -470,7 +470,7 @@ def separable_conv2d(
 
 @with_unsupported_dtypes(
     {
-        "2.14.0 and below": (
+        "2.15.0 and below": (
             "int8",
             "int16",
             "int32",
@@ -497,7 +497,7 @@ def silu(features, beta: float = 1.0):
     return ivy.multiply(features, ivy.sigmoid(ivy.multiply(beta, features)))
 
 
-@with_unsupported_dtypes({"2.14.0 and below": ("float16",)}, "tensorflow")
+@with_unsupported_dtypes({"2.15.0 and below": ("float16",)}, "tensorflow")
 @to_ivy_arrays_and_back
 def softmax(logits, axis=None, name=None):
     return ivy.softmax(logits, axis=axis)
@@ -506,7 +506,7 @@ def softmax(logits, axis=None, name=None):
 # Softsign
 @with_unsupported_dtypes(
     {
-        "2.14.0 and below": (
+        "2.15.0 and below": (
             "int8",
             "int16",
             "int32",
@@ -557,7 +557,7 @@ def sufficient_statistics(x, axes, shift=None, keepdims=False, name=None):
 
 @with_unsupported_dtypes(
     {
-        "2.14.0 and below": (
+        "2.15.0 and below": (
             "int8",
             "int16",
             "int32",

--- a/ivy/functional/frontends/tensorflow/random.py
+++ b/ivy/functional/frontends/tensorflow/random.py
@@ -12,7 +12,7 @@ def gamma(shape, alpha, beta=None, dtype=ivy.float32, seed=None, name=None):
 
 
 @with_unsupported_dtypes(
-    {"2.14.0 and below": ("int8", "int16", "int32", "int64", "unsigned")}, "tensorflow"
+    {"2.15.0 and below": ("int8", "int16", "int32", "int64", "unsigned")}, "tensorflow"
 )
 @to_ivy_arrays_and_back
 def normal(shape, mean=0.0, stddev=1.0, dtype=ivy.float32, seed=None, name=None):
@@ -20,7 +20,7 @@ def normal(shape, mean=0.0, stddev=1.0, dtype=ivy.float32, seed=None, name=None)
 
 
 @with_unsupported_dtypes(
-    {"2.14.0 and below": ("int8", "int16", "unsigned")}, "tensorflow"
+    {"2.15.0 and below": ("int8", "int16", "unsigned")}, "tensorflow"
 )
 @to_ivy_arrays_and_back
 @handle_tf_dtype
@@ -34,7 +34,7 @@ def poisson(shape, lam, dtype=ivy.float32, seed=None, name=None):
 
 # implement random shuffle
 @with_unsupported_dtypes(
-    {"2.14.0 and below": ("int8", "int16", "in32", "int64", "unsigned")}, "tensorflow"
+    {"2.15.0 and below": ("int8", "int16", "in32", "int64", "unsigned")}, "tensorflow"
 )
 @to_ivy_arrays_and_back
 def shuffle(value, seed=None, name=None):
@@ -42,7 +42,7 @@ def shuffle(value, seed=None, name=None):
 
 
 @with_unsupported_dtypes(
-    {"2.14.0 and below": ("int8", "int16", "unsigned")}, "tensorflow"
+    {"2.15.0 and below": ("int8", "int16", "unsigned")}, "tensorflow"
 )
 @to_ivy_arrays_and_back
 def stateless_normal(
@@ -54,7 +54,7 @@ def stateless_normal(
 
 
 @with_unsupported_dtypes(
-    {"2.14.0 and below": ("int8", "int16", "unsigned")}, "tensorflow"
+    {"2.15.0 and below": ("int8", "int16", "unsigned")}, "tensorflow"
 )
 @to_ivy_arrays_and_back
 def stateless_poisson(shape, seed, lam, dtype=ivy.int32, name=None):
@@ -71,7 +71,7 @@ def stateless_uniform(
 
 
 @with_unsupported_dtypes(
-    {"2.14.0 and below": ("int8", "int16", "unsigned")}, "tensorflow"
+    {"2.15.0 and below": ("int8", "int16", "unsigned")}, "tensorflow"
 )
 @to_ivy_arrays_and_back
 def uniform(shape, minval=0, maxval=None, dtype=ivy.float32, seed=None, name=None):

--- a/ivy/functional/frontends/tensorflow/raw_ops.py
+++ b/ivy/functional/frontends/tensorflow/raw_ops.py
@@ -18,7 +18,7 @@ AddN = to_ivy_arrays_and_back(map_raw_ops_alias(tf_frontend.math.add_n))
 AddV2 = to_ivy_arrays_and_back(map_raw_ops_alias(tf_frontend.math.add))
 ArgMax = to_ivy_arrays_and_back(
     with_unsupported_dtypes(
-        {"2.14.0 and below": ("complex",)},
+        {"2.15.0 and below": ("complex",)},
         "tensorflow",
     )(
         map_raw_ops_alias(
@@ -28,7 +28,7 @@ ArgMax = to_ivy_arrays_and_back(
 )
 ArgMin = to_ivy_arrays_and_back(
     with_unsupported_dtypes(
-        {"2.14.0 and below": ("complex",)},
+        {"2.15.0 and below": ("complex",)},
         "tensorflow",
     )(
         map_raw_ops_alias(
@@ -40,7 +40,7 @@ Asin = to_ivy_arrays_and_back(map_raw_ops_alias(tf_frontend.math.asin))
 Atan = to_ivy_arrays_and_back(map_raw_ops_alias(tf_frontend.math.atan))
 Atan2 = to_ivy_arrays_and_back(
     with_unsupported_dtypes(
-        {"2.14.0 and below": "float16"},
+        {"2.15.0 and below": "float16"},
         "tensorflow",
     )(map_raw_ops_alias(tf_frontend.math.atan2))
 )
@@ -69,7 +69,7 @@ Div = to_ivy_arrays_and_back(map_raw_ops_alias(tf_frontend.math.divide))
 Einsum = to_ivy_arrays_and_back(
     with_supported_dtypes(
         {
-            "2.14.0 and below": (
+            "2.15.0 and below": (
                 "bfloat16",
                 "complex128 ",
                 "complex64",
@@ -92,7 +92,7 @@ IdentityN = to_ivy_arrays_and_back(
 Igamma = to_ivy_arrays_and_back(
     with_supported_dtypes(
         {
-            "2.14.0 and below": (
+            "2.15.0 and below": (
                 "float64",
                 "float32",
                 "half",
@@ -104,7 +104,7 @@ Igamma = to_ivy_arrays_and_back(
 LeakyRelu = to_ivy_arrays_and_back(
     with_supported_dtypes(
         {
-            "2.14.0 and below": ("bfloat16", "float16", "float32", "float64"),
+            "2.15.0 and below": ("bfloat16", "float16", "float32", "float64"),
         },
         "tensorflow",
     )(
@@ -116,7 +116,7 @@ LeakyRelu = to_ivy_arrays_and_back(
 LessEqual = to_ivy_arrays_and_back(
     with_unsupported_dtypes(
         {
-            "2.14.0 and below": ("complex",),
+            "2.15.0 and below": ("complex",),
         },
         "tensorflow",
     )(map_raw_ops_alias(tf_frontend.math.less_equal))
@@ -125,7 +125,7 @@ Log1p = to_ivy_arrays_and_back(map_raw_ops_alias(tf_frontend.math.log1p))
 LogSoftmax = to_ivy_arrays_and_back(
     with_supported_dtypes(
         {
-            "2.14.0 and below": (
+            "2.15.0 and below": (
                 "bfloat16",
                 "float32",
                 "float64",
@@ -139,7 +139,7 @@ MatrixDeterminant = to_ivy_arrays_and_back(map_raw_ops_alias(tf_frontend.linalg.
 Max = to_ivy_arrays_and_back(
     with_unsupported_dtypes(
         {
-            "2.14.0 and below": ("complex",),
+            "2.15.0 and below": ("complex",),
         },
         "tensorflow",
     )(
@@ -155,7 +155,7 @@ Max = to_ivy_arrays_and_back(
 MaxPool3D = to_ivy_arrays_and_back(
     with_supported_dtypes(
         {
-            "2.14.0 and below": ("float32",),
+            "2.15.0 and below": ("float32",),
         },
         "tensorflow",
     )(
@@ -167,7 +167,7 @@ MaxPool3D = to_ivy_arrays_and_back(
 Maximum = to_ivy_arrays_and_back(
     with_unsupported_dtypes(
         {
-            "2.14.0 and below": ("complex",),
+            "2.15.0 and below": ("complex",),
         },
         "tensorflow",
     )(map_raw_ops_alias(tf_frontend.math.maximum))
@@ -184,7 +184,7 @@ Mean = to_ivy_arrays_and_back(
 Min = to_ivy_arrays_and_back(
     with_unsupported_dtypes(
         {
-            "2.14.0 and below": ("complex",),
+            "2.15.0 and below": ("complex",),
         },
         "tensorflow",
     )(
@@ -204,7 +204,7 @@ Pow = to_ivy_arrays_and_back(map_raw_ops_alias(tf_frontend.math.pow))
 RealDiv = to_ivy_arrays_and_back(
     with_supported_dtypes(
         {
-            "2.14.0 and below": (
+            "2.15.0 and below": (
                 "complex",
                 "bfloat16",
                 "float16",
@@ -219,7 +219,7 @@ Reciprocal = to_ivy_arrays_and_back(map_raw_ops_alias(tf_frontend.math.reciproca
 Relu = to_ivy_arrays_and_back(
     with_unsupported_dtypes(
         {
-            "2.14.0 and below": ("complex", "float16"),
+            "2.15.0 and below": ("complex", "float16"),
         },
         "tensorflow",
     )(map_raw_ops_alias(tf_frontend.nn.relu))
@@ -227,7 +227,7 @@ Relu = to_ivy_arrays_and_back(
 Relu6 = to_ivy_arrays_and_back(
     with_unsupported_dtypes(
         {
-            "2.14.0 and below": ("complex", "float16"),
+            "2.15.0 and below": ("complex", "float16"),
         },
         "tensorflow",
     )(
@@ -251,7 +251,7 @@ Size = to_ivy_arrays_and_back(map_raw_ops_alias(tf_frontend.general_functions.si
 Softmax = to_ivy_arrays_and_back(
     with_unsupported_dtypes(
         {
-            "2.14.0 and below": ("float16",),
+            "2.15.0 and below": ("float16",),
         },
         "tensorflow",
     )(map_raw_ops_alias(tf_frontend.nn.softmax))
@@ -264,7 +264,7 @@ Split = to_ivy_arrays_and_back(
 SquaredDifference = to_ivy_arrays_and_back(
     with_supported_dtypes(
         {
-            "2.14.0 and below": (
+            "2.15.0 and below": (
                 "complex",
                 "bfloat16",
                 "float16",
@@ -287,7 +287,7 @@ Xlogy = to_ivy_arrays_and_back(map_raw_ops_alias(tf_frontend.math.xlogy))
 Zeta = to_ivy_arrays_and_back(
     with_supported_dtypes(
         {
-            "2.14.0 and below": ("float32", "float64"),
+            "2.15.0 and below": ("float32", "float64"),
         },
         "tensorflow",
     )(map_raw_ops_alias(tf_frontend.math.zeta))
@@ -342,7 +342,7 @@ def Angle(
 
 @with_unsupported_dtypes(
     {
-        "2.14.0 and below": (
+        "2.15.0 and below": (
             "float16",
             "bool",
             "bfloat16",
@@ -526,7 +526,7 @@ def Diag(*, diagonal, name="Diag"):
 
 
 @with_supported_dtypes(
-    {"2.14.0 and below": ("bfloat16", "float16", "float32", "float64")},
+    {"2.15.0 and below": ("bfloat16", "float16", "float32", "float64")},
     "tensorflow",
 )
 @to_ivy_arrays_and_back
@@ -775,7 +775,7 @@ def Shape(*, input, output_type=ivy.int32, name="Shape"):
 
 
 @with_unsupported_dtypes(
-    {"2.14.0 and below": ("unsigned",)},
+    {"2.15.0 and below": ("unsigned",)},
     "tensorflow",
 )
 @to_ivy_arrays_and_back
@@ -820,7 +820,7 @@ def Sum(*, input, axis, keep_dims=False, name="Sum"):
 
 
 @with_supported_dtypes(
-    {"2.14.0 and below": ("float64", "float128", "halfcomplex64", "complex128")},
+    {"2.15.0 and below": ("float64", "float128", "halfcomplex64", "complex128")},
     "tensorflow",
 )
 @to_ivy_arrays_and_back
@@ -844,7 +844,7 @@ def TruncateDiv(*, x, y, name="TruncateDiv"):
     return ivy.astype(ivy.trunc_divide(x, y), x.dtype)
 
 
-@with_unsupported_dtypes({"2.14.0 and below": ("float16", "bfloat16")}, "tensorflow")
+@with_unsupported_dtypes({"2.15.0 and below": ("float16", "bfloat16")}, "tensorflow")
 @to_ivy_arrays_and_back
 def Unpack(*, value, num, axis=0, name="Unpack"):
     return ivy.unstack(value, axis=axis)[:num]
@@ -857,7 +857,7 @@ def Xdivy(*, x, y, name="Xdivy"):
     return ivy.divide(x, y)
 
 
-@with_unsupported_dtypes({"2.14.0 and below": ("bfloat16",)}, "tensorflow")
+@with_unsupported_dtypes({"2.15.0 and below": ("bfloat16",)}, "tensorflow")
 @to_ivy_arrays_and_back
 def Xlog1py(*, x, y, name="Xlog1py"):
     if (x == 0).all():

--- a/ivy/functional/frontends/tensorflow/signal.py
+++ b/ivy/functional/frontends/tensorflow/signal.py
@@ -29,7 +29,7 @@ def kaiser_bessel_derived_window(
 
 
 @with_supported_dtypes(
-    {"2.14.0 and below": ("float32", "float64", "float16", "bfloat16")},
+    {"2.15.0 and below": ("float32", "float64", "float16", "bfloat16")},
     "tensorflow",
 )
 @handle_tf_dtype
@@ -62,7 +62,7 @@ def stft(
 
 
 @with_supported_dtypes(
-    {"2.14.0 and below": ("float16", "float32", "float64", "bfloat16")},
+    {"2.15.0 and below": ("float16", "float32", "float64", "bfloat16")},
     "tensorflow",
 )
 @to_ivy_arrays_and_back

--- a/ivy/functional/frontends/tensorflow/tensor.py
+++ b/ivy/functional/frontends/tensorflow/tensor.py
@@ -108,7 +108,7 @@ class EagerTensor:
         return tf_frontend.raw_ops.FloorDiv(x=self, y=y, name=name)
 
     @with_unsupported_dtypes(
-        {"2.14.0 and below": ("complex",)},
+        {"2.15.0 and below": ("complex",)},
         "tensorflow",
     )
     def __ge__(self, y, name="ge"):
@@ -120,7 +120,7 @@ class EagerTensor:
         return EagerTensor(ret)
 
     @with_unsupported_dtypes(
-        {"2.14.0 and below": ("complex",)},
+        {"2.15.0 and below": ("complex",)},
         "tensorflow",
     )
     def __gt__(self, y, name="gt"):
@@ -130,14 +130,14 @@ class EagerTensor:
         return tf_frontend.raw_ops.Invert(x=self, name=name)
 
     @with_unsupported_dtypes(
-        {"2.14.0 and below": ("complex",)},
+        {"2.15.0 and below": ("complex",)},
         "tensorflow",
     )
     def __le__(self, y, name="le"):
         return tf_frontend.raw_ops.LessEqual(x=self, y=y, name=name)
 
     @with_unsupported_dtypes(
-        {"2.14.0 and below": ("complex",)},
+        {"2.15.0 and below": ("complex",)},
         "tensorflow",
     )
     def __lt__(self, y, name="lt"):
@@ -150,7 +150,7 @@ class EagerTensor:
         return tf_frontend.math.multiply(self, y, name=name)
 
     @with_unsupported_dtypes(
-        {"2.14.0 and below": ("complex",)},
+        {"2.15.0 and below": ("complex",)},
         "tensorflow",
     )
     def __mod__(self, y, name="mod"):


### PR DESCRIPTION
# PR Description
New version of [TensorFlow 2.15.0](https://github.com/tensorflow/tensorflow/releases/tag/v2.15.0) is released. So, I updated the version from `2.14.0` to `2.15.0`.


## Related Issue
Closes #

## Checklist

- [ ] Did you add a function?
- [ ] Did you add the tests?
- [ ] Did you run your tests and are your tests passing?
- [x] Did pre-commit not fail on any check?
- [ ] Did you follow the steps we provided?


### Socials
https://twitter.com/Sai_Suraj_27