### PR TITLE
fix: Fixed `ivy.adjoint` test for all backends

### DIFF
--- a/ivy_tests/test_ivy/test_functional/test_experimental/test_core/test_linalg.py
+++ b/ivy_tests/test_ivy/test_functional/test_experimental/test_core/test_linalg.py
@@ -859,7 +859,6 @@ def _tucker_data(draw):
     fn_tree="functional.ivy.experimental.adjoint",
     dtype_x=helpers.dtype_and_values(
         available_dtypes=(
-            ivy.float16,
             ivy.float32,
             ivy.float64,
             ivy.complex64,
@@ -875,7 +874,7 @@ def _tucker_data(draw):
         shared_dtype=True,
     ),
 )
-def test_adjoint(dtype_x, test_flags, backend_fw, fn_name):
+def test_adjoint(dtype_x, test_flags, backend_fw, fn_name, on_device):
     dtype, x = dtype_x
     helpers.test_function(
         input_dtypes=dtype,
@@ -883,6 +882,7 @@ def test_adjoint(dtype_x, test_flags, backend_fw, fn_name):
         backend_to_test=backend_fw,
         fn_name=fn_name,
         x=x[0],
+        on_device=on_device,
     )
 
 


### PR DESCRIPTION
# PR Description
Fixed `ivy.adjoint` tests at all backends.
![image](https://github.com/unifyai/ivy/assets/87087741/475c643a-46ce-418c-acbe-51288aa63eb2)


## Related Issue
Closes #27979,
Closes #27980 
Closes #27981 
Closes #27982 
Closes #27983 

## Checklist

- [ ] Did you add a function?
- [ ] Did you add the tests?
- [x] Did you run your tests and are your tests passing?
- [x] Did pre-commit not fail on any check?
- [x] Did you follow the steps we provided?

### Socials
