### PR TITLE
fix: Fixed passing of un-necessary argument `dtype`

### DIFF
--- a/ivy/functional/frontends/paddle/tensor/tensor.py
+++ b/ivy/functional/frontends/paddle/tensor/tensor.py
@@ -560,9 +560,9 @@ class Tensor:
         return paddle_frontend.isfinite(self)
 
     @with_supported_dtypes({"2.4.2 and below": ("float16", "bfloat16")}, "paddle")
-    def all(self, axis=None, keepdim=False, dtype=None, name=None):
+    def all(self, axis=None, keepdim=False, name=None):
         return paddle_frontend.Tensor(
-            ivy.all(self.ivy_array, axis=axis, keepdims=keepdim, dtype=dtype)
+            ivy.all(self.ivy_array, axis=axis, keepdims=keepdim)
         )
 
     @with_supported_dtypes({"2.5.2 and below": ("float16", "bfloat16")}, "paddle")


### PR DESCRIPTION
# PR Description
In the following function call, the argument `dtype` is un-necessarily passed
https://github.com/unifyai/ivy/blob/3318cd16ec60a05a467393c64afbdd65d46ce2de/ivy/functional/frontends/paddle/tensor/tensor.py#L563-L566
From the actual function definition of `ivy.all()`, there is no argument `dtype`
https://github.com/unifyai/ivy/blob/3318cd16ec60a05a467393c64afbdd65d46ce2de/ivy/functional/ivy/utility.py#L28-L35
Also, from the PaddlePaddle docs we can see that there is no `dtype` argument for the `all()` function.
https://www.paddlepaddle.org.cn/documentation/docs/en/api/paddle/all_en.html#all

## Related Issue
Closes #27879 

## Checklist

- [ ] Did you add a function?
- [ ] Did you add the tests?
- [ ] Did you run your tests and are your tests passing?
- [x] Did pre-commit not fail on any check?
- [ ] Did you follow the steps we provided?

### Socials
