### PR TITLE
fix: Fixed passing of wrong argument in `ivy.matrix_transpose()` function call

### DIFF
--- a/ivy/functional/ivy/linear_algebra.py
+++ b/ivy/functional/ivy/linear_algebra.py
@@ -3182,7 +3182,7 @@ def tensorsolve(
             allaxes.remove(k)
             allaxes.insert(ndim1, k)
 
-        x1 = ivy.matrix_transpose(x1, allaxes)
+        x1 = ivy.matrix_transpose(x1)
 
     old_shape = x1.shape[-(ndim1 - ndim2) :]
 


### PR DESCRIPTION
# PR Description
In the following function call the argument `allaxes` is wrongly passed.
https://github.com/unifyai/ivy/blob/6f408fc5efb588530375527bc15e50ca0a8241a7/ivy/functional/ivy/linear_algebra.py#L3185

From the actual function definition of `matrix_transpose` only 1 positional argument should be passed. So, the argument `allaxes` should not be passed.
https://github.com/unifyai/ivy/blob/6f408fc5efb588530375527bc15e50ca0a8241a7/ivy/functional/ivy/linear_algebra.py#L1526-L1532

## Related Issue
Closes #27404 

## Checklist

- [ ] Did you add a function?
- [ ] Did you add the tests?
- [ ] Did you run your tests and are your tests passing?
- [x] Did pre-commit not fail on any check?
- [ ] Did you follow the steps we provided?


### Socials
https://twitter.com/Sai_Suraj_27