### PR TITLE
fix: Fixed `math.paddle.pow` for paddle backend

### DIFF
--- a/ivy/functional/backends/paddle/elementwise.py
+++ b/ivy/functional/backends/paddle/elementwise.py
@@ -399,13 +399,12 @@ def divide(
     *,
     out: Optional[paddle.Tensor] = None,
 ) -> paddle.Tensor:
-    if isinstance(x1, paddle.Tensor) and isinstance(x2, paddle.Tensor):
-        if paddle.is_complex(x1) or paddle.is_complex(x2):
-            angle_value = paddle.angle(x1) - paddle.angle(x2)
-            abs_value = paddle.abs(x1) / paddle.abs(x2)
-            return paddle.complex(
-                abs_value * paddle.cos(angle_value), abs_value * paddle.sin(angle_value)
-            )
+    if paddle.is_complex(x1) or paddle.is_complex(x2):
+        angle_value = paddle.angle(x1) - paddle.angle(x2)
+        abs_value = paddle.abs(x1) / paddle.abs(x2)
+        return paddle.complex(
+            abs_value * paddle.cos(angle_value), abs_value * paddle.sin(angle_value)
+        )
     x1, x2, ret_dtype = _elementwise_helper(x1, x2)
     return (x1 / x2).astype(ret_dtype)
 

--- a/ivy/functional/backends/paddle/elementwise.py
+++ b/ivy/functional/backends/paddle/elementwise.py
@@ -399,12 +399,13 @@ def divide(
     *,
     out: Optional[paddle.Tensor] = None,
 ) -> paddle.Tensor:
-    if paddle.is_complex(x1) or paddle.is_complex(x2):
-        angle_value = paddle.angle(x1) - paddle.angle(x2)
-        abs_value = paddle.abs(x1) / paddle.abs(x2)
-        return paddle.complex(
-            abs_value * paddle.cos(angle_value), abs_value * paddle.sin(angle_value)
-        )
+    if isinstance(x1, paddle.Tensor) and isinstance(x2, paddle.Tensor):
+        if paddle.is_complex(x1) or paddle.is_complex(x2):
+            angle_value = paddle.angle(x1) - paddle.angle(x2)
+            abs_value = paddle.abs(x1) / paddle.abs(x2)
+            return paddle.complex(
+                abs_value * paddle.cos(angle_value), abs_value * paddle.sin(angle_value)
+            )
     x1, x2, ret_dtype = _elementwise_helper(x1, x2)
     return (x1 / x2).astype(ret_dtype)
 
@@ -727,7 +728,16 @@ def square(
 
 
 @with_supported_device_and_dtypes(
-    {"2.6.0 and below": {"cpu": ("float32", "float64", "int32", "int64", "complex")}},
+    {
+        "2.6.0 and below": {
+            "cpu": (
+                "float32",
+                "float64",
+                "int32",
+                "int64",
+            )
+        }
+    },
     backend_version,
 )
 def pow(

--- a/ivy/functional/frontends/paddle/math.py
+++ b/ivy/functional/frontends/paddle/math.py
@@ -514,7 +514,9 @@ def outer(x, y, name=None):
     return ivy.outer(x, y)
 
 
-@with_unsupported_dtypes({"2.6.0 and below": ("float16", "bfloat16")}, "paddle")
+@with_supported_dtypes(
+    {"2.6.0 and below": ("float16", "float32", "float64", "int32", "int64")}, "paddle"
+)
 @to_ivy_arrays_and_back
 def pow(x, y, name=None):
     return ivy.pow(x, y)


### PR DESCRIPTION
# PR Description

Fixed `math.paddle.pow` for paddle backend
![image](https://github.com/unifyai/ivy/assets/87087741/d946e921-19fd-46c5-98d1-3bdf172f55f7)

## Related Issue
Closes #28090 

## Checklist

- [ ] Did you add a function?
- [ ] Did you add the tests?
- [x] Did you run your tests and are your tests passing?
- [x] Did pre-commit not fail on any check?
- [x] Did you follow the steps we provided?

### Socials
