### PR TITLE
fix: Fixed passing of wrong key-word argument `dim` in `ivy.ifftn()` function call.

### DIFF
--- a/ivy/functional/frontends/scipy/fft/fft.py
+++ b/ivy/functional/frontends/scipy/fft/fft.py
@@ -38,7 +38,7 @@ def ifft(x, n=None, axis=-1, norm=None, overwrite_x=False):
 def ifftn(
     x, s=None, axes=None, norm=None, overwrite_x=False, workers=None, *, plan=None
 ):
-    return ivy.ifftn(x, s=s, dim=axes, norm=norm)
+    return ivy.ifftn(x, s=s, axes=axes, norm=norm)
 
 
 @to_ivy_arrays_and_back


### PR DESCRIPTION
# PR Description
In the following function call, the key-word argument `dim` is used:
https://github.com/unifyai/ivy/blob/207dec0cee120a5898749d7b3f7b984341fff313/ivy/functional/frontends/scipy/fft/fft.py#L41
From the actual function definition, the argument should be `axes`
https://github.com/unifyai/ivy/blob/207dec0cee120a5898749d7b3f7b984341fff313/ivy/functional/ivy/experimental/layers.py#L2789-L2796

## Related Issue
Closes #27849 

## Checklist

- [ ] Did you add a function?
- [ ] Did you add the tests?
- [ ] Did you run your tests and are your tests passing?
- [x] Did pre-commit not fail on any check?
- [ ] Did you follow the steps we provided?

### Socials
