### PR TITLE
feat: Updated `ruff` and `black` pre-commit hook versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,13 +7,13 @@ repos:
       - id: check-toml
       - id: end-of-file-fixer
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.1.8
+    rev: v0.1.11
     hooks:
       # Run the linter.
       - id: ruff
         args: [ --fix ]
   - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 23.12.0
+    rev: 23.12.1
     hooks:
       - id: black
         language_version: python3


### PR DESCRIPTION
# PR Description
New versions of [`black`](https://github.com/psf/black-pre-commit-mirror/releases/tag/23.12.1) and [`ruff`](https://github.com/astral-sh/ruff-pre-commit/releases/tag/v0.1.11) are released. So, I have Updated their pre-commit hook versions and modified all the files accordingly.

## Related Issue
Closes #

## Checklist

- [ ] Did you add a function?
- [ ] Did you add the tests?
- [ ] Did you run your tests and are your tests passing?
- [x] Did pre-commit not fail on any check?
- [ ] Did you follow the steps we provided?


### Socials
