### PR TITLE
fix: Fixed raising of `keyError()` to properly include `path_type` in the error message

### DIFF
--- a/ivy/functional/frontends/jax/numpy/mathematical_functions.py
+++ b/ivy/functional/frontends/jax/numpy/mathematical_functions.py
@@ -315,7 +315,7 @@ def einsum_path(subscripts, *operands, optimize="greedy"):
     elif path_type == "optimal":
         path = optimal_path(input_sets, output_set, dimension_dict, memory_arg)
     else:
-        raise KeyError("Path name %s not found", path_type)
+        raise KeyError("Path name %s not found" % (path_type))
 
     cost_list, scale_list, size_list, contraction_list = [], [], [], []
 

--- a/ivy/functional/frontends/jax/numpy/mathematical_functions.py
+++ b/ivy/functional/frontends/jax/numpy/mathematical_functions.py
@@ -315,7 +315,7 @@ def einsum_path(subscripts, *operands, optimize="greedy"):
     elif path_type == "optimal":
         path = optimal_path(input_sets, output_set, dimension_dict, memory_arg)
     else:
-        raise KeyError("Path name %s not found" % (path_type))
+        raise KeyError(f"Path name {path_type} not found")
 
     cost_list, scale_list, size_list, contraction_list = [], [], [], []
 


### PR DESCRIPTION
# PR Description
In the following line, `path_type` is passed separately as an argument while raising `KeyError()`
https://github.com/unifyai/ivy/blob/e2a250393aea9f527466584a885c99c36cf9b1cb/ivy/functional/frontends/jax/numpy/mathematical_functions.py#L318
It should be raise `KeyError("Path name %s not found" % path_type)` for correct output.


## Related Issue
Closes #27964 

## Checklist

- [ ] Did you add a function?
- [ ] Did you add the tests?
- [ ] Did you run your tests and are your tests passing?
- [x] Did pre-commit not fail on any check?
- [ ] Did you follow the steps we provided?

### Socials
