### PR TITLE
feat: Replaced `pydocstyle` with `ruff` and modified files accordingly

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,12 +32,12 @@ repos:
     rev: v1.7.5
     hooks:
       - id: docformatter
-  - repo: https://github.com/pycqa/pydocstyle
-    rev: 6.3.0
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.1.8
     hooks:
-      - id: pydocstyle
-        # Exclude everything in frontends except __init__.py, and func_wrapper.py
-        exclude: 'ivy/functional/(frontends|backends)/(?!.*/func_wrapper\.py$).*(?!__init__\.py$)'
+      # Run the linter.
+      - id: ruff
+        args: [ --fix ]
   - repo: https://github.com/unifyai/lint-hook
     rev: a72ffb17562d919311653d7f593cb537d1245c19
     hooks:

--- a/ivy/functional/backends/paddle/experimental/elementwise.py
+++ b/ivy/functional/backends/paddle/experimental/elementwise.py
@@ -751,9 +751,11 @@ def _is_scalar(x):
     """Determines if the given tensor is a scalar.
 
     Args:
+    ----
     - x (paddle.Tensor): Input tensor.
 
     Returns:
+    -------
     - bool: True if the tensor is a scalar, False otherwise.
     """
     return x.size == 1 and x.dim() == 0 and tuple(x.shape) == ()

--- a/ivy/functional/frontends/torch/tensor.py
+++ b/ivy/functional/frontends/torch/tensor.py
@@ -285,6 +285,7 @@ class Tensor:
             - list of ints
             - torch.Size object
             - ints
+
         Parameters
         ----------
         args:int arguments

--- a/ivy/functional/ivy/device.py
+++ b/ivy/functional/ivy/device.py
@@ -297,6 +297,7 @@ def set_soft_device_mode(mode: bool) -> None:
     ---------
     mode
         boolean whether to move input arrays
+
     Examples
     --------
     >>> ivy.set_soft_device_mode(False)

--- a/ivy_tests/test_docstrings.py
+++ b/ivy_tests/test_docstrings.py
@@ -68,7 +68,6 @@ def check_docstring_examples_run(
     -------
     None if the test passes, else marks the test as failed.
     """
-
     """
     Functions skipped as their output dependent on outside factors:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,3 +5,35 @@ requires = [
     "pip"
 ]
 build-backend = "setuptools.build_meta"
+
+[tool.ruff]
+
+target-version = "py38"
+
+select = ["D"] # Only pydocstyle as of now (https://docs.astral.sh/ruff/rules/#pydocstyle-d)
+
+ignore = [
+
+    "D100", # Missing docstring in public module.
+    "D101", # Missing docstring in public class.
+    "D102", # Missing docstring in public method.
+    "D103", # Missing docstring in public function.
+    "D104", # Missing docstring in public package.
+    "D105", # Missing docstring in magic method.
+    "D106", # Missing docstring in public nested class.
+    "D107", # Missing docstring in `__init__`.
+    "D203", # 1 blank line required before class docstring.
+    "D205", # 1 blank line required between summary line and description.
+    "D212", # Multi-line docstring summary should start at the first line.
+    "D213", # Multi-line docstring summary should start at the second line.
+    "D209", # Multi-line docstring closing quotes should be on a separate line.
+    "D400", # First line should end with a period.
+    "D401", # First line of docstring should be in imperative mood.
+    "D415", # First line should end with a period, question mark, or exclamation point.
+    "D416", # Section name should end with a colon ("Attributes").
+    "D417", # Missing argument description in the docstring for argument "X".
+]
+
+exclude = [
+'ivy/functional/(frontends|backends)/(?!.*/func_wrapper\.py$).*(?!__init__\.py$)',
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "setuptools.build_meta"
 [tool.ruff]
 target-version = "py38"
 
-select = ["D"] # Only pydocstyle as of now (https://docs.astral.sh/ruff/rules/#pydocstyle-d)
+select = ["D"] # Enabling Only pydocstyle checks as of now (https://docs.astral.sh/ruff/rules/#pydocstyle-d)
 
 ignore = [
     "D100", # Missing docstring in public module.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,13 +7,11 @@ requires = [
 build-backend = "setuptools.build_meta"
 
 [tool.ruff]
-
 target-version = "py38"
 
 select = ["D"] # Only pydocstyle as of now (https://docs.astral.sh/ruff/rules/#pydocstyle-d)
 
 ignore = [
-
     "D100", # Missing docstring in public module.
     "D101", # Missing docstring in public class.
     "D102", # Missing docstring in public method.


### PR DESCRIPTION
# PR Description
The `Pydocstyle` repo is [officially depreciated](https://github.com/pycqa/pydocstyle#deprecation-notice-pydocstyle). They [advised](https://github.com/pycqa/pydocstyle#ruff-a-modern-alternative) to switch to the `ruff` linter.
So, we can configure `Ruff` in the `pyproject.toml` file to only run the `Pydocstyle` related checks (As ruff offers many other checks too).

This can be easily done following [this section](https://docs.astral.sh/ruff/linter/#rule-selection) in documentation of `ruff`.

## Related Issue
Closes #27739

## Checklist

- [ ] Did you add a function?
- [ ] Did you add the tests?
- [ ] Did you run your tests and are your tests passing?
- [x] Did pre-commit not fail on any check?
- [ ] Did you follow the steps we provided?

### Socials
