### PR TITLE
fix: Fixed passing `shape` argument in 2 functions.

### DIFF
--- a/ivy/functional/frontends/paddle/tensor/tensor.py
+++ b/ivy/functional/frontends/paddle/tensor/tensor.py
@@ -235,7 +235,8 @@ class Tensor:
                 return paddle_frontend.reshape(self, shape)
             else:
                 return paddle_frontend.reshape(self, args)
-        return paddle_frontend.reshape(self)
+        else:
+            raise ValueError("reshape() got no values for argument 'shape'")
 
     def dim(self):
         return self.ivy_array.ndim

--- a/ivy/functional/frontends/torch/tensor.py
+++ b/ivy/functional/frontends/torch/tensor.py
@@ -142,7 +142,8 @@ class Tensor:
                 return torch_frontend.reshape(self, shape)
             else:
                 return torch_frontend.reshape(self, args)
-        return torch_frontend.reshape(self)
+        else:
+            raise ValueError("reshape() got no values for argument 'shape'")
 
     @with_unsupported_dtypes({"2.1.1 and below": ("bfloat16",)}, "torch")
     @with_unsupported_dtypes({"2.5.1 and below": ("float16",)}, "paddle")


### PR DESCRIPTION
# PR Description
In the following function calls, the `shape` argument is not passed.
https://github.com/unifyai/ivy/blob/79de1aaeb45883e8a9a3119caa749dfac39d9b34/ivy/functional/frontends/paddle/tensor/tensor.py#L231
https://github.com/unifyai/ivy/blob/79de1aaeb45883e8a9a3119caa749dfac39d9b34/ivy/functional/frontends/torch/tensor.py#L145

## Related Issue
Closes #27351 

## Checklist

- [ ] Did you add a function?
- [ ] Did you add the tests?
- [ ] Did you run your tests and are your tests passing?
- [x] Did pre-commit not fail on any check?
- [ ] Did you follow the steps we provided?


### Socials
https://twitter.com/Sai_Suraj_27