### PR TITLE
fix: Fixed passing of arguments to `ivy.polyval()` function call

### DIFF
--- a/ivy/data_classes/array/experimental/creation.py
+++ b/ivy/data_classes/array/experimental/creation.py
@@ -342,6 +342,4 @@ def polyval(
     return ivy.polyval(
         coeffs,
         x,
-        dtype=dtype,
-        device=device,
     )


### PR DESCRIPTION
# PR Description
In the following function call, the key-word arguments `dtype` and `device` are used,
https://github.com/unifyai/ivy/blob/66e0c4905908633fa1b2966d6da05a183c9f40d5/ivy/data_classes/array/experimental/creation.py#L342-L347
From the actual `def` of `polyval` function, there are no arguments `dtype` and `device`.
https://github.com/unifyai/ivy/blob/66e0c4905908633fa1b2966d6da05a183c9f40d5/ivy/functional/ivy/experimental/creation.py#L1167-L1170


## Related Issue
Closes #27904 

## Checklist

- [ ] Did you add a function?
- [ ] Did you add the tests?
- [ ] Did you run your tests and are your tests passing?
- [x] Did pre-commit not fail on any check?
- [ ] Did you follow the steps we provided?

### Socials
