### PR TITLE
fix: Added missing `assert` to 3 comparison checks

### DIFF
--- a/ivy_tests/test_ivy/test_frontends/test_jax/test_numpy/test_mathematical_functions.py
+++ b/ivy_tests/test_ivy/test_frontends/test_jax/test_numpy/test_mathematical_functions.py
@@ -1103,9 +1103,9 @@ def test_jax_einsum_path(
         **kw,
         optimize=optimize,
     )
-    len(ret[0]) == len(ret_gt[0])
-    all(x == y for x, y in zip(ret[0], ret_gt[0]))
-    ret[1] == str(ret_gt[1])
+    assert len(ret[0]) == len(ret_gt[0])
+    assert all(x == y for x, y in zip(ret[0], ret_gt[0]))
+    assert ret[1] == str(ret_gt[1])
 
 
 # exp


### PR DESCRIPTION
# PR Description
In the following test function, these 3 lines are missing `assert`
https://github.com/unifyai/ivy/blob/f057407029669edeaf1fc49b90883978e4f0c3aa/ivy_tests/test_ivy/test_frontends/test_jax/test_numpy/test_mathematical_functions.py#L1106-L1108
Reference:
Comment under that PR (https://github.com/unifyai/ivy/pull/27003#discussion_r1365411148)/)

## Related Issue
Closes #27925 

## Checklist

- [ ] Did you add a function?
- [ ] Did you add the tests?
- [ ] Did you run your tests and are your tests passing?
- [x] Did pre-commit not fail on any check?
- [ ] Did you follow the steps we provided?
