### PR TITLE
fix: fix test_torch__getitem fixing the empty dim case in tf backend

### DIFF
--- a/ivy/functional/backends/tensorflow/general.py
+++ b/ivy/functional/backends/tensorflow/general.py
@@ -60,6 +60,9 @@ def get_item(
     *,
     copy: Optional[bool] = None,
 ) -> Union[tf.Tensor, tf.Variable]:
+    if ivy.is_array(query) and ivy.is_bool_dtype(query):
+        if not len(query.shape):
+            return tf.expand_dims(x, 0)
     return x.__getitem__(query)
 
 


### PR DESCRIPTION
This fixes `test_torch___getitem`. Passes with 200+ examples tested.
As an example, it fixes the following mismatch of behaviour between native torch and our torch frontend when tensorflow is set.

```python
import torch
x = torch.tensor([])
y = torch.tensor(True)
print(x.__getitem__(y)) # tensor([], size=(1, 0))

import ivy.functional.frontends.torch as tivy
import ivy
ivy.set_backend('tensorflow')
x = tivy.tensor([])
y = tivy.tensor(True)
print("tf backend:", x.__getitem__(y)) # throws error
```