### PR TITLE
fix: Added `timeout` argument in requests call

### DIFF
--- a/docker/gpu_framework_directory.py
+++ b/docker/gpu_framework_directory.py
@@ -15,7 +15,7 @@ import requests
 def get_latest_package_version(package_name):
     try:
         url = f"https://pypi.org/pypi/{package_name}/json"
-        response = requests.get(url)
+        response = requests.get(url, timeout=10)
         response.raise_for_status()
         package_info = response.json()
         return package_info["info"]["version"]

--- a/scripts/run_tests/helpers.py
+++ b/scripts/run_tests/helpers.py
@@ -4,7 +4,7 @@ import requests
 def get_latest_package_version(package_name):
     try:
         url = f"https://pypi.org/pypi/{package_name}/json"
-        response = requests.get(url)
+        response = requests.get(url, timeout=10)
         response.raise_for_status()
         package_info = response.json()
         return package_info["info"]["version"]


### PR DESCRIPTION
# PR Description
In the following places, `timeout` parameter is not used.
https://github.com/unifyai/ivy/blob/1f6264e1be8946b4b142668a0201fbaa73ee0810/docker/gpu_framework_directory.py#L18
https://github.com/unifyai/ivy/blob/1f6264e1be8946b4b142668a0201fbaa73ee0810/scripts/run_tests/helpers.py#L7
The `timeout` parameter is used to set the maximum time to wait for a response from the server. By omitting the `timeout` parameter, the program may hang indefinitely while awaiting a response.

From the [documentation](https://requests.readthedocs.io/en/latest/user/advanced/#timeouts), I see that the value of timeout can be mentioned in seconds (like 5 seconds).

I think it's good to use the `timeout` parameter with a value of 10 seconds.


## Related Issue
Closes #27741 

## Checklist

- [ ] Did you add a function?
- [ ] Did you add the tests?
- [ ] Did you run your tests and are your tests passing?
- [x] Did pre-commit not fail on any check?
- [ ] Did you follow the steps we provided?

### Socials
https://twitter.com/Sai_Suraj_27