### PR TITLE
fix: Fixed raising `TypeError` exception instead or `ValueError` exception for invalid type

### DIFF
--- a/ivy/compiler/replace_with.py
+++ b/ivy/compiler/replace_with.py
@@ -15,7 +15,7 @@ def replace_with(new_func):
 
     def decorator(original_func):
         if not callable(original_func) or not callable(new_func):
-            raise ValueError(
+            raise TypeError(
                 f"Both '{original_func.__name__}' and '{new_func.__name__}' should be"
                 " callable."
             )

--- a/ivy/functional/frontends/jax/numpy/fft.py
+++ b/ivy/functional/frontends/jax/numpy/fft.py
@@ -24,7 +24,7 @@ def fftfreq(n, d=1.0, *, dtype=None):
     if not isinstance(
         n, (int, type(ivy.int8), type(ivy.int16), type(ivy.int32), type(ivy.int64))
     ):
-        raise ValueError("n should be an integer")
+        raise TypeError("n should be an integer")
 
     dtype = ivy.float64 if dtype is None else ivy.as_ivy_dtype(dtype)
 

--- a/ivy/functional/frontends/jax/numpy/indexing.py
+++ b/ivy/functional/frontends/jax/numpy/indexing.py
@@ -52,7 +52,7 @@ class _AxisConcat(abc.ABC):
                 newobj = _make_1d_grid_from_slice(item)
                 item_ndim = 0
             elif isinstance(item, str):
-                raise ValueError("string directive must be placed at the beginning")
+                raise TypeError("string directive must be placed at the beginning")
             else:
                 newobj = array(item, copy=False)
                 item_ndim = newobj.ndim

--- a/ivy/functional/frontends/numpy/fft/discrete_fourier_transform.py
+++ b/ivy/functional/frontends/numpy/fft/discrete_fourier_transform.py
@@ -31,7 +31,7 @@ def fftfreq(n, d=1.0):
     if not isinstance(
         n, (int, type(ivy.int8), type(ivy.int16), type(ivy.int32), type(ivy.int64))
     ):
-        raise ValueError("n should be an integer")
+        raise TypeError("n should be an integer")
 
     N = (n - 1) // 2 + 1
     val = 1.0 / (n * d)
@@ -135,7 +135,7 @@ def rfftfreq(n, d=1.0):
     if not isinstance(
         n, (int, type(ivy.int8), type(ivy.int16), type(ivy.int32), type(ivy.int64))
     ):
-        raise ValueError("n should be an integer")
+        raise TypeError("n should be an integer")
 
     val = 1.0 / (n * d)
     N = n // 2 + 1

--- a/ivy/functional/frontends/paddle/nn/functional/vision.py
+++ b/ivy/functional/frontends/paddle/nn/functional/vision.py
@@ -118,7 +118,7 @@ def pixel_shuffle(x, upscale_factor, data_format="NCHW"):
     )
 
     if not isinstance(upscale_factor, int):
-        raise ValueError("upscale factor must be int type")
+        raise TypeError("upscale factor must be int type")
 
     if data_format not in ["NCHW", "NHWC"]:
         raise ValueError(
@@ -172,7 +172,7 @@ def pixel_unshuffle(x, downscale_factor, data_format="NCHW"):
         )
 
     if not isinstance(downscale_factor, int):
-        raise ValueError("Downscale factor must be int type")
+        raise TypeError("Downscale factor must be int type")
 
     if downscale_factor <= 0:
         raise ValueError("Downscale factor must be positive")

--- a/ivy/functional/frontends/torch/nn/modules/module.py
+++ b/ivy/functional/frontends/torch/nn/modules/module.py
@@ -147,7 +147,7 @@ class Module(ivy.Module):
             mod = getattr(mod, item)
 
             if not isinstance(mod, Module):
-                raise AttributeError("`" + item + "` is not an nn.Module")
+                raise TypeError("`" + item + "` is not an nn.Module")
 
         return mod
 

--- a/ivy/utils/assertions.py
+++ b/ivy/utils/assertions.py
@@ -184,7 +184,7 @@ def check_same_dtype(x1, x2, message=""):
 
 def check_unsorted_segment_valid_params(data, segment_ids, num_segments):
     if not isinstance(num_segments, int):
-        raise ValueError("num_segments must be of integer type")
+        raise TypeError("num_segments must be of integer type")
 
     valid_dtypes = [
         ivy.int32,


### PR DESCRIPTION
# PR Description
In few places in the codebase, We are raising `ValueError` upon encountering an inappropriate type. It is more appropriate to raise `TypeError` instead of `ValueError` at these places:
https://github.com/unifyai/ivy/blob/6a7517784ea9c062b3735def4bb81c10d8989078/ivy/functional/frontends/numpy/fft/discrete_fourier_transform.py#L34
https://github.com/unifyai/ivy/blob/6a7517784ea9c062b3735def4bb81c10d8989078/ivy/functional/frontends/numpy/fft/discrete_fourier_transform.py#L138
https://github.com/unifyai/ivy/blob/6a7517784ea9c062b3735def4bb81c10d8989078/ivy/functional/frontends/paddle/nn/functional/vision.py#L121
https://github.com/unifyai/ivy/blob/6a7517784ea9c062b3735def4bb81c10d8989078/ivy/functional/frontends/paddle/nn/functional/vision.py#L175


## Related Issue
Closes #27438 

## Checklist

- [ ] Did you add a function?
- [ ] Did you add the tests?
- [ ] Did you run your tests and are your tests passing?
- [x] Did pre-commit not fail on any check?
- [ ] Did you follow the steps we provided?

### Socials
https://twitter.com/Sai_Suraj_27