### PR TITLE
fix: Fixed passing of missing `backend` argument in few function calls

### DIFF
--- a/ivy_tests/test_ivy/test_frontends/test_tensorflow/test_linalg.py
+++ b/ivy_tests/test_ivy/test_frontends/test_tensorflow/test_linalg.py
@@ -414,6 +414,7 @@ def test_tensorflow_eigvals(
         rtol=1e-06,
         atol=1e-06,
         ground_truth_backend=frontend,
+        backend=backend_fw,
     )
 
 
@@ -969,6 +970,7 @@ def test_tensorflow_qr(
         rtol=1e-2,
         atol=1e-2,
         ground_truth_backend=frontend,
+        backend=backend_fw,
     )
 
 
@@ -1120,6 +1122,7 @@ def test_tensorflow_svd(
         rtol=1e-2,
         atol=1e-2,
         ground_truth_backend=frontend,
+        backend=backend_fw,
     )
 
 

--- a/ivy_tests/test_ivy/test_frontends/test_tensorflow/test_raw_ops.py
+++ b/ivy_tests/test_ivy/test_frontends/test_tensorflow/test_raw_ops.py
@@ -4279,6 +4279,7 @@ def test_tensorflow_Svd(
         rtol=1e-2,
         atol=1e-2,
         ground_truth_backend=frontend,
+        backend=backend_fw,
     )
 
 

--- a/ivy_tests/test_ivy/test_frontends/test_tensorflow/test_tensor.py
+++ b/ivy_tests/test_ivy/test_frontends/test_tensorflow/test_tensor.py
@@ -1552,6 +1552,7 @@ def test_tensorflow_ivy_array(
         ret_np_flat=ret,
         ret_np_from_gt_flat=ret_gt,
         ground_truth_backend="tensorflow",
+        backend=backend_fw,
     )
     ivy.previous_backend()
 

--- a/ivy_tests/test_ivy/test_frontends/test_torch/test_linalg.py
+++ b/ivy_tests/test_ivy/test_frontends/test_torch/test_linalg.py
@@ -467,6 +467,7 @@ def test_torch_eig(
         rtol=1e-2,
         atol=1e-2,
         ground_truth_backend=frontend,
+        backend=backend_fw,
     )
 
 
@@ -511,6 +512,7 @@ def test_torch_eigh(
         ret_np=Q @ np.diag(L) @ Q.T,
         ret_from_gt_np=frontend_Q @ np.diag(frontend_L) @ frontend_Q.T,
         atol=1e-02,
+        backend=backend_fw,
     )
 
 
@@ -581,6 +583,7 @@ def test_torch_eigvals(
         rtol=1e-2,
         atol=1e-2,
         ground_truth_backend=frontend,
+        backend=backend_fw,
     )
 
 
@@ -1001,6 +1004,7 @@ def test_torch_qr(
         rtol=1e-2,
         atol=1e-2,
         ground_truth_backend=frontend,
+        backend=backend_fw,
     )
     ivy.previous_backend()
 
@@ -1150,6 +1154,7 @@ def test_torch_svd(
         rtol=1e-2,
         atol=1e-2,
         ground_truth_backend=frontend,
+        backend=backend_fw,
     )
 
 

--- a/ivy_tests/test_ivy/test_frontends/test_torch/test_tensor.py
+++ b/ivy_tests/test_ivy/test_frontends/test_torch/test_tensor.py
@@ -10384,8 +10384,8 @@ def test_torch_normal_(
         return
 
     ret_np, ret_from_np = ret
-    ret_np = helpers.flatten_and_to_np(ret=ret_np)
-    ret_from_np = helpers.flatten_and_to_np(ret=ret_from_np)
+    ret_np = helpers.flatten_and_to_np(ret=ret_np, backend=backend_fw)
+    ret_from_np = helpers.flatten_and_to_np(ret=ret_from_np, backend=backend_fw)
     for u, v in zip(ret_np, ret_from_np):
         assert u.dtype == v.dtype
         assert u.shape == v.shape
@@ -10510,9 +10510,10 @@ def test_torch_numpy(
     )
     # manual testing required as function return is numpy frontend
     helpers.value_test(
-        ret_np_flat=helpers.flatten_and_to_np(ret=ret),
+        ret_np_flat=helpers.flatten_and_to_np(ret=ret, backend=backend_fw),
         ret_np_from_gt_flat=frontend_ret[0],
         ground_truth_backend="torch",
+        backend=backend_fw,
     )
 
 

--- a/ivy_tests/test_ivy/test_stateful/test_layers.py
+++ b/ivy_tests/test_ivy/test_stateful/test_layers.py
@@ -1053,7 +1053,7 @@ def test_dropout_layer(
         test_values=False,
         on_device=on_device,
     )
-    ret = helpers.flatten_and_to_np(ret=ret)
+    ret = helpers.flatten_and_to_np(ret=ret, backend=backend_fw)
     for u in ret:
         # cardinality test
         assert u.shape == x[0].shape


### PR DESCRIPTION
# PR Description
In few files, in some of the function calls, the mandatory key-word argument `backend` is missing:
like in the following cases:
https://github.com/unifyai/ivy/blob/b5422a79808a860068e63d11233b0c0a2461d30f/ivy_tests/test_ivy/test_frontends/test_torch/test_tensor.py#L10194
https://github.com/unifyai/ivy/blob/b5422a79808a860068e63d11233b0c0a2461d30f/ivy_tests/test_ivy/test_frontends/test_torch/test_tensor.py#L10195


From the definition of `flatten_and_to_np` I see that `backend` is a mandatory key-word argument.
https://github.com/unifyai/ivy/blob/b5422a79808a860068e63d11233b0c0a2461d30f/ivy_tests/test_ivy/helpers/function_testing.py#L2408
So, I see that this argument is missing at few places when calling `helpers.flatten_and_to_np()` I think at all these places `backend=backend_fw` should be passed.

## Related Issue
Closes #27110 

## Checklist

- [ ] Did you add a function?
- [ ] Did you add the tests?
- [ ] Did you run your tests and are your tests passing?
- [x] Did pre-commit not fail on any check?
- [ ] Did you follow the steps we provided?


### Socials
