### PR TITLE
fix: Fixed inconsistent `naming` of some tests

### DIFF
--- a/ivy_tests/test_ivy/test_frontends/test_jax/test_array.py
+++ b/ivy_tests/test_ivy/test_frontends/test_jax/test_array.py
@@ -208,6 +208,40 @@ def dtype_x_axis(draw):
 @handle_frontend_method(
     class_tree=CLASS_TREE,
     init_tree="jax.numpy.array",
+    method_name="__abs__",
+    dtype_and_x=helpers.dtype_and_values(
+        available_dtypes=helpers.get_dtypes("numeric"),
+    ),
+)
+def test_jax___abs__(
+    dtype_and_x,
+    frontend,
+    frontend_method_data,
+    init_flags,
+    method_flags,
+    backend_fw,
+    on_device,
+):
+    input_dtype, x = dtype_and_x
+    helpers.test_frontend_method(
+        init_input_dtypes=input_dtype,
+        backend_to_test=backend_fw,
+        init_all_as_kwargs_np={
+            "object": x[0],
+        },
+        method_input_dtypes=input_dtype,
+        method_all_as_kwargs_np={},
+        frontend=frontend,
+        frontend_method_data=frontend_method_data,
+        init_flags=init_flags,
+        method_flags=method_flags,
+        on_device=on_device,
+    )
+
+
+@handle_frontend_method(
+    class_tree=CLASS_TREE,
+    init_tree="jax.numpy.array",
     method_name="__add__",
     dtype_x=helpers.dtype_and_values(
         available_dtypes=helpers.get_dtypes("numeric"),
@@ -225,6 +259,42 @@ def test_jax___add__(
     on_device,
 ):
     input_dtype, x = dtype_x
+    helpers.test_frontend_method(
+        init_input_dtypes=input_dtype,
+        backend_to_test=backend_fw,
+        init_all_as_kwargs_np={
+            "object": x[0],
+        },
+        method_input_dtypes=input_dtype,
+        method_all_as_kwargs_np={"other": x[1]},
+        frontend=frontend,
+        frontend_method_data=frontend_method_data,
+        init_flags=init_flags,
+        method_flags=method_flags,
+        on_device=on_device,
+    )
+
+
+@handle_frontend_method(
+    class_tree=CLASS_TREE,
+    init_tree="jax.numpy.array",
+    method_name="__and__",
+    dtype_and_x=helpers.dtype_and_values(
+        available_dtypes=st.one_of(st.just(("bool",)), helpers.get_dtypes("integer")),
+        num_arrays=2,
+        shared_dtype=True,
+    ),
+)
+def test_jax___and__(
+    dtype_and_x,
+    frontend,
+    frontend_method_data,
+    init_flags,
+    method_flags,
+    backend_fw,
+    on_device,
+):
+    input_dtype, x = dtype_and_x
     helpers.test_frontend_method(
         init_input_dtypes=input_dtype,
         backend_to_test=backend_fw,
@@ -278,6 +348,82 @@ def test_jax___div__(
     )
 
 
+@handle_frontend_method(
+    class_tree=CLASS_TREE,
+    init_tree="jax.numpy.array",
+    method_name="__eq__",
+    dtype_and_x=helpers.dtype_and_values(
+        available_dtypes=helpers.get_dtypes("numeric"),
+        num_arrays=2,
+    ),
+)
+def test_jax___eq__(
+    dtype_and_x,
+    frontend,
+    frontend_method_data,
+    init_flags,
+    method_flags,
+    backend_fw,
+    on_device,
+):
+    input_dtype, x = dtype_and_x
+    assume("bfloat16" not in input_dtype)
+    helpers.test_frontend_method(
+        init_input_dtypes=input_dtype,
+        backend_to_test=backend_fw,
+        init_all_as_kwargs_np={
+            "object": x[0],
+        },
+        method_input_dtypes=input_dtype,
+        method_all_as_kwargs_np={
+            "other": x[1],
+        },
+        frontend=frontend,
+        frontend_method_data=frontend_method_data,
+        init_flags=init_flags,
+        method_flags=method_flags,
+        on_device=on_device,
+    )
+
+
+@handle_frontend_method(
+    class_tree=CLASS_TREE,
+    init_tree="jax.numpy.array",
+    method_name="__ge__",
+    dtype_and_x=helpers.dtype_and_values(
+        available_dtypes=helpers.get_dtypes("float_and_integer"),
+        num_arrays=2,
+    ),
+)
+def test_jax___ge__(
+    dtype_and_x,
+    frontend,
+    frontend_method_data,
+    init_flags,
+    method_flags,
+    backend_fw,
+    on_device,
+):
+    input_dtype, x = dtype_and_x
+    assume("bfloat16" not in input_dtype)
+    helpers.test_frontend_method(
+        init_input_dtypes=input_dtype,
+        backend_to_test=backend_fw,
+        init_all_as_kwargs_np={
+            "object": x[0],
+        },
+        method_input_dtypes=input_dtype,
+        method_all_as_kwargs_np={
+            "other": x[1],
+        },
+        frontend=frontend,
+        frontend_method_data=frontend_method_data,
+        init_flags=init_flags,
+        method_flags=method_flags,
+        on_device=on_device,
+    )
+
+
 # __getitem__
 @handle_frontend_method(
     class_tree=CLASS_TREE,
@@ -303,6 +449,44 @@ def test_jax___getitem__(
         init_all_as_kwargs_np={"object": x},
         method_input_dtypes=[*input_dtype[1:]],
         method_all_as_kwargs_np={"idx": index},
+        frontend=frontend,
+        frontend_method_data=frontend_method_data,
+        init_flags=init_flags,
+        method_flags=method_flags,
+        on_device=on_device,
+    )
+
+
+@handle_frontend_method(
+    class_tree=CLASS_TREE,
+    init_tree="jax.numpy.array",
+    method_name="__gt__",
+    dtype_and_x=helpers.dtype_and_values(
+        available_dtypes=helpers.get_dtypes("float_and_integer"),
+        num_arrays=2,
+    ),
+)
+def test_jax___gt__(
+    dtype_and_x,
+    frontend,
+    frontend_method_data,
+    init_flags,
+    method_flags,
+    backend_fw,
+    on_device,
+):
+    input_dtype, x = dtype_and_x
+    assume("bfloat16" not in input_dtype)
+    helpers.test_frontend_method(
+        init_input_dtypes=input_dtype,
+        backend_to_test=backend_fw,
+        init_all_as_kwargs_np={
+            "object": x[0],
+        },
+        method_input_dtypes=input_dtype,
+        method_all_as_kwargs_np={
+            "other": x[1],
+        },
         frontend=frontend,
         frontend_method_data=frontend_method_data,
         init_flags=init_flags,
@@ -348,6 +532,44 @@ def test_jax___invert__(
 @handle_frontend_method(
     class_tree=CLASS_TREE,
     init_tree="jax.numpy.array",
+    method_name="__le__",
+    dtype_and_x=helpers.dtype_and_values(
+        available_dtypes=helpers.get_dtypes("float_and_integer"),
+        num_arrays=2,
+    ),
+)
+def test_jax___le__(
+    dtype_and_x,
+    frontend,
+    frontend_method_data,
+    init_flags,
+    method_flags,
+    backend_fw,
+    on_device,
+):
+    input_dtype, x = dtype_and_x
+    assume("bfloat16" not in input_dtype)
+    helpers.test_frontend_method(
+        init_input_dtypes=input_dtype,
+        backend_to_test=backend_fw,
+        init_all_as_kwargs_np={
+            "object": x[0],
+        },
+        method_input_dtypes=input_dtype,
+        method_all_as_kwargs_np={
+            "other": x[1],
+        },
+        frontend=frontend,
+        frontend_method_data=frontend_method_data,
+        init_flags=init_flags,
+        method_flags=method_flags,
+        on_device=on_device,
+    )
+
+
+@handle_frontend_method(
+    class_tree=CLASS_TREE,
+    init_tree="jax.numpy.array",
     method_name="__lshift__",
     dtype_x_shift=_get_dtype_x_and_int_shift(dtype="signed_integer"),
 )
@@ -369,6 +591,44 @@ def test_jax___lshift__(
         },
         method_input_dtypes=input_dtype,
         method_all_as_kwargs_np={"other": shift},
+        frontend=frontend,
+        frontend_method_data=frontend_method_data,
+        init_flags=init_flags,
+        method_flags=method_flags,
+        on_device=on_device,
+    )
+
+
+@handle_frontend_method(
+    class_tree=CLASS_TREE,
+    init_tree="jax.numpy.array",
+    method_name="__lt__",
+    dtype_and_x=helpers.dtype_and_values(
+        available_dtypes=helpers.get_dtypes("float_and_integer"),
+        num_arrays=2,
+        shared_dtype=True,
+    ),
+)
+def test_jax___lt__(
+    dtype_and_x,
+    frontend,
+    frontend_method_data,
+    init_flags,
+    method_flags,
+    backend_fw,
+    on_device,
+):
+    input_dtype, x = dtype_and_x
+    helpers.test_frontend_method(
+        init_input_dtypes=input_dtype,
+        backend_to_test=backend_fw,
+        init_all_as_kwargs_np={
+            "object": x[0],
+        },
+        method_input_dtypes=input_dtype,
+        method_all_as_kwargs_np={
+            "other": x[1],
+        },
         frontend=frontend,
         frontend_method_data=frontend_method_data,
         init_flags=init_flags,
@@ -485,6 +745,186 @@ def test_jax___mul__(
 @handle_frontend_method(
     class_tree=CLASS_TREE,
     init_tree="jax.numpy.array",
+    method_name="__ne__",
+    dtype_and_x=helpers.dtype_and_values(
+        available_dtypes=helpers.get_dtypes("numeric"),
+        num_arrays=2,
+    ),
+)
+def test_jax___ne__(
+    dtype_and_x,
+    frontend,
+    frontend_method_data,
+    init_flags,
+    method_flags,
+    backend_fw,
+    on_device,
+):
+    input_dtype, x = dtype_and_x
+    assume("bfloat16" not in input_dtype)
+    helpers.test_frontend_method(
+        init_input_dtypes=input_dtype,
+        backend_to_test=backend_fw,
+        init_all_as_kwargs_np={
+            "object": x[0],
+        },
+        method_input_dtypes=input_dtype,
+        method_all_as_kwargs_np={
+            "other": x[1],
+        },
+        frontend=frontend,
+        frontend_method_data=frontend_method_data,
+        init_flags=init_flags,
+        method_flags=method_flags,
+        on_device=on_device,
+    )
+
+
+@handle_frontend_method(
+    class_tree=CLASS_TREE,
+    init_tree="jax.numpy.array",
+    method_name="__neg__",
+    dtype_and_x=helpers.dtype_and_values(
+        available_dtypes=helpers.get_dtypes("signed_integer"),
+    ),
+)
+def test_jax___neg__(
+    dtype_and_x,
+    frontend,
+    frontend_method_data,
+    init_flags,
+    method_flags,
+    backend_fw,
+    on_device,
+):
+    input_dtype, x = dtype_and_x
+    helpers.test_frontend_method(
+        init_input_dtypes=input_dtype,
+        backend_to_test=backend_fw,
+        init_all_as_kwargs_np={
+            "object": x[0],
+        },
+        method_input_dtypes=input_dtype,
+        method_all_as_kwargs_np={},
+        frontend=frontend,
+        frontend_method_data=frontend_method_data,
+        init_flags=init_flags,
+        method_flags=method_flags,
+        on_device=on_device,
+    )
+
+
+@handle_frontend_method(
+    class_tree=CLASS_TREE,
+    init_tree="jax.numpy.array",
+    method_name="__or__",
+    dtype_and_x=helpers.dtype_and_values(
+        available_dtypes=st.one_of(st.just(("bool",)), helpers.get_dtypes("integer")),
+        num_arrays=2,
+        shared_dtype=True,
+    ),
+)
+def test_jax___or__(
+    dtype_and_x,
+    frontend,
+    frontend_method_data,
+    init_flags,
+    method_flags,
+    backend_fw,
+    on_device,
+):
+    input_dtype, x = dtype_and_x
+    helpers.test_frontend_method(
+        init_input_dtypes=input_dtype,
+        backend_to_test=backend_fw,
+        init_all_as_kwargs_np={
+            "object": x[0],
+        },
+        method_input_dtypes=input_dtype,
+        method_all_as_kwargs_np={"other": x[1]},
+        frontend=frontend,
+        frontend_method_data=frontend_method_data,
+        init_flags=init_flags,
+        method_flags=method_flags,
+        on_device=on_device,
+    )
+
+
+@handle_frontend_method(
+    class_tree=CLASS_TREE,
+    init_tree="jax.numpy.array",
+    method_name="__pos__",
+    dtype_and_x=helpers.dtype_and_values(
+        available_dtypes=helpers.get_dtypes("valid"),
+    ),
+)
+def test_jax___pos__(
+    dtype_and_x,
+    frontend,
+    frontend_method_data,
+    init_flags,
+    method_flags,
+    backend_fw,
+    on_device,
+):
+    input_dtype, x = dtype_and_x
+    helpers.test_frontend_method(
+        init_input_dtypes=input_dtype,
+        backend_to_test=backend_fw,
+        on_device=on_device,
+        init_all_as_kwargs_np={
+            "object": x[0],
+        },
+        method_input_dtypes=input_dtype,
+        method_all_as_kwargs_np={},
+        frontend=frontend,
+        frontend_method_data=frontend_method_data,
+        init_flags=init_flags,
+        method_flags=method_flags,
+    )
+
+
+@handle_frontend_method(
+    class_tree=CLASS_TREE,
+    init_tree="jax.numpy.array",
+    method_name="__pow__",
+    dtype_x_pow=helpers.dtype_and_values(
+        available_dtypes=helpers.get_dtypes("float"),
+        num_arrays=2,
+        shared_dtype=True,
+    ),
+)
+def test_jax___pow__(
+    dtype_x_pow,
+    frontend,
+    frontend_method_data,
+    init_flags,
+    method_flags,
+    backend_fw,
+    on_device,
+):
+    input_dtype, x = dtype_x_pow
+    helpers.test_frontend_method(
+        init_input_dtypes=input_dtype,
+        backend_to_test=backend_fw,
+        init_all_as_kwargs_np={
+            "object": x[0],
+        },
+        method_input_dtypes=input_dtype,
+        method_all_as_kwargs_np={
+            "other": x[1],
+        },
+        frontend=frontend,
+        frontend_method_data=frontend_method_data,
+        init_flags=init_flags,
+        method_flags=method_flags,
+        on_device=on_device,
+    )
+
+
+@handle_frontend_method(
+    class_tree=CLASS_TREE,
+    init_tree="jax.numpy.array",
     method_name="__radd__",
     dtype_x=helpers.dtype_and_values(
         available_dtypes=helpers.get_dtypes("numeric"),
@@ -502,6 +942,42 @@ def test_jax___radd__(
     on_device,
 ):
     input_dtype, x = dtype_x
+    helpers.test_frontend_method(
+        init_input_dtypes=input_dtype,
+        backend_to_test=backend_fw,
+        init_all_as_kwargs_np={
+            "object": x[0],
+        },
+        method_input_dtypes=input_dtype,
+        method_all_as_kwargs_np={"other": x[1]},
+        frontend=frontend,
+        frontend_method_data=frontend_method_data,
+        init_flags=init_flags,
+        method_flags=method_flags,
+        on_device=on_device,
+    )
+
+
+@handle_frontend_method(
+    class_tree=CLASS_TREE,
+    init_tree="jax.numpy.array",
+    method_name="__rand__",
+    dtype_and_x=helpers.dtype_and_values(
+        available_dtypes=st.one_of(st.just(("bool",)), helpers.get_dtypes("integer")),
+        num_arrays=2,
+        shared_dtype=True,
+    ),
+)
+def test_jax___rand__(
+    dtype_and_x,
+    frontend,
+    frontend_method_data,
+    init_flags,
+    method_flags,
+    backend_fw,
+    on_device,
+):
+    input_dtype, x = dtype_and_x
     helpers.test_frontend_method(
         init_input_dtypes=input_dtype,
         backend_to_test=backend_fw,
@@ -695,6 +1171,76 @@ def test_jax___rmul__(
 @handle_frontend_method(
     class_tree=CLASS_TREE,
     init_tree="jax.numpy.array",
+    method_name="__ror__",
+    dtype_and_x=helpers.dtype_and_values(
+        available_dtypes=st.one_of(st.just(("bool",)), helpers.get_dtypes("integer")),
+        num_arrays=2,
+        shared_dtype=True,
+    ),
+)
+def test_jax___ror__(
+    dtype_and_x,
+    frontend,
+    frontend_method_data,
+    init_flags,
+    method_flags,
+    backend_fw,
+    on_device,
+):
+    input_dtype, x = dtype_and_x
+    helpers.test_frontend_method(
+        init_input_dtypes=input_dtype,
+        backend_to_test=backend_fw,
+        init_all_as_kwargs_np={
+            "object": x[0],
+        },
+        method_input_dtypes=input_dtype,
+        method_all_as_kwargs_np={"other": x[1]},
+        frontend=frontend,
+        frontend_method_data=frontend_method_data,
+        init_flags=init_flags,
+        method_flags=method_flags,
+        on_device=on_device,
+    )
+
+
+@handle_frontend_method(
+    class_tree=CLASS_TREE,
+    init_tree="jax.numpy.array",
+    method_name="__rpow__",
+    dtype_x_pow=_get_dtype_x_and_int(),
+)
+def test_jax___rpow__(
+    dtype_x_pow,
+    frontend,
+    frontend_method_data,
+    init_flags,
+    method_flags,
+    backend_fw,
+    on_device,
+):
+    input_dtype, x, pow = dtype_x_pow
+    helpers.test_frontend_method(
+        init_input_dtypes=input_dtype,
+        backend_to_test=backend_fw,
+        init_all_as_kwargs_np={
+            "object": pow[0],
+        },
+        method_input_dtypes=input_dtype,
+        method_all_as_kwargs_np={
+            "other": x[0],
+        },
+        frontend=frontend,
+        frontend_method_data=frontend_method_data,
+        init_flags=init_flags,
+        method_flags=method_flags,
+        on_device=on_device,
+    )
+
+
+@handle_frontend_method(
+    class_tree=CLASS_TREE,
+    init_tree="jax.numpy.array",
     method_name="__rrshift__",
     dtype_x_shift=_get_dtype_x_and_int_shift(dtype="signed_integer"),
 )
@@ -832,6 +1378,42 @@ def test_jax___rtruediv__(
 @handle_frontend_method(
     class_tree=CLASS_TREE,
     init_tree="jax.numpy.array",
+    method_name="__rxor__",
+    dtype_and_x=helpers.dtype_and_values(
+        available_dtypes=st.one_of(st.just(("bool",)), helpers.get_dtypes("integer")),
+        num_arrays=2,
+        shared_dtype=True,
+    ),
+)
+def test_jax___rxor__(
+    dtype_and_x,
+    frontend,
+    frontend_method_data,
+    init_flags,
+    method_flags,
+    backend_fw,
+    on_device,
+):
+    input_dtype, x = dtype_and_x
+    helpers.test_frontend_method(
+        init_input_dtypes=input_dtype,
+        backend_to_test=backend_fw,
+        init_all_as_kwargs_np={
+            "object": x[0],
+        },
+        method_input_dtypes=input_dtype,
+        method_all_as_kwargs_np={"other": x[1]},
+        frontend=frontend,
+        frontend_method_data=frontend_method_data,
+        init_flags=init_flags,
+        method_flags=method_flags,
+        on_device=on_device,
+    )
+
+
+@handle_frontend_method(
+    class_tree=CLASS_TREE,
+    init_tree="jax.numpy.array",
     method_name="__sub__",
     dtype_x=helpers.dtype_and_values(
         available_dtypes=helpers.get_dtypes("numeric"),
@@ -889,588 +1471,6 @@ def test_jax___truediv__(
 ):
     input_dtype, x = dtype_x
     assume(not np.any(np.isclose(x[1], 0)))
-    helpers.test_frontend_method(
-        init_input_dtypes=input_dtype,
-        backend_to_test=backend_fw,
-        init_all_as_kwargs_np={
-            "object": x[0],
-        },
-        method_input_dtypes=input_dtype,
-        method_all_as_kwargs_np={"other": x[1]},
-        frontend=frontend,
-        frontend_method_data=frontend_method_data,
-        init_flags=init_flags,
-        method_flags=method_flags,
-        on_device=on_device,
-    )
-
-
-@handle_frontend_method(
-    class_tree=CLASS_TREE,
-    init_tree="jax.numpy.array",
-    method_name="__abs__",
-    dtype_and_x=helpers.dtype_and_values(
-        available_dtypes=helpers.get_dtypes("numeric"),
-    ),
-)
-def test_jax___abs__(
-    dtype_and_x,
-    frontend,
-    frontend_method_data,
-    init_flags,
-    method_flags,
-    backend_fw,
-    on_device,
-):
-    input_dtype, x = dtype_and_x
-    helpers.test_frontend_method(
-        init_input_dtypes=input_dtype,
-        backend_to_test=backend_fw,
-        init_all_as_kwargs_np={
-            "object": x[0],
-        },
-        method_input_dtypes=input_dtype,
-        method_all_as_kwargs_np={},
-        frontend=frontend,
-        frontend_method_data=frontend_method_data,
-        init_flags=init_flags,
-        method_flags=method_flags,
-        on_device=on_device,
-    )
-
-
-@handle_frontend_method(
-    class_tree=CLASS_TREE,
-    init_tree="jax.numpy.array",
-    method_name="__and__",
-    dtype_and_x=helpers.dtype_and_values(
-        available_dtypes=st.one_of(st.just(("bool",)), helpers.get_dtypes("integer")),
-        num_arrays=2,
-        shared_dtype=True,
-    ),
-)
-def test_jax___and__(
-    dtype_and_x,
-    frontend,
-    frontend_method_data,
-    init_flags,
-    method_flags,
-    backend_fw,
-    on_device,
-):
-    input_dtype, x = dtype_and_x
-    helpers.test_frontend_method(
-        init_input_dtypes=input_dtype,
-        backend_to_test=backend_fw,
-        init_all_as_kwargs_np={
-            "object": x[0],
-        },
-        method_input_dtypes=input_dtype,
-        method_all_as_kwargs_np={"other": x[1]},
-        frontend=frontend,
-        frontend_method_data=frontend_method_data,
-        init_flags=init_flags,
-        method_flags=method_flags,
-        on_device=on_device,
-    )
-
-
-@handle_frontend_method(
-    class_tree=CLASS_TREE,
-    init_tree="jax.numpy.array",
-    method_name="__eq__",
-    dtype_and_x=helpers.dtype_and_values(
-        available_dtypes=helpers.get_dtypes("numeric"),
-        num_arrays=2,
-    ),
-)
-def test_jax___eq__(
-    dtype_and_x,
-    frontend,
-    frontend_method_data,
-    init_flags,
-    method_flags,
-    backend_fw,
-    on_device,
-):
-    input_dtype, x = dtype_and_x
-    assume("bfloat16" not in input_dtype)
-    helpers.test_frontend_method(
-        init_input_dtypes=input_dtype,
-        backend_to_test=backend_fw,
-        init_all_as_kwargs_np={
-            "object": x[0],
-        },
-        method_input_dtypes=input_dtype,
-        method_all_as_kwargs_np={
-            "other": x[1],
-        },
-        frontend=frontend,
-        frontend_method_data=frontend_method_data,
-        init_flags=init_flags,
-        method_flags=method_flags,
-        on_device=on_device,
-    )
-
-
-@handle_frontend_method(
-    class_tree=CLASS_TREE,
-    init_tree="jax.numpy.array",
-    method_name="__ge__",
-    dtype_and_x=helpers.dtype_and_values(
-        available_dtypes=helpers.get_dtypes("float_and_integer"),
-        num_arrays=2,
-    ),
-)
-def test_jax___ge__(
-    dtype_and_x,
-    frontend,
-    frontend_method_data,
-    init_flags,
-    method_flags,
-    backend_fw,
-    on_device,
-):
-    input_dtype, x = dtype_and_x
-    assume("bfloat16" not in input_dtype)
-    helpers.test_frontend_method(
-        init_input_dtypes=input_dtype,
-        backend_to_test=backend_fw,
-        init_all_as_kwargs_np={
-            "object": x[0],
-        },
-        method_input_dtypes=input_dtype,
-        method_all_as_kwargs_np={
-            "other": x[1],
-        },
-        frontend=frontend,
-        frontend_method_data=frontend_method_data,
-        init_flags=init_flags,
-        method_flags=method_flags,
-        on_device=on_device,
-    )
-
-
-@handle_frontend_method(
-    class_tree=CLASS_TREE,
-    init_tree="jax.numpy.array",
-    method_name="__gt__",
-    dtype_and_x=helpers.dtype_and_values(
-        available_dtypes=helpers.get_dtypes("float_and_integer"),
-        num_arrays=2,
-    ),
-)
-def test_jax___gt__(
-    dtype_and_x,
-    frontend,
-    frontend_method_data,
-    init_flags,
-    method_flags,
-    backend_fw,
-    on_device,
-):
-    input_dtype, x = dtype_and_x
-    assume("bfloat16" not in input_dtype)
-    helpers.test_frontend_method(
-        init_input_dtypes=input_dtype,
-        backend_to_test=backend_fw,
-        init_all_as_kwargs_np={
-            "object": x[0],
-        },
-        method_input_dtypes=input_dtype,
-        method_all_as_kwargs_np={
-            "other": x[1],
-        },
-        frontend=frontend,
-        frontend_method_data=frontend_method_data,
-        init_flags=init_flags,
-        method_flags=method_flags,
-        on_device=on_device,
-    )
-
-
-@handle_frontend_method(
-    class_tree=CLASS_TREE,
-    init_tree="jax.numpy.array",
-    method_name="__le__",
-    dtype_and_x=helpers.dtype_and_values(
-        available_dtypes=helpers.get_dtypes("float_and_integer"),
-        num_arrays=2,
-    ),
-)
-def test_jax___le__(
-    dtype_and_x,
-    frontend,
-    frontend_method_data,
-    init_flags,
-    method_flags,
-    backend_fw,
-    on_device,
-):
-    input_dtype, x = dtype_and_x
-    assume("bfloat16" not in input_dtype)
-    helpers.test_frontend_method(
-        init_input_dtypes=input_dtype,
-        backend_to_test=backend_fw,
-        init_all_as_kwargs_np={
-            "object": x[0],
-        },
-        method_input_dtypes=input_dtype,
-        method_all_as_kwargs_np={
-            "other": x[1],
-        },
-        frontend=frontend,
-        frontend_method_data=frontend_method_data,
-        init_flags=init_flags,
-        method_flags=method_flags,
-        on_device=on_device,
-    )
-
-
-@handle_frontend_method(
-    class_tree=CLASS_TREE,
-    init_tree="jax.numpy.array",
-    method_name="__lt__",
-    dtype_and_x=helpers.dtype_and_values(
-        available_dtypes=helpers.get_dtypes("float_and_integer"),
-        num_arrays=2,
-        shared_dtype=True,
-    ),
-)
-def test_jax___lt__(
-    dtype_and_x,
-    frontend,
-    frontend_method_data,
-    init_flags,
-    method_flags,
-    backend_fw,
-    on_device,
-):
-    input_dtype, x = dtype_and_x
-    helpers.test_frontend_method(
-        init_input_dtypes=input_dtype,
-        backend_to_test=backend_fw,
-        init_all_as_kwargs_np={
-            "object": x[0],
-        },
-        method_input_dtypes=input_dtype,
-        method_all_as_kwargs_np={
-            "other": x[1],
-        },
-        frontend=frontend,
-        frontend_method_data=frontend_method_data,
-        init_flags=init_flags,
-        method_flags=method_flags,
-        on_device=on_device,
-    )
-
-
-@handle_frontend_method(
-    class_tree=CLASS_TREE,
-    init_tree="jax.numpy.array",
-    method_name="__ne__",
-    dtype_and_x=helpers.dtype_and_values(
-        available_dtypes=helpers.get_dtypes("numeric"),
-        num_arrays=2,
-    ),
-)
-def test_jax___ne__(
-    dtype_and_x,
-    frontend,
-    frontend_method_data,
-    init_flags,
-    method_flags,
-    backend_fw,
-    on_device,
-):
-    input_dtype, x = dtype_and_x
-    assume("bfloat16" not in input_dtype)
-    helpers.test_frontend_method(
-        init_input_dtypes=input_dtype,
-        backend_to_test=backend_fw,
-        init_all_as_kwargs_np={
-            "object": x[0],
-        },
-        method_input_dtypes=input_dtype,
-        method_all_as_kwargs_np={
-            "other": x[1],
-        },
-        frontend=frontend,
-        frontend_method_data=frontend_method_data,
-        init_flags=init_flags,
-        method_flags=method_flags,
-        on_device=on_device,
-    )
-
-
-@handle_frontend_method(
-    class_tree=CLASS_TREE,
-    init_tree="jax.numpy.array",
-    method_name="__neg__",
-    dtype_and_x=helpers.dtype_and_values(
-        available_dtypes=helpers.get_dtypes("signed_integer"),
-    ),
-)
-def test_jax___neg__(
-    dtype_and_x,
-    frontend,
-    frontend_method_data,
-    init_flags,
-    method_flags,
-    backend_fw,
-    on_device,
-):
-    input_dtype, x = dtype_and_x
-    helpers.test_frontend_method(
-        init_input_dtypes=input_dtype,
-        backend_to_test=backend_fw,
-        init_all_as_kwargs_np={
-            "object": x[0],
-        },
-        method_input_dtypes=input_dtype,
-        method_all_as_kwargs_np={},
-        frontend=frontend,
-        frontend_method_data=frontend_method_data,
-        init_flags=init_flags,
-        method_flags=method_flags,
-        on_device=on_device,
-    )
-
-
-@handle_frontend_method(
-    class_tree=CLASS_TREE,
-    init_tree="jax.numpy.array",
-    method_name="__or__",
-    dtype_and_x=helpers.dtype_and_values(
-        available_dtypes=st.one_of(st.just(("bool",)), helpers.get_dtypes("integer")),
-        num_arrays=2,
-        shared_dtype=True,
-    ),
-)
-def test_jax___or__(
-    dtype_and_x,
-    frontend,
-    frontend_method_data,
-    init_flags,
-    method_flags,
-    backend_fw,
-    on_device,
-):
-    input_dtype, x = dtype_and_x
-    helpers.test_frontend_method(
-        init_input_dtypes=input_dtype,
-        backend_to_test=backend_fw,
-        init_all_as_kwargs_np={
-            "object": x[0],
-        },
-        method_input_dtypes=input_dtype,
-        method_all_as_kwargs_np={"other": x[1]},
-        frontend=frontend,
-        frontend_method_data=frontend_method_data,
-        init_flags=init_flags,
-        method_flags=method_flags,
-        on_device=on_device,
-    )
-
-
-@handle_frontend_method(
-    class_tree=CLASS_TREE,
-    init_tree="jax.numpy.array",
-    method_name="__pos__",
-    dtype_and_x=helpers.dtype_and_values(
-        available_dtypes=helpers.get_dtypes("valid"),
-    ),
-)
-def test_jax___pos__(
-    dtype_and_x,
-    frontend,
-    frontend_method_data,
-    init_flags,
-    method_flags,
-    backend_fw,
-    on_device,
-):
-    input_dtype, x = dtype_and_x
-    helpers.test_frontend_method(
-        init_input_dtypes=input_dtype,
-        backend_to_test=backend_fw,
-        on_device=on_device,
-        init_all_as_kwargs_np={
-            "object": x[0],
-        },
-        method_input_dtypes=input_dtype,
-        method_all_as_kwargs_np={},
-        frontend=frontend,
-        frontend_method_data=frontend_method_data,
-        init_flags=init_flags,
-        method_flags=method_flags,
-    )
-
-
-@handle_frontend_method(
-    class_tree=CLASS_TREE,
-    init_tree="jax.numpy.array",
-    method_name="__pow__",
-    dtype_x_pow=helpers.dtype_and_values(
-        available_dtypes=helpers.get_dtypes("float"),
-        num_arrays=2,
-        shared_dtype=True,
-    ),
-)
-def test_jax___pow__(
-    dtype_x_pow,
-    frontend,
-    frontend_method_data,
-    init_flags,
-    method_flags,
-    backend_fw,
-    on_device,
-):
-    input_dtype, x = dtype_x_pow
-    helpers.test_frontend_method(
-        init_input_dtypes=input_dtype,
-        backend_to_test=backend_fw,
-        init_all_as_kwargs_np={
-            "object": x[0],
-        },
-        method_input_dtypes=input_dtype,
-        method_all_as_kwargs_np={
-            "other": x[1],
-        },
-        frontend=frontend,
-        frontend_method_data=frontend_method_data,
-        init_flags=init_flags,
-        method_flags=method_flags,
-        on_device=on_device,
-    )
-
-
-@handle_frontend_method(
-    class_tree=CLASS_TREE,
-    init_tree="jax.numpy.array",
-    method_name="__rand__",
-    dtype_and_x=helpers.dtype_and_values(
-        available_dtypes=st.one_of(st.just(("bool",)), helpers.get_dtypes("integer")),
-        num_arrays=2,
-        shared_dtype=True,
-    ),
-)
-def test_jax___rand__(
-    dtype_and_x,
-    frontend,
-    frontend_method_data,
-    init_flags,
-    method_flags,
-    backend_fw,
-    on_device,
-):
-    input_dtype, x = dtype_and_x
-    helpers.test_frontend_method(
-        init_input_dtypes=input_dtype,
-        backend_to_test=backend_fw,
-        init_all_as_kwargs_np={
-            "object": x[0],
-        },
-        method_input_dtypes=input_dtype,
-        method_all_as_kwargs_np={"other": x[1]},
-        frontend=frontend,
-        frontend_method_data=frontend_method_data,
-        init_flags=init_flags,
-        method_flags=method_flags,
-        on_device=on_device,
-    )
-
-
-@handle_frontend_method(
-    class_tree=CLASS_TREE,
-    init_tree="jax.numpy.array",
-    method_name="__ror__",
-    dtype_and_x=helpers.dtype_and_values(
-        available_dtypes=st.one_of(st.just(("bool",)), helpers.get_dtypes("integer")),
-        num_arrays=2,
-        shared_dtype=True,
-    ),
-)
-def test_jax___ror__(
-    dtype_and_x,
-    frontend,
-    frontend_method_data,
-    init_flags,
-    method_flags,
-    backend_fw,
-    on_device,
-):
-    input_dtype, x = dtype_and_x
-    helpers.test_frontend_method(
-        init_input_dtypes=input_dtype,
-        backend_to_test=backend_fw,
-        init_all_as_kwargs_np={
-            "object": x[0],
-        },
-        method_input_dtypes=input_dtype,
-        method_all_as_kwargs_np={"other": x[1]},
-        frontend=frontend,
-        frontend_method_data=frontend_method_data,
-        init_flags=init_flags,
-        method_flags=method_flags,
-        on_device=on_device,
-    )
-
-
-@handle_frontend_method(
-    class_tree=CLASS_TREE,
-    init_tree="jax.numpy.array",
-    method_name="__rpow__",
-    dtype_x_pow=_get_dtype_x_and_int(),
-)
-def test_jax___rpow__(
-    dtype_x_pow,
-    frontend,
-    frontend_method_data,
-    init_flags,
-    method_flags,
-    backend_fw,
-    on_device,
-):
-    input_dtype, x, pow = dtype_x_pow
-    helpers.test_frontend_method(
-        init_input_dtypes=input_dtype,
-        backend_to_test=backend_fw,
-        init_all_as_kwargs_np={
-            "object": pow[0],
-        },
-        method_input_dtypes=input_dtype,
-        method_all_as_kwargs_np={
-            "other": x[0],
-        },
-        frontend=frontend,
-        frontend_method_data=frontend_method_data,
-        init_flags=init_flags,
-        method_flags=method_flags,
-        on_device=on_device,
-    )
-
-
-@handle_frontend_method(
-    class_tree=CLASS_TREE,
-    init_tree="jax.numpy.array",
-    method_name="__rxor__",
-    dtype_and_x=helpers.dtype_and_values(
-        available_dtypes=st.one_of(st.just(("bool",)), helpers.get_dtypes("integer")),
-        num_arrays=2,
-        shared_dtype=True,
-    ),
-)
-def test_jax___rxor__(
-    dtype_and_x,
-    frontend,
-    frontend_method_data,
-    init_flags,
-    method_flags,
-    backend_fw,
-    on_device,
-):
-    input_dtype, x = dtype_and_x
     helpers.test_frontend_method(
         init_input_dtypes=input_dtype,
         backend_to_test=backend_fw,

--- a/ivy_tests/test_ivy/test_frontends/test_jax/test_array.py
+++ b/ivy_tests/test_ivy/test_frontends/test_jax/test_array.py
@@ -913,7 +913,7 @@ def test_jax___truediv__(
         available_dtypes=helpers.get_dtypes("numeric"),
     ),
 )
-def test_jax__abs_(
+def test_jax___abs__(
     dtype_and_x,
     frontend,
     frontend_method_data,
@@ -949,7 +949,7 @@ def test_jax__abs_(
         shared_dtype=True,
     ),
 )
-def test_jax__and_(
+def test_jax___and__(
     dtype_and_x,
     frontend,
     frontend_method_data,
@@ -984,7 +984,7 @@ def test_jax__and_(
         num_arrays=2,
     ),
 )
-def test_jax__eq_(
+def test_jax___eq__(
     dtype_and_x,
     frontend,
     frontend_method_data,
@@ -1022,7 +1022,7 @@ def test_jax__eq_(
         num_arrays=2,
     ),
 )
-def test_jax__ge_(
+def test_jax___ge__(
     dtype_and_x,
     frontend,
     frontend_method_data,
@@ -1060,7 +1060,7 @@ def test_jax__ge_(
         num_arrays=2,
     ),
 )
-def test_jax__gt_(
+def test_jax___gt__(
     dtype_and_x,
     frontend,
     frontend_method_data,
@@ -1098,7 +1098,7 @@ def test_jax__gt_(
         num_arrays=2,
     ),
 )
-def test_jax__le_(
+def test_jax___le__(
     dtype_and_x,
     frontend,
     frontend_method_data,
@@ -1137,7 +1137,7 @@ def test_jax__le_(
         shared_dtype=True,
     ),
 )
-def test_jax__lt_(
+def test_jax___lt__(
     dtype_and_x,
     frontend,
     frontend_method_data,
@@ -1174,7 +1174,7 @@ def test_jax__lt_(
         num_arrays=2,
     ),
 )
-def test_jax__ne_(
+def test_jax___ne__(
     dtype_and_x,
     frontend,
     frontend_method_data,
@@ -1211,7 +1211,7 @@ def test_jax__ne_(
         available_dtypes=helpers.get_dtypes("signed_integer"),
     ),
 )
-def test_jax__neg_(
+def test_jax___neg__(
     dtype_and_x,
     frontend,
     frontend_method_data,
@@ -1247,7 +1247,7 @@ def test_jax__neg_(
         shared_dtype=True,
     ),
 )
-def test_jax__or_(
+def test_jax___or__(
     dtype_and_x,
     frontend,
     frontend_method_data,
@@ -1281,7 +1281,7 @@ def test_jax__or_(
         available_dtypes=helpers.get_dtypes("valid"),
     ),
 )
-def test_jax__pos_(
+def test_jax___pos__(
     dtype_and_x,
     frontend,
     frontend_method_data,
@@ -1317,7 +1317,7 @@ def test_jax__pos_(
         shared_dtype=True,
     ),
 )
-def test_jax__pow_(
+def test_jax___pow__(
     dtype_x_pow,
     frontend,
     frontend_method_data,
@@ -1355,7 +1355,7 @@ def test_jax__pow_(
         shared_dtype=True,
     ),
 )
-def test_jax__rand_(
+def test_jax___rand__(
     dtype_and_x,
     frontend,
     frontend_method_data,
@@ -1391,7 +1391,7 @@ def test_jax__rand_(
         shared_dtype=True,
     ),
 )
-def test_jax__ror_(
+def test_jax___ror__(
     dtype_and_x,
     frontend,
     frontend_method_data,
@@ -1423,7 +1423,7 @@ def test_jax__ror_(
     method_name="__rpow__",
     dtype_x_pow=_get_dtype_x_and_int(),
 )
-def test_jax__rpow_(
+def test_jax___rpow__(
     dtype_x_pow,
     frontend,
     frontend_method_data,
@@ -1461,7 +1461,7 @@ def test_jax__rpow_(
         shared_dtype=True,
     ),
 )
-def test_jax__rxor_(
+def test_jax___rxor__(
     dtype_and_x,
     frontend,
     frontend_method_data,
@@ -1497,7 +1497,7 @@ def test_jax__rxor_(
         shared_dtype=True,
     ),
 )
-def test_jax__xor_(
+def test_jax___xor__(
     dtype_and_x,
     frontend,
     frontend_method_data,

--- a/ivy_tests/test_ivy/test_frontends/test_paddle/test_tensor/test_tensor.py
+++ b/ivy_tests/test_ivy/test_frontends/test_paddle/test_tensor/test_tensor.py
@@ -756,7 +756,7 @@ def test_paddle___sub__(
         max_num_dims=0,
     ),
 )
-def test_paddle__float__(
+def test_paddle___float__(
     dtype_and_x,
     frontend_method_data,
     init_flags,
@@ -796,7 +796,7 @@ def test_paddle__float__(
         safety_factor_scale="log",
     ),
 )
-def test_paddle__floordiv__(
+def test_paddle___floordiv__(
     dtype_and_x,
     frontend_method_data,
     init_flags,
@@ -836,7 +836,7 @@ def test_paddle__floordiv__(
         allow_neg_step=False,
     ).filter(lambda x: x[0][0] == x[0][-1] and _filter_query(x[-2])),
 )
-def test_paddle__getitem__(
+def test_paddle___getitem__(
     dtype_x_index,
     frontend_method_data,
     init_flags,
@@ -871,7 +871,7 @@ def test_paddle__getitem__(
         max_value=1e15,
     ),
 )
-def test_paddle__int__(
+def test_paddle___int__(
     dtype_and_x,
     frontend_method_data,
     init_flags,
@@ -909,7 +909,7 @@ def test_paddle__int__(
         max_num_dims=0,
     ),
 )
-def test_paddle__invert__(
+def test_paddle___invert__(
     dtype_and_x,
     frontend_method_data,
     init_flags,
@@ -945,7 +945,7 @@ def test_paddle__invert__(
         max_num_dims=5,
     ),
 )
-def test_paddle__len__(
+def test_paddle___len__(
     dtype_and_x,
     frontend,
     frontend_method_data,
@@ -983,7 +983,7 @@ def test_paddle__len__(
         max_value=1e15,
     ),
 )
-def test_paddle__long__(
+def test_paddle___long__(
     dtype_and_x,
     frontend_method_data,
     init_flags,
@@ -1024,7 +1024,7 @@ def test_paddle__long__(
         allow_inf=False,
     ),
 )
-def test_paddle__ne__(
+def test_paddle___ne__(
     dtype_and_x,
     frontend_method_data,
     init_flags,
@@ -1064,7 +1064,7 @@ def test_paddle__ne__(
         allow_inf=False,
     ),
 )
-def test_paddle__neg__(
+def test_paddle___neg__(
     dtype_and_x,
     frontend_method_data,
     init_flags,
@@ -1103,7 +1103,7 @@ def test_paddle__neg__(
         safety_factor_scale="log",
     ),
 )
-def test_paddle__rdiv__(
+def test_paddle___rdiv__(
     dtype_and_x,
     frontend,
     frontend_method_data,
@@ -1140,7 +1140,7 @@ def test_paddle__rdiv__(
     method_name="reshape",
     dtype_x_shape=_reshape_helper(),
 )
-def test_paddle__reshape(
+def test_paddle_reshape(
     dtype_x_shape,
     frontend_method_data,
     init_flags,
@@ -1177,7 +1177,7 @@ def test_paddle__reshape(
     method_name="reshape_",
     dtype_x_shape=_reshape_helper(),
 )
-def test_paddle__reshape_(
+def test_paddle_reshape_(
     dtype_x_shape,
     frontend_method_data,
     init_flags,
@@ -1220,7 +1220,7 @@ def test_paddle__reshape_(
         allow_inf=False,
     ),
 )
-def test_paddle__rmul__(
+def test_paddle___rmul__(
     dtype_and_x,
     frontend_method_data,
     init_flags,
@@ -1259,7 +1259,7 @@ def test_paddle__rmul__(
         shared_dtype=True,
     ),
 )
-def test_paddle__rsub__(
+def test_paddle___rsub__(
     dtype_and_x,
     frontend,
     frontend_method_data,
@@ -1300,7 +1300,7 @@ def test_paddle__rsub__(
         safety_factor_scale="log",
     ),
 )
-def test_paddle__rtruediv__(
+def test_paddle___rtruediv__(
     dtype_and_x,
     frontend,
     frontend_method_data,
@@ -1341,7 +1341,7 @@ def test_paddle__rtruediv__(
         shared_dtype=True,
     ),
 )
-def test_paddle__xor__(
+def test_paddle___xor__(
     dtype_and_x,
     frontend,
     frontend_method_data,

--- a/ivy_tests/test_ivy/test_frontends/test_paddle/test_tensor/test_tensor.py
+++ b/ivy_tests/test_ivy/test_frontends/test_paddle/test_tensor/test_tensor.py
@@ -418,335 +418,6 @@ def test_paddle___add__(
     )
 
 
-# __ge__
-@handle_frontend_method(
-    class_tree=CLASS_TREE,
-    init_tree="paddle.to_tensor",
-    method_name="__ge__",
-    dtype_and_x=helpers.dtype_and_values(
-        available_dtypes=helpers.get_dtypes("numeric"), num_arrays=2, shared_dtype=True
-    ),
-)
-def test_paddle___ge__(
-    dtype_and_x,
-    frontend_method_data,
-    init_flags,
-    method_flags,
-    frontend,
-    on_device,
-    backend_fw,
-):
-    input_dtype, x = dtype_and_x
-    helpers.test_frontend_method(
-        init_input_dtypes=input_dtype,
-        backend_to_test=backend_fw,
-        init_all_as_kwargs_np={
-            "data": x[0],
-        },
-        method_input_dtypes=input_dtype,
-        method_all_as_kwargs_np={
-            "y": x[1],
-        },
-        frontend_method_data=frontend_method_data,
-        init_flags=init_flags,
-        method_flags=method_flags,
-        frontend=frontend,
-        on_device=on_device,
-    )
-
-
-# __gt__
-@handle_frontend_method(
-    class_tree=CLASS_TREE,
-    init_tree="paddle.to_tensor",
-    method_name="__gt__",
-    dtype_and_x=helpers.dtype_and_values(
-        available_dtypes=helpers.get_dtypes("numeric"), num_arrays=2, shared_dtype=True
-    ),
-)
-def test_paddle___gt__(
-    dtype_and_x,
-    frontend_method_data,
-    init_flags,
-    method_flags,
-    frontend,
-    on_device,
-    backend_fw,
-):
-    input_dtype, x = dtype_and_x
-    helpers.test_frontend_method(
-        init_input_dtypes=input_dtype,
-        backend_to_test=backend_fw,
-        init_all_as_kwargs_np={
-            "data": x[0],
-        },
-        method_input_dtypes=input_dtype,
-        method_all_as_kwargs_np={
-            "y": x[1],
-        },
-        frontend_method_data=frontend_method_data,
-        init_flags=init_flags,
-        method_flags=method_flags,
-        frontend=frontend,
-        on_device=on_device,
-    )
-
-
-# __le__
-@handle_frontend_method(
-    class_tree=CLASS_TREE,
-    init_tree="paddle.to_tensor",
-    method_name="__le__",
-    dtype_and_x=helpers.dtype_and_values(
-        available_dtypes=helpers.get_dtypes("valid"), num_arrays=2, shared_dtype=True
-    ),
-)
-def test_paddle___le__(
-    dtype_and_x,
-    frontend_method_data,
-    init_flags,
-    method_flags,
-    frontend,
-    on_device,
-    backend_fw,
-):
-    input_dtype, x = dtype_and_x
-    helpers.test_frontend_method(
-        init_input_dtypes=input_dtype,
-        backend_to_test=backend_fw,
-        init_all_as_kwargs_np={
-            "data": x[0],
-        },
-        method_input_dtypes=input_dtype,
-        method_all_as_kwargs_np={
-            "y": x[1],
-        },
-        frontend_method_data=frontend_method_data,
-        init_flags=init_flags,
-        method_flags=method_flags,
-        frontend=frontend,
-        on_device=on_device,
-    )
-
-
-# __lt__
-@handle_frontend_method(
-    class_tree=CLASS_TREE,
-    init_tree="paddle.to_tensor",
-    method_name="__lt__",
-    dtype_and_x=helpers.dtype_and_values(
-        available_dtypes=helpers.get_dtypes("numeric"), num_arrays=2, shared_dtype=True
-    ),
-)
-def test_paddle___lt__(
-    dtype_and_x,
-    frontend_method_data,
-    init_flags,
-    method_flags,
-    frontend,
-    on_device,
-    backend_fw,
-):
-    input_dtype, x = dtype_and_x
-    helpers.test_frontend_method(
-        init_input_dtypes=input_dtype,
-        backend_to_test=backend_fw,
-        init_all_as_kwargs_np={
-            "data": x[0],
-        },
-        method_input_dtypes=input_dtype,
-        method_all_as_kwargs_np={
-            "y": x[1],
-        },
-        frontend_method_data=frontend_method_data,
-        init_flags=init_flags,
-        method_flags=method_flags,
-        frontend=frontend,
-        on_device=on_device,
-    )
-
-
-# __mul__
-@handle_frontend_method(
-    class_tree=CLASS_TREE,
-    init_tree="paddle.to_tensor",
-    method_name="__mul__",
-    dtype_and_x=helpers.dtype_and_values(
-        available_dtypes=helpers.get_dtypes("numeric"), num_arrays=2, shared_dtype=True
-    ),
-)
-def test_paddle___mul__(
-    dtype_and_x,
-    frontend_method_data,
-    init_flags,
-    method_flags,
-    frontend,
-    on_device,
-    backend_fw,
-):
-    input_dtype, x = dtype_and_x
-    helpers.test_frontend_method(
-        init_input_dtypes=input_dtype,
-        backend_to_test=backend_fw,
-        init_all_as_kwargs_np={
-            "data": x[0],
-        },
-        method_input_dtypes=input_dtype,
-        method_all_as_kwargs_np={
-            "y": x[1],
-        },
-        frontend_method_data=frontend_method_data,
-        init_flags=init_flags,
-        method_flags=method_flags,
-        frontend=frontend,
-        on_device=on_device,
-    )
-
-
-# __or__
-@handle_frontend_method(
-    class_tree=CLASS_TREE,
-    init_tree="paddle.to_tensor",
-    method_name="__or__",
-    dtype_and_x=helpers.dtype_and_values(
-        available_dtypes=helpers.get_dtypes("integer"), num_arrays=2, shared_dtype=True
-    ),
-)
-def test_paddle___or__(
-    dtype_and_x,
-    frontend_method_data,
-    init_flags,
-    method_flags,
-    frontend,
-    on_device,
-    backend_fw,
-):
-    input_dtype, x = dtype_and_x
-    helpers.test_frontend_method(
-        init_input_dtypes=input_dtype,
-        backend_to_test=backend_fw,
-        init_all_as_kwargs_np={
-            "data": x[0],
-        },
-        method_input_dtypes=input_dtype,
-        method_all_as_kwargs_np={
-            "y": x[1],
-        },
-        frontend_method_data=frontend_method_data,
-        init_flags=init_flags,
-        method_flags=method_flags,
-        frontend=frontend,
-        on_device=on_device,
-    )
-
-
-# __radd__
-@handle_frontend_method(
-    class_tree=CLASS_TREE,
-    init_tree="paddle.to_tensor",
-    method_name="__radd__",
-    dtype_and_x=helpers.dtype_and_values(
-        available_dtypes=helpers.get_dtypes("valid"), num_arrays=2, shared_dtype=True
-    ),
-)
-def test_paddle___radd__(
-    dtype_and_x,
-    frontend_method_data,
-    init_flags,
-    method_flags,
-    frontend,
-    on_device,
-    backend_fw,
-):
-    input_dtype, x = dtype_and_x
-    helpers.test_frontend_method(
-        init_input_dtypes=input_dtype,
-        backend_to_test=backend_fw,
-        init_all_as_kwargs_np={
-            "data": x[0],
-        },
-        method_input_dtypes=input_dtype,
-        method_all_as_kwargs_np={
-            "x": x[1],
-        },
-        frontend_method_data=frontend_method_data,
-        init_flags=init_flags,
-        method_flags=method_flags,
-        frontend=frontend,
-        on_device=on_device,
-    )
-
-
-# __setitem__
-@handle_frontend_method(
-    class_tree=CLASS_TREE,
-    init_tree="paddle.to_tensor",
-    method_name="__setitem__",
-    dtypes_x_index_val=helpers.dtype_array_query_val(
-        available_dtypes=helpers.get_dtypes("valid"),
-    ).filter(lambda x: x[0][0] == x[0][-1] and _filter_query(x[-2])),
-)
-def test_paddle___setitem__(
-    dtypes_x_index_val,
-    frontend_method_data,
-    init_flags,
-    method_flags,
-    frontend,
-    on_device,
-    backend_fw,
-):
-    input_dtype, x, index, val = dtypes_x_index_val
-    helpers.test_frontend_method(
-        init_input_dtypes=[input_dtype[0]],
-        backend_to_test=backend_fw,
-        init_all_as_kwargs_np={"data": x},
-        method_input_dtypes=[*input_dtype[1:]],
-        method_all_as_kwargs_np={"item": index, "value": val},
-        frontend_method_data=frontend_method_data,
-        init_flags=init_flags,
-        method_flags=method_flags,
-        frontend=frontend,
-        on_device=on_device,
-    )
-
-
-# __sub__
-@handle_frontend_method(
-    class_tree=CLASS_TREE,
-    init_tree="paddle.to_tensor",
-    method_name="__sub__",
-    dtype_and_x=helpers.dtype_and_values(
-        available_dtypes=helpers.get_dtypes("valid"), num_arrays=2, shared_dtype=True
-    ),
-)
-def test_paddle___sub__(
-    dtype_and_x,
-    frontend_method_data,
-    init_flags,
-    method_flags,
-    frontend,
-    on_device,
-    backend_fw,
-):
-    input_dtype, x = dtype_and_x
-    helpers.test_frontend_method(
-        init_input_dtypes=input_dtype,
-        backend_to_test=backend_fw,
-        init_all_as_kwargs_np={
-            "data": x[0],
-        },
-        method_input_dtypes=input_dtype,
-        method_all_as_kwargs_np={
-            "y": x[1],
-        },
-        frontend_method_data=frontend_method_data,
-        init_flags=init_flags,
-        method_flags=method_flags,
-        frontend=frontend,
-        on_device=on_device,
-    )
-
-
 @handle_frontend_method(
     class_tree=CLASS_TREE,
     init_tree="paddle.to_tensor",
@@ -826,6 +497,43 @@ def test_paddle___floordiv__(
     )
 
 
+# __ge__
+@handle_frontend_method(
+    class_tree=CLASS_TREE,
+    init_tree="paddle.to_tensor",
+    method_name="__ge__",
+    dtype_and_x=helpers.dtype_and_values(
+        available_dtypes=helpers.get_dtypes("numeric"), num_arrays=2, shared_dtype=True
+    ),
+)
+def test_paddle___ge__(
+    dtype_and_x,
+    frontend_method_data,
+    init_flags,
+    method_flags,
+    frontend,
+    on_device,
+    backend_fw,
+):
+    input_dtype, x = dtype_and_x
+    helpers.test_frontend_method(
+        init_input_dtypes=input_dtype,
+        backend_to_test=backend_fw,
+        init_all_as_kwargs_np={
+            "data": x[0],
+        },
+        method_input_dtypes=input_dtype,
+        method_all_as_kwargs_np={
+            "y": x[1],
+        },
+        frontend_method_data=frontend_method_data,
+        init_flags=init_flags,
+        method_flags=method_flags,
+        frontend=frontend,
+        on_device=on_device,
+    )
+
+
 # __getitem__
 @handle_frontend_method(
     class_tree=CLASS_TREE,
@@ -852,6 +560,43 @@ def test_paddle___getitem__(
         init_all_as_kwargs_np={"data": x},
         method_input_dtypes=[*input_dtype[1:]],
         method_all_as_kwargs_np={"item": index},
+        frontend_method_data=frontend_method_data,
+        init_flags=init_flags,
+        method_flags=method_flags,
+        frontend=frontend,
+        on_device=on_device,
+    )
+
+
+# __gt__
+@handle_frontend_method(
+    class_tree=CLASS_TREE,
+    init_tree="paddle.to_tensor",
+    method_name="__gt__",
+    dtype_and_x=helpers.dtype_and_values(
+        available_dtypes=helpers.get_dtypes("numeric"), num_arrays=2, shared_dtype=True
+    ),
+)
+def test_paddle___gt__(
+    dtype_and_x,
+    frontend_method_data,
+    init_flags,
+    method_flags,
+    frontend,
+    on_device,
+    backend_fw,
+):
+    input_dtype, x = dtype_and_x
+    helpers.test_frontend_method(
+        init_input_dtypes=input_dtype,
+        backend_to_test=backend_fw,
+        init_all_as_kwargs_np={
+            "data": x[0],
+        },
+        method_input_dtypes=input_dtype,
+        method_all_as_kwargs_np={
+            "y": x[1],
+        },
         frontend_method_data=frontend_method_data,
         init_flags=init_flags,
         method_flags=method_flags,
@@ -935,6 +680,43 @@ def test_paddle___invert__(
     )
 
 
+# __le__
+@handle_frontend_method(
+    class_tree=CLASS_TREE,
+    init_tree="paddle.to_tensor",
+    method_name="__le__",
+    dtype_and_x=helpers.dtype_and_values(
+        available_dtypes=helpers.get_dtypes("valid"), num_arrays=2, shared_dtype=True
+    ),
+)
+def test_paddle___le__(
+    dtype_and_x,
+    frontend_method_data,
+    init_flags,
+    method_flags,
+    frontend,
+    on_device,
+    backend_fw,
+):
+    input_dtype, x = dtype_and_x
+    helpers.test_frontend_method(
+        init_input_dtypes=input_dtype,
+        backend_to_test=backend_fw,
+        init_all_as_kwargs_np={
+            "data": x[0],
+        },
+        method_input_dtypes=input_dtype,
+        method_all_as_kwargs_np={
+            "y": x[1],
+        },
+        frontend_method_data=frontend_method_data,
+        init_flags=init_flags,
+        method_flags=method_flags,
+        frontend=frontend,
+        on_device=on_device,
+    )
+
+
 # __len__
 @handle_frontend_method(
     class_tree=CLASS_TREE,
@@ -1007,6 +789,80 @@ def test_paddle___long__(
         frontend_method_data=frontend_method_data,
         init_flags=init_flags,
         method_flags=method_flags,
+        on_device=on_device,
+    )
+
+
+# __lt__
+@handle_frontend_method(
+    class_tree=CLASS_TREE,
+    init_tree="paddle.to_tensor",
+    method_name="__lt__",
+    dtype_and_x=helpers.dtype_and_values(
+        available_dtypes=helpers.get_dtypes("numeric"), num_arrays=2, shared_dtype=True
+    ),
+)
+def test_paddle___lt__(
+    dtype_and_x,
+    frontend_method_data,
+    init_flags,
+    method_flags,
+    frontend,
+    on_device,
+    backend_fw,
+):
+    input_dtype, x = dtype_and_x
+    helpers.test_frontend_method(
+        init_input_dtypes=input_dtype,
+        backend_to_test=backend_fw,
+        init_all_as_kwargs_np={
+            "data": x[0],
+        },
+        method_input_dtypes=input_dtype,
+        method_all_as_kwargs_np={
+            "y": x[1],
+        },
+        frontend_method_data=frontend_method_data,
+        init_flags=init_flags,
+        method_flags=method_flags,
+        frontend=frontend,
+        on_device=on_device,
+    )
+
+
+# __mul__
+@handle_frontend_method(
+    class_tree=CLASS_TREE,
+    init_tree="paddle.to_tensor",
+    method_name="__mul__",
+    dtype_and_x=helpers.dtype_and_values(
+        available_dtypes=helpers.get_dtypes("numeric"), num_arrays=2, shared_dtype=True
+    ),
+)
+def test_paddle___mul__(
+    dtype_and_x,
+    frontend_method_data,
+    init_flags,
+    method_flags,
+    frontend,
+    on_device,
+    backend_fw,
+):
+    input_dtype, x = dtype_and_x
+    helpers.test_frontend_method(
+        init_input_dtypes=input_dtype,
+        backend_to_test=backend_fw,
+        init_all_as_kwargs_np={
+            "data": x[0],
+        },
+        method_input_dtypes=input_dtype,
+        method_all_as_kwargs_np={
+            "y": x[1],
+        },
+        frontend_method_data=frontend_method_data,
+        init_flags=init_flags,
+        method_flags=method_flags,
+        frontend=frontend,
         on_device=on_device,
     )
 
@@ -1090,6 +946,80 @@ def test_paddle___neg__(
     )
 
 
+# __or__
+@handle_frontend_method(
+    class_tree=CLASS_TREE,
+    init_tree="paddle.to_tensor",
+    method_name="__or__",
+    dtype_and_x=helpers.dtype_and_values(
+        available_dtypes=helpers.get_dtypes("integer"), num_arrays=2, shared_dtype=True
+    ),
+)
+def test_paddle___or__(
+    dtype_and_x,
+    frontend_method_data,
+    init_flags,
+    method_flags,
+    frontend,
+    on_device,
+    backend_fw,
+):
+    input_dtype, x = dtype_and_x
+    helpers.test_frontend_method(
+        init_input_dtypes=input_dtype,
+        backend_to_test=backend_fw,
+        init_all_as_kwargs_np={
+            "data": x[0],
+        },
+        method_input_dtypes=input_dtype,
+        method_all_as_kwargs_np={
+            "y": x[1],
+        },
+        frontend_method_data=frontend_method_data,
+        init_flags=init_flags,
+        method_flags=method_flags,
+        frontend=frontend,
+        on_device=on_device,
+    )
+
+
+# __radd__
+@handle_frontend_method(
+    class_tree=CLASS_TREE,
+    init_tree="paddle.to_tensor",
+    method_name="__radd__",
+    dtype_and_x=helpers.dtype_and_values(
+        available_dtypes=helpers.get_dtypes("valid"), num_arrays=2, shared_dtype=True
+    ),
+)
+def test_paddle___radd__(
+    dtype_and_x,
+    frontend_method_data,
+    init_flags,
+    method_flags,
+    frontend,
+    on_device,
+    backend_fw,
+):
+    input_dtype, x = dtype_and_x
+    helpers.test_frontend_method(
+        init_input_dtypes=input_dtype,
+        backend_to_test=backend_fw,
+        init_all_as_kwargs_np={
+            "data": x[0],
+        },
+        method_input_dtypes=input_dtype,
+        method_all_as_kwargs_np={
+            "x": x[1],
+        },
+        frontend_method_data=frontend_method_data,
+        init_flags=init_flags,
+        method_flags=method_flags,
+        frontend=frontend,
+        on_device=on_device,
+    )
+
+
 @handle_frontend_method(
     class_tree=CLASS_TREE,
     init_tree="paddle.to_tensor",
@@ -1129,80 +1059,6 @@ def test_paddle___rdiv__(
         frontend_method_data=frontend_method_data,
         init_flags=init_flags,
         method_flags=method_flags,
-        on_device=on_device,
-    )
-
-
-# reshape
-@handle_frontend_method(
-    class_tree=CLASS_TREE,
-    init_tree="paddle.to_tensor",
-    method_name="reshape",
-    dtype_x_shape=_reshape_helper(),
-)
-def test_paddle_reshape(
-    dtype_x_shape,
-    frontend_method_data,
-    init_flags,
-    method_flags,
-    frontend,
-    on_device,
-    backend_fw,
-):
-    input_dtype, x, shape = dtype_x_shape
-    assume(len(shape) != 0)
-    shape = {
-        "shape": shape,
-    }
-    helpers.test_frontend_method(
-        init_input_dtypes=input_dtype,
-        backend_to_test=backend_fw,
-        init_all_as_kwargs_np={
-            "data": x[0],
-        },
-        method_input_dtypes=input_dtype,
-        method_all_as_kwargs_np=shape,
-        frontend_method_data=frontend_method_data,
-        init_flags=init_flags,
-        method_flags=method_flags,
-        frontend=frontend,
-        on_device=on_device,
-    )
-
-
-# reshape_
-@handle_frontend_method(
-    class_tree=CLASS_TREE,
-    init_tree="paddle.to_tensor",
-    method_name="reshape_",
-    dtype_x_shape=_reshape_helper(),
-)
-def test_paddle_reshape_(
-    dtype_x_shape,
-    frontend_method_data,
-    init_flags,
-    method_flags,
-    frontend,
-    on_device,
-    backend_fw,
-):
-    input_dtype, x, shape = dtype_x_shape
-    assume(len(shape) != 0)
-    shape = {
-        "shape": shape,
-    }
-    helpers.test_frontend_method(
-        init_input_dtypes=input_dtype,
-        backend_to_test=backend_fw,
-        init_all_as_kwargs_np={
-            "data": x[0],
-        },
-        method_input_dtypes=input_dtype,
-        method_all_as_kwargs_np=shape,
-        frontend_method_data=frontend_method_data,
-        init_flags=init_flags,
-        method_flags=method_flags,
-        frontend=frontend,
         on_device=on_device,
     )
 
@@ -1326,6 +1182,76 @@ def test_paddle___rtruediv__(
         frontend_method_data=frontend_method_data,
         init_flags=init_flags,
         method_flags=method_flags,
+        on_device=on_device,
+    )
+
+
+# __setitem__
+@handle_frontend_method(
+    class_tree=CLASS_TREE,
+    init_tree="paddle.to_tensor",
+    method_name="__setitem__",
+    dtypes_x_index_val=helpers.dtype_array_query_val(
+        available_dtypes=helpers.get_dtypes("valid"),
+    ).filter(lambda x: x[0][0] == x[0][-1] and _filter_query(x[-2])),
+)
+def test_paddle___setitem__(
+    dtypes_x_index_val,
+    frontend_method_data,
+    init_flags,
+    method_flags,
+    frontend,
+    on_device,
+    backend_fw,
+):
+    input_dtype, x, index, val = dtypes_x_index_val
+    helpers.test_frontend_method(
+        init_input_dtypes=[input_dtype[0]],
+        backend_to_test=backend_fw,
+        init_all_as_kwargs_np={"data": x},
+        method_input_dtypes=[*input_dtype[1:]],
+        method_all_as_kwargs_np={"item": index, "value": val},
+        frontend_method_data=frontend_method_data,
+        init_flags=init_flags,
+        method_flags=method_flags,
+        frontend=frontend,
+        on_device=on_device,
+    )
+
+
+# __sub__
+@handle_frontend_method(
+    class_tree=CLASS_TREE,
+    init_tree="paddle.to_tensor",
+    method_name="__sub__",
+    dtype_and_x=helpers.dtype_and_values(
+        available_dtypes=helpers.get_dtypes("valid"), num_arrays=2, shared_dtype=True
+    ),
+)
+def test_paddle___sub__(
+    dtype_and_x,
+    frontend_method_data,
+    init_flags,
+    method_flags,
+    frontend,
+    on_device,
+    backend_fw,
+):
+    input_dtype, x = dtype_and_x
+    helpers.test_frontend_method(
+        init_input_dtypes=input_dtype,
+        backend_to_test=backend_fw,
+        init_all_as_kwargs_np={
+            "data": x[0],
+        },
+        method_input_dtypes=input_dtype,
+        method_all_as_kwargs_np={
+            "y": x[1],
+        },
+        frontend_method_data=frontend_method_data,
+        init_flags=init_flags,
+        method_flags=method_flags,
+        frontend=frontend,
         on_device=on_device,
     )
 
@@ -4810,6 +4736,80 @@ def test_paddle_remainder_(
         method_all_as_kwargs_np={
             "y": x[1],
         },
+        frontend_method_data=frontend_method_data,
+        init_flags=init_flags,
+        method_flags=method_flags,
+        frontend=frontend,
+        on_device=on_device,
+    )
+
+
+# reshape
+@handle_frontend_method(
+    class_tree=CLASS_TREE,
+    init_tree="paddle.to_tensor",
+    method_name="reshape",
+    dtype_x_shape=_reshape_helper(),
+)
+def test_paddle_reshape(
+    dtype_x_shape,
+    frontend_method_data,
+    init_flags,
+    method_flags,
+    frontend,
+    on_device,
+    backend_fw,
+):
+    input_dtype, x, shape = dtype_x_shape
+    assume(len(shape) != 0)
+    shape = {
+        "shape": shape,
+    }
+    helpers.test_frontend_method(
+        init_input_dtypes=input_dtype,
+        backend_to_test=backend_fw,
+        init_all_as_kwargs_np={
+            "data": x[0],
+        },
+        method_input_dtypes=input_dtype,
+        method_all_as_kwargs_np=shape,
+        frontend_method_data=frontend_method_data,
+        init_flags=init_flags,
+        method_flags=method_flags,
+        frontend=frontend,
+        on_device=on_device,
+    )
+
+
+# reshape_
+@handle_frontend_method(
+    class_tree=CLASS_TREE,
+    init_tree="paddle.to_tensor",
+    method_name="reshape_",
+    dtype_x_shape=_reshape_helper(),
+)
+def test_paddle_reshape_(
+    dtype_x_shape,
+    frontend_method_data,
+    init_flags,
+    method_flags,
+    frontend,
+    on_device,
+    backend_fw,
+):
+    input_dtype, x, shape = dtype_x_shape
+    assume(len(shape) != 0)
+    shape = {
+        "shape": shape,
+    }
+    helpers.test_frontend_method(
+        init_input_dtypes=input_dtype,
+        backend_to_test=backend_fw,
+        init_all_as_kwargs_np={
+            "data": x[0],
+        },
+        method_input_dtypes=input_dtype,
+        method_all_as_kwargs_np=shape,
         frontend_method_data=frontend_method_data,
         init_flags=init_flags,
         method_flags=method_flags,

--- a/ivy_tests/test_ivy/test_frontends/test_tensorflow/test_tensor.py
+++ b/ivy_tests/test_ivy/test_frontends/test_tensorflow/test_tensor.py
@@ -85,7 +85,7 @@ def _check_query(query):
         shared_dtype=True,
     ),
 )
-def test_tensorflow__add__(
+def test_tensorflow___add__(
     dtype_and_x,
     frontend,
     frontend_method_data,
@@ -160,7 +160,7 @@ def test_tensorflow__and__(
     dtype_and_x=helpers.dtype_and_values(available_dtypes=helpers.get_dtypes("valid")),
     dtype=helpers.get_dtypes("valid", full=False),
 )
-def test_tensorflow__array__(
+def test_tensorflow___array__(
     dtype_and_x,
     dtype,
     frontend,
@@ -193,7 +193,7 @@ def test_tensorflow__array__(
         max_dim_size=1,
     ),
 )
-def test_tensorflow__bool__(
+def test_tensorflow___bool__(
     dtype_and_x,
     frontend,
     frontend_method_data,
@@ -232,7 +232,7 @@ def test_tensorflow__bool__(
         safety_factor_scale="log",
     ),
 )
-def test_tensorflow__div__(
+def test_tensorflow___div__(
     dtype_and_x,
     frontend,
     frontend_method_data,
@@ -271,7 +271,7 @@ def test_tensorflow__div__(
         num_arrays=2,
     ),
 )
-def test_tensorflow__eq__(
+def test_tensorflow___eq__(
     dtype_and_x,
     frontend,
     frontend_method_data,
@@ -312,7 +312,7 @@ def test_tensorflow__eq__(
         safety_factor_scale="log",
     ),
 )
-def test_tensorflow__floordiv__(
+def test_tensorflow___floordiv__(
     dtype_and_x,
     frontend,
     frontend_method_data,
@@ -351,7 +351,7 @@ def test_tensorflow__floordiv__(
         shared_dtype=True,
     ),
 )
-def test_tensorflow__ge__(
+def test_tensorflow___ge__(
     dtype_and_x,
     frontend,
     frontend_method_data,
@@ -394,7 +394,7 @@ def test_tensorflow__ge__(
         )
     ),
 )
-def test_tensorflow__getitem__(
+def test_tensorflow___getitem__(
     dtype_x_index,
     frontend,
     frontend_method_data,
@@ -429,7 +429,7 @@ def test_tensorflow__getitem__(
         shared_dtype=True,
     ),
 )
-def test_tensorflow__gt__(
+def test_tensorflow___gt__(
     dtype_and_x,
     frontend,
     frontend_method_data,
@@ -466,7 +466,7 @@ def test_tensorflow__gt__(
         available_dtypes=helpers.get_dtypes("integer")
     ),
 )
-def test_tensorflow__invert__(
+def test_tensorflow___invert__(
     dtype_and_x,
     frontend,
     frontend_method_data,
@@ -503,7 +503,7 @@ def test_tensorflow__invert__(
         shared_dtype=True,
     ),
 )
-def test_tensorflow__le__(
+def test_tensorflow___le__(
     dtype_and_x,
     frontend,
     frontend_method_data,
@@ -541,7 +541,7 @@ def test_tensorflow__le__(
         max_num_dims=5,
     ),
 )
-def test_tensorflow__len__(
+def test_tensorflow___len__(
     dtype_and_x,
     frontend,
     frontend_method_data,
@@ -578,7 +578,7 @@ def test_tensorflow__len__(
         shared_dtype=True,
     ),
 )
-def test_tensorflow__lt__(
+def test_tensorflow___lt__(
     dtype_and_x,
     frontend,
     frontend_method_data,
@@ -626,7 +626,7 @@ def test_tensorflow__lt__(
         safety_factor_scale="log",
     ),
 )
-def test_tensorflow__matmul__(
+def test_tensorflow___matmul__(
     dtype_and_x,
     frontend,
     frontend_method_data,
@@ -665,7 +665,7 @@ def test_tensorflow__matmul__(
         shared_dtype=True,
     ),
 )
-def test_tensorflow__mod__(
+def test_tensorflow___mod__(
     dtype_and_x,
     frontend,
     frontend_method_data,
@@ -705,7 +705,7 @@ def test_tensorflow__mod__(
         shared_dtype=True,
     ),
 )
-def test_tensorflow__mul__(
+def test_tensorflow___mul__(
     dtype_and_x,
     frontend,
     frontend_method_data,
@@ -744,7 +744,7 @@ def test_tensorflow__mul__(
         shared_dtype=True,
     ),
 )
-def test_tensorflow__ne__(
+def test_tensorflow___ne__(
     dtype_and_x,
     frontend,
     frontend_method_data,
@@ -788,7 +788,7 @@ def test_tensorflow__ne__(
         ],
     ),
 )
-def test_tensorflow__neg__(
+def test_tensorflow___neg__(
     dtype_and_x,
     frontend,
     frontend_method_data,
@@ -824,7 +824,7 @@ def test_tensorflow__neg__(
         max_dim_size=1,
     ),
 )
-def test_tensorflow__nonzero__(
+def test_tensorflow___nonzero__(
     dtype_and_x,
     frontend,
     frontend_method_data,
@@ -861,7 +861,7 @@ def test_tensorflow__nonzero__(
         shared_dtype=True,
     ),
 )
-def test_tensorflow__or__(
+def test_tensorflow___or__(
     dtype_and_x,
     frontend,
     frontend_method_data,
@@ -906,7 +906,7 @@ def test_tensorflow__or__(
         shared_dtype=True,
     ),
 )
-def test_tensorflow__pow__(
+def test_tensorflow___pow__(
     dtype_and_x,
     frontend,
     frontend_method_data,
@@ -952,7 +952,7 @@ def test_tensorflow__pow__(
         shared_dtype=True,
     ),
 )
-def test_tensorflow__radd__(
+def test_tensorflow___radd__(
     dtype_and_x,
     frontend,
     frontend_method_data,
@@ -991,7 +991,7 @@ def test_tensorflow__radd__(
         shared_dtype=True,
     ),
 )
-def test_tensorflow__rand__(
+def test_tensorflow___rand__(
     dtype_and_x,
     frontend,
     frontend_method_data,
@@ -1033,7 +1033,7 @@ def test_tensorflow__rand__(
         safety_factor_scale="log",
     ),
 )
-def test_tensorflow__rfloordiv__(
+def test_tensorflow___rfloordiv__(
     dtype_and_x,
     frontend,
     frontend_method_data,
@@ -1081,7 +1081,7 @@ def test_tensorflow__rfloordiv__(
         safety_factor_scale="log",
     ),
 )
-def test_tensorflow__rmatmul__(
+def test_tensorflow___rmatmul__(
     dtype_and_x,
     frontend,
     frontend_method_data,
@@ -1122,7 +1122,7 @@ def test_tensorflow__rmatmul__(
         max_value=100,
     ),
 )
-def test_tensorflow__rmul__(
+def test_tensorflow___rmul__(
     dtype_and_x,
     frontend,
     frontend_method_data,
@@ -1161,7 +1161,7 @@ def test_tensorflow__rmul__(
         shared_dtype=True,
     ),
 )
-def test_tensorflow__ror__(
+def test_tensorflow___ror__(
     dtype_and_x,
     frontend,
     frontend_method_data,
@@ -1196,7 +1196,7 @@ def test_tensorflow__ror__(
     method_name="__rpow__",
     dtype_and_x=_pow_helper_shared_dtype(),
 )
-def test_tensorflow__rpow__(
+def test_tensorflow___rpow__(
     dtype_and_x,
     frontend,
     frontend_method_data,
@@ -1235,7 +1235,7 @@ def test_tensorflow__rpow__(
         shared_dtype=True,
     ),
 )
-def test_tensorflow__rsub__(
+def test_tensorflow___rsub__(
     dtype_and_x,
     frontend,
     frontend_method_data,
@@ -1277,7 +1277,7 @@ def test_tensorflow__rsub__(
         safety_factor_scale="log",
     ),
 )
-def test_tensorflow__rtruediv__(
+def test_tensorflow___rtruediv__(
     dtype_and_x,
     frontend,
     frontend_method_data,
@@ -1316,7 +1316,7 @@ def test_tensorflow__rtruediv__(
         shared_dtype=True,
     ),
 )
-def test_tensorflow__rxor__(
+def test_tensorflow___rxor__(
     dtype_and_x,
     frontend,
     frontend_method_data,
@@ -1355,7 +1355,7 @@ def test_tensorflow__rxor__(
         shared_dtype=True,
     ),
 )
-def test_tensorflow__sub__(
+def test_tensorflow___sub__(
     dtype_and_x,
     frontend,
     frontend_method_data,
@@ -1397,7 +1397,7 @@ def test_tensorflow__sub__(
         safety_factor_scale="log",
     ),
 )
-def test_tensorflow__truediv__(
+def test_tensorflow___truediv__(
     dtype_and_x,
     frontend,
     frontend_method_data,
@@ -1437,7 +1437,7 @@ def test_tensorflow__truediv__(
         shared_dtype=True,
     ),
 )
-def test_tensorflow__xor__(
+def test_tensorflow___xor__(
     dtype_and_x,
     frontend,
     frontend_method_data,

--- a/ivy_tests/test_ivy/test_frontends/test_tensorflow/test_tensor.py
+++ b/ivy_tests/test_ivy/test_frontends/test_tensorflow/test_tensor.py
@@ -113,45 +113,6 @@ def test_tensorflow___add__(
     )
 
 
-# __and__
-@handle_frontend_method(
-    class_tree=CLASS_TREE,
-    init_tree="tensorflow.constant",
-    method_name="__and__",
-    dtype_and_x=helpers.dtype_and_values(
-        available_dtypes=helpers.get_dtypes("integer"),
-        num_arrays=2,
-        shared_dtype=True,
-    ),
-)
-def test_tensorflow__and__(
-    dtype_and_x,
-    frontend,
-    frontend_method_data,
-    init_flags,
-    method_flags,
-    backend_fw,
-    on_device,
-):
-    input_dtype, x = dtype_and_x
-    helpers.test_frontend_method(
-        init_input_dtypes=input_dtype,
-        backend_to_test=backend_fw,
-        init_all_as_kwargs_np={
-            "value": x[0],
-        },
-        method_input_dtypes=input_dtype,
-        method_all_as_kwargs_np={
-            "y": x[1],
-        },
-        frontend=frontend,
-        frontend_method_data=frontend_method_data,
-        init_flags=init_flags,
-        method_flags=method_flags,
-        on_device=on_device,
-    )
-
-
 # __array__
 @handle_frontend_method(
     class_tree=CLASS_TREE,
@@ -1438,6 +1399,45 @@ def test_tensorflow___truediv__(
     ),
 )
 def test_tensorflow___xor__(
+    dtype_and_x,
+    frontend,
+    frontend_method_data,
+    init_flags,
+    method_flags,
+    backend_fw,
+    on_device,
+):
+    input_dtype, x = dtype_and_x
+    helpers.test_frontend_method(
+        init_input_dtypes=input_dtype,
+        backend_to_test=backend_fw,
+        init_all_as_kwargs_np={
+            "value": x[0],
+        },
+        method_input_dtypes=input_dtype,
+        method_all_as_kwargs_np={
+            "y": x[1],
+        },
+        frontend=frontend,
+        frontend_method_data=frontend_method_data,
+        init_flags=init_flags,
+        method_flags=method_flags,
+        on_device=on_device,
+    )
+
+
+# __and__
+@handle_frontend_method(
+    class_tree=CLASS_TREE,
+    init_tree="tensorflow.constant",
+    method_name="__and__",
+    dtype_and_x=helpers.dtype_and_values(
+        available_dtypes=helpers.get_dtypes("integer"),
+        num_arrays=2,
+        shared_dtype=True,
+    ),
+)
+def test_tensorflow__and__(
     dtype_and_x,
     frontend,
     frontend_method_data,

--- a/ivy_tests/test_ivy/test_frontends/test_torch/test_tensor.py
+++ b/ivy_tests/test_ivy/test_frontends/test_torch/test_tensor.py
@@ -1416,7 +1416,7 @@ def test_torch___truediv__(
     dtype_and_x=helpers.dtype_and_values(available_dtypes=helpers.get_dtypes("valid")),
     dtype=helpers.get_dtypes("valid", full=False),
 )
-def test_torch__array__(
+def test_torch___array__(
     dtype_and_x,
     dtype,
     frontend,

--- a/ivy_tests/test_ivy/test_frontends/test_torch/test_tensor.py
+++ b/ivy_tests/test_ivy/test_frontends/test_torch/test_tensor.py
@@ -516,6 +516,37 @@ def test_torch___and__(
 @handle_frontend_method(
     class_tree=CLASS_TREE,
     init_tree="torch.tensor",
+    method_name="__array__",
+    dtype_and_x=helpers.dtype_and_values(available_dtypes=helpers.get_dtypes("valid")),
+    dtype=helpers.get_dtypes("valid", full=False),
+)
+def test_torch___array__(
+    dtype_and_x,
+    dtype,
+    frontend,
+    backend_fw,
+):
+    input_dtype, x = dtype_and_x
+    if x[0].dtype == "bfloat16":
+        return
+    dtype[0] = np.dtype(dtype[0])
+    ret_gt = torch.tensor(x[0]).__array__(dtype[0])
+    with BackendHandler.update_backend(backend_fw) as ivy_backend:
+        local_importer = ivy_backend.utils.dynamic_import
+        function_module = local_importer.import_module("ivy.functional.frontends.torch")
+        ret = function_module.tensor(x[0]).__array__(dtype[0])
+
+    helpers.value_test(
+        ret_np_flat=ret.ravel(),
+        ret_np_from_gt_flat=ret_gt.ravel(),
+        ground_truth_backend="torch",
+        backend=backend_fw,
+    )
+
+
+@handle_frontend_method(
+    class_tree=CLASS_TREE,
+    init_tree="torch.tensor",
     method_name="__array_wrap__",
     dtype_and_x=helpers.dtype_and_values(
         available_dtypes=helpers.get_dtypes("valid"),
@@ -1406,37 +1437,6 @@ def test_torch___truediv__(
         method_flags=method_flags,
         frontend=frontend,
         on_device=on_device,
-    )
-
-
-@handle_frontend_method(
-    class_tree=CLASS_TREE,
-    init_tree="torch.tensor",
-    method_name="__array__",
-    dtype_and_x=helpers.dtype_and_values(available_dtypes=helpers.get_dtypes("valid")),
-    dtype=helpers.get_dtypes("valid", full=False),
-)
-def test_torch___array__(
-    dtype_and_x,
-    dtype,
-    frontend,
-    backend_fw,
-):
-    input_dtype, x = dtype_and_x
-    if x[0].dtype == "bfloat16":
-        return
-    dtype[0] = np.dtype(dtype[0])
-    ret_gt = torch.tensor(x[0]).__array__(dtype[0])
-    with BackendHandler.update_backend(backend_fw) as ivy_backend:
-        local_importer = ivy_backend.utils.dynamic_import
-        function_module = local_importer.import_module("ivy.functional.frontends.torch")
-        ret = function_module.tensor(x[0]).__array__(dtype[0])
-
-    helpers.value_test(
-        ret_np_flat=ret.ravel(),
-        ret_np_from_gt_flat=ret_gt.ravel(),
-        ground_truth_backend="torch",
-        backend=backend_fw,
     )
 
 


### PR DESCRIPTION
# PR Description
For many tests, in the name of the test, there should there be 3 underscores on the left, like `test___float__` if the method being tested is __float__? But i see at many places tests are named like `test__float__` with just 2 underscores instead of 3.
https://github.com/unifyai/ivy/blob/82ccaebd9743a6d7d0d47309fc0db3b43c315cbe/ivy_tests/test_ivy/test_frontends/test_paddle/test_tensor/test_tensor.py#L759
This is happening at few places. So, the name of the tests should be fixed.


## Related Issue
Closes #28027 

## Checklist

- [ ] Did you add a function?
- [ ] Did you add the tests?
- [ ] Did you run your tests and are your tests passing?
- [ ] Did pre-commit not fail on any check?
- [ ] Did you follow the steps we provided?


### Socials
