### PR TITLE
refactor: Removed un-necessary global declaration for `avg` variable

### DIFF
--- a/ivy/functional/frontends/numpy/statistics/averages_and_variances.py
+++ b/ivy/functional/frontends/numpy/statistics/averages_and_variances.py
@@ -13,7 +13,6 @@ from ivy.functional.frontends.numpy.func_wrapper import (
 @from_zero_dim_arrays_to_scalar
 def average(a, /, *, axis=None, weights=None, returned=False, keepdims=False):
     axis = tuple(axis) if isinstance(axis, list) else axis
-    global avg
     avg = 0
 
     if keepdims is None:


### PR DESCRIPTION
# PR Description
In the following line, we are initializing a `global variable` but, the variable is not defined in the module scope.
https://github.com/unifyai/ivy/blob/06508027180ea29977b4cafd316d536247cb5664/ivy/functional/frontends/numpy/statistics/averages_and_variances.py#L16-L17
The variable `avg` is only used in that function and not anywhere else in the file.
So, the `global` statement is un-necessary and the `avg` variable can be defined normally in the function.

## Related Issue
Closes #27898

## Checklist

- [ ] Did you add a function?
- [ ] Did you add the tests?
- [ ] Did you run your tests and are your tests passing?
- [x] Did pre-commit not fail on any check?
- [ ] Did you follow the steps we provided?


### Socials
