### PR TITLE
fix: broadcasting issue in compositional set_item

### DIFF
--- a/ivy/functional/ivy/general.py
+++ b/ivy/functional/ivy/general.py
@@ -2932,16 +2932,6 @@ def _broadcast_to(input, target_shape):
         return ivy.reshape(input, target_shape)
     else:
         input = input if len(input.shape) else ivy.expand_dims(input, axis=0)
-        new_dims = ()
-        i_i = len(input.shape) - 1
-        for i_t in range(len(target_shape) - 1, -1, -1):
-            if len(input.shape) + len(new_dims) >= len(target_shape):
-                break
-            if i_i < 0 or target_shape[i_t] != input.shape[i_i]:
-                new_dims += (i_t,)
-            else:
-                i_i -= 1
-        input = ivy.expand_dims(input, axis=new_dims)
         return ivy.broadcast_to(input, target_shape)
 
 

--- a/ivy_tests/test_ivy/test_functional/test_core/test_general.py
+++ b/ivy_tests/test_ivy/test_functional/test_core/test_general.py
@@ -6,7 +6,7 @@ import math
 from types import SimpleNamespace
 
 import pytest
-from hypothesis import given, assume, strategies as st
+from hypothesis import given, assume, example, strategies as st
 import numpy as np
 from collections.abc import Sequence
 
@@ -15,7 +15,11 @@ import threading
 import ivy
 
 import ivy_tests.test_ivy.helpers as helpers
-from ivy_tests.test_ivy.helpers import handle_test, BackendHandler
+from ivy_tests.test_ivy.helpers import (
+    handle_test,
+    BackendHandler,
+    test_parameter_flags as pf,
+)
 from ivy_tests.test_ivy.helpers.assertions import assert_all_close
 from ivy_tests.test_ivy.test_functional.test_core.test_elementwise import pow_helper
 
@@ -1642,6 +1646,31 @@ def test_set_inplace_mode(mode):
     test_instance_method=st.just(False),
     container_flags=st.just([False]),
     test_with_copy=st.just(True),
+)
+@example(
+    dtypes_x_query_val=(
+        ["int32", "int32"],
+        np.ones((1, 3, 3, 3)),
+        (slice(None, None, None), slice(None, None, None), slice(None, None, None), 1),
+        np.zeros((3, 1)),
+    ),
+    copy=False,
+    fn_name="set_item",
+    test_flags=pf.FunctionTestFlags(
+        ground_truth_backend="numpy",
+        num_positional_args=3,
+        instance_method=False,
+        with_out=False,
+        with_copy=False,
+        test_gradients=False,
+        test_trace=False,
+        transpile=False,
+        as_variable=[False],
+        native_arrays=[False],
+        container=[False],
+        precision_mode=False,
+        test_cython_wrapper=False,
+    ),
 )
 def test_set_item(
     dtypes_x_query_val,


### PR DESCRIPTION
This fixes the following for tf and jax (already works for torch/numpy):

```python
import ivy

query = (slice(None, None, None), slice(None, None, None), slice(None, None, None), 1)

ivy.set_tensorflow_backend()
x = ivy.ones((1, 3, 3, 3))
val = ivy.zeros((3, 1))
x[query] = val
print(x)

ivy.set_jax_backend()
x = ivy.ones((1, 3, 3, 3))
val = ivy.zeros((3, 1))
x[query] = val
print(x)
```
I suspect the expanding dims logic maybe isn't necessary before the broadcasting but not sure.

Any ideas on if it's possibe with hypothesis to add a very specifc example to a test, like my example. I imagine it being a lot more complicated to get examples like this to appear in a property based way, but i don't think property based testing is really that important here and just testing one specific example would be sufficient. Is this possible @vedpatwardhan @Ishticode ?