### PR TITLE
fix: Fixed missing argument in `ivy.inplace_update()` function call

### DIFF
--- a/ivy/functional/backends/jax/experimental/manipulation.py
+++ b/ivy/functional/backends/jax/experimental/manipulation.py
@@ -462,7 +462,7 @@ def take(
     # clip, wrap, fill
     ret = jnp.take(x, indices, axis=axis, mode=mode, fill_value=fill_value)
     if ivy.exists(out):
-        ivy.inplace_update(out)
+        ivy.inplace_update(out, ret)
     return ret
 
 


### PR DESCRIPTION
# PR Description
In the following function call, the argument for `val` is not passed.
https://github.com/unifyai/ivy/blob/3f28537e0a0783ebcd68e2c11e9c6a30ed4b4d17/ivy/functional/backends/jax/experimental/manipulation.py#L462-L465
From the actual definition of the inplace_update() function, 2 arguments should be passed (`x, and val`)
https://github.com/unifyai/ivy/blob/3f28537e0a0783ebcd68e2c11e9c6a30ed4b4d17/ivy/functional/ivy/general.py#L2954-L2961


## Related Issue
Closes #27807 

## Checklist

- [ ] Did you add a function?
- [ ] Did you add the tests?
- [ ] Did you run your tests and are your tests passing?
- [x] Did pre-commit not fail on any check?
- [ ] Did you follow the steps we provided?

### Socials
