### PR TITLE
feat: handle case for float values with int dtype specified in tf backend

### DIFF
--- a/ivy/functional/backends/tensorflow/creation.py
+++ b/ivy/functional/backends/tensorflow/creation.py
@@ -93,10 +93,10 @@ def asarray(
     with tf.device(device):
         if tf.is_tensor(obj):
             ret = tf.cast(obj, dtype) if obj.dtype != dtype else obj
-        # elif dtype.is_integer and np.issubdtype(
-        #     (obj_np := np.array(obj)).dtype, np.floating
-        # ):
-        #     ret = tf.constant(obj_np, dtype=dtype)
+        elif dtype.is_integer and np.issubdtype(
+            (obj_np := np.array(obj)).dtype, np.floating
+        ):
+            ret = tf.constant(obj_np, dtype=dtype)
         else:
             ret = tf.convert_to_tensor(obj, dtype)
         return tf.identity(ret) if (copy or ret.device != device) else ret

--- a/ivy/functional/backends/tensorflow/creation.py
+++ b/ivy/functional/backends/tensorflow/creation.py
@@ -96,7 +96,7 @@ def asarray(
         elif dtype.is_integer and np.issubdtype(
             (obj_np := np.array(obj)).dtype, np.floating
         ):
-            ret = tf.constant(obj_np, dtype=dtype)
+            ret = tf.convert_to_tensor(obj_np, dtype)
         else:
             ret = tf.convert_to_tensor(obj, dtype)
         return tf.identity(ret) if (copy or ret.device != device) else ret

--- a/ivy/functional/backends/tensorflow/creation.py
+++ b/ivy/functional/backends/tensorflow/creation.py
@@ -93,6 +93,10 @@ def asarray(
     with tf.device(device):
         if tf.is_tensor(obj):
             ret = tf.cast(obj, dtype) if obj.dtype != dtype else obj
+        # elif dtype.is_integer and np.issubdtype(
+        #     (obj_np := np.array(obj)).dtype, np.floating
+        # ):
+        #     ret = tf.constant(obj_np, dtype=dtype)
         else:
             ret = tf.convert_to_tensor(obj, dtype)
         return tf.identity(ret) if (copy or ret.device != device) else ret


### PR DESCRIPTION
Previously

```python
import torch
import ivy
import ivy.functional.frontends.torch as torch_frontend
print(torch.tensor(0.5, dtype=torch.int64)) # works - creates tensor(0)

ivy.set_tensorflow_backend()
print(torch_frontend.tensor(0.5, dtype='int64')) # throws error
```
But after this the frontend torch will create `ivy.frontends.torch.Tensor(0)`