### PR TITLE
fix: Fixed passing of wrong key-word argument `dim` in `ivy.ifftn()` function call.

### DIFF
--- a/ivy/functional/frontends/paddle/fft.py
+++ b/ivy/functional/frontends/paddle/fft.py
@@ -280,7 +280,7 @@ def irfft2(x, s=None, axes=(-2, -1), norm="backward"):
     # Calculate the normalization factor 'n' based on the shape 's'
     n = ivy.prod(ivy.array(s))
 
-    result = ivy.ifftn(x, dim=axes[0], norm=norm)
+    result = ivy.ifftn(x, axes=axes[0], norm=norm)
 
     # Normalize the result based on the 'norm' parameter
     if norm == "backward":


### PR DESCRIPTION
# PR Description
In the following function call, the key-word argument `dim` is used:
https://github.com/unifyai/ivy/blob/61c5e083cd33860401a489b434ea46ab7b260e54/ivy/functional/frontends/paddle/fft.py#L283
From the actual function definition, the argument should be `axes`
https://github.com/unifyai/ivy/blob/207dec0cee120a5898749d7b3f7b984341fff313/ivy/functional/ivy/experimental/layers.py#L2789-L2796


## Related Issue
Closes #27884

## Checklist

- [ ] Did you add a function?
- [ ] Did you add the tests?
- [ ] Did you run your tests and are your tests passing?
- [x] Did pre-commit not fail on any check?
- [ ] Did you follow the steps we provided?

### Socials
