### PR TITLE
fix: Improved error handling by raising `ValueError`

### DIFF
--- a/ivy/functional/frontends/tensorflow/linalg.py
+++ b/ivy/functional/frontends/tensorflow/linalg.py
@@ -506,4 +506,4 @@ def tridiagonal_solve(
         )
         return ivy.solve(constructed_matrix, rhs_copy)
     else:
-        raise "Unexpected diagonals_format"
+        raise ValueError("Unexpected diagonals_format")


### PR DESCRIPTION
# PR Description
In the following line, a `string` is raised but this will also result in a `TypeError: exceptions must derive from BaseException`
https://github.com/unifyai/ivy/blob/3b449c63256153a401961bd2ee0c31a897531123/ivy/functional/frontends/tensorflow/linalg.py#L509
So, I changed it to raise like this: `ValueError("Unexpected diagonals_format")`

## Related Issue
Closes #27444

## Checklist

- [ ] Did you add a function?
- [ ] Did you add the tests?
- [ ] Did you run your tests and are your tests passing?
- [x] Did pre-commit not fail on any check?
- [ ] Did you follow the steps we provided?


### Socials
https://twitter.com/Sai_Suraj_27