### PR TITLE
fix: Fix Ivy Failing Test: numpy - manipulation.swapaxes

### DIFF
--- a/ivy/functional/backends/numpy/manipulation.py
+++ b/ivy/functional/backends/numpy/manipulation.py
@@ -1,12 +1,14 @@
 # global
 import math
 from numbers import Number
-from typing import Union, Tuple, Optional, List, Sequence
+from typing import List, Optional, Sequence, Tuple, Union
+
 import numpy as np
 
 # local
 import ivy
 from ivy.func_wrapper import with_unsupported_dtypes
+
 from . import backend_version
 
 
@@ -233,6 +235,8 @@ def swapaxes(
     copy: Optional[bool] = None,
     out: Optional[np.ndarray] = None,
 ) -> np.ndarray:
+    if copy:
+        x = x.copy()
     return np.swapaxes(x, axis0, axis1)
 
 


### PR DESCRIPTION
<!--
This template will help you to have a meaningful PR, please follow it and do not leave it blank.
-->

# PR Description

<!--
If there is no related issue, please add a short description about your PR.
-->
Solves `numpy - manipulation.swapaxes`

```
❯ pytest ivy_tests/test_ivy/test_functional/test_core/test_manipulation.py::test_swapaxes --backend numpy --no-header --no-summary
Use Database in ReadOnly Mode with local caching !
===================================================================== test session starts =====================================================================
collected 1 item                                                                                                                                              

ivy_tests/test_ivy/test_functional/test_core/test_manipulation.py .                                                                                     [100%]

================================================================ 1 passed, 4 warnings in 5.83s ================================================================
```

## Related Issue

<!--
Please use this format to link other issues with their numbers: Close #123
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes #28038

## Checklist

- [ ] Did you add a function?
- [ ] Did you add the tests?
- [x] Did you run your tests and are your tests passing?
- [x] Did pre-commit not fail on any check?
- [x] Did you follow the steps we provided?

<!--
Please mark your PR as a draft if you realise after the fact that your tests are not passing or
that your pre-commit check has some failures.

Here are some relevant resources regarding tests and pre-commit:

https://unify.ai/docs/ivy/overview/deep_dive/ivy_tests.html
https://unify.ai/docs/ivy/overview/deep_dive/formatting.html#pre-commit

-->

### Socials

<!--
If you have Twitter, please provide it here otherwise just ignore this.
-->
