### PR TITLE
fix: fixed sigmoid test function by adding atol and rtol to support f…

### DIFF
--- a/ivy_tests/test_ivy/test_functional/test_nn/test_activations.py
+++ b/ivy_tests/test_ivy/test_functional/test_nn/test_activations.py
@@ -208,6 +208,8 @@ def test_sigmoid(
         test_flags=test_flags,
         fn_name=fn_name,
         on_device=on_device,
+        atol_=1e-02,
+        rtol_=1e-02,
         x=x[0],
         complex_mode=complex_mode,
     )


### PR DESCRIPTION
…loat16 also


<!--
This template will help you to have a meaningful PR, please follow it and do not leave it blank.
-->

# fixed sigmoid test function by adding atol and rtol to support float16 dtype

<!--
If there is no related issue, please add a short description about your PR.
-->

## passing all test at local.
![image](https://github.com/unifyai/ivy/assets/83540902/b8da6a78-f606-46fa-ba9e-d1062adf3278)


<!--
Please use this format to link other issues with their numbers: Close #123
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes #28078

## Checklist

- [ ] Did you add a function?
- [ ] Did you add the tests?
- [ ] Did you run your tests and are your tests passing?
- [ ] Did pre-commit not fail on any check?
- [ ] Did you follow the steps we provided?

<!--
Please mark your PR as a draft if you realise after the fact that your tests are not passing or
that your pre-commit check has some failures.

Here are some relevant resources regarding tests and pre-commit:

https://unify.ai/docs/ivy/overview/deep_dive/ivy_tests.html
https://unify.ai/docs/ivy/overview/deep_dive/formatting.html#pre-commit

-->

<!--
If you have Twitter, please provide it here otherwise just ignore this.
-->
