### PR TITLE
fix: Fixed using of deprecated `inspect.getargspec()` function

### DIFF
--- a/ivy/functional/frontends/torch/utilities.py
+++ b/ivy/functional/frontends/torch/utilities.py
@@ -27,7 +27,7 @@ def bincount(x, weights=None, minlength=0):
 
 
 def if_else(cond_fn, body_fn, orelse_fn, vars):
-    cond_keys = inspect.getargspec(cond_fn).args
+    cond_keys = inspect.getfullargspec(cond_fn).args
     cond_vars = dict(zip(cond_keys, vars))
     return ivy.if_else(cond_fn, body_fn, orelse_fn, cond_vars)
 


### PR DESCRIPTION
# PR Description
In the following line, `inspect.getargspect()` is used,
https://github.com/unifyai/ivy/blob/66e0c4905908633fa1b2966d6da05a183c9f40d5/ivy/functional/frontends/torch/utilities.py#L30
The `getargspec()` function is deprecated since Python 3.0; use [inspect.signature()](https://docs.python.org/3/library/inspect.html#inspect.signature) or [inspect.getfullargspec()](https://docs.python.org/3/library/inspect.html#inspect.getfullargspec) instead.

For reference:
https://docs.python.org/3/library/inspect.html#inspect.getfullargspec

## Related Issue
Closes #27906 

## Checklist

- [ ] Did you add a function?
- [ ] Did you add the tests?
- [ ] Did you run your tests and are your tests passing?
- [x] Did pre-commit not fail on any check?
- [ ] Did you follow the steps we provided?


### Socials
