### PR TITLE
fix: Fixed passing of argument `seed` to class `Generator`

### DIFF
--- a/ivy/functional/frontends/numpy/random/Generator/Generator.py
+++ b/ivy/functional/frontends/numpy/random/Generator/Generator.py
@@ -11,4 +11,4 @@ class Generator:
 
 
 def default__rng(seed=None):
-    return Generator(seed=seed)
+    return Generator(bit_generator=seed)


### PR DESCRIPTION
# PR Description
In the following line, the class `Generator` is called with wrong key-word argument `seed`.
https://github.com/unifyai/ivy/blob/1948300fad770695c3df18aea42751056871396a/ivy/functional/frontends/numpy/random/Generator/Generator.py#L13-L14
From the actual definition of the `Generator` class, the argument should be `bit_generator`.
https://github.com/unifyai/ivy/blob/1948300fad770695c3df18aea42751056871396a/ivy/functional/frontends/numpy/random/Generator/Generator.py#L5-L10

## Related Issue
Closes #27398 

## Checklist

- [ ] Did you add a function?
- [ ] Did you add the tests?
- [ ] Did you run your tests and are your tests passing?
- [x] Did pre-commit not fail on any check?
- [ ] Did you follow the steps we provided?


### Socials
https://twitter.com/Sai_Suraj_27