### PR TITLE
fix: Fixed the lint warnings, failures and Updated black version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
       - id: ruff
         args: [ --fix ]
   - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 24.1.0
+    rev: 24.1.1
     hooks:
       - id: black
         language_version: python3

--- a/ivy/functional/backends/paddle/data_type.py
+++ b/ivy/functional/backends/paddle/data_type.py
@@ -231,7 +231,7 @@ def as_ivy_dtype(dtype_in: Union[paddle.dtype, str, bool, int, float], /) -> ivy
 
 
 def as_native_dtype(
-    dtype_in: Union[paddle.dtype, str, bool, int, float]
+    dtype_in: Union[paddle.dtype, str, bool, int, float],
 ) -> paddle.dtype:
     if dtype_in is int:
         return ivy.default_int_dtype(as_native=True)

--- a/ivy/functional/backends/torch/data_type.py
+++ b/ivy/functional/backends/torch/data_type.py
@@ -183,7 +183,7 @@ def as_ivy_dtype(
 
 @with_unsupported_dtypes({"2.1.2 and below": ("uint16",)}, backend_version)
 def as_native_dtype(
-    dtype_in: Union[torch.dtype, str, bool, int, float, np.dtype]
+    dtype_in: Union[torch.dtype, str, bool, int, float, np.dtype],
 ) -> torch.dtype:
     if dtype_in is int:
         return ivy.default_int_dtype(as_native=True)

--- a/ivy/functional/ivy/general.py
+++ b/ivy/functional/ivy/general.py
@@ -1574,7 +1574,7 @@ def to_ivy_shape(shape: Union[ivy.Shape, ivy.NativeShape]) -> ivy.Shape:
 
 @handle_exceptions
 def to_native_shape(
-    shape: Union[ivy.Array, ivy.Shape, ivy.NativeShape, tuple, int, list]
+    shape: Union[ivy.Array, ivy.Shape, ivy.NativeShape, tuple, int, list],
 ) -> ivy.NativeShape:
     """Return the input shape in its native backend framework form.
 

--- a/ivy/functional/ivy/gradients.py
+++ b/ivy/functional/ivy/gradients.py
@@ -337,7 +337,7 @@ def _is_variable(x, exclusive=False, to_ignore=None) -> bool:
 
 
 def _variable_data(
-    x: Union[ivy.Array, ivy.NativeArray]
+    x: Union[ivy.Array, ivy.NativeArray],
 ) -> Union[ivy.Array, ivy.NativeArray]:
     """Get the contents of the input.
 

--- a/ivy/utils/einsum_parser.py
+++ b/ivy/utils/einsum_parser.py
@@ -178,7 +178,7 @@ def convert_subscripts(old_sub: List[Any], symbol_map: Dict[Any, Any]) -> str:
 
 
 def convert_interleaved_input(
-    operands: Union[List[Any], Tuple[Any]]
+    operands: Union[List[Any], Tuple[Any]],
 ) -> Tuple[str, List[Any]]:
     """Convert 'interleaved' input to standard einsum input."""
     tmp_operands = list(operands)

--- a/ivy/utils/profiler.py
+++ b/ivy/utils/profiler.py
@@ -81,7 +81,7 @@ def tensorflow_profile_start(
     Returns
     -------
     None
-    """
+    """  # noqa: E501
     from tensorflow.profiler.experimental import ProfilerOptions, start
 
     options = ProfilerOptions(
@@ -159,7 +159,7 @@ def torch_profiler_init(
     Returns
     -------
     Torch profiler instance.
-    """
+    """  # noqa: E501
     from torch.profiler import profile, tensorboard_trace_handler
 
     profiler = profile(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,6 @@ select = [
 
 
 ignore = [
-    "F841", # Local variable `xyz` is assigned to but never used.
     "E203",	# Whitespace-before-punctuation.
     "E402", # Module-import-not-at-top-of-file.
     "E731", # Do not assign a lambda expression, use a def.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,6 @@ exclude = ["__init__.py"]
 
 
 [tool.ruff]
-preview=true
 line-length = 88
 target-version = "py38"
 
@@ -38,9 +37,6 @@ select = [
     "I002",     # Missing required import.
     "UP008",    # Checks for super calls that pass redundant arguments.
     "PGH002",   # deprecated-log-warn.
-    "PLR0203",  # Static method defined without decorator.
-    "PLR0202",  # Class method defined without decorator.
-    "PLW0245",  # super call is missing parentheses.
     "PLR1722",  # Use sys.exit() instead of exit() and quit().
     "TRY004",   # Prefer TypeError exception for invalid type.
     "PT014",    # pytest-duplicate-parametrize-test-cases.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ exclude = ["__init__.py"]
 
 
 [tool.ruff]
+preview=true
 line-length = 88
 target-version = "py38"
 
@@ -50,6 +51,7 @@ select = [
 
 
 ignore = [
+    "F841", # Local variable `xyz` is assigned to but never used.
     "E203",	# Whitespace-before-punctuation.
     "E402", # Module-import-not-at-top-of-file.
     "E731", # Do not assign a lambda expression, use a def.


### PR DESCRIPTION
# PR Description
Over the past few days, these warnings and failures are present in the lint check.
![image](https://github.com/unifyai/ivy/assets/87087741/28618ab1-f5df-4d66-b8d4-dca542375921)
I removed few unstable checks related to ruff and added `noqa` comments wherever required to fix these warnings and failures.




## Related Issue
Closes #

## Checklist

- [ ] Did you add a function?
- [ ] Did you add the tests?
- [x] Did you run your tests and are your tests passing?
- [x] Did pre-commit not fail on any check?
- [x] Did you follow the steps we provided?

### Socials
