### PR TITLE
fix: use of ivy.Shape in conditions

### DIFF
--- a/ivy/__init__.py
+++ b/ivy/__init__.py
@@ -294,7 +294,7 @@ class Shape(Sequence):
         return self
 
     def __bool__(self):
-        return self._shape.__bool__()
+        return builtins.bool(self._shape)
 
     def __div__(self, other):
         return self._shape // other

--- a/ivy_tests/test_ivy/test_misc/test_shape.py
+++ b/ivy_tests/test_ivy/test_misc/test_shape.py
@@ -1,6 +1,7 @@
 from hypothesis import assume, strategies as st
 import numpy as np
 
+import ivy
 import ivy_tests.test_ivy.helpers as helpers
 
 from ivy_tests.test_ivy.helpers import handle_method
@@ -682,3 +683,13 @@ def test_shape__sub__(
         class_name=class_name,
         method_name=method_name,
     )
+
+
+def test_shape_in_conditions():
+    shape = ivy.Shape((1, 2))
+    condition_is_true = True if shape else False
+    assert condition_is_true
+
+    shape = ivy.Shape(())
+    condition_is_true = True if shape else False
+    assert not condition_is_true


### PR DESCRIPTION
fixing the `__bool__` method of `ivy.Shape`. problem is lists/tuples don't have a `__bool__` method, instead we need to call `bool()` on them for it to work. this breaks the use of an `ivy.Shape` object in conditions, and added a test which shows what this fixes @vedpatwardhan 