### PR TITLE
fix tf get item with non 0 dim tensor queries

### DIFF
--- a/ivy/functional/backends/tensorflow/general.py
+++ b/ivy/functional/backends/tensorflow/general.py
@@ -49,7 +49,7 @@ def current_backend_str() -> str:
 
 def _check_query(query):
     return not isinstance(query, list) and (
-        not (ivy.is_array(query) and ivy.is_bool_dtype(query) and bool(query.ndim > 0))
+        not (ivy.is_array(query) and bool(query.ndim > 0))
     )
 
 
@@ -60,8 +60,6 @@ def get_item(
     *,
     copy: Optional[bool] = None,
 ) -> Union[tf.Tensor, tf.Variable]:
-    if isinstance(query, (tf.Tensor, tf.Variable)):
-        return tf.gather(x, query)
     return x.__getitem__(query)
 
 


### PR DESCRIPTION
fixes something like the following:
```python
import ivy
ivy.set_tensorflow_backend()
x = ivy.array([[0.]])
print(x[(slice(None, None, None), ivy.array([0]))])
```
where non 0 dimensional tensors are used in the query. there was a check filtering out non 0 dim boolean tensors, but i think this needs to be extensed to any non 0 dim tensor, as i've done. I also believe the fix you made @Ishticode is no longer necessary after this fix, so i removed this as well. Do you think we can add some of these cases to the get item tests @Ishticode ?
