### PR TITLE
fix: fixed tests not passing at jax backend

### DIFF
--- a/ivy/functional/backends/jax/elementwise.py
+++ b/ivy/functional/backends/jax/elementwise.py
@@ -68,6 +68,7 @@ def atan2(x1: JaxArray, x2: JaxArray, /, *, out: Optional[JaxArray] = None) -> J
     return jnp.arctan2(x1, x2)
 
 
+@with_unsupported_dtypes({"0.4.23 and below": ("complex",)}, backend_version)
 def atanh(x: JaxArray, /, *, out: Optional[JaxArray] = None) -> JaxArray:
     return jnp.arctanh(x)
 

--- a/ivy_tests/test_ivy/test_functional/test_core/test_elementwise.py
+++ b/ivy_tests/test_ivy/test_functional/test_core/test_elementwise.py
@@ -390,7 +390,9 @@ def test_atan2(*, dtype_and_x, test_flags, backend_fw, fn_name, on_device):
 @handle_test(
     fn_tree="functional.ivy.atanh",
     dtype_and_x=helpers.dtype_and_values(
-        available_dtypes=helpers.get_dtypes("float_and_complex")
+        min_value=1e-30,
+        max_value=1e30,
+        available_dtypes=helpers.get_dtypes("float_and_complex"),
     ),
 )
 def test_atanh(*, dtype_and_x, test_flags, backend_fw, fn_name, on_device):


### PR DESCRIPTION
<!--
This template will help you to have a meaningful PR, please follow it and do not leave it blank.
-->

# Fixed the test failing at jax and paddle backend in ivy.atanh.


<!--
If there is no related issue, please add a short description about your PR.
-->

## passing all the tests at locally.
![image](https://github.com/unifyai/ivy/assets/83540902/34a1ecc6-457d-47b6-90c0-a17b5b925f52)


<!--
Please use this format to link other issues with their numbers: Close #123
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes #27846

## Checklist

- [x] Did you add a function?
- [x] Did you add the tests?
- [x] Did you run your tests and are your tests passing?
- [x] Did pre-commit not fail on any check?
- [x] Did you follow the steps we provided?

<!--
Please mark your PR as a draft if you realise after the fact that your tests are not passing or
that your pre-commit check has some failures.

Here are some relevant resources regarding tests and pre-commit:

https://unify.ai/docs/ivy/overview/deep_dive/ivy_tests.html
https://unify.ai/docs/ivy/overview/deep_dive/formatting.html#pre-commit

-->

### Socials

<!--
If you have Twitter, please provide it here otherwise just ignore this.
-->
