### PR TITLE
Updated a Minor Grammar Issue in building_blocks.rst

### DIFF
--- a/docs/overview/design/building_blocks.rst
+++ b/docs/overview/design/building_blocks.rst
@@ -11,7 +11,7 @@ These are the 4 parts labelled as (a) in the image below:
 Backend Functional APIs ✅
 --------------------------
 
-The first important point to make is that, Ivy does not implement it’s own C++ or CUDA backend.
+The first important point to make is that, Ivy does not implement its own C++ or CUDA backend.
 Instead, Ivy **wraps** the functional APIs of existing frameworks, bringing them into syntactic and semantic alignment.
 Let’s take the function :func:`ivy.stack` as an example.
 


### PR DESCRIPTION
The sentence is correct in terms of its meaning, but there is a minor issue with the use of the apostrophe in "it’s."  The correct form should be "its" without an apostrophe. Here's the corrected version: "The first important point to make is that Ivy does not implement its own C++ or CUDA backend."


<!--
This template will help you to have a meaningful PR, please follow it and do not leave it blank.
-->

# PR Description

<!--
If there is no related issue, please add a short description about your PR.
-->

## Related Issue

<!--
Please use this format to link other issues with their numbers: Close #123
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes #

## Checklist

- [ ] Did you add a function?
- [ ] Did you add the tests?
- [ ] Did you run your tests and are your tests passing?
- [ ] Did pre-commit not fail on any check?
- [ ] Did you follow the steps we provided?

<!--
Please mark your PR as a draft if you realise after the fact that your tests are not passing or
that your pre-commit check has some failures.

Here are some relevant resources regarding tests and pre-commit:

https://unify.ai/docs/ivy/overview/deep_dive/ivy_tests.html
https://unify.ai/docs/ivy/overview/deep_dive/formatting.html#pre-commit

-->

### Socials

<!--
If you have Twitter, please provide it here otherwise just ignore this.
-->
