### PR TITLE
fix: Fixed passing of un-necessary `device` argument in `ivy.blackman_window()`

### DIFF
--- a/ivy/data_classes/array/experimental/creation.py
+++ b/ivy/data_classes/array/experimental/creation.py
@@ -167,9 +167,7 @@ class _ArrayWithCreationExperimental(abc.ABC):
         ivy.array([-1.38777878e-17,  1.30000000e-01,  6.30000000e-01,  1.00000000e+00,
         6.30000000e-01,  1.30000000e-01, -1.38777878e-17])
         """
-        return ivy.blackman_window(
-            self._data, periodic=periodic, dtype=dtype, device=device, out=out
-        )
+        return ivy.blackman_window(self._data, periodic=periodic, dtype=dtype, out=out)
 
     def trilu(
         self: ivy.Array,


### PR DESCRIPTION
# PR Description
In the following function call, the argument `device` is passed,
https://github.com/unifyai/ivy/blob/06508027180ea29977b4cafd316d536247cb5664/ivy/data_classes/array/experimental/creation.py#L170-L172
From the actual definition of `blackman_window` there is no argument `device`
https://github.com/unifyai/ivy/blob/06508027180ea29977b4cafd316d536247cb5664/ivy/functional/ivy/experimental/creation.py#L684-L690

## Related Issue
Closes #27896 

## Checklist

- [ ] Did you add a function?
- [ ] Did you add the tests?
- [ ] Did you run your tests and are your tests passing?
- [x] Did pre-commit not fail on any check?
- [ ] Did you follow the steps we provided?


### Socials
