### PR TITLE
fix: Fixed passing of arguments in `get_referrers_recursive()` function call

### DIFF
--- a/ivy/functional/ivy/general.py
+++ b/ivy/functional/ivy/general.py
@@ -254,7 +254,11 @@ def get_referrers_recursive(
 
         def get_referrers_recursive_inner():
             return get_referrers_recursive(
-                ref, depth + 1, max_depth, seen_set, local_set
+                ref,
+                depth=depth + 1,
+                max_depth=max_depth,
+                seen_set=seen_set,
+                local_set=local_set,
             )
 
         this_repr = "tracked" if seen else str(ref).replace(" ", "")


### PR DESCRIPTION
# PR Description
In the following function call, all the arguments are passed as `positional` arguments. 
https://github.com/unifyai/ivy/blob/0984dae7599deb043d491e339eb7d908cb16a774/ivy/functional/ivy/general.py#L256-L258
From the function definition few of them should be passed as `key-word only` arguments.
https://github.com/unifyai/ivy/blob/0984dae7599deb043d491e339eb7d908cb16a774/ivy/functional/ivy/general.py#L182-L189

## Related Issue
Closes #27427

## Checklist

- [ ] Did you add a function?
- [ ] Did you add the tests?
- [ ] Did you run your tests and are your tests passing?
- [x] Did pre-commit not fail on any check?
- [ ] Did you follow the steps we provided?


### Socials
https://twitter.com/Sai_Suraj_27