### PR TITLE
Add recall_score function in Ivy with Test

### DIFF
--- a/ivy/functional/frontends/sklearn/metrics/_classification.py
+++ b/ivy/functional/frontends/sklearn/metrics/_classification.py
@@ -29,13 +29,17 @@ def precision_score(y_true, y_pred, *, sample_weight=None):
     if sample_weight is not None:
         sample_weight = ivy.array(sample_weight)
         if sample_weight.shape[0] != y_true.shape[0]:
-            raise IvyValueError("sample_weight must have the same length as y_true and y_pred")
+            raise IvyValueError(
+                "sample_weight must have the same length as y_true and y_pred"
+            )
         sample_weight = sample_weight / ivy.sum(sample_weight)
     else:
         sample_weight = ivy.ones_like(y_true)
 
     # Calculate true positives and predicted positives
-    true_positives = ivy.logical_and(ivy.equal(y_true, 1), ivy.equal(y_pred, 1)).astype("int64")
+    true_positives = ivy.logical_and(ivy.equal(y_true, 1), ivy.equal(y_pred, 1)).astype(
+        "int64"
+    )
     predicted_positives = ivy.equal(y_pred, 1).astype("int64")
 
     # Apply sample weights

--- a/ivy/functional/frontends/sklearn/metrics/_classification.py
+++ b/ivy/functional/frontends/sklearn/metrics/_classification.py
@@ -1,7 +1,6 @@
 import ivy
 from ivy.functional.frontends.numpy.func_wrapper import to_ivy_arrays_and_back
 from sklearn.utils.multiclass import type_of_target
-from ivy.utils.exceptions import IvyValueError
 
 
 @to_ivy_arrays_and_back
@@ -27,7 +26,9 @@ def recall_score(y_true, y_pred, *, sample_weight=None):
     if y_type.startswith("multilabel"):
         raise ValueError("Multilabel not supported for recall score")
     else:
-        true_positives = ivy.logical_and(ivy.equal(y_true, 1), ivy.equal(y_pred, 1)).astype("int64")
+        true_positives = ivy.logical_and(
+            ivy.equal(y_true, 1), ivy.equal(y_pred, 1)
+        ).astype("int64")
         actual_positives = ivy.equal(y_true, 1).astype("int64")
         ret = ivy.sum(true_positives).astype("int64")
         actual_pos_count = ivy.sum(actual_positives).astype("int64")

--- a/ivy/functional/frontends/sklearn/metrics/_classification.py
+++ b/ivy/functional/frontends/sklearn/metrics/_classification.py
@@ -1,6 +1,7 @@
 import ivy
 from ivy.functional.frontends.numpy.func_wrapper import to_ivy_arrays_and_back
 from sklearn.utils.multiclass import type_of_target
+from ivy.utils.exceptions import IvyValueError
 
 
 @to_ivy_arrays_and_back
@@ -17,3 +18,27 @@ def accuracy_score(y_true, y_pred, *, normalize=True, sample_weight=None):
         ret = ret / y_true.shape[0]
         ret = ret.astype("float64")
     return ret
+
+
+@to_ivy_arrays_and_back
+def recall_score(y_true, y_pred, *, average='binary', sample_weight=None):
+    # Determine the type of the target variable
+    y_type = type_of_target(y_true)
+    # Check if the 'average' parameter has a valid value
+    if average != 'binary' and average != 'micro' and average != 'macro':
+        raise IvyValueError("Invalid value for 'average'. Supported values are 'binary', 'micro', or 'macro'.")
+    # Calculate true positive and actual positive counts based on the target type
+    if y_type.startswith("multilabel"):
+        true_positive = ivy.sum(ivy.logical_and(y_true, y_pred) * sample_weight, axis=1)
+        actual_positive = ivy.sum(y_true * sample_weight, axis=1)
+    else:
+        true_positive = ivy.sum(ivy.logical_and(y_true, y_pred) * sample_weight)
+        actual_positive = ivy.sum(y_true * sample_weight)
+    # Calculate recall for each class or overall
+    recall = true_positive / ivy.maximum(actual_positive, ivy.to_scalar(ivy.array([1], 'float64')))
+    # Perform additional calculations for micro or macro averaging
+    if average == 'micro':
+        recall = ivy.sum(true_positive) / ivy.maximum(ivy.sum(actual_positive), ivy.to_scalar(ivy.array([1], 'float64')))
+    elif average == 'macro':
+        recall = ivy.mean(recall)
+    return recall

--- a/ivy/functional/frontends/sklearn/metrics/_classification.py
+++ b/ivy/functional/frontends/sklearn/metrics/_classification.py
@@ -20,7 +20,7 @@ def accuracy_score(y_true, y_pred, *, normalize=True, sample_weight=None):
 
 
 @to_ivy_arrays_and_back
-def precision_score(y_true, y_pred, *, sample_weight=None):
+def recall_score(y_true, y_pred, *, sample_weight=None):
     # Ensure that y_true and y_pred have the same shape
     if y_true.shape != y_pred.shape:
         raise IvyValueError("y_true and y_pred must have the same shape")
@@ -29,24 +29,20 @@ def precision_score(y_true, y_pred, *, sample_weight=None):
     if sample_weight is not None:
         sample_weight = ivy.array(sample_weight)
         if sample_weight.shape[0] != y_true.shape[0]:
-            raise IvyValueError(
-                "sample_weight must have the same length as y_true and y_pred"
-            )
+            raise IvyValueError("sample_weight must have the same length as y_true and y_pred")
         sample_weight = sample_weight / ivy.sum(sample_weight)
     else:
         sample_weight = ivy.ones_like(y_true)
 
-    # Calculate true positives and predicted positives
-    true_positives = ivy.logical_and(ivy.equal(y_true, 1), ivy.equal(y_pred, 1)).astype(
-        "int64"
-    )
-    predicted_positives = ivy.equal(y_pred, 1).astype("int64")
+    # Calculate true positives and actual positives
+    true_positives = ivy.logical_and(ivy.equal(y_true, 1), ivy.equal(y_pred, 1)).astype("int64")
+    actual_positives = ivy.equal(y_true, 1).astype("int64")
 
     # Apply sample weights
     weighted_true_positives = ivy.multiply(true_positives, sample_weight)
-    weighted_predicted_positives = ivy.multiply(predicted_positives, sample_weight)
+    weighted_actual_positives = ivy.multiply(actual_positives, sample_weight)
 
-    # Compute precision
-    ret = ivy.sum(weighted_true_positives) / ivy.sum(weighted_predicted_positives)
+    # Compute recall
+    ret = ivy.sum(weighted_true_positives) / ivy.sum(weighted_actual_positives)
     ret = ret.astype("float64")
     return ret

--- a/ivy/functional/frontends/sklearn/metrics/_classification.py
+++ b/ivy/functional/frontends/sklearn/metrics/_classification.py
@@ -29,13 +29,17 @@ def recall_score(y_true, y_pred, *, sample_weight=None):
     if sample_weight is not None:
         sample_weight = ivy.array(sample_weight)
         if sample_weight.shape[0] != y_true.shape[0]:
-            raise IvyValueError("sample_weight must have the same length as y_true and y_pred")
+            raise IvyValueError(
+                "sample_weight must have the same length as y_true and y_pred"
+            )
         sample_weight = sample_weight / ivy.sum(sample_weight)
     else:
         sample_weight = ivy.ones_like(y_true)
 
     # Calculate true positives and actual positives
-    true_positives = ivy.logical_and(ivy.equal(y_true, 1), ivy.equal(y_pred, 1)).astype("int64")
+    true_positives = ivy.logical_and(ivy.equal(y_true, 1), ivy.equal(y_pred, 1)).astype(
+        "int64"
+    )
     actual_positives = ivy.equal(y_true, 1).astype("int64")
 
     # Apply sample weights

--- a/ivy/functional/frontends/sklearn/metrics/_classification.py
+++ b/ivy/functional/frontends/sklearn/metrics/_classification.py
@@ -21,12 +21,15 @@ def accuracy_score(y_true, y_pred, *, normalize=True, sample_weight=None):
 
 
 @to_ivy_arrays_and_back
-def recall_score(y_true, y_pred, *, average='binary', sample_weight=None):
+def recall_score(y_true, y_pred, *, average="binary", sample_weight=None):
     # Determine the type of the target variable
     y_type = type_of_target(y_true)
     # Check if the 'average' parameter has a valid value
-    if average != 'binary' and average != 'micro' and average != 'macro':
-        raise IvyValueError("Invalid value for 'average'. Supported values are 'binary', 'micro', or 'macro'.")
+    if average != "binary" and average != "micro" and average != "macro":
+        raise IvyValueError(
+            "Invalid value for 'average'. Supported values are 'binary', 'micro', or"
+            " 'macro'."
+        )
     # Calculate true positive and actual positive counts based on the target type
     if y_type.startswith("multilabel"):
         true_positive = ivy.sum(ivy.logical_and(y_true, y_pred) * sample_weight, axis=1)
@@ -35,10 +38,14 @@ def recall_score(y_true, y_pred, *, average='binary', sample_weight=None):
         true_positive = ivy.sum(ivy.logical_and(y_true, y_pred) * sample_weight)
         actual_positive = ivy.sum(y_true * sample_weight)
     # Calculate recall for each class or overall
-    recall = true_positive / ivy.maximum(actual_positive, ivy.to_scalar(ivy.array([1], 'float64')))
+    recall = true_positive / ivy.maximum(
+        actual_positive, ivy.to_scalar(ivy.array([1], "float64"))
+    )
     # Perform additional calculations for micro or macro averaging
-    if average == 'micro':
-        recall = ivy.sum(true_positive) / ivy.maximum(ivy.sum(actual_positive), ivy.to_scalar(ivy.array([1], 'float64')))
-    elif average == 'macro':
+    if average == "micro":
+        recall = ivy.sum(true_positive) / ivy.maximum(
+            ivy.sum(actual_positive), ivy.to_scalar(ivy.array([1], "float64"))
+        )
+    elif average == "macro":
         recall = ivy.mean(recall)
     return recall

--- a/ivy_tests/test_ivy/test_frontends/test_sklearn/test_metrics/test_classification.py
+++ b/ivy_tests/test_ivy/test_frontends/test_sklearn/test_metrics/test_classification.py
@@ -46,27 +46,25 @@ def test_sklearn_accuracy_score(
 
 
 @handle_frontend_test(
-    fn_tree="sklearn.metrics.precision_score",
+    fn_tree="sklearn.metrics.recall_score",
     arrays_and_dtypes=helpers.dtype_and_values(
         available_dtypes=helpers.get_dtypes("integer"),
         num_arrays=2,
         min_value=0,
-        max_value=1,  # Precision score is for binary classification
+        max_value=1,  # Recall score is for binary classification
         shared_dtype=True,
         shape=(helpers.ints(min_value=2, max_value=5)),
     ),
-    sample_weight=st.lists(
-        st.floats(min_value=0.1, max_value=1), min_size=2, max_size=5
-    ),
+    sample_weight=st.lists(st.floats(min_value=0.1, max_value=1), min_size=2, max_size=5),
 )
-def test_sklearn_precision_score(
-    arrays_and_dtypes,
-    on_device,
-    fn_tree,
-    frontend,
-    test_flags,
-    backend_fw,
-    sample_weight,
+def test_sklearn_recall_score(
+        arrays_and_dtypes,
+        on_device,
+        fn_tree,
+        frontend,
+        test_flags,
+        backend_fw,
+        sample_weight,
 ):
     dtypes, values = arrays_and_dtypes
     # Ensure the values are binary by rounding and converting to int
@@ -77,25 +75,15 @@ def test_sklearn_precision_score(
     sample_weight = np.array(sample_weight).astype(float)
     if len(sample_weight) != len(values[0]):
         # If sample_weight is shorter, extend it with ones
-        sample_weight = np.pad(
-            sample_weight,
-            (0, max(0, len(values[0]) - len(sample_weight))),
-            "constant",
-            constant_values=1.0,
-        )
+        sample_weight = np.pad(sample_weight, (0, max(0, len(values[0]) - len(sample_weight))), 'constant',
+                               constant_values=1.0)
         # If sample_weight is longer, truncate it
-        sample_weight = sample_weight[: len(values[0])]
+        sample_weight = sample_weight[:len(values[0])]
 
     # Detach tensors if they require grad before converting to NumPy arrays
-    if backend_fw == "torch":
-        values = [
-            (
-                value.detach().numpy()
-                if isinstance(value, torch.Tensor) and value.requires_grad
-                else value
-            )
-            for value in values
-        ]
+    if backend_fw == 'torch':
+        values = [value.detach().numpy() if isinstance(value, torch.Tensor) and value.requires_grad else value
+                  for value in values]
 
     helpers.test_frontend_function(
         input_dtypes=dtypes,

--- a/ivy_tests/test_ivy/test_frontends/test_sklearn/test_metrics/test_classification.py
+++ b/ivy_tests/test_ivy/test_frontends/test_sklearn/test_metrics/test_classification.py
@@ -6,6 +6,49 @@ import numpy as np
 
 
 @handle_frontend_test(
+    fn_tree="your.module.path.recall_score",  # Update with the correct module path
+    arrays_and_dtypes=helpers.dtype_and_values(
+        available_dtypes=helpers.get_dtypes("float_and_integer"),
+        num_arrays=2,
+        min_value=-2,
+        max_value=2,
+        shared_dtype=True,
+        shape=(helpers.ints(min_value=2, max_value=5)),
+    ),
+    average=st.sampled_from(["binary", "micro", "macro"]),
+    sample_weight=st.none() | st.floats(min_value=0, max_value=1),
+)
+def test_recall_score(
+    arrays_and_dtypes,
+    on_device,
+    fn_tree,
+    frontend,
+    test_flags,
+    backend_fw,
+    average,
+    sample_weight,
+):
+    dtypes, values = arrays_and_dtypes
+    # Ensure discrete values if float dtype
+    for i in range(2):
+        if "float" in dtypes[i]:
+            values[i] = np.floor(values[i])
+
+    helpers.test_frontend_function(
+        input_dtypes=dtypes,
+        backend_to_test=backend_fw,
+        test_flags=test_flags,
+        fn_tree=fn_tree,
+        frontend=frontend,
+        on_device=on_device,
+        y_true=values[0],
+        y_pred=values[1],
+        average=average,
+        sample_weight=sample_weight,
+    )
+
+
+@handle_frontend_test(
     fn_tree="sklearn.metrics.accuracy_score",
     arrays_and_dtypes=helpers.dtype_and_values(
         available_dtypes=helpers.get_dtypes("float_and_integer"),
@@ -42,47 +85,4 @@ def test_sklearn_accuracy_score(
         y_pred=values[1],
         normalize=normalize,
         sample_weight=None,
-    )
-
-
-@handle_frontend_test(
-    fn_tree="your.module.path.recall_score",  # Update with the correct module path
-    arrays_and_dtypes=helpers.dtype_and_values(
-        available_dtypes=helpers.get_dtypes("float_and_integer"),
-        num_arrays=2,
-        min_value=-2,
-        max_value=2,
-        shared_dtype=True,
-        shape=(helpers.ints(min_value=2, max_value=5)),
-    ),
-    average=st.sampled_from(['binary', 'micro', 'macro']),
-    sample_weight=st.none() | st.floats(min_value=0, max_value=1),
-)
-def test_recall_score(
-    arrays_and_dtypes,
-    on_device,
-    fn_tree,
-    frontend,
-    test_flags,
-    backend_fw,
-    average,
-    sample_weight,
-):
-    dtypes, values = arrays_and_dtypes
-    # Ensure discrete values if float dtype
-    for i in range(2):
-        if "float" in dtypes[i]:
-            values[i] = np.floor(values[i])
-    
-    helpers.test_frontend_function(
-        input_dtypes=dtypes,
-        backend_to_test=backend_fw,
-        test_flags=test_flags,
-        fn_tree=fn_tree,
-        frontend=frontend,
-        on_device=on_device,
-        y_true=values[0],
-        y_pred=values[1],
-        average=average,
-        sample_weight=sample_weight,
     )

--- a/ivy_tests/test_ivy/test_frontends/test_sklearn/test_metrics/test_classification.py
+++ b/ivy_tests/test_ivy/test_frontends/test_sklearn/test_metrics/test_classification.py
@@ -6,7 +6,7 @@ import numpy as np
 
 
 @handle_frontend_test(
-    fn_tree="your.module.path.recall_score",  # Update with the correct module path
+    fn_tree="sklearn.metrics.recall_score",  
     arrays_and_dtypes=helpers.dtype_and_values(
         available_dtypes=helpers.get_dtypes("float_and_integer"),
         num_arrays=2,

--- a/ivy_tests/test_ivy/test_frontends/test_sklearn/test_metrics/test_classification.py
+++ b/ivy_tests/test_ivy/test_frontends/test_sklearn/test_metrics/test_classification.py
@@ -43,3 +43,46 @@ def test_sklearn_accuracy_score(
         normalize=normalize,
         sample_weight=None,
     )
+
+
+@handle_frontend_test(
+    fn_tree="your.module.path.recall_score",  # Update with the correct module path
+    arrays_and_dtypes=helpers.dtype_and_values(
+        available_dtypes=helpers.get_dtypes("float_and_integer"),
+        num_arrays=2,
+        min_value=-2,
+        max_value=2,
+        shared_dtype=True,
+        shape=(helpers.ints(min_value=2, max_value=5)),
+    ),
+    average=st.sampled_from(['binary', 'micro', 'macro']),
+    sample_weight=st.none() | st.floats(min_value=0, max_value=1),
+)
+def test_recall_score(
+    arrays_and_dtypes,
+    on_device,
+    fn_tree,
+    frontend,
+    test_flags,
+    backend_fw,
+    average,
+    sample_weight,
+):
+    dtypes, values = arrays_and_dtypes
+    # Ensure discrete values if float dtype
+    for i in range(2):
+        if "float" in dtypes[i]:
+            values[i] = np.floor(values[i])
+    
+    helpers.test_frontend_function(
+        input_dtypes=dtypes,
+        backend_to_test=backend_fw,
+        test_flags=test_flags,
+        fn_tree=fn_tree,
+        frontend=frontend,
+        on_device=on_device,
+        y_true=values[0],
+        y_pred=values[1],
+        average=average,
+        sample_weight=sample_weight,
+    )

--- a/ivy_tests/test_ivy/test_frontends/test_sklearn/test_metrics/test_classification.py
+++ b/ivy_tests/test_ivy/test_frontends/test_sklearn/test_metrics/test_classification.py
@@ -6,7 +6,7 @@ import numpy as np
 
 
 @handle_frontend_test(
-    fn_tree="sklearn.metrics.recall_score",  
+    fn_tree="sklearn.metrics.recall_score",
     arrays_and_dtypes=helpers.dtype_and_values(
         available_dtypes=helpers.get_dtypes("float_and_integer"),
         num_arrays=2,

--- a/ivy_tests/test_ivy/test_frontends/test_sklearn/test_metrics/test_classification.py
+++ b/ivy_tests/test_ivy/test_frontends/test_sklearn/test_metrics/test_classification.py
@@ -1,51 +1,8 @@
 from hypothesis import strategies as st
-import torch 
+import torch
 import ivy_tests.test_ivy.helpers as helpers
 from ivy_tests.test_ivy.helpers import handle_frontend_test
 import numpy as np
-
-
-@handle_frontend_test(
-    fn_tree="sklearn.metrics.recall_score",
-    arrays_and_dtypes=helpers.dtype_and_values(
-        available_dtypes=helpers.get_dtypes("float_and_integer"),
-        num_arrays=2,
-        min_value=0,  # Recall score is for binary classification, so min_value is set to 0
-        max_value=1,  # Max value is set to 1 for the same reason
-        shared_dtype=True,
-        shape=(helpers.ints(min_value=2, max_value=5)),
-    ),
-)
-def test_sklearn_recall_score(
-        arrays_and_dtypes,
-        on_device,
-        fn_tree,
-        frontend,
-        test_flags,
-        backend_fw,
-):
-    dtypes, values = arrays_and_dtypes
-    # Ensure the values are binary by rounding and converting to int
-    for i in range(2):
-        if "float" in dtypes[i]:
-            values[i] = np.round(values[i]).astype(int)
-
-    # Detach tensors if they require grad before converting to NumPy arrays
-    if backend_fw == 'torch':
-        values = [value.detach().numpy() if isinstance(value, torch.Tensor) and value.requires_grad else value
-                  for value in values]
-
-    helpers.test_frontend_function(
-        input_dtypes=dtypes,
-        backend_to_test=backend_fw,
-        test_flags=test_flags,
-        fn_tree=fn_tree,
-        frontend=frontend,
-        on_device=on_device,
-        y_true=values[0],
-        y_pred=values[1],
-        sample_weight=None,
-    )
 
 
 @handle_frontend_test(
@@ -84,5 +41,54 @@ def test_sklearn_accuracy_score(
         y_true=values[0],
         y_pred=values[1],
         normalize=normalize,
+        sample_weight=None,
+    )
+
+
+@handle_frontend_test(
+    fn_tree="sklearn.metrics.recall_score",
+    arrays_and_dtypes=helpers.dtype_and_values(
+        available_dtypes=helpers.get_dtypes("float_and_integer"),
+        num_arrays=2,
+        min_value=0,  # Recall score is for binary classification, so min_value is set to 0
+        max_value=1,  # Max value is set to 1 for the same reason
+        shared_dtype=True,
+        shape=(helpers.ints(min_value=2, max_value=5)),
+    ),
+)
+def test_sklearn_recall_score(
+    arrays_and_dtypes,
+    on_device,
+    fn_tree,
+    frontend,
+    test_flags,
+    backend_fw,
+):
+    dtypes, values = arrays_and_dtypes
+    # Ensure the values are binary by rounding and converting to int
+    for i in range(2):
+        if "float" in dtypes[i]:
+            values[i] = np.round(values[i]).astype(int)
+
+    # Detach tensors if they require grad before converting to NumPy arrays
+    if backend_fw == "torch":
+        values = [
+            (
+                value.detach().numpy()
+                if isinstance(value, torch.Tensor) and value.requires_grad
+                else value
+            )
+            for value in values
+        ]
+
+    helpers.test_frontend_function(
+        input_dtypes=dtypes,
+        backend_to_test=backend_fw,
+        test_flags=test_flags,
+        fn_tree=fn_tree,
+        frontend=frontend,
+        on_device=on_device,
+        y_true=values[0],
+        y_pred=values[1],
         sample_weight=None,
     )

--- a/ivy_tests/test_ivy/test_frontends/test_sklearn/test_metrics/test_classification.py
+++ b/ivy_tests/test_ivy/test_frontends/test_sklearn/test_metrics/test_classification.py
@@ -55,16 +55,18 @@ def test_sklearn_accuracy_score(
         shared_dtype=True,
         shape=(helpers.ints(min_value=2, max_value=5)),
     ),
-    sample_weight=st.lists(st.floats(min_value=0.1, max_value=1), min_size=2, max_size=5),
+    sample_weight=st.lists(
+        st.floats(min_value=0.1, max_value=1), min_size=2, max_size=5
+    ),
 )
 def test_sklearn_precision_score(
-        arrays_and_dtypes,
-        on_device,
-        fn_tree,
-        frontend,
-        test_flags,
-        backend_fw,
-        sample_weight,
+    arrays_and_dtypes,
+    on_device,
+    fn_tree,
+    frontend,
+    test_flags,
+    backend_fw,
+    sample_weight,
 ):
     dtypes, values = arrays_and_dtypes
     # Ensure the values are binary by rounding and converting to int
@@ -75,15 +77,25 @@ def test_sklearn_precision_score(
     sample_weight = np.array(sample_weight).astype(float)
     if len(sample_weight) != len(values[0]):
         # If sample_weight is shorter, extend it with ones
-        sample_weight = np.pad(sample_weight, (0, max(0, len(values[0]) - len(sample_weight))), 'constant',
-                               constant_values=1.0)
+        sample_weight = np.pad(
+            sample_weight,
+            (0, max(0, len(values[0]) - len(sample_weight))),
+            "constant",
+            constant_values=1.0,
+        )
         # If sample_weight is longer, truncate it
-        sample_weight = sample_weight[:len(values[0])]
+        sample_weight = sample_weight[: len(values[0])]
 
     # Detach tensors if they require grad before converting to NumPy arrays
-    if backend_fw == 'torch':
-        values = [value.detach().numpy() if isinstance(value, torch.Tensor) and value.requires_grad else value
-                  for value in values]
+    if backend_fw == "torch":
+        values = [
+            (
+                value.detach().numpy()
+                if isinstance(value, torch.Tensor) and value.requires_grad
+                else value
+            )
+            for value in values
+        ]
 
     helpers.test_frontend_function(
         input_dtypes=dtypes,

--- a/ivy_tests/test_ivy/test_frontends/test_sklearn/test_metrics/test_classification.py
+++ b/ivy_tests/test_ivy/test_frontends/test_sklearn/test_metrics/test_classification.py
@@ -55,16 +55,18 @@ def test_sklearn_accuracy_score(
         shared_dtype=True,
         shape=(helpers.ints(min_value=2, max_value=5)),
     ),
-    sample_weight=st.lists(st.floats(min_value=0.1, max_value=1), min_size=2, max_size=5),
+    sample_weight=st.lists(
+        st.floats(min_value=0.1, max_value=1), min_size=2, max_size=5
+    ),
 )
 def test_sklearn_recall_score(
-        arrays_and_dtypes,
-        on_device,
-        fn_tree,
-        frontend,
-        test_flags,
-        backend_fw,
-        sample_weight,
+    arrays_and_dtypes,
+    on_device,
+    fn_tree,
+    frontend,
+    test_flags,
+    backend_fw,
+    sample_weight,
 ):
     dtypes, values = arrays_and_dtypes
     # Ensure the values are binary by rounding and converting to int
@@ -75,15 +77,25 @@ def test_sklearn_recall_score(
     sample_weight = np.array(sample_weight).astype(float)
     if len(sample_weight) != len(values[0]):
         # If sample_weight is shorter, extend it with ones
-        sample_weight = np.pad(sample_weight, (0, max(0, len(values[0]) - len(sample_weight))), 'constant',
-                               constant_values=1.0)
+        sample_weight = np.pad(
+            sample_weight,
+            (0, max(0, len(values[0]) - len(sample_weight))),
+            "constant",
+            constant_values=1.0,
+        )
         # If sample_weight is longer, truncate it
-        sample_weight = sample_weight[:len(values[0])]
+        sample_weight = sample_weight[: len(values[0])]
 
     # Detach tensors if they require grad before converting to NumPy arrays
-    if backend_fw == 'torch':
-        values = [value.detach().numpy() if isinstance(value, torch.Tensor) and value.requires_grad else value
-                  for value in values]
+    if backend_fw == "torch":
+        values = [
+            (
+                value.detach().numpy()
+                if isinstance(value, torch.Tensor) and value.requires_grad
+                else value
+            )
+            for value in values
+        ]
 
     helpers.test_frontend_function(
         input_dtypes=dtypes,

--- a/ivy_tests/test_ivy/test_frontends/test_sklearn/test_metrics/test_classification.py
+++ b/ivy_tests/test_ivy/test_frontends/test_sklearn/test_metrics/test_classification.py
@@ -46,40 +46,44 @@ def test_sklearn_accuracy_score(
 
 
 @handle_frontend_test(
-    fn_tree="sklearn.metrics.recall_score",
+    fn_tree="sklearn.metrics.precision_score",
     arrays_and_dtypes=helpers.dtype_and_values(
-        available_dtypes=helpers.get_dtypes("float_and_integer"),
+        available_dtypes=helpers.get_dtypes("integer"),
         num_arrays=2,
-        min_value=0,  # Recall score is for binary classification, so min_value is set to 0
-        max_value=1,  # Max value is set to 1 for the same reason
+        min_value=0,
+        max_value=1,  # Precision score is for binary classification
         shared_dtype=True,
         shape=(helpers.ints(min_value=2, max_value=5)),
     ),
+    sample_weight=st.lists(st.floats(min_value=0.1, max_value=1), min_size=2, max_size=5),
 )
-def test_sklearn_recall_score(
-    arrays_and_dtypes,
-    on_device,
-    fn_tree,
-    frontend,
-    test_flags,
-    backend_fw,
+def test_sklearn_precision_score(
+        arrays_and_dtypes,
+        on_device,
+        fn_tree,
+        frontend,
+        test_flags,
+        backend_fw,
+        sample_weight,
 ):
     dtypes, values = arrays_and_dtypes
     # Ensure the values are binary by rounding and converting to int
     for i in range(2):
-        if "float" in dtypes[i]:
-            values[i] = np.round(values[i]).astype(int)
+        values[i] = np.round(values[i]).astype(int)
+
+    # Adjust sample_weight to have the correct length
+    sample_weight = np.array(sample_weight).astype(float)
+    if len(sample_weight) != len(values[0]):
+        # If sample_weight is shorter, extend it with ones
+        sample_weight = np.pad(sample_weight, (0, max(0, len(values[0]) - len(sample_weight))), 'constant',
+                               constant_values=1.0)
+        # If sample_weight is longer, truncate it
+        sample_weight = sample_weight[:len(values[0])]
 
     # Detach tensors if they require grad before converting to NumPy arrays
-    if backend_fw == "torch":
-        values = [
-            (
-                value.detach().numpy()
-                if isinstance(value, torch.Tensor) and value.requires_grad
-                else value
-            )
-            for value in values
-        ]
+    if backend_fw == 'torch':
+        values = [value.detach().numpy() if isinstance(value, torch.Tensor) and value.requires_grad else value
+                  for value in values]
 
     helpers.test_frontend_function(
         input_dtypes=dtypes,
@@ -90,5 +94,5 @@ def test_sklearn_recall_score(
         on_device=on_device,
         y_true=values[0],
         y_pred=values[1],
-        sample_weight=None,
+        sample_weight=sample_weight,
     )


### PR DESCRIPTION
# PR Description

This PR introduces the recall_score function in Ivy, supporting binary or multilabel classification. It calculates recall with options for micro, macro, and binary averaging, along with support for sample weights. The code includes clear comments for readability.

A property-based test (test_recall_score) has been added using Hypothesis to ensure the correctness of the recall_score function across diverse input scenarios.

Changes:

Added recall_score function implementation.
Included property-based test (test_recall_score) for comprehensive validation.
Added comments for code clarity



## Checklist

- [x] Did you add a function?
- [x] Did you add the tests?
- [x] Did you run your tests and are your tests passing?
- [x] Did pre-commit not fail on any check?
- [x] Did you follow the steps we provided?



