### PR TITLE
fix: Added missing `staticmethod` decorator

### DIFF
--- a/ivy/__init__.py
+++ b/ivy/__init__.py
@@ -429,6 +429,7 @@ class Shape(Sequence):
         if self.rank not in (None, rank):
             raise ValueError(f"Shape {self} must have rank {rank}")
 
+    @staticmethod
     def unknown_shape(rank=None, **kwargs):
         if rank is None and "ndims" in kwargs:
             rank = kwargs.pop("ndims")
@@ -457,6 +458,7 @@ class Shape(Sequence):
         else:
             return self
 
+    @staticmethod
     def as_shape(shape):
         if isinstance(shape, Shape):
             return shape


### PR DESCRIPTION
# PR Description
For the following methods, the `staticmethod` decorator is missing.
https://github.com/unifyai/ivy/blob/4eda5bfb91e45d182afc75f21c3b200253ee64c0/ivy/__init__.py#L432
https://github.com/unifyai/ivy/blob/4eda5bfb91e45d182afc75f21c3b200253ee64c0/ivy/__init__.py#L460

## Related Issue
Closes #27750 

## Checklist

- [ ] Did you add a function?
- [ ] Did you add the tests?
- [ ] Did you run your tests and are your tests passing?
- [x] Did pre-commit not fail on any check?
- [ ] Did you follow the steps we provided?

### Socials
https://twitter.com/Sai_Suraj_27