### PR TITLE
fix: Fixed typos (used `codespell` pre-commit hook)

### DIFF
--- a/ivy/data_classes/array/experimental/creation.py
+++ b/ivy/data_classes/array/experimental/creation.py
@@ -335,7 +335,7 @@ def polyval(
     Returns
     -------
     ret
-        Simplified result of substituing x in the coefficients - final value of
+        Simplified result of substituting x in the coefficients - final value of
         polynomial.
 
     Examples

--- a/ivy/data_classes/container/base.py
+++ b/ivy/data_classes/container/base.py
@@ -1602,7 +1602,7 @@ class ContainerBase(dict, abc.ABC):
     # ---------------#
 
     def cont_duplicate_array_keychains(self):
-        duplciates = ()
+        duplicates = ()
         key_chains = self.cont_all_key_chains()
         skips = set()
         for i in range(len(key_chains)):
@@ -1618,9 +1618,9 @@ class ContainerBase(dict, abc.ABC):
                     if key_chains[j] not in temp_duplicates:
                         temp_duplicates += (key_chains[j],)
             if len(temp_duplicates) > 0:
-                duplciates += (temp_duplicates,)
-            skips = chain.from_iterable(duplciates)
-        return duplciates
+                duplicates += (temp_duplicates,)
+            skips = chain.from_iterable(duplicates)
+        return duplicates
 
     def cont_update_config(self, **config):
         new_config = {}

--- a/ivy/data_classes/container/experimental/creation.py
+++ b/ivy/data_classes/container/experimental/creation.py
@@ -1290,7 +1290,7 @@ class _ContainerWithCreationExperimental(ContainerBase):
         Returns
         -------
         ret
-            Output container containing simplified result of substituing x in the
+            Output container containing simplified result of substituting x in the
             coefficients - final value of polynomial.
         """
         return ContainerBase.cont_multi_map_in_function(
@@ -1385,7 +1385,7 @@ class _ContainerWithCreationExperimental(ContainerBase):
         Returns
         -------
         ret
-            Output container containing simplified result of substituing x in the
+            Output container containing simplified result of substituting x in the
             coefficients - final value of polynomial.
         """
         return self.static_polyval(self, coeffs, x)

--- a/ivy/engines/XLA/rust_api/xla_rs/xla_rs.cc
+++ b/ivy/engines/XLA/rust_api/xla_rs/xla_rs.cc
@@ -1188,7 +1188,7 @@ status execute(const pjrt_loaded_executable exe, const literal *inputs,
     ASSIGN_OR_RETURN_STATUS(buffer,
                             client->BufferFromHostLiteral(*inputs[i], device));
     // Wait for the transfer to have completed to avoid the literal potentially
-    // getting out of scope before it has been transfered.
+    // getting out of scope before it has been transferred.
     MAYBE_RETURN_STATUS(buffer->GetReadyFuture().Await());
     input_buffer_ptrs.push_back(buffer.release());
   }

--- a/ivy/functional/ivy/experimental/activations.py
+++ b/ivy/functional/ivy/experimental/activations.py
@@ -799,7 +799,7 @@ def celu(
     out: Optional[ivy.Array] = None,
 ) -> ivy.Array:
     """
-    Apply the Continously Differentiable Exponential Linear Unit (CELU) activation
+    Apply the Continuosly Differentiable Exponential Linear Unit (CELU) activation
     function to each element of the input.
 
     Parameters

--- a/ivy/functional/ivy/experimental/activations.py
+++ b/ivy/functional/ivy/experimental/activations.py
@@ -799,7 +799,7 @@ def celu(
     out: Optional[ivy.Array] = None,
 ) -> ivy.Array:
     """
-    Apply the Continuosly Differentiable Exponential Linear Unit (CELU) activation
+    Apply the Continuously Differentiable Exponential Linear Unit (CELU) activation
     function to each element of the input.
 
     Parameters

--- a/ivy/functional/ivy/experimental/creation.py
+++ b/ivy/functional/ivy/experimental/creation.py
@@ -1197,7 +1197,7 @@ def polyval(
     Returns
     -------
     ret
-       Simplified result of substituing x in the coefficients - final value
+       Simplified result of substituting x in the coefficients - final value
        of polynomial.
 
     Examples

--- a/ivy/functional/ivy/general.py
+++ b/ivy/functional/ivy/general.py
@@ -2841,7 +2841,7 @@ def get_item(
         if query.ndim == 0:
             if query is False:
                 return ivy.zeros(shape=(0,) + x.shape, dtype=x.dtype)
-            return x[None]  # eqivalent to ivy.expand_dims(x, axis=0)
+            return x[None]  # equivalent to ivy.expand_dims(x, axis=0)
         query = ivy.nonzero(query, as_tuple=False)
         ret = ivy.gather_nd(x, query)
     else:

--- a/ivy/stateful/module.py
+++ b/ivy/stateful/module.py
@@ -571,7 +571,7 @@ class Module(ModuleHelpers, ModuleConverters, ModuleMeta):
         main_str += ")"
         return main_str
 
-    # Methods to be Optionally Overriden #
+    # Methods to be Optionally Overridden #
     # -----------------------------------#
 
     def _create_variables(self, *, device=None, dtype=None):

--- a/ivy_tests/test_ivy/helpers/hypothesis_helpers/general_helpers.py
+++ b/ivy_tests/test_ivy/helpers/hypothesis_helpers/general_helpers.py
@@ -165,7 +165,7 @@ def general_helpers_dtype_info_helper(backend, kind_dtype, dtype):
 
 # from array-api repo
 class BroadcastError(ValueError):
-    """Shapes do not broadcast with eachother."""
+    """Shapes do not broadcast with each other."""
 
 
 # from array-api repo

--- a/scripts/backend_generation/generate.py
+++ b/scripts/backend_generation/generate.py
@@ -268,9 +268,9 @@ def _update_valid_config_value(key):
     ret = ret.strip("")
     if ret == "":
         return True
-    indicies = ret.split(" ")
-    indicies = [int(item.strip(" ")) for item in indicies]
-    for i in sorted(indicies, reverse=True):
+    indices = ret.split(" ")
+    indices = [int(item.strip(" ")) for item in indices]
+    for i in sorted(indices, reverse=True):
         del config_valids[key][i]
     return True
 


### PR DESCRIPTION
# PR Description
I used [codespell](https://github.com/codespell-project/codespell) pre-commit hook to identify misspellings across the entire repo. I fixed almost all of the spelling mistakes currently present in the repo. 

## Related Issue
Closes #27425

## Checklist

- [ ] Did you add a function?
- [ ] Did you add the tests?
- [ ] Did you run your tests and are your tests passing?
- [x] Did pre-commit not fail on any check?
- [ ] Did you follow the steps we provided?


### Socials
https://twitter.com/Sai_Suraj_27