### PR TITLE
fix Ivy Failing Test: paddle - activations.softmax

### DIFF
--- a/ivy/functional/backends/paddle/activations.py
+++ b/ivy/functional/backends/paddle/activations.py
@@ -16,6 +16,7 @@ import ivy
 from ivy.func_wrapper import (
     with_unsupported_device_and_dtypes,
     with_supported_dtypes,
+    with_unsupported_dtypes,
     with_supported_device_and_dtypes,
 )
 from . import backend_version
@@ -87,8 +88,8 @@ def sigmoid(
     return F.sigmoid(x)
 
 
-@with_unsupported_device_and_dtypes(
-    {"2.6.0 and below": {"cpu": ("bfloat16", "float16")}}, backend_version
+@with_unsupported_dtypes(
+    {"2.6.0 and below": ("bfloat16", "float16", "complex128")}, backend_version
 )
 def softmax(
     x: paddle.Tensor,


### PR DESCRIPTION
<!--
This template will help you to have a meaningful PR, please follow it and do not leave it blank.
-->

# PR Description
Test and pass 200 test cases on local for paddle backend
![Screenshot from 2024-02-10 22-35-30](https://github.com/unifyai/ivy/assets/78148524/62b1e436-ce76-4840-8a0f-eff5600c3b3a)
Also tested for all backend to make sure nothing is broken with the fix 
![Screenshot from 2024-02-10 22-40-23](https://github.com/unifyai/ivy/assets/78148524/31503480-ba73-4b01-8dd8-704e273246b9)
Error occured due to complex128 which is not supported I assume is not supported in paddle
<!--
If there is no related issue, please add a short description about your PR.
-->

## Related Issue

<!--
Please use this format to link other issues with their numbers: Close #123
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes https://github.com/unifyai/ivy/issues/28240

## Checklist

- [ ] Did you add a function?
- [ ] Did you add the tests?
- [x] Did you run your tests and are your tests passing?
- [x] Did pre-commit not fail on any check?
- [x] Did you follow the steps we provided?

<!--
Please mark your PR as a draft if you realise after the fact that your tests are not passing or
that your pre-commit check has some failures.

Here are some relevant resources regarding tests and pre-commit:

https://unify.ai/docs/ivy/overview/deep_dive/ivy_tests.html
https://unify.ai/docs/ivy/overview/deep_dive/formatting.html#pre-commit

-->
