### PR TITLE
feat: add segment_sum function to Ivy TensorFlow frontend

### DIFF
--- a/ivy/functional/frontends/tensorflow/math.py
+++ b/ivy/functional/frontends/tensorflow/math.py
@@ -831,7 +831,7 @@ def segment_sum(data, segment_ids, name="segment_sum"):
         list(segment_ids.shape), [list(data.shape)[0]], as_array=False
     )
     sum_array = ivy.zeros(
-        tuple([int(segment_ids[-1] + 1)] + (list(data.shape))[1:]), dtype=ivy.int32
+        tuple([int(segment_ids[-1] + 1)] + (list(data.shape))[1:]), dtype=data.dtype
     )
     for i in range((segment_ids).shape[0]):
         sum_array[segment_ids[i]] = sum_array[segment_ids[i]] + data[i]

--- a/ivy/functional/frontends/tensorflow/math.py
+++ b/ivy/functional/frontends/tensorflow/math.py
@@ -819,6 +819,21 @@ def unsorted_segment_sum(data, segment_ids, num_segments, name="unsorted_segment
     return sum_array
 
 
+@to_ivy_arrays_and_back
+def segment_sum(data, segment_ids, name="segment_sum"):
+    data = ivy.array(data)
+    segment_ids = ivy.array(segment_ids)
+    ivy.utils.assertions.check_equal(
+        list(segment_ids.shape), [list(data.shape)[0]], as_array=False
+    )
+    sum_array = ivy.zeros(
+        tuple([int(segment_ids[-1] + 1)] + (list(data.shape))[1:]), dtype=ivy.int32
+    )
+    for i in range((segment_ids).shape[0]):
+        sum_array[segment_ids[i]] = sum_array[segment_ids[i]] + data[i]
+    return sum_array
+
+
 @with_supported_dtypes(
     {"2.15.0 and below": ("float32", "float64", "complex64", "complex128")},
     "tensorflow",
@@ -861,18 +876,3 @@ def zero_fraction(value, name="zero_fraction"):
 )
 def zeta(x, q, name=None):
     return ivy.zeta(x, q)
-
-
-@to_ivy_arrays_and_back
-def segment_sum(data, segment_ids, name="segment_sum"):
-    data = ivy.array(data)
-    segment_ids = ivy.array(segment_ids)
-    ivy.utils.assertions.check_equal(
-        list(segment_ids.shape), [list(data.shape)[0]], as_array=False
-    )
-    sum_array = ivy.zeros(
-        tuple([int(segment_ids[-1] + 1)] + (list(data.shape))[1:]), dtype=ivy.int32
-    )
-    for i in range((segment_ids).shape[0]):
-        sum_array[segment_ids[i]] = sum_array[segment_ids[i]] + data[i]
-    return sum_array

--- a/ivy/functional/frontends/tensorflow/math.py
+++ b/ivy/functional/frontends/tensorflow/math.py
@@ -637,6 +637,25 @@ def scalar_mul(scalar, x, name="scalar_mul"):
     return ivy.multiply(x, scalar).astype(x.dtype)
 
 
+@with_unsupported_dtypes(
+    {"2.15.0 and below": ("float16", "bool", "int8")},
+    "tensorflow",
+)
+@to_ivy_arrays_and_back
+def segment_sum(data, segment_ids, name="segment_sum"):
+    data = ivy.array(data)
+    segment_ids = ivy.array(segment_ids)
+    ivy.utils.assertions.check_equal(
+        list(segment_ids.shape), [list(data.shape)[0]], as_array=False
+    )
+    sum_array = ivy.zeros(
+        tuple([int(segment_ids[-1] + 1)] + (list(data.shape))[1:]), dtype=data.dtype
+    )
+    for i in range((segment_ids).shape[0]):
+        sum_array[segment_ids[i]] = sum_array[segment_ids[i]] + data[i]
+    return sum_array
+
+
 @to_ivy_arrays_and_back
 def sigmoid(x, name=None):
     return ivy.sigmoid(x)
@@ -813,25 +832,6 @@ def unsorted_segment_sum(data, segment_ids, num_segments, name="unsorted_segment
     )
     sum_array = ivy.zeros(
         tuple([num_segments.item()] + (list(data.shape))[1:]), dtype=ivy.int32
-    )
-    for i in range((segment_ids).shape[0]):
-        sum_array[segment_ids[i]] = sum_array[segment_ids[i]] + data[i]
-    return sum_array
-
-
-@with_unsupported_dtypes(
-    {"2.15.0 and below": ("float16", "bool", "int8")},
-    "tensorflow",
-)
-@to_ivy_arrays_and_back
-def segment_sum(data, segment_ids, name="segment_sum"):
-    data = ivy.array(data)
-    segment_ids = ivy.array(segment_ids)
-    ivy.utils.assertions.check_equal(
-        list(segment_ids.shape), [list(data.shape)[0]], as_array=False
-    )
-    sum_array = ivy.zeros(
-        tuple([int(segment_ids[-1] + 1)] + (list(data.shape))[1:]), dtype=data.dtype
     )
     for i in range((segment_ids).shape[0]):
         sum_array[segment_ids[i]] = sum_array[segment_ids[i]] + data[i]

--- a/ivy/functional/frontends/tensorflow/math.py
+++ b/ivy/functional/frontends/tensorflow/math.py
@@ -819,6 +819,10 @@ def unsorted_segment_sum(data, segment_ids, num_segments, name="unsorted_segment
     return sum_array
 
 
+@with_unsupported_dtypes(
+    {"2.15.0 and below": ("float16", "bool")},
+    "tensorflow",
+)
 @to_ivy_arrays_and_back
 def segment_sum(data, segment_ids, name="segment_sum"):
     data = ivy.array(data)

--- a/ivy/functional/frontends/tensorflow/math.py
+++ b/ivy/functional/frontends/tensorflow/math.py
@@ -820,7 +820,7 @@ def unsorted_segment_sum(data, segment_ids, num_segments, name="unsorted_segment
 
 
 @with_unsupported_dtypes(
-    {"2.15.0 and below": ("float16", "bool")},
+    {"2.15.0 and below": ("float16", "bool", "int8")},
     "tensorflow",
 )
 @to_ivy_arrays_and_back

--- a/ivy/functional/frontends/tensorflow/math.py
+++ b/ivy/functional/frontends/tensorflow/math.py
@@ -862,6 +862,7 @@ def zero_fraction(value, name="zero_fraction"):
 def zeta(x, q, name=None):
     return ivy.zeta(x, q)
 
+
 @to_ivy_arrays_and_back
 def segment_sum(data, segment_ids, name="segment_sum"):
     data = ivy.array(data)

--- a/ivy/functional/frontends/tensorflow/math.py
+++ b/ivy/functional/frontends/tensorflow/math.py
@@ -861,3 +861,17 @@ def zero_fraction(value, name="zero_fraction"):
 )
 def zeta(x, q, name=None):
     return ivy.zeta(x, q)
+
+@to_ivy_arrays_and_back
+def segment_sum(data, segment_ids, name="segment_sum"):
+    data = ivy.array(data)
+    segment_ids = ivy.array(segment_ids)
+    ivy.utils.assertions.check_equal(
+        list(segment_ids.shape), [list(data.shape)[0]], as_array=False
+    )
+    sum_array = ivy.zeros(
+        tuple([int(segment_ids[-1] + 1)] + (list(data.shape))[1:]), dtype=ivy.int32
+    )
+    for i in range((segment_ids).shape[0]):
+        sum_array[segment_ids[i]] = sum_array[segment_ids[i]] + data[i]
+    return sum_array

--- a/ivy/functional/frontends/tensorflow/math.py
+++ b/ivy/functional/frontends/tensorflow/math.py
@@ -862,7 +862,6 @@ def zero_fraction(value, name="zero_fraction"):
 def zeta(x, q, name=None):
     return ivy.zeta(x, q)
 
-
 @to_ivy_arrays_and_back
 def segment_sum(data, segment_ids, name="segment_sum"):
     data = ivy.array(data)

--- a/ivy/functional/frontends/tensorflow/math.py
+++ b/ivy/functional/frontends/tensorflow/math.py
@@ -638,7 +638,7 @@ def scalar_mul(scalar, x, name="scalar_mul"):
 
 
 @with_unsupported_dtypes(
-    {"2.15.0 and below": ("float16", "bool", "int8")},
+    {"2.15.0 and below": ("float16", "bool", "int16", "int8")},
     "tensorflow",
 )
 @to_ivy_arrays_and_back

--- a/ivy_tests/test_ivy/test_frontends/test_tensorflow/test_math.py
+++ b/ivy_tests/test_ivy/test_frontends/test_tensorflow/test_math.py
@@ -3201,7 +3201,7 @@ def test_tensorflow_unsorted_segment_sum(
 
 @handle_frontend_test(
     fn_tree="tensorflow.math.segment_sum",
-    data=helpers.array_values(dtype=ivy.int32, shape=(5, 6), min_value=1, max_value=9),
+    data=helpers.array_values(dtype=helpers.get_dtypes(), shape=(5, 6)),
     segment_ids=helpers.array_values(
         dtype=ivy.int32,
         shape=(5,),
@@ -3221,7 +3221,7 @@ def test_tensorflow_segment_sum(
     on_device,
 ):
     helpers.test_frontend_function(
-        input_dtypes=["int32", "int64"],
+        input_dtypes=[],
         frontend=frontend,
         backend_to_test=backend_fw,
         test_flags=test_flags,

--- a/ivy_tests/test_ivy/test_frontends/test_tensorflow/test_math.py
+++ b/ivy_tests/test_ivy/test_frontends/test_tensorflow/test_math.py
@@ -3373,7 +3373,6 @@ def test_tensorflow_zeta(
     ),
     test_with_out=st.just(False),
 )
-
 def test_tensorflow_segment_sum(
     *,
     data,

--- a/ivy_tests/test_ivy/test_frontends/test_tensorflow/test_math.py
+++ b/ivy_tests/test_ivy/test_frontends/test_tensorflow/test_math.py
@@ -3203,7 +3203,7 @@ def test_tensorflow_unsorted_segment_sum(
     fn_tree="tensorflow.math.segment_sum",
     data=helpers.array_values(dtype=helpers.get_dtypes(), shape=(5, 6)),
     segment_ids=helpers.array_values(
-        dtype=ivy.int32,
+        dtype=helpers.get_dtypes(kind="integer", prune_function=True),
         shape=(5,),
         min_value=0,
         max_value=4,
@@ -3221,7 +3221,7 @@ def test_tensorflow_segment_sum(
     on_device,
 ):
     helpers.test_frontend_function(
-        input_dtypes=[str(data.dtype), "int32"],
+        input_dtypes=[str(data.dtype), "int32", "int64"],
         frontend=frontend,
         backend_to_test=backend_fw,
         test_flags=test_flags,

--- a/ivy_tests/test_ivy/test_frontends/test_tensorflow/test_math.py
+++ b/ivy_tests/test_ivy/test_frontends/test_tensorflow/test_math.py
@@ -3360,3 +3360,35 @@ def test_tensorflow_zeta(
         x=x[0],
         q=x[1],
     )
+
+@handle_frontend_test(
+    fn_tree="tensorflow.math.segment_sum",
+    data=helpers.array_values(dtype=ivy.int32, shape=(5, 6), min_value=1, max_value=9),
+    segment_ids=helpers.array_values(
+        dtype=ivy.int32,
+        shape=(5,),
+        min_value=0,
+        max_value=4,
+    ),
+    test_with_out=st.just(False),
+)
+def test_tensorflow_segment_sum(
+    *,
+    data,
+    segment_ids,
+    frontend,
+    test_flags,
+    fn_tree,
+    backend_fw,
+    on_device,
+):
+    helpers.test_frontend_function(
+        input_dtypes=["int32", "int64"],
+        frontend=frontend,
+        backend_to_test=backend_fw,
+        test_flags=test_flags,
+        fn_tree=fn_tree,
+        on_device=on_device,
+        data=data,
+        segment_ids=np.sort(segment_ids),
+    )

--- a/ivy_tests/test_ivy/test_frontends/test_tensorflow/test_math.py
+++ b/ivy_tests/test_ivy/test_frontends/test_tensorflow/test_math.py
@@ -3199,6 +3199,39 @@ def test_tensorflow_unsorted_segment_sum(
     )
 
 
+@handle_frontend_test(
+    fn_tree="tensorflow.math.segment_sum",
+    data=helpers.array_values(dtype=ivy.int32, shape=(5, 6), min_value=1, max_value=9),
+    segment_ids=helpers.array_values(
+        dtype=ivy.int32,
+        shape=(5,),
+        min_value=0,
+        max_value=4,
+    ),
+    test_with_out=st.just(False),
+)
+def test_tensorflow_segment_sum(
+    *,
+    data,
+    segment_ids,
+    frontend,
+    test_flags,
+    fn_tree,
+    backend_fw,
+    on_device,
+):
+    helpers.test_frontend_function(
+        input_dtypes=["int32", "int64"],
+        frontend=frontend,
+        backend_to_test=backend_fw,
+        test_flags=test_flags,
+        fn_tree=fn_tree,
+        on_device=on_device,
+        data=data,
+        segment_ids=np.sort(segment_ids),
+    )
+
+
 # xdivy
 @handle_frontend_test(
     fn_tree="tensorflow.math.xdivy",
@@ -3359,37 +3392,4 @@ def test_tensorflow_zeta(
         on_device=on_device,
         x=x[0],
         q=x[1],
-    )
-
-
-@handle_frontend_test(
-    fn_tree="tensorflow.math.segment_sum",
-    data=helpers.array_values(dtype=ivy.int32, shape=(5, 6), min_value=1, max_value=9),
-    segment_ids=helpers.array_values(
-        dtype=ivy.int32,
-        shape=(5,),
-        min_value=0,
-        max_value=4,
-    ),
-    test_with_out=st.just(False),
-)
-def test_tensorflow_segment_sum(
-    *,
-    data,
-    segment_ids,
-    frontend,
-    test_flags,
-    fn_tree,
-    backend_fw,
-    on_device,
-):
-    helpers.test_frontend_function(
-        input_dtypes=["int32", "int64"],
-        frontend=frontend,
-        backend_to_test=backend_fw,
-        test_flags=test_flags,
-        fn_tree=fn_tree,
-        on_device=on_device,
-        data=data,
-        segment_ids=np.sort(segment_ids),
     )

--- a/ivy_tests/test_ivy/test_frontends/test_tensorflow/test_math.py
+++ b/ivy_tests/test_ivy/test_frontends/test_tensorflow/test_math.py
@@ -2650,6 +2650,39 @@ def test_tensorflow_scalar_mul(
     )
 
 
+@handle_frontend_test(
+    fn_tree="tensorflow.math.segment_sum",
+    data=helpers.array_values(dtype=helpers.get_dtypes(), shape=(5, 6)),
+    segment_ids=helpers.array_values(
+        dtype=helpers.get_dtypes(kind="integer", prune_function=True),
+        shape=(5,),
+        min_value=0,
+        max_value=4,
+    ),
+    test_with_out=st.just(False),
+)
+def test_tensorflow_segment_sum(
+    *,
+    data,
+    segment_ids,
+    frontend,
+    test_flags,
+    fn_tree,
+    backend_fw,
+    on_device,
+):
+    helpers.test_frontend_function(
+        input_dtypes=[str(data.dtype), "int32", "int64"],
+        frontend=frontend,
+        backend_to_test=backend_fw,
+        test_flags=test_flags,
+        fn_tree=fn_tree,
+        on_device=on_device,
+        data=data,
+        segment_ids=np.sort(segment_ids),
+    )
+
+
 # sigmoid
 @handle_frontend_test(
     fn_tree="tensorflow.math.sigmoid",
@@ -3196,39 +3229,6 @@ def test_tensorflow_unsorted_segment_sum(
         data=data,
         segment_ids=segment_ids,
         num_segments=np.max(segment_ids) + 1,
-    )
-
-
-@handle_frontend_test(
-    fn_tree="tensorflow.math.segment_sum",
-    data=helpers.array_values(dtype=helpers.get_dtypes(), shape=(5, 6)),
-    segment_ids=helpers.array_values(
-        dtype=helpers.get_dtypes(kind="integer", prune_function=True),
-        shape=(5,),
-        min_value=0,
-        max_value=4,
-    ),
-    test_with_out=st.just(False),
-)
-def test_tensorflow_segment_sum(
-    *,
-    data,
-    segment_ids,
-    frontend,
-    test_flags,
-    fn_tree,
-    backend_fw,
-    on_device,
-):
-    helpers.test_frontend_function(
-        input_dtypes=[str(data.dtype), "int32", "int64"],
-        frontend=frontend,
-        backend_to_test=backend_fw,
-        test_flags=test_flags,
-        fn_tree=fn_tree,
-        on_device=on_device,
-        data=data,
-        segment_ids=np.sort(segment_ids),
     )
 
 

--- a/ivy_tests/test_ivy/test_frontends/test_tensorflow/test_math.py
+++ b/ivy_tests/test_ivy/test_frontends/test_tensorflow/test_math.py
@@ -3373,6 +3373,7 @@ def test_tensorflow_zeta(
     ),
     test_with_out=st.just(False),
 )
+
 def test_tensorflow_segment_sum(
     *,
     data,

--- a/ivy_tests/test_ivy/test_frontends/test_tensorflow/test_math.py
+++ b/ivy_tests/test_ivy/test_frontends/test_tensorflow/test_math.py
@@ -3361,6 +3361,7 @@ def test_tensorflow_zeta(
         q=x[1],
     )
 
+
 @handle_frontend_test(
     fn_tree="tensorflow.math.segment_sum",
     data=helpers.array_values(dtype=ivy.int32, shape=(5, 6), min_value=1, max_value=9),

--- a/ivy_tests/test_ivy/test_frontends/test_tensorflow/test_math.py
+++ b/ivy_tests/test_ivy/test_frontends/test_tensorflow/test_math.py
@@ -3221,7 +3221,7 @@ def test_tensorflow_segment_sum(
     on_device,
 ):
     helpers.test_frontend_function(
-        input_dtypes=[],
+        input_dtypes=[str(data.dtype), "int32"],
         frontend=frontend,
         backend_to_test=backend_fw,
         test_flags=test_flags,

--- a/ivy_tests/test_ivy/test_frontends/test_tensorflow/test_math.py
+++ b/ivy_tests/test_ivy/test_frontends/test_tensorflow/test_math.py
@@ -2652,9 +2652,9 @@ def test_tensorflow_scalar_mul(
 
 @handle_frontend_test(
     fn_tree="tensorflow.math.segment_sum",
-    data=helpers.array_values(dtype=helpers.get_dtypes(), shape=(5, 6)),
+    data=helpers.array_values(dtype=helpers.get_dtypes("valid"), shape=(5, 6)),
     segment_ids=helpers.array_values(
-        dtype=helpers.get_dtypes(kind="integer", prune_function=True),
+        dtype=helpers.get_dtypes("signed_integer", prune_function=True),
         shape=(5,),
         min_value=0,
         max_value=4,


### PR DESCRIPTION
<!--
This template will help you to have a meaningful PR, please follow it and do not leave it blank.
-->

# add segment_sum function to Ivy TensorFlow frontend under math 

<!--
Computes the sum along segments of a tensor.
-->

## 27220

<!--
Please use this format to link other issues with their numbers: Close #123
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes #27220

## Checklist

- [x] Did you add a function?
- [x] Did you add the tests?
- [x] Did you run your tests and are your tests passing?
- [x] Did pre-commit not fail on any check?
- [x] Did you follow the steps we provided?

<!--
Please mark your PR as a draft if you realise after the fact that your tests are not passing or
that your pre-commit check has some failures.

Here are some relevant resources regarding tests and pre-commit:

https://unify.ai/docs/ivy/overview/deep_dive/ivy_tests.html
https://unify.ai/docs/ivy/overview/deep_dive/formatting.html#pre-commit

-->

### Socials

<!--
If you have Twitter, please provide it here otherwise just ignore this.
-->
