### PR TITLE
fix: fixed unsupported dtype at paddle backend

### DIFF
--- a/ivy/functional/backends/paddle/elementwise.py
+++ b/ivy/functional/backends/paddle/elementwise.py
@@ -340,13 +340,13 @@ def less(
     return paddle.less_than(x1, x2)
 
 
-@with_unsupported_dtypes(
+@with_supported_dtypes(
     {
         "2.5.1 and below": (
-            "int8",
-            "int16",
-            "uint8",
-            "float16",
+            "int32",
+            "int64",
+            "float32",
+            "float64",
         )
     },
     backend_version,

--- a/ivy/functional/backends/paddle/elementwise.py
+++ b/ivy/functional/backends/paddle/elementwise.py
@@ -342,7 +342,7 @@ def less(
 
 @with_supported_dtypes(
     {
-        "2.5.1 and below": (
+        "2.6.0 and below": (
             "int32",
             "int64",
             "float32",

--- a/ivy_tests/test_ivy/helpers/function_testing.py
+++ b/ivy_tests/test_ivy/helpers/function_testing.py
@@ -266,14 +266,24 @@ def test_function_backend_computation(
                     ret_from_target,
                     ret_np_flat_from_target,
                 ) = get_ret_and_flattened_np_array(
-                    fw, instance.__getattribute__(fn_name), *args, **kwargs, out=out, precision_mode=test_flags.precision_mode
+                    fw,
+                    instance.__getattribute__(fn_name),
+                    *args,
+                    **kwargs,
+                    out=out,
+                    precision_mode=test_flags.precision_mode,
                 )
             else:
                 (
                     ret_from_target,
                     ret_np_flat_from_target,
                 ) = get_ret_and_flattened_np_array(
-                    fw, ivy_backend.__dict__[fn_name], *args, **kwargs, out=out, precision_mode=test_flags.precision_mode
+                    fw,
+                    ivy_backend.__dict__[fn_name],
+                    *args,
+                    **kwargs,
+                    out=out,
+                    precision_mode=test_flags.precision_mode,
                 )
             test_ret = (
                 ret_from_target[getattr(ivy_backend.__dict__[fn_name], "out_index")]


### PR DESCRIPTION
<!--
This template will help you to have a meaningful PR, please follow it and do not leave it blank.
-->

# Fixed unsupported dtype at paddle backend in ivy.multiply

<!--
If there is no related issue, please add a short description about your PR.
-->

## passing all the test cases.

![image](https://github.com/unifyai/ivy/assets/83540902/b810c43a-91e0-4747-ba58-35e4da2e090c)


<!--
Please use this format to link other issues with their numbers: Close #123
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes #27936

## Checklist

- [x] Did you add a function?
- [x] Did you add the tests?
- [x] Did you run your tests and are your tests passing?
- [x] Did pre-commit not fail on any check?
- [x] Did you follow the steps we provided?

<!--
Please mark your PR as a draft if you realise after the fact that your tests are not passing or
that your pre-commit check has some failures.

Here are some relevant resources regarding tests and pre-commit:

https://unify.ai/docs/ivy/overview/deep_dive/ivy_tests.html
https://unify.ai/docs/ivy/overview/deep_dive/formatting.html#pre-commit

-->

### Socials

<!--
If you have Twitter, please provide it here otherwise just ignore this.
-->
