### PR TITLE
feat: triplet margin loss added to functional experimental

### DIFF
--- a/ivy/functional/ivy/experimental/losses.py
+++ b/ivy/functional/ivy/experimental/losses.py
@@ -635,8 +635,8 @@ def triplet_loss(
     >>> ivy.triplet_loss(anchor, positive, negative, reduction='none')
     ivy.array([1.0, 1.0])
     """
-    pos_distance = ivy.reduce_sum((anchor - positive)**2, axis=-1)
-    neg_distance = ivy.reduce_sum((anchor - negative)**2, axis=-1)
+    pos_distance = ivy.reduce_sum((anchor - positive) ** 2, axis=-1)
+    neg_distance = ivy.reduce_sum((anchor - negative) ** 2, axis=-1)
     loss = ivy.maximum(0.0, pos_distance - neg_distance + margin)
 
     if reduction == "mean":
@@ -647,4 +647,3 @@ def triplet_loss(
         loss = ivy.inplace_update(out, loss) if out is not None else loss
 
     return loss
-

--- a/ivy/functional/ivy/experimental/losses.py
+++ b/ivy/functional/ivy/experimental/losses.py
@@ -626,5 +626,5 @@ def triplet_margin_loss(
     distance_positive = ivy.norm(anchor - positive, ord=2, axis=-1)
     distance_negative = ivy.norm(anchor - negative, ord=2, axis=-1)
     loss = ivy.clip(distance_positive - distance_negative + margin, 0.0, None)
-    
+
     return _reduce_loss(reduction, loss, axis=None, out=out)

--- a/ivy/functional/ivy/experimental/losses.py
+++ b/ivy/functional/ivy/experimental/losses.py
@@ -571,3 +571,60 @@ def poisson_nll_loss(
         eps=eps,
         reduction=reduction,
     )
+
+
+@handle_exceptions
+@handle_nestable
+@handle_array_like_without_promotion
+@inputs_to_ivy_arrays
+@handle_array_function
+def triplet_margin_loss(
+    anchor: Union[ivy.Array, ivy.NativeArray],
+    positive: Union[ivy.Array, ivy.NativeArray],
+    negative: Union[ivy.Array, ivy.NativeArray],
+    /,
+    *,
+    margin: float = 0.2,
+    reduction: str = "mean",
+    out: Optional[ivy.Array] = None,
+) -> ivy.Array:
+    """Compute triplet margin loss.
+
+    Parameters
+    ----------
+    anchor
+        input array containing anchor points.
+    positive
+        input array containing positive points.
+    negative
+        input array containing negative points.
+    margin
+        margin parameter for the triplet margin loss. Default: 0.2.
+    reduction
+        ``'none'``: No reduction will be applied to the output.
+        ``'mean'``: The output will be averaged.
+        ``'sum'``: The output will be summed. Default: ``'mean'``.
+    out
+        optional output array, for writing the result to. It must have a shape
+        that the inputs broadcast to.
+
+    Returns
+    -------
+    ret
+        The triplet margin loss.
+
+    Examples
+    --------
+    >>> anchor = ivy.array([1.0, 2.0, 3.0])
+    >>> positive = ivy.array([4.0, 5.0, 6.0])
+    >>> negative = ivy.array([7.0, 8.0, 9.0])
+    >>> loss = ivy.triplet_margin_loss(anchor, positive, negative)
+    >>> print(loss)
+    ivy.array(0.0)
+    """
+    # Implementation of the triplet margin loss
+    distance_positive = ivy.norm(anchor - positive, ord=2, axis=-1)
+    distance_negative = ivy.norm(anchor - negative, ord=2, axis=-1)
+    loss = ivy.clip(distance_positive - distance_negative + margin, 0.0, None)
+    
+    return _reduce_loss(reduction, loss, axis=None, out=out)


### PR DESCRIPTION
Updated ivy/ functional/ ivy/ experimental/ losses.py with the inclusion of "triplet_margin_loss".

# PR Description

## Changes Made
Added a new function `triplet_margin_loss` to the `ivy` library, which computes the triplet margin loss. This loss is commonly used in triplet loss scenarios, such as in siamese networks for learning embeddings.

## Purpose
The purpose of this addition is to provide users with a convenient and efficient way to compute triplet margin loss, allowing for better support of applications involving metric learning and similarity-based tasks.

## Related Issue
Closes #27204

## Checklist

- [X] Did you add a function?
- [ ] Did you add the tests?
- [ ] Did you run your tests and are your tests passing?
- [ ] Did pre-commit not fail on any check?
- [ ] Did you follow the steps we provided?

<!--
Please mark your PR as a draft if you realise after the fact that your tests are not passing or
that your pre-commit check has some failures.

Here are some relevant resources regarding tests and pre-commit:

https://unify.ai/docs/ivy/overview/deep_dive/ivy_tests.html
https://unify.ai/docs/ivy/overview/deep_dive/formatting.html#pre-commit

-->

