### PR TITLE
fix jax backend set item with scalar values

### DIFF
--- a/ivy/functional/backends/jax/general.py
+++ b/ivy/functional/backends/jax/general.py
@@ -91,6 +91,7 @@ def set_item(
 ) -> JaxArray:
     if ivy.is_array(query) and ivy.is_bool_dtype(query):
         query, expected_shape = _mask_to_index(query, x)
+    if ivy.is_array(val):
         val = _broadcast_to(val, expected_shape)._data
     ret = x.at[query].set(val)
     if copy:

--- a/ivy/functional/backends/jax/general.py
+++ b/ivy/functional/backends/jax/general.py
@@ -91,8 +91,8 @@ def set_item(
 ) -> JaxArray:
     if ivy.is_array(query) and ivy.is_bool_dtype(query):
         query, expected_shape = _mask_to_index(query, x)
-    if ivy.is_array(val):
-        val = _broadcast_to(val, expected_shape)._data
+        if ivy.is_array(val):
+            val = _broadcast_to(val, expected_shape)._data
     ret = x.at[query].set(val)
     if copy:
         return ret


### PR DESCRIPTION
this fixes the jax backend for `set_item` when scalar values are used i.e.

```python
import ivy
ivy.set_jax_backend()
x = ivy.array([[1., 2.], [3., 4.]])
query = ivy.array([[True, False], [True, True]])
val = 5.
print(ivy.set_item(x, query, val))
```