### PR TITLE
Fix handling of empty arrays in get_item function

### DIFF
--- a/ivy/functional/backends/paddle/general.py
+++ b/ivy/functional/backends/paddle/general.py
@@ -98,6 +98,8 @@ def get_item(
     *,
     copy: Optional[bool] = None,
 ) -> paddle.Tensor:
+    if x.numel() == 0:
+        return paddle.to_tensor([], dtype=x.dtype)
     if copy:
         x = paddle.clone(x)
 


### PR DESCRIPTION
It has identified a runtime issue where the `get_item` function raises a `RuntimeError` when an empty array is passed as an input. This error occurs under the specific condition when `ivy.array([])` is used as an argument, leading to an uninitialized tensor error within the Paddle backend.

This PR aims at introducing a check for empty arrays at the beginning of the `get_item` function. If the input array is empty, the function now returns an appropriately shaped and typed empty Paddle tensor, preventing the uninitialized tensor error. With this change, the `get_item` function can now safely handle empty array inputs without raising an error, ensuring consistent behavior and robustness. This fix also aligns with the expected behavior when using scalar boolean indices, where an empty tensor is returned if the boolean condition is False. This change does not affect any existing functionality or performance for non-empty array inputs.

This fix is in response to the issue reported in [https://github.com/unifyai/ivy/issues/28050] where users encountered runtime errors during testing scenarios involving empty arrays.
