### PR TITLE
fix: Fixed passing of wrong key-word argument in `paddle.nn.functional.smooth_l1_loss()`

### DIFF
--- a/ivy/functional/backends/paddle/experimental/losses.py
+++ b/ivy/functional/backends/paddle/experimental/losses.py
@@ -66,7 +66,7 @@ def smooth_l1_loss(
     reduction: Optional[str] = "mean",
 ) -> paddle.Tensor:
     return paddle.nn.functional.smooth_l1_loss(
-        input, target, reduction=reduction, beta=beta
+        input, target, reduction=reduction, delta=beta
     )
 
 


### PR DESCRIPTION
# PR Description
In the following function call,
https://github.com/unifyai/ivy/blob/d3a7737d0b3b0957c5379b6adcb8b7041cbf2d15/ivy/functional/backends/paddle/experimental/losses.py#L68-L70

The key-word argument `beta` is used, it should be `delta` 
https://github.com/PaddlePaddle/Paddle/blob/48c21b50fa2ecce7e48753da9b3e9b1cdac60e36/python/paddle/nn/functional/loss.py#L1049

## Related Issue
Closes #27793

## Checklist

- [ ] Did you add a function?
- [ ] Did you add the tests?
- [ ] Did you run your tests and are your tests passing?
- [x] Did pre-commit not fail on any check?
- [ ] Did you follow the steps we provided?

### Socials
