### PR TITLE
fix: Fixed passing `prob` argument in 1 function.

### DIFF
--- a/ivy/functional/frontends/paddle/nn/functional/common.py
+++ b/ivy/functional/frontends/paddle/nn/functional/common.py
@@ -55,7 +55,7 @@ def dropout(x, p=0.5, axis=None, training=True, mode="upscale_in_train", name=No
 @to_ivy_arrays_and_back
 @with_supported_dtypes({"2.5.2 and below": ("float32", "float64")}, "paddle")
 def dropout2d(x, *, p=0.5, training=True, data_format="NCHW", name=None):
-    return ivy.dropout2d(x, p=p, training=training, data_format=data_format)
+    return ivy.dropout2d(x, p, training=training, data_format=data_format)
 
 
 @to_ivy_arrays_and_back


### PR DESCRIPTION
# PR Description
In the following function call, the argument is passed wrongly as `p=p`.
https://github.com/unifyai/ivy/blob/039f79399f6f8c8d2db8ac33577ea6dcd34fb08b/ivy/functional/frontends/paddle/nn/functional/common.py#L58
From the function definition, it should be passed just as `p` because argument `prob` is a position only argument.
https://github.com/unifyai/ivy/blob/039f79399f6f8c8d2db8ac33577ea6dcd34fb08b/ivy/functional/ivy/experimental/layers.py#L1016-L1024

## Related Issue
Closes #27372 

## Checklist

- [ ] Did you add a function?
- [ ] Did you add the tests?
- [ ] Did you run your tests and are your tests passing?
- [x] Did pre-commit not fail on any check?
- [ ] Did you follow the steps we provided?


### Socials
https://twitter.com/Sai_Suraj_27