### PR TITLE
fix: Fixed using of deprecated `logging.warn()` method

### DIFF
--- a/ivy/wrappers/utils.py
+++ b/ivy/wrappers/utils.py
@@ -14,7 +14,7 @@ wrapers_dir = os.path.join(folder_path, "ivy/wrappers")
 def download_cython_wrapper(func_name: str):
     """Get the wrapper for the given function name."""
     if func_name + ".so" not in wrappers["ivy"]["functional"]:
-        logging.warn(f"Wrapper for {func_name} not found.")
+        logging.warning(f"Wrapper for {func_name} not found.")
         return False
     try:
         response = request.urlopen(
@@ -29,7 +29,7 @@ def download_cython_wrapper(func_name: str):
         print("Downloaded wrapper for " + func_name)
         return True
     except request.HTTPError:
-        logging.warn(f"Unable to download wrapper for {func_name}.")
+        logging.warning(f"Unable to download wrapper for {func_name}.")
         return False
 
 

--- a/ivy_tests/test_ivy/helpers/function_testing.py
+++ b/ivy_tests/test_ivy/helpers/function_testing.py
@@ -66,7 +66,7 @@ def traced_if_required(backend: str, fn, test_trace=False, args=None, kwargs=Non
             except Exception:
                 import logging
 
-                logging.warn("API key is invalid, test_trace is skipped.")
+                logging.warning("API key is invalid, test_trace is skipped.")
     return fn
 
 


### PR DESCRIPTION
# PR Description
`logging.warn()` has been deprecated since Python 3.3 and `logging.warning()` should be used.
The two functions are functionally equivalent, but `logging.warn()` is no longer considered the preferred way to log warnings.


## Related Issue
Closes #27881 

## Checklist

- [ ] Did you add a function?
- [ ] Did you add the tests?
- [ ] Did you run your tests and are your tests passing?
- [x] Did pre-commit not fail on any check?
- [ ] Did you follow the steps we provided?


### Socials
