### PR TITLE
fix: Fixed passing `dims` argument in 1 function

### DIFF
--- a/ivy/functional/frontends/torch/tensor.py
+++ b/ivy/functional/frontends/torch/tensor.py
@@ -849,7 +849,8 @@ class Tensor:
                 return torch_frontend.permute(self, dims)
             else:
                 return torch_frontend.permute(self, args)
-        return torch_frontend.permute(self)
+        else:
+            raise ValueError("permute() got no values for argument 'dims'")
 
     @numpy_to_torch_style_args
     @with_unsupported_dtypes({"2.1.1 and below": ("float16", "bfloat16")}, "torch")


### PR DESCRIPTION
# PR Description
In the following function call, the `dims` argument is not passed.
https://github.com/unifyai/ivy/blob/79de1aaeb45883e8a9a3119caa749dfac39d9b34/ivy/functional/frontends/torch/tensor.py#L851
From the if-else conditions above, this function call happens when both `dims` and `args` are `None`.
https://github.com/unifyai/ivy/blob/79de1aaeb45883e8a9a3119caa749dfac39d9b34/ivy/functional/frontends/torch/tensor.py#L840-L851
This is similar to this issue #27351 which Is fixed here https://github.com/unifyai/ivy/pull/27363.

## Related Issue
Closes #27375 

## Checklist

- [ ] Did you add a function?
- [ ] Did you add the tests?
- [ ] Did you run your tests and are your tests passing?
- [x] Did pre-commit not fail on any check?
- [ ] Did you follow the steps we provided?


### Socials
https://twitter.com/Sai_Suraj_27