### PR TITLE
fix: Fixed passing `key-word` arguments in 2 functions

### DIFF
--- a/ivy/functional/backends/torch/layers.py
+++ b/ivy/functional/backends/torch/layers.py
@@ -526,7 +526,7 @@ def depthwise_conv2d(
     dilations = [dilations] * 2 if isinstance(dilations, int) else dilations
     if data_format == "NHWC":
         x = x.permute(0, 3, 1, 2)
-    filters = ivy.squeeze(filters, 3).to_native() if filters.ndim == 4 else filters
+    filters = ivy.squeeze(filters, axis=3).to_native() if filters.ndim == 4 else filters
     filters = torch.unsqueeze(filters, -1)
     dims_in = filters.shape[-2]
     filters = filters.permute(2, 3, 0, 1)

--- a/ivy/functional/frontends/jax/numpy/statistical.py
+++ b/ivy/functional/frontends/jax/numpy/statistical.py
@@ -495,7 +495,7 @@ def nanpercentile(
     ):
         """Assumes that q is in [0, 1], and is an ndarray."""
         if a.size == 0:
-            return ivy.nanmean(a, axis, out=out, keepdims=keepdims)
+            return ivy.nanmean(a, axis=axis, out=out, keepdims=keepdims)
         return _ureduce(
             a,
             func=_nanquantile_ureduce_func,


### PR DESCRIPTION
# PR Description
In the following function calls, some of the arguments are passed as positional arguments but from the function definition they should be passed as key-word arguments.
https://github.com/unifyai/ivy/blob/af8db63c36d85c9c02db73bbc3b02ef09b15f29a/ivy/functional/frontends/jax/numpy/statistical.py#L498
https://github.com/unifyai/ivy/blob/af8db63c36d85c9c02db73bbc3b02ef09b15f29a/ivy/functional/ivy/experimental/statistical.py#L207-L215
https://github.com/unifyai/ivy/blob/af8db63c36d85c9c02db73bbc3b02ef09b15f29a/ivy/functional/backends/torch/layers.py#L529
https://github.com/unifyai/ivy/blob/af8db63c36d85c9c02db73bbc3b02ef09b15f29a/ivy/functional/ivy/manipulation.py#L683-L690
At both the places `axis` should be the key-word argument.

## Related Issue
Closes #27299 

## Checklist

- [ ] Did you add a function?
- [ ] Did you add the tests?
- [ ] Did you run your tests and are your tests passing?
- [x] Did pre-commit not fail on any check?
- [ ] Did you follow the steps we provided?


### Socials
https://twitter.com/Sai_Suraj_27