### PR TITLE
(fix)(TF backend): optimized the backend implementation of `ivy.linear` for TF backend to make use of `tf.matmul` for the 2D input case

### DIFF
--- a/ivy/functional/backends/tensorflow/layers.py
+++ b/ivy/functional/backends/tensorflow/layers.py
@@ -28,7 +28,7 @@ def linear(
     bias: Optional[Union[tf.Tensor, tf.Variable]] = None,
     out: Optional[Union[tf.Tensor, tf.Variable]] = None,
 ) -> Union[tf.Tensor, tf.Variable]:
-    return tf.einsum("...i,...ji->...j", x, weight) + bias
+    return tf.add(tf.matmul(x, weight, transpose_b=True), bias)
 
 
 def _x_dil_before_conv(x, dims, x_dilations, data_format):

--- a/ivy/functional/backends/tensorflow/layers.py
+++ b/ivy/functional/backends/tensorflow/layers.py
@@ -37,7 +37,7 @@ def linear(
         result = tf.einsum("...i,...ji->...j", x, weight)
 
     if bias is not None:
-        return result + add
+        return tf.add(result, bias)
     return result
 
 

--- a/ivy/functional/backends/tensorflow/layers.py
+++ b/ivy/functional/backends/tensorflow/layers.py
@@ -28,11 +28,14 @@ def linear(
     bias: Optional[Union[tf.Tensor, tf.Variable]] = None,
     out: Optional[Union[tf.Tensor, tf.Variable]] = None,
 ) -> Union[tf.Tensor, tf.Variable]:
+    # TODO: try to generalize this for >=2 dimensions
     if len(x.shape) == 2 and len(weight.shape) == 2:
         if x.shape[-1] == weight.shape[-2]:
             result = tf.matmul(x, weight)
         elif x.shape[-1] == weight.shape[-1]:
             result = tf.matmul(x, weight, transpose_b=True)
+        else:
+            result = tf.einsum("...i,...ji->...j", x, weight)
     else:
         result = tf.einsum("...i,...ji->...j", x, weight)
 

--- a/ivy/functional/backends/tensorflow/layers.py
+++ b/ivy/functional/backends/tensorflow/layers.py
@@ -37,7 +37,7 @@ def linear(
         result = tf.einsum("...i,...ji->...j", x, weight)
 
     if bias is not None:
-        return tf.add(result, add)
+        return result + add
     return result
 
 

--- a/ivy/functional/backends/tensorflow/layers.py
+++ b/ivy/functional/backends/tensorflow/layers.py
@@ -28,7 +28,7 @@ def linear(
     bias: Optional[Union[tf.Tensor, tf.Variable]] = None,
     out: Optional[Union[tf.Tensor, tf.Variable]] = None,
 ) -> Union[tf.Tensor, tf.Variable]:
-    if len(x.shape) >= 2 and len(weight.shape) >= 2:
+    if len(x.shape) == 2 and len(weight.shape) == 2:
         if x.shape[-1] == weight.shape[-2]:
             result = tf.matmul(x, weight)
         elif x.shape[-1] == weight.shape[-1]:

--- a/ivy/functional/backends/tensorflow/layers.py
+++ b/ivy/functional/backends/tensorflow/layers.py
@@ -30,11 +30,15 @@ def linear(
 ) -> Union[tf.Tensor, tf.Variable]:
     if len(x.shape) >= 2 and len(weight.shape) >= 2:
         if x.shape[-1] == weight.shape[-2]:
-            return tf.matmul(x, weight) + bias
+            result = tf.matmul(x, weight)
         elif x.shape[-1] == weight.shape[-1]:
-            return tf.matmul(x, weight, transpose_b=True) + bias
+            result = tf.matmul(x, weight, transpose_b=True)
+    else:
+        result = tf.einsum("...i,...ji->...j", x, weight)
 
-    return tf.einsum("...i,...ji->...j", x, weight) + bias
+    if bias is not None:
+        return tf.add(result, add)
+    return result
 
 
 def _x_dil_before_conv(x, dims, x_dilations, data_format):

--- a/ivy/functional/backends/tensorflow/layers.py
+++ b/ivy/functional/backends/tensorflow/layers.py
@@ -28,7 +28,13 @@ def linear(
     bias: Optional[Union[tf.Tensor, tf.Variable]] = None,
     out: Optional[Union[tf.Tensor, tf.Variable]] = None,
 ) -> Union[tf.Tensor, tf.Variable]:
-    return tf.add(tf.matmul(x, weight, transpose_b=True), bias)
+    if len(x.shape) >= 2 and len(weight.shape) >= 2:
+        if x.shape[-1] == weight.shape[-2]:
+            return tf.matmul(x, weight) + bias
+        elif x.shape[-1] == weight.shape[-1]:
+            return tf.matmul(x, weight, transpose_b=True) + bias
+
+    return tf.einsum("...i,...ji->...j", x, weight) + bias
 
 
 def _x_dil_before_conv(x, dims, x_dilations, data_format):


### PR DESCRIPTION
Rewrote the implementation to use the classic (x*w.T + b) formula instead of the more sophisticated tf.einsum op which was also causing a huge slowdown during training.


<!--
This template will help you to have a meaningful PR, please follow it and do not leave it blank.
-->

# PR Description

<!--
If there is no related issue, please add a short description about your PR.
-->

## Related Issue

<!--
Please use this format to link other issues with their numbers: Close #123
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes #

## Checklist

- [ ] Did you add a function?
- [ ] Did you add the tests?
- [ ] Did you run your tests and are your tests passing?
- [ ] Did pre-commit not fail on any check?
- [ ] Did you follow the steps we provided?

<!--
Please mark your PR as a draft if you realise after the fact that your tests are not passing or
that your pre-commit check has some failures.

Here are some relevant resources regarding tests and pre-commit:

https://unify.ai/docs/ivy/overview/deep_dive/ivy_tests.html
https://unify.ai/docs/ivy/overview/deep_dive/formatting.html#pre-commit

-->

### Socials

<!--
If you have Twitter, please provide it here otherwise just ignore this.
-->
