### PR TITLE
fix: Fixed the link to `github_rewards` in docs

### DIFF
--- a/docs/overview/contributing/volunteer_workflow.rst
+++ b/docs/overview/contributing/volunteer_workflow.rst
@@ -3,7 +3,7 @@ Volunteer Workflow
 
 We've created a promotion workflow to help you advance through the different tiers of contribution, from Contributor to Core Contributor, Rising Contributor, and finally, Top Contributor.
 
-Our promotion structure is based on our GitHub badge system. Check out `Github Rewards <contributing/github_rewards.rst>`_ for more information about them!
+Our promotion structure is based on our GitHub badge system. Check out `Github Rewards <github_rewards.rst>`_ for more information about them!
 
 Contributor
 -----------


### PR DESCRIPTION
# PR Description
In the following line, the link to `github_rewards` is not working
https://github.com/unifyai/ivy/blob/939d7b09b90f1418b470234206907bdb48c30ca1/docs/overview/contributing/volunteer_workflow.rst?plain=1#L6
![image](https://github.com/unifyai/ivy/assets/87087741/40a438c7-10c9-4be2-8596-ba842fdd4a26)


## Related Issue
Closes #27911

## Checklist

- [ ] Did you add a function?
- [ ] Did you add the tests?
- [ ] Did you run your tests and are your tests passing?
- [x] Did pre-commit not fail on any check?
- [ ] Did you follow the steps we provided?

### Socials
