### PR TITLE
fix: Fix Frontend Failing Test: torch - creation_ops.torch.full

### DIFF
--- a/ivy/functional/frontends/torch/creation_ops.py
+++ b/ivy/functional/frontends/torch/creation_ops.py
@@ -1,14 +1,11 @@
 # local
 import ivy
+import ivy.functional.frontends.torch as torch_frontend
+from ivy.func_wrapper import with_supported_dtypes, with_unsupported_dtypes
 from ivy.functional.frontends.torch.func_wrapper import (
     to_ivy_arrays_and_back,
     to_ivy_shape,
 )
-from ivy.func_wrapper import (
-    with_unsupported_dtypes,
-    with_supported_dtypes,
-)
-import ivy.functional.frontends.torch as torch_frontend
 
 
 @to_ivy_arrays_and_back
@@ -179,6 +176,7 @@ def frombuffer(
 
 
 @to_ivy_arrays_and_back
+@with_unsupported_dtypes({"2.1.2 and below": ("complex",)}, "torch")
 def full(
     size,
     fill_value,


### PR DESCRIPTION
<!--
This template will help you to have a meaningful PR, please follow it and do not leave it blank.
-->

# PR Description

<!--
If there is no related issue, please add a short description about your PR.
-->
Issue was with `paddle` backend where it didn't support complex type.
```python
>>> ivy.set_backend("paddle")
<module 'ivy.functional.backends.paddle' from '/home/r0gue_shinobi/Desktop/ivy/ivy/functional/backends/paddle/__init__.py'>
>>> size = (1,)
>>> fill_value = ivy.array(ivy.array(-1.+0.j), dtype="complex64")
>>> ivy.full(size, fill_value)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/r0gue_shinobi/Desktop/ivy/ivy/func_wrapper.py", line 1599, in _handle_backend_invalid
    return fn(*args, **kwargs)
  File "/home/r0gue_shinobi/Desktop/ivy/ivy/func_wrapper.py", line 909, in _handle_nestable
    return fn(*args, **kwargs)
  File "/home/r0gue_shinobi/Desktop/ivy/ivy/func_wrapper.py", line 372, in _handle_array_like_without_promotion
    return fn(*args, **kwargs)
  File "/home/r0gue_shinobi/Desktop/ivy/ivy/func_wrapper.py", line 803, in _handle_out_argument
    return fn(*args, out=out, **kwargs)
  File "/home/r0gue_shinobi/Desktop/ivy/ivy/func_wrapper.py", line 466, in _inputs_to_native_shapes
    return fn(*args, **kwargs)
  File "/home/r0gue_shinobi/Desktop/ivy/ivy/func_wrapper.py", line 411, in _inputs_to_native_arrays
    return fn(*new_args, **new_kwargs)
  File "/home/r0gue_shinobi/Desktop/ivy/ivy/func_wrapper.py", line 514, in _outputs_to_ivy_arrays
    ret = fn(*args, **kwargs)
  File "/home/r0gue_shinobi/Desktop/ivy/ivy/func_wrapper.py", line 327, in _handle_array_function
    return fn(*args, **kwargs)
  File "/home/r0gue_shinobi/Desktop/ivy/ivy/func_wrapper.py", line 758, in _handle_device
    with ivy.DefaultDevice(ivy.default_device(dst_dev)):
  File "/home/r0gue_shinobi/Desktop/ivy/ivy/functional/ivy/device.py", line 133, in __exit__
    raise exc_val
  File "/home/r0gue_shinobi/Desktop/ivy/ivy/func_wrapper.py", line 759, in _handle_device
    return ivy.handle_soft_device_variable(*args, fn=fn, **kwargs)
  File "/home/r0gue_shinobi/Desktop/ivy/ivy/functional/backends/paddle/device.py", line 117, in handle_soft_device_variable
    ret = fn(*args, **kwargs)
  File "/home/r0gue_shinobi/Desktop/ivy/ivy/functional/backends/paddle/creation.py", line 236, in full
    ret = paddle.full(shape=shape, fill_value=fill_value, dtype=dtype_)
  File "/home/r0gue_shinobi/.miniconda3/envs/ivy_dev/lib/python3.10/site-packages/paddle/tensor/creation.py", line 1295, in full
    return fill_constant(shape=shape, dtype=dtype, value=fill_value, name=name)
  File "/home/r0gue_shinobi/.miniconda3/envs/ivy_dev/lib/python3.10/site-packages/paddle/tensor/creation.py", line 900, in fill_constant
    value = float(value)
  File "/home/r0gue_shinobi/.miniconda3/envs/ivy_dev/lib/python3.10/site-packages/paddle/base/dygraph/math_op_patch.py", line 112, in _float_
    return float(np.array(var))
TypeError: float() argument must be a string or a real number, not 'complex'
```

## Related Issue

<!--
Please use this format to link other issues with their numbers: Close #123
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes #28052

## Checklist

- [ ] Did you add a function?
- [ ] Did you add the tests?
- [x] Did you run your tests and are your tests passing?
- [x] Did pre-commit not fail on any check?
- [x] Did you follow the steps we provided?

<!--
Please mark your PR as a draft if you realise after the fact that your tests are not passing or
that your pre-commit check has some failures.

Here are some relevant resources regarding tests and pre-commit:

https://unify.ai/docs/ivy/overview/deep_dive/ivy_tests.html
https://unify.ai/docs/ivy/overview/deep_dive/formatting.html#pre-commit

-->

### Socials

<!--
If you have Twitter, please provide it here otherwise just ignore this.
-->
