### PR TITLE
fix: Fixed raising `TypeError` for invalid type

### DIFF
--- a/ivy/functional/backends/paddle/layers.py
+++ b/ivy/functional/backends/paddle/layers.py
@@ -30,10 +30,11 @@ def _convert_to_list(value, n, name="padding", _type=int):
     else:
         try:
             value_list = list(value)
-        except TypeError:
-            raise ValueError(
-                f"The input {name}'s type must be list or tuple. Received: {value}"
-            )
+        except TypeError as e:
+            raise TypeError(
+                f"The input {value}'s type must be list or tuple. Received:"
+                f" {type(value)}"
+            ) from e
         else:
             return value_list
 


### PR DESCRIPTION
# PR Description
In the following function, `ValueError` is raised after excepting a `TypeError`
https://github.com/unifyai/ivy/blob/f057407029669edeaf1fc49b90883978e4f0c3aa/ivy/functional/backends/paddle/layers.py#L33-L36

## Related Issue
Closes #27927

## Checklist

- [ ] Did you add a function?
- [ ] Did you add the tests?
- [ ] Did you run your tests and are your tests passing?
- [x] Did pre-commit not fail on any check?
- [ ] Did you follow the steps we provided?

### Socials
