### PR TITLE
fix: Fixed `paddle.take_along_axis` for all backends

### DIFF
--- a/ivy/functional/frontends/paddle/manipulation.py
+++ b/ivy/functional/frontends/paddle/manipulation.py
@@ -198,6 +198,11 @@ def stack(x, axis=0, name=None):
     return ivy.stack(x, axis=axis)
 
 
+@with_supported_dtypes(
+    {"2.6.0 and below": ("float32", "float64")},
+    "paddle",
+)
+@to_ivy_arrays_and_back
 def take_along_axis(arr, indices, axis):
     return ivy.take_along_axis(arr, indices, axis)
 


### PR DESCRIPTION
# PR Description
Fixed `paddle.take_along_axis` for all backends

![image](https://github.com/unifyai/ivy/assets/87087741/4052a085-26ee-4556-900d-94f1e189c4eb)



## Related Issue
Closes #28316
Closes #28317
Closes #28318
Closes #28319
Closes #28320

## Checklist

- [ ] Did you add a function?
- [ ] Did you add the tests?
- [x] Did you run your tests and are your tests passing?
- [x] Did pre-commit not fail on any check?
- [x] Did you follow the steps we provided?

### Socials
