### PR TITLE
fix: Fixed `ivy.remainder()` function call which contains wrong argument

### DIFF
--- a/ivy/functional/frontends/tensorflow/variable.py
+++ b/ivy/functional/frontends/tensorflow/variable.py
@@ -188,7 +188,7 @@ class Variable:
         return tf_frontend.math.multiply(x, self._ivy_array, name=name)
 
     def __mod__(self, x, name="mod"):
-        return ivy.remainder(x, self._ivy_array, name=name)
+        return tf_frontend.math.mod(x, self._ivy_array, name=name)
 
     def __ne__(self, other):
         return tf_frontend.raw_ops.NotEqual(


### PR DESCRIPTION
# PR Description
In the following line, the name argument is passed,
https://github.com/unifyai/ivy/blob/bec4752711c314f01298abc3845f02c24a99acab/ivy/functional/frontends/tensorflow/variable.py#L191
From the actual function definition, there is no such argument
https://github.com/unifyai/ivy/blob/8ff497a8c592b75f010160b313dc431218c2b475/ivy/functional/ivy/elementwise.py#L5415-L5422

## Related Issue
Closes #28044

## Checklist

- [ ] Did you add a function?
- [ ] Did you add the tests?
- [ ] Did you run your tests and are your tests passing?
- [x] Did pre-commit not fail on any check?
- [ ] Did you follow the steps we provided?

### Socials
