### PR TITLE
fix: Fixed positional arguments for 2 `staticmethod` calls.

### DIFF
--- a/ivy/data_classes/container/creation.py
+++ b/ivy/data_classes/container/creation.py
@@ -1654,7 +1654,6 @@ class _ContainerWithCreation(ContainerBase):
         out: Optional[Union[Tuple[ivy.Array], ivy.Container]] = None,
     ) -> ivy.Container:
         return self.static_triu_indices(
-            self,
             n_rows,
             n_cols,
             k,

--- a/ivy/data_classes/container/experimental/creation.py
+++ b/ivy/data_classes/container/experimental/creation.py
@@ -599,7 +599,6 @@ class _ContainerWithCreationExperimental(ContainerBase):
         device: Optional[Union[ivy.Device, ivy.NativeDevice, ivy.Container]] = None,
     ) -> ivy.Container:
         return self.static_tril_indices(
-            self,
             n_rows,
             n_cols,
             k,


### PR DESCRIPTION
# PR Description
In the following function calls, the `self` argument is passed un-necessarily.
https://github.com/unifyai/ivy/blob/f5c75e99f3a414ced9b580ad0c3e815a002c1ce9/ivy/data_classes/container/creation.py#L1656-L1667
From the actual function definition `self` should not be passed.
https://github.com/unifyai/ivy/blob/f5c75e99f3a414ced9b580ad0c3e815a002c1ce9/ivy/data_classes/container/creation.py#L1616-L1628
https://github.com/unifyai/ivy/blob/f5c75e99f3a414ced9b580ad0c3e815a002c1ce9/ivy/data_classes/container/experimental/creation.py#L601-L611
From the actual function definition `self` should not be passed.
https://github.com/unifyai/ivy/blob/f5c75e99f3a414ced9b580ad0c3e815a002c1ce9/ivy/data_classes/container/experimental/creation.py#L564-L575

## Related Issue
Closes #27356

## Checklist

- [ ] Did you add a function?
- [ ] Did you add the tests?
- [ ] Did you run your tests and are your tests passing?
- [x] Did pre-commit not fail on any check?
- [ ] Did you follow the steps we provided?


### Socials
https://twitter.com/Sai_Suraj_27