### PR TITLE
fix: Updated `WSL` section of `Setting Up` by adding a code-snippet to install optional dependencies

### DIFF
--- a/docs/overview/contributing/setting_up.rst
+++ b/docs/overview/contributing/setting_up.rst
@@ -650,12 +650,16 @@ the steps explained below will help you in setting up a less resource-intensive 
 
       pip install git+https://github.com/unifyai/ivy.git
 
-#. If you want to set up a local repository, you can do so by following :ref:`this guide <overview/contributing/setting_up:Forking and cloning the repo>`
+#. Or else, if you want to set up a local repository, you can do so by following :ref:`this guide <overview/contributing/setting_up:Forking and cloning the repo>`
    as explained above and install the required development dependencies by running:
 
    .. code-block:: none
 
       cd ivy/
+
+   .. code-block:: none
+
+      pip install -r requirements/requirements.txt
 
    .. code-block:: none
 

--- a/docs/overview/contributing/setting_up.rst
+++ b/docs/overview/contributing/setting_up.rst
@@ -660,9 +660,6 @@ the steps explained below will help you in setting up a less resource-intensive 
    .. code-block:: none
 
       pip install -r requirements/requirements.txt
-
-   .. code-block:: none
-
       pip install -r requirements/optional.txt
 
 #. Once done, you can now open VSCode right from your terminal and get started with your development by just running:

--- a/docs/overview/contributing/setting_up.rst
+++ b/docs/overview/contributing/setting_up.rst
@@ -659,7 +659,7 @@ the steps explained below will help you in setting up a less resource-intensive 
 
    .. code-block:: none
 
-      pip install -r requirements/requirements.txt
+      pip install -r requirements/optional.txt
 
 #. Once done, you can now open VSCode right from your terminal and get started with your development by just running:
 


### PR DESCRIPTION
# PR Description
In this following section, the `code-snippet` will install the requirements.txt 
https://github.com/unifyai/ivy/blob/be82a7a7ddaa74eff3c915505edf05db47e11f6d/docs/overview/contributing/setting_up.rst?plain=1#L653-L663

But we already did that with the previous command just above this command
https://github.com/unifyai/ivy/blob/be82a7a7ddaa74eff3c915505edf05db47e11f6d/docs/overview/contributing/setting_up.rst?plain=1#L647-L651

The actual `code-snippet` should be to download the development dependencies in `optional.txt` like this:
https://github.com/unifyai/ivy/blob/be82a7a7ddaa74eff3c915505edf05db47e11f6d/docs/overview/contributing/setting_up.rst?plain=1#L143-L149


## Related Issue
Closes #27950

## Checklist

- [ ] Did you add a function?
- [ ] Did you add the tests?
- [ ] Did you run your tests and are your tests passing?
- [x] Did pre-commit not fail on any check?
- [ ] Did you follow the steps we provided?


### Socials
