### PR TITLE
fix: Fixed wrong links in docs.

### DIFF
--- a/docs/overview/contributing/open_tasks.rst
+++ b/docs/overview/contributing/open_tasks.rst
@@ -3,7 +3,7 @@ Open Tasks
 
 .. _`repo`: https://github.com/unifyai/ivy
 .. _`discord`: https://discord.gg/sXyFF8tDtm
-.. _`open tasks channel`: https://discord.com/channels/799879767196958751/985156466963021854
+.. _`open tasks channel`: https://discord.com/channels/799879767196958751/982728618469912627
 .. _`issue description`: https://github.com/unifyai/ivy/issues/1526
 .. _`reference API`: https://numpy.org/doc/stable/reference/routines.linalg.html
 .. _`imports`: https://github.com/unifyai/ivy/blob/38dbb607334cb32eb513630c4496ad0024f80e1c/ivy/functional/frontends/numpy/__init__.py#L27

--- a/docs/overview/contributing/the_basics.rst
+++ b/docs/overview/contributing/the_basics.rst
@@ -7,7 +7,6 @@ The Basics
 .. _`Atlassian tutorial`: https://www.atlassian.com/git/tutorials/saving-changes/git-stash
 .. _`fork management channel`: https://discord.com/channels/799879767196958751/982728689408167956
 .. _`pull requests channel`: https://discord.com/channels/799879767196958751/982728733859414056
-.. _`commit frequency channel`: https://discord.com/channels/799879767196958751/982728822317256712
 .. _`PyCharm blog`: https://www.jetbrains.com/help/pycharm/finding-and-replacing-text-in-file.html
 .. _`Debugging`: https://www.jetbrains.com/help/pycharm/debugging-code.html
 
@@ -599,4 +598,4 @@ with PyCharm
 
 This should have hopefully given you a good understanding of the basics for contributing.
 
-If you have any questions, please feel free to reach out on `discord`_ in the `todo list issues channel`_, `fork management channel`_, `pull requests channel`_, `commit frequency channel`_ depending on the question!
+If you have any questions, please feel free to reach out on `discord`_ in the `todo list issues channel`_, `fork management channel`_, `pull requests channel`_, depending on the question!


### PR DESCRIPTION
# PR Description
The link to [open tasks channel](https://discord.com/channels/799879767196958751/985156466963021854) is wrong. It is taking us to the `rules` channel in discord.
https://github.com/unifyai/ivy/blob/a395c0a565f4f02a81393e67f715333dc63d5f1c/docs/overview/contributing/open_tasks.rst?plain=1#L6

I guess the `open tasks channel` is removed. It is best to change this link to the [`todo-list-issues`](https://discord.com/channels/799879767196958751/982728618469912627) channel.

Also, I think this `commit frequency` channel is removed now:
https://github.com/unifyai/ivy/blob/a395c0a565f4f02a81393e67f715333dc63d5f1c/docs/overview/contributing/the_basics.rst?plain=1#L10

## Related Issue
Closes #27747 

## Checklist

- [ ] Did you add a function?
- [ ] Did you add the tests?
- [ ] Did you run your tests and are your tests passing?
- [x] Did pre-commit not fail on any check?
- [ ] Did you follow the steps we provided?


### Socials
https://twitter.com/Sai_Suraj_27