### PR TITLE
fix: Fixed `ivy.fix` for paddle backend

### DIFF
--- a/ivy/functional/backends/paddle/experimental/elementwise.py
+++ b/ivy/functional/backends/paddle/experimental/elementwise.py
@@ -266,6 +266,9 @@ def allclose(
     return paddle.allclose(x1, x2, rtol=rtol, atol=atol, equal_nan=equal_nan).squeeze(0)
 
 
+@with_supported_dtypes(
+    {"2.6.0 and below": ("float32", "float64", "int32", "int64")}, backend_version
+)
 def fix(
     x: paddle.Tensor,
     /,

--- a/ivy/functional/backends/paddle/experimental/elementwise.py
+++ b/ivy/functional/backends/paddle/experimental/elementwise.py
@@ -266,9 +266,7 @@ def allclose(
     return paddle.allclose(x1, x2, rtol=rtol, atol=atol, equal_nan=equal_nan).squeeze(0)
 
 
-@with_supported_dtypes(
-    {"2.6.0 and below": ("float32", "float64", "int32", "int64")}, backend_version
-)
+@with_unsupported_dtypes({"2.6.0 and below": ("float16",)}, backend_version)
 def fix(
     x: paddle.Tensor,
     /,

--- a/ivy_tests/test_ivy/test_functional/test_experimental/test_core/test_elementwise.py
+++ b/ivy_tests/test_ivy/test_functional/test_experimental/test_core/test_elementwise.py
@@ -514,7 +514,10 @@ def test_erfc(
 @handle_test(
     fn_tree="functional.ivy.experimental.fix",
     dtype_and_x=helpers.dtype_and_values(
-        available_dtypes=helpers.get_dtypes("float"),
+        available_dtypes=(
+            ivy.float32,
+            ivy.float64,
+        ),
         min_num_dims=1,
         max_num_dims=3,
         min_dim_size=1,

--- a/ivy_tests/test_ivy/test_functional/test_experimental/test_core/test_elementwise.py
+++ b/ivy_tests/test_ivy/test_functional/test_experimental/test_core/test_elementwise.py
@@ -514,10 +514,7 @@ def test_erfc(
 @handle_test(
     fn_tree="functional.ivy.experimental.fix",
     dtype_and_x=helpers.dtype_and_values(
-        available_dtypes=(
-            ivy.float32,
-            ivy.float64,
-        ),
+        available_dtypes=helpers.get_dtypes("float"),
         min_num_dims=1,
         max_num_dims=3,
         min_dim_size=1,


### PR DESCRIPTION
# PR Description
Fixed `ivy.fix` for paddle backend.

![image](https://github.com/unifyai/ivy/assets/87087741/77b16cbb-1e4e-45cf-8009-bcc20fc56b03)


## Related Issue
Closes #27987 

## Checklist

- [ ] Did you add a function?
- [ ] Did you add the tests?
- [x] Did you run your tests and are your tests passing?
- [x] Did pre-commit not fail on any check?
- [x] Did you follow the steps we provided?

### Socials
