### PR TITLE
fix: Fixed arguments in `staticmethod`

### DIFF
--- a/ivy/data_classes/container/general.py
+++ b/ivy/data_classes/container/general.py
@@ -1545,7 +1545,7 @@ class _ContainerWithGeneral(ContainerBase):
 
     @staticmethod
     def _static_has_nans(
-        self: ivy.Container,
+        x: ivy.Container,
         /,
         *,
         include_infs: Union[bool, ivy.Container] = True,
@@ -1560,7 +1560,7 @@ class _ContainerWithGeneral(ContainerBase):
 
         Parameters
         ----------
-        self
+        x
             The container to check for nans.
         include_infs
             Whether to include infs and -infs in the check. Default is True.
@@ -1593,7 +1593,7 @@ class _ContainerWithGeneral(ContainerBase):
         """
         return ContainerBase.cont_multi_map_in_function(
             "has_nans",
-            self,
+            x,
             include_infs=include_infs,
             key_chains=key_chains,
             to_apply=to_apply,


### PR DESCRIPTION
# PR Description
In the following `staticmethod` definition the first argument is used as `self`.
https://github.com/unifyai/ivy/blob/3d8175d486636c15ec0b03bf9886ea5423296593/ivy/data_classes/container/general.py#L1546-L1556
I changed it to `x` to follow the recommended way like in other `staticmethods`.

## Related Issue
Closes #27466

## Checklist

- [ ] Did you add a function?
- [ ] Did you add the tests?
- [ ] Did you run your tests and are your tests passing?
- [x] Did pre-commit not fail on any check?
- [ ] Did you follow the steps we provided?

### Socials
https://twitter.com/Sai_Suraj_27