### PR TITLE
fix: unsupported dtype at jax asinh

### DIFF
--- a/ivy/functional/backends/jax/elementwise.py
+++ b/ivy/functional/backends/jax/elementwise.py
@@ -55,6 +55,7 @@ def asin(x: JaxArray, /, *, out: Optional[JaxArray] = None) -> JaxArray:
     return jnp.arcsin(x)
 
 
+@with_unsupported_dtypes({"0.4.23 and below": ("complex",)}, backend_version)
 def asinh(x: JaxArray, /, *, out: Optional[JaxArray] = None) -> JaxArray:
     return jnp.arcsinh(x)
 


### PR DESCRIPTION
<!--
This template will help you to have a meaningful PR, please follow it and do not leave it blank.
-->

# Fixed the complex dtype not supported by asinh.

<!--
If there is no related issue, please add a short description about your PR.
-->

## passing all the tests at local.
![image](https://github.com/unifyai/ivy/assets/83540902/5889c751-5ab7-421c-b228-42a25d983ee2)


<!--
Please use this format to link other issues with their numbers: Close #123
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes #27942

## Checklist

- [ ] Did you add a function?
- [ ] Did you add the tests?
- [ ] Did you run your tests and are your tests passing?
- [ ] Did pre-commit not fail on any check?
- [ ] Did you follow the steps we provided?

<!--
Please mark your PR as a draft if you realise after the fact that your tests are not passing or
that your pre-commit check has some failures.

Here are some relevant resources regarding tests and pre-commit:

https://unify.ai/docs/ivy/overview/deep_dive/ivy_tests.html
https://unify.ai/docs/ivy/overview/deep_dive/formatting.html#pre-commit

-->

### Socials

<!--
If you have Twitter, please provide it here otherwise just ignore this.
-->
