### PR TITLE
fix: undocumented args for torch frontend- added `axis` support for `stack`, and `value` support for `scatter_` + extended tests

### DIFF
--- a/ivy/functional/frontends/torch/indexing_slicing_joining_mutating_ops.py
+++ b/ivy/functional/frontends/torch/indexing_slicing_joining_mutating_ops.py
@@ -398,7 +398,9 @@ def squeeze(input, dim=None):
 
 
 @to_ivy_arrays_and_back
-def stack(tensors, dim=0, *, out=None):
+def stack(tensors, dim=0, *, out=None, axis=None):
+    if axis is not None:
+        dim = axis
     return ivy.stack(tensors, axis=dim, out=out)
 
 

--- a/ivy/functional/frontends/torch/indexing_slicing_joining_mutating_ops.py
+++ b/ivy/functional/frontends/torch/indexing_slicing_joining_mutating_ops.py
@@ -397,10 +397,9 @@ def squeeze(input, dim=None):
     return ivy.squeeze(input, axis=dim)
 
 
+@numpy_to_torch_style_args
 @to_ivy_arrays_and_back
-def stack(tensors, dim=0, *, out=None, axis=None):
-    if axis is not None:
-        dim = axis
+def stack(tensors, dim=0, *, out=None):
     return ivy.stack(tensors, axis=dim, out=out)
 
 

--- a/ivy/functional/frontends/torch/tensor.py
+++ b/ivy/functional/frontends/torch/tensor.py
@@ -1806,9 +1806,7 @@ class Tensor:
     @with_supported_dtypes(
         {"2.2 and below": ("float32", "float64", "int32", "int64")}, "torch"
     )
-    def scatter_(self, dim, index, src=None, *, reduce=None, value=None):
-        if src is None and value is not None:
-            src = value
+    def scatter_(self, dim, index, src, *, reduce=None):
         if reduce is None:
             reduce = "replace"
         else:

--- a/ivy/functional/frontends/torch/tensor.py
+++ b/ivy/functional/frontends/torch/tensor.py
@@ -1806,7 +1806,9 @@ class Tensor:
     @with_supported_dtypes(
         {"2.2 and below": ("float32", "float64", "int32", "int64")}, "torch"
     )
-    def scatter_(self, dim, index, src, *, reduce=None):
+    def scatter_(self, dim, index, src=None, *, reduce=None, value=None):
+        if src is None and value is not None:
+            src = value
         if reduce is None:
             reduce = "replace"
         else:

--- a/ivy_tests/test_ivy/test_frontends/test_torch/test_indexing_slicing_joining_mutating_ops.py
+++ b/ivy_tests/test_ivy/test_frontends/test_torch/test_indexing_slicing_joining_mutating_ops.py
@@ -1356,11 +1356,13 @@ def test_torch_squeeze(
     dim=helpers.get_axis(
         shape=st.shared(helpers.get_shape(min_num_dims=1), key="shape"),
     ).filter(lambda axis: isinstance(axis, int)),
+    use_axis_arg=st.booleans(),
 )
 def test_torch_stack(
     *,
     dtype_value_shape,
     dim,
+    use_axis_arg,
     on_device,
     fn_tree,
     frontend,
@@ -1368,6 +1370,7 @@ def test_torch_stack(
     backend_fw,
 ):
     input_dtype, value = dtype_value_shape
+    dim_arg = {"axis" if use_axis_arg else "dim": dim}
     helpers.test_frontend_function(
         input_dtypes=input_dtype,
         backend_to_test=backend_fw,
@@ -1376,7 +1379,7 @@ def test_torch_stack(
         fn_tree=fn_tree,
         on_device=on_device,
         tensors=value,
-        dim=dim,
+        **dim_arg,
     )
 
 

--- a/ivy_tests/test_ivy/test_frontends/test_torch/test_tensor.py
+++ b/ivy_tests/test_ivy/test_frontends/test_torch/test_tensor.py
@@ -11484,10 +11484,12 @@ def test_torch_scatter(
     method_name="scatter_",
     args=put_along_axis_helper(),
     reduce=st.sampled_from(["add", "multiply"]),
+    use_value_arg=st.booleans(),
 )
 def test_torch_scatter_(
     args,
     reduce,
+    use_value_arg,
     frontend,
     frontend_method_data,
     init_flags,
@@ -11496,19 +11498,21 @@ def test_torch_scatter_(
     backend_fw,
 ):
     input_dtypes, x, indices, values, axis = args
+    kwargs_np = {
+        "dim": axis,
+        "index": indices,
+        "src": values,
+        "reduce": reduce,
+    }
+    if use_value_arg:
+        kwargs_np.pop("src")
+        kwargs_np["value"] = 1
     helpers.test_frontend_method(
         init_input_dtypes=[input_dtypes[0]],
         backend_to_test=backend_fw,
-        init_all_as_kwargs_np={
-            "data": x,
-        },
+        init_all_as_kwargs_np={"data": x},
         method_input_dtypes=["int64", input_dtypes[0]],
-        method_all_as_kwargs_np={
-            "dim": axis,
-            "index": indices,
-            "src": values,
-            "reduce": reduce,
-        },
+        method_all_as_kwargs_np=kwargs_np,
         frontend=frontend,
         frontend_method_data=frontend_method_data,
         init_flags=init_flags,

--- a/ivy_tests/test_ivy/test_frontends/test_torch/test_tensor.py
+++ b/ivy_tests/test_ivy/test_frontends/test_torch/test_tensor.py
@@ -11501,12 +11501,9 @@ def test_torch_scatter_(
     kwargs_np = {
         "dim": axis,
         "index": indices,
-        "src": values,
+        "value" if use_value_arg else "src": 1 if use_value_arg else values,
         "reduce": reduce,
     }
-    if use_value_arg:
-        kwargs_np.pop("src")
-        kwargs_np["value"] = 1
     helpers.test_frontend_method(
         init_input_dtypes=[input_dtypes[0]],
         backend_to_test=backend_fw,

--- a/ivy_tests/test_ivy/test_frontends/test_torch/test_tensor.py
+++ b/ivy_tests/test_ivy/test_frontends/test_torch/test_tensor.py
@@ -11484,12 +11484,10 @@ def test_torch_scatter(
     method_name="scatter_",
     args=put_along_axis_helper(),
     reduce=st.sampled_from(["add", "multiply"]),
-    use_value_arg=st.booleans(),
 )
 def test_torch_scatter_(
     args,
     reduce,
-    use_value_arg,
     frontend,
     frontend_method_data,
     init_flags,
@@ -11498,18 +11496,17 @@ def test_torch_scatter_(
     backend_fw,
 ):
     input_dtypes, x, indices, values, axis = args
-    kwargs_np = {
-        "dim": axis,
-        "index": indices,
-        "value" if use_value_arg else "src": 1 if use_value_arg else values,
-        "reduce": reduce,
-    }
     helpers.test_frontend_method(
         init_input_dtypes=[input_dtypes[0]],
         backend_to_test=backend_fw,
         init_all_as_kwargs_np={"data": x},
         method_input_dtypes=["int64", input_dtypes[0]],
-        method_all_as_kwargs_np=kwargs_np,
+        method_all_as_kwargs_np={
+            "dim": axis,
+            "index": indices,
+            "src": values,
+            "reduce": reduce,
+        },
         frontend=frontend,
         frontend_method_data=frontend_method_data,
         init_flags=init_flags,


### PR DESCRIPTION
This adds support for behaviour which works for native torch i.e.  `torch.stack` allows the `dim` argument to also be passed using keyword `axis`, although it isn't in the documentation it does support this and so occasionally pops up in botorch.