### PR TITLE
fix: Fixed wrong argument name in `paddle.concat()` function call

### DIFF
--- a/ivy/functional/backends/paddle/set.py
+++ b/ivy/functional/backends/paddle/set.py
@@ -135,7 +135,7 @@ def unique_inverse(
             x.dtype
         )
         unique = paddle.concat(
-            input=[unique.astype(x.dtype), paddle.reshape(unique_nan, [nan_count])],
+            [unique.astype(x.dtype), paddle.reshape(unique_nan, [nan_count])],
             axis=-1,
         )
     inverse_val = paddle.reshape(inverse_val, shape=x.shape)


### PR DESCRIPTION
# PR Description
In the following function call,
https://github.com/unifyai/ivy/blob/d3a7737d0b3b0957c5379b6adcb8b7041cbf2d15/ivy/functional/backends/paddle/set.py#L137-L140
The argument `input` is passed but if we see the actual definition of `paddle.concat()` there is no argument with the name of `input`. 
The correct argument is `x` but it is not mandatory to pass it as a key-word argument.
https://github.com/PaddlePaddle/Paddle/blob/48c21b50fa2ecce7e48753da9b3e9b1cdac60e36/python/paddle/tensor/manipulation.py#L1206

The correct way to call the function is:
https://github.com/unifyai/ivy/blob/d3a7737d0b3b0957c5379b6adcb8b7041cbf2d15/ivy/functional/backends/paddle/set.py#L100-L102
https://github.com/unifyai/ivy/blob/d3a7737d0b3b0957c5379b6adcb8b7041cbf2d15/ivy/functional/backends/paddle/set.py#L103-L105 


## Related Issue
Closes #27798 

## Checklist

- [ ] Did you add a function?
- [ ] Did you add the tests?
- [ ] Did you run your tests and are your tests passing?
- [x] Did pre-commit not fail on any check?
- [ ] Did you follow the steps we provided?

### Socials
