### PR TITLE
docs: Updated helpful_resources page in docs

### DIFF
--- a/docs/overview/contributing/helpful_resources.rst
+++ b/docs/overview/contributing/helpful_resources.rst
@@ -20,11 +20,11 @@ Useful when working on almost any section in the Deep Dive.
 **Co-Pilot**
 
 GitHub Co-Pilot can be used to write any bit of code in Ivy.
-They are often very useful when developing code and also helps gets things done faster.
+They are often very useful when developing code and also help get things done faster.
 
 **GitHub - Reference**
 
-Git docs is the first place you must head to when you are stuck which any issue related to git.
+`Git docs <https://git-scm.com/doc>`_ is the first place you must head to when you are stuck with any issue related to git.
 
 **IDE extension for spell checking**
 
@@ -36,4 +36,4 @@ Though this may sound odd, a spell-checking extension is very useful to people c
 
 **Github Actions**
 
-GitHub Actions can be the best place to understand Continuous Integration and how testing is done to keep our repo error free.
+`GitHub Actions <https://docs.github.com/en/actions>`_ can be the best place to understand Continuous Integration and how testing is done to keep our repo error free.


### PR DESCRIPTION
# PR Description
The links to `GitHub actions` and `Git docs` can be added to provide more clarity. Also, there is a grammatical mistake in one of the lines.
I added the required links and corrected the grammatical mistake.
https://github.com/unifyai/ivy/blob/6297c303ca813cc31bcd7d36ab54f524b902b8e6/docs/overview/contributing/helpful_resources.rst?plain=1#L27
It should not be `which` it should be `with`.

## Related Issue
Closes #27407 

## Checklist

- [ ] Did you add a function?
- [ ] Did you add the tests?
- [ ] Did you run your tests and are your tests passing?
- [x] Did pre-commit not fail on any check?
- [ ] Did you follow the steps we provided?

### Socials
https://twitter.com/Sai_Suraj_27