### PR TITLE
fix: use plural reviewers actor type for Vaunt

### DIFF
--- a/.vaunt/config.yaml
+++ b/.vaunt/config.yaml
@@ -47,7 +47,7 @@ achievements:
       description: Awarded for reviewing pull requests.
       triggers:
         - trigger:
-            actor: reviewer
+            actor: reviewers
             action: pull_request
             condition: count(created_at >= "2023-12-26" & merged = true) >= 1
 
@@ -97,7 +97,7 @@ achievements:
       description: Awarded for reviewing 5 pull requests.
       triggers:
         - trigger:
-            actor: reviewer
+            actor: reviewers
             action: pull_request
             condition: count(created_at >= "2023-12-26" & merged = true) >= 5
 
@@ -147,7 +147,7 @@ achievements:
       description: Awarded for reviewing 15 pull requests.
       triggers:
         - trigger:
-            actor: reviewer
+            actor: reviewers
             action: pull_request
             condition: count(created_at >= "2023-12-26" & merged = true) >= 15
 
@@ -197,6 +197,6 @@ achievements:
       description: Awarded for reviewing 30 pull requests.
       triggers:
         - trigger:
-            actor: reviewer
+            actor: reviewers
             action: pull_request
             condition: count(created_at >= "2023-12-26" & merged = true) >= 30


### PR DESCRIPTION
<!--
This template will help you to have a meaningful PR, please follow it and do not leave it blank.
-->

# PR Description

The Vaunt config specification uses "reviewers" rather than "reviewer" for the actor type on pull_requests to award achievements based on review contributions.

Updating the config to match so these can be awarded.

## Related Issue

<!--
Please use this format to link other issues with their numbers: Close #123
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

## Checklist

- [ ] Did you add a function?
- [ ] Did you add the tests?
- [ ] Did you run your tests and are your tests passing?
- [ ] Did pre-commit not fail on any check?
- [ ] Did you follow the steps we provided?

<!--
Please mark your PR as a draft if you realise after the fact that your tests are not passing or
that your pre-commit check has some failures.

Here are some relevant resources regarding tests and pre-commit:

https://unify.ai/docs/ivy/overview/deep_dive/ivy_tests.html
https://unify.ai/docs/ivy/overview/deep_dive/formatting.html#pre-commit

-->

### Socials

<!--
If you have Twitter, please provide it here otherwise just ignore this.
-->
