### PR TITLE
fix: Fixed torch.Tensor.not_equal for paddle backend

### DIFF
--- a/ivy/functional/backends/paddle/elementwise.py
+++ b/ivy/functional/backends/paddle/elementwise.py
@@ -612,6 +612,10 @@ def negative(
     return paddle.neg(x)
 
 
+@with_unsupported_dtypes(
+    {"2.6.0": ("float16",)},
+    backend_version,
+)
 def not_equal(
     x1: Union[float, paddle.Tensor],
     x2: Union[float, paddle.Tensor],

--- a/ivy/functional/frontends/torch/tensor.py
+++ b/ivy/functional/frontends/torch/tensor.py
@@ -491,7 +491,6 @@ class Tensor:
                 "uint64",
                 "complex128",
                 "complex64",
-                "float16",
             )
         },
         "torch",

--- a/ivy/functional/frontends/torch/tensor.py
+++ b/ivy/functional/frontends/torch/tensor.py
@@ -491,6 +491,7 @@ class Tensor:
                 "uint64",
                 "complex128",
                 "complex64",
+                "float16",
             )
         },
         "torch",


### PR DESCRIPTION
# PR Description
Fixed `torch.Tensor.not_equal` for paddle backend

![image](https://github.com/unifyai/ivy/assets/87087741/72839e3b-67a1-4c8d-94c6-1afc258581a3)


## Related Issue
Closes #27996 

## Checklist

- [ ] Did you add a function?
- [ ] Did you add the tests?
- [x] Did you run your tests and are your tests passing?
- [x] Did pre-commit not fail on any check?
- [x] Did you follow the steps we provided?

### Socials
