### PR TITLE
fix: fixing tests for `Shape` `__add__` and `__radd__` methods

### DIFF
--- a/ivy_tests/test_ivy/test_misc/test_shape.py
+++ b/ivy_tests/test_ivy/test_misc/test_shape.py
@@ -461,18 +461,14 @@ def test_shape__mul__(
 
 
 @handle_method(
+    init_tree=CLASS_TREE,
     method_tree="Shape.__radd__",
-    dtype_and_x=helpers.dtype_and_values(
-        available_dtypes=helpers.get_dtypes("numeric"),
-        num_arrays=2,
-        large_abs_safety_factor=2.5,
-        small_abs_safety_factor=2.5,
-        safety_factor_scale="log",
-        shared_dtype=True,
-    ),
+    shape_1=helpers.get_shape(),
+    shape_2=helpers.get_shape(),
 )
 def test_shape__radd__(
-    dtype_and_x,
+    shape_1,
+    shape_2,
     method_name,
     class_name,
     backend_fw,
@@ -481,17 +477,16 @@ def test_shape__radd__(
     method_flags,
     on_device,
 ):
-    dtype, x = dtype_and_x
     helpers.test_method(
         on_device=on_device,
         ground_truth_backend=ground_truth_backend,
         backend_to_test=backend_fw,
         init_flags=init_flags,
         method_flags=method_flags,
-        init_all_as_kwargs_np={"shape": x[0]},
-        init_input_dtypes=dtype,
-        method_input_dtypes=dtype,
-        method_all_as_kwargs_np={"other": x[1]},
+        init_all_as_kwargs_np={"shape_tup": shape_1},
+        init_input_dtypes=DUMMY_DTYPE,
+        method_input_dtypes=DUMMY_DTYPE,
+        method_all_as_kwargs_np={"other": shape_2},
         class_name=class_name,
         method_name=method_name,
     )

--- a/ivy_tests/test_ivy/test_misc/test_shape.py
+++ b/ivy_tests/test_ivy/test_misc/test_shape.py
@@ -7,19 +7,19 @@ import ivy_tests.test_ivy.helpers as helpers
 from ivy_tests.test_ivy.helpers import handle_method
 
 
+CLASS_TREE = "ivy.Shape"
+DUMMY_DTYPE = ["int32"]
+
+
 @handle_method(
+    init_tree=CLASS_TREE,
     method_tree="Shape.__add__",
-    dtype_and_x=helpers.dtype_and_values(
-        available_dtypes=helpers.get_dtypes("numeric"),
-        num_arrays=2,
-        large_abs_safety_factor=2.5,
-        small_abs_safety_factor=2.5,
-        safety_factor_scale="log",
-        shared_dtype=True,
-    ),
+    shape_1=helpers.get_shape(),
+    shape_2=helpers.get_shape(),
 )
 def test_shape__add__(
-    dtype_and_x,
+    shape_1,
+    shape_2,
     method_name,
     class_name,
     ground_truth_backend,
@@ -28,17 +28,16 @@ def test_shape__add__(
     method_flags,
     on_device,
 ):
-    dtype, x = dtype_and_x
     helpers.test_method(
         on_device=on_device,
         ground_truth_backend=ground_truth_backend,
         backend_to_test=backend_fw,
         init_flags=init_flags,
         method_flags=method_flags,
-        init_all_as_kwargs_np={"shape": x[0]},
-        init_input_dtypes=dtype,
-        method_input_dtypes=dtype,
-        method_all_as_kwargs_np={"other": x[1]},
+        init_all_as_kwargs_np={"shape_tup": shape_1},
+        init_input_dtypes=DUMMY_DTYPE,
+        method_input_dtypes=DUMMY_DTYPE,
+        method_all_as_kwargs_np={"other": shape_2},
         class_name=class_name,
         method_name=method_name,
     )


### PR DESCRIPTION
<!--
This template will help you to have a meaningful PR, please follow it and do not leave it blank.
-->

This PR fixes the tests for `__add__` and `__radd__` methods for the shape class where I modified the unit tests to use the `get_shape` strategy. I'm not sure if this is enough to test this class's methods, or if we can extend to examples using other strategies. Just requesting a review and inputs on this @vedpatwardhan 

<!--
If there is no related issue, please add a short description about your PR.
-->

## Related Issue

<!--
Please use this format to link other issues with their numbers: Close #123
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Fixes #28253
Fixes #28254
Fixes #28255 
Fixes #28256 
Fixes #28257 
Fixes #28258 
Fixes #28259 
Fixes #28260
Fixes #28261 
Fixes #28262
## Checklist

- [ ] Did you add a function?
- [ ] Did you add the tests?
- [x] Did you run your tests and are your tests passing?
- [x] Did pre-commit not fail on any check?
- [x] Did you follow the steps we provided?

<!--
Please mark your PR as a draft if you realise after the fact that your tests are not passing or
that your pre-commit check has some failures.

Here are some relevant resources regarding tests and pre-commit:

https://unify.ai/docs/ivy/overview/deep_dive/ivy_tests.html
https://unify.ai/docs/ivy/overview/deep_dive/formatting.html#pre-commit

-->

### Socials

<!--
If you have Twitter, please provide it here otherwise just ignore this.
-->
