### PR TITLE
fix: Fixed TensorFlow attributes `sum` and `mean`

### DIFF
--- a/ivy/functional/backends/tensorflow/experimental/losses.py
+++ b/ivy/functional/backends/tensorflow/experimental/losses.py
@@ -23,9 +23,9 @@ def huber_loss(
     loss = tf.where(abs_diff <= delta, quadratic_loss, linear_loss)
 
     if reduction == "sum":
-        return tf.sum(loss)
+        return tf.reduce_sum(loss)
     elif reduction == "mean":
-        return tf.mean(loss)
+        return tf.reduce_mean(loss)
     else:
         return loss
 


### PR DESCRIPTION
# PR Description
In the following function, the attributes `sum` and `mean` are used
https://github.com/unifyai/ivy/blob/f1fc4cb543615bdc1364821b122c1c2127d4b461/ivy/functional/backends/tensorflow/experimental/losses.py#L25-L30
They should be `reduce_sum` and `reduce_mean`


## Related Issue
Closes #27977

## Checklist

- [ ] Did you add a function?
- [ ] Did you add the tests?
- [ ] Did you run your tests and are your tests passing?
- [x] Did pre-commit not fail on any check?
- [ ] Did you follow the steps we provided?

### Socials
