### PR TITLE
fix: Fixed raising `TypeError` instead or `ValueError`

### DIFF
--- a/ivy/functional/backends/jax/experimental/losses.py
+++ b/ivy/functional/backends/jax/experimental/losses.py
@@ -83,7 +83,7 @@ def _validate_poisson_nll_params(
     # Validate dtypes
     for parameter, name in zip([input, label], ["input", "label"]):
         if parameter.dtype not in allowed_dtypes:
-            raise ValueError(
+            raise TypeError(
                 "The dtype of '%s' in poisson_nll_loss should be one of %s, but"
                 " received %s." % (name, allowed_dtypes, parameter.dtype)
             )

--- a/ivy/functional/backends/numpy/experimental/creation.py
+++ b/ivy/functional/backends/numpy/experimental/creation.py
@@ -98,7 +98,7 @@ def unsorted_segment_min(
     elif data.dtype in [np.int32, np.int64, np.int8, np.int16, np.uint8]:
         init_val = np.iinfo(data.dtype).max
     else:
-        raise ValueError("Unsupported data type")
+        raise TypeError("Unsupported data type")
 
     res = np.full((num_segments,) + data.shape[1:], init_val, dtype=data.dtype)
 

--- a/ivy/functional/backends/numpy/experimental/elementwise.py
+++ b/ivy/functional/backends/numpy/experimental/elementwise.py
@@ -571,7 +571,7 @@ def erfc(
     out: Optional[np.ndarray] = None,
 ) -> np.ndarray:
     if x.dtype not in [np.float16, np.float32, np.float64]:
-        raise ValueError("Input must be of type float16, float32, or float64.")
+        raise TypeError("Input must be of type float16, float32, or float64.")
 
     input_dtype = x.dtype
 

--- a/ivy/functional/backends/numpy/experimental/losses.py
+++ b/ivy/functional/backends/numpy/experimental/losses.py
@@ -97,7 +97,7 @@ def _validate_poisson_nll_params(
     # Validate dtypes
     for parameter, name in zip([input, label], ["input", "label"]):
         if parameter.dtype not in allowed_dtypes:
-            raise ValueError(
+            raise TypeError(
                 f"The dtype of '{name}' in poisson_nll_loss should be one of"
                 f" {allowed_dtypes}, but received {parameter.dtype}."
             )

--- a/ivy/functional/backends/numpy/sorting.py
+++ b/ivy/functional/backends/numpy/sorting.py
@@ -62,7 +62,7 @@ def searchsorted(
     ret_dtype: np.dtype = np.int64,
     out: Optional[np.ndarray] = None,
 ) -> np.ndarray:
-    assert ivy.is_int_dtype(ret_dtype), ValueError(
+    assert ivy.is_int_dtype(ret_dtype), TypeError(
         "only Integer data types are supported for ret_dtype."
     )
     is_sorter_provided = sorter is not None

--- a/ivy/functional/backends/paddle/experimental/creation.py
+++ b/ivy/functional/backends/paddle/experimental/creation.py
@@ -115,7 +115,7 @@ def unsorted_segment_min(
     elif data.dtype == paddle.int64:
         init_val = 9223372036854775807
     else:
-        raise ValueError("Unsupported data type")
+        raise TypeError("Unsupported data type")
     # Using paddle.full is causing integer overflow for int64
     res = paddle.empty((num_segments,) + tuple(data.shape[1:]), dtype=data.dtype)
     res[:] = init_val

--- a/ivy/functional/backends/paddle/sorting.py
+++ b/ivy/functional/backends/paddle/sorting.py
@@ -52,7 +52,7 @@ def searchsorted(
     out: Optional[paddle.Tensor] = None,
 ) -> paddle.Tensor:
     right = True if side == "right" else False
-    assert ivy.is_int_dtype(ret_dtype), ValueError(
+    assert ivy.is_int_dtype(ret_dtype), TypeError(
         "only Integer data types are supported for ret_dtype."
     )
 

--- a/ivy/functional/backends/tensorflow/experimental/losses.py
+++ b/ivy/functional/backends/tensorflow/experimental/losses.py
@@ -87,7 +87,7 @@ def _validate_poisson_nll_params(
     # Validate dtypes
     for parameter, name in zip([input, label], ["input", "label"]):
         if parameter.dtype not in allowed_dtypes:
-            raise ValueError(
+            raise TypeError(
                 f"The dtype of '{name}' in poisson_nll_loss should be one of"
                 f" {allowed_dtypes}, but received {parameter.dtype}."
             )

--- a/ivy/functional/backends/tensorflow/sorting.py
+++ b/ivy/functional/backends/tensorflow/sorting.py
@@ -64,7 +64,7 @@ def searchsorted(
     ret_dtype: tf.DType = tf.int64,
     out: Optional[Union[tf.Tensor, tf.Variable]] = None,
 ) -> Union[tf.Tensor, tf.Variable]:
-    assert ivy.is_int_dtype(ret_dtype), ValueError(
+    assert ivy.is_int_dtype(ret_dtype), TypeError(
         "only Integer data types are supported for ret_dtype."
     )
     is_supported_int_ret_dtype = ret_dtype in [tf.int32, tf.int64]

--- a/ivy/functional/backends/torch/experimental/creation.py
+++ b/ivy/functional/backends/torch/experimental/creation.py
@@ -139,7 +139,7 @@ def unsorted_segment_min(
     elif data.dtype in [torch.int32, torch.int64, torch.int8, torch.int16, torch.uint8]:
         init_val = torch.iinfo(data.dtype).max
     else:
-        raise ValueError("Unsupported data type")
+        raise TypeError("Unsupported data type")
 
     res = torch.full(
         (num_segments,) + data.shape[1:], init_val, dtype=data.dtype, device=data.device

--- a/ivy/functional/backends/torch/sorting.py
+++ b/ivy/functional/backends/torch/sorting.py
@@ -72,7 +72,7 @@ def searchsorted(
     ret_dtype: torch.dtype = torch.int64,
     out: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
-    assert ivy.is_int_dtype(ret_dtype), ValueError(
+    assert ivy.is_int_dtype(ret_dtype), TypeError(
         "only Integer data types are supported for ret_dtype."
     )
     if sorter is not None:

--- a/ivy/functional/frontends/numpy/ndarray/ndarray.py
+++ b/ivy/functional/frontends/numpy/ndarray/ndarray.py
@@ -732,7 +732,7 @@ def _to_bytes_helper(array, order="C"):
         elif ivy.is_uint_dtype(dtype):
             return _unsigned_int_bytes_repr(scalar_value, dtype=dtype)
         else:
-            raise ValueError("Unsupported data type for the array.")
+            raise TypeError("Unsupported data type for the array.")
     else:
         if order == "F":
             array = np_frontend.ravel(array, order="F").ivy_array

--- a/ivy/functional/frontends/torch/creation_ops.py
+++ b/ivy/functional/frontends/torch/creation_ops.py
@@ -82,7 +82,7 @@ def complex(
     *,
     out=None,
 ):
-    assert real.dtype == imag.dtype, ValueError(
+    assert real.dtype == imag.dtype, TypeError(
         "Expected real and imag to have the same dtype, "
         f" but got real.dtype = {real.dtype} and imag.dtype = {imag.dtype}."
     )

--- a/ivy/utils/assertions.py
+++ b/ivy/utils/assertions.py
@@ -211,7 +211,7 @@ def check_unsorted_segment_valid_params(data, segment_ids, num_segments):
             num_segments = num_segments.item()
 
     if segment_ids.dtype not in valid_dtypes:
-        raise ValueError("segment_ids must have an integer dtype")
+        raise TypeError("segment_ids must have an integer dtype")
 
     if data.shape[0] != segment_ids.shape[0]:
         raise ValueError("The length of segment_ids should be equal to data.shape[0].")


### PR DESCRIPTION
# PR Description
In few places in the codebase, We are raising `ValueError` upon encountering an inappropriate type. It is more appropriate to raise `TypeError` instead of `ValueError` at these places:
https://github.com/unifyai/ivy/blob/ef98ac9ab4425c1a8f57cd283bead11520861866/ivy/functional/backends/torch/sorting.py#L75-L76
https://github.com/unifyai/ivy/blob/ef98ac9ab4425c1a8f57cd283bead11520861866/ivy/functional/backends/numpy/experimental/elementwise.py#L574
https://github.com/unifyai/ivy/blob/ef98ac9ab4425c1a8f57cd283bead11520861866/ivy/functional/frontends/numpy/ndarray/ndarray.py#L735
https://github.com/unifyai/ivy/blob/ef98ac9ab4425c1a8f57cd283bead11520861866/ivy/functional/backends/paddle/sorting.py#L55-L56
https://github.com/unifyai/ivy/blob/ef98ac9ab4425c1a8f57cd283bead11520861866/ivy/functional/backends/paddle/experimental/creation.py#L118

## Related Issue
Closes #27735 

## Checklist

- [ ] Did you add a function?
- [ ] Did you add the tests?
- [ ] Did you run your tests and are your tests passing?
- [x] Did pre-commit not fail on any check?
- [ ] Did you follow the steps we provided?


### Socials
