### PR TITLE
fix: Fixed `tf.math.argmin` for torch, jax, and paddle backends

### DIFF
--- a/ivy/functional/backends/torch/searching.py
+++ b/ivy/functional/backends/torch/searching.py
@@ -41,7 +41,15 @@ def argmax(
     return ret
 
 
-@with_unsupported_dtypes({"2.2 and below": ("complex",)}, backend_version)
+@with_unsupported_dtypes(
+    {
+        "2.2 and below": (
+            "complex",
+            "bool",
+        )
+    },
+    backend_version,
+)
 def argmin(
     x: torch.Tensor,
     /,

--- a/ivy/functional/frontends/tensorflow/math.py
+++ b/ivy/functional/frontends/tensorflow/math.py
@@ -202,10 +202,6 @@ def argmax(input, axis, output_type=None, name=None):
         return ivy.astype(ivy.argmax(input, axis=axis), "int64")
 
 
-@with_unsupported_dtypes(
-    {"2.15.0 and below": ("bool",)},
-    "tensorflow",
-)
 @to_ivy_arrays_and_back
 def argmin(input, axis=None, output_type="int64", name=None):
     output_type = to_ivy_dtype(output_type)

--- a/ivy/functional/frontends/tensorflow/math.py
+++ b/ivy/functional/frontends/tensorflow/math.py
@@ -202,6 +202,10 @@ def argmax(input, axis, output_type=None, name=None):
         return ivy.astype(ivy.argmax(input, axis=axis), "int64")
 
 
+@with_unsupported_dtypes(
+    {"2.15.0 and below": ("bool",)},
+    "tensorflow",
+)
 @to_ivy_arrays_and_back
 def argmin(input, axis=None, output_type="int64", name=None):
     output_type = to_ivy_dtype(output_type)

--- a/ivy_tests/test_ivy/test_frontends/test_tensorflow/test_math.py
+++ b/ivy_tests/test_ivy/test_frontends/test_tensorflow/test_math.py
@@ -286,7 +286,7 @@ def test_tensorflow_argmin(
     on_device,
     output_type,
 ):
-    input_dtype, x, axis, dtype3, where = dtype_and_x
+    input_dtype, x, axis = dtype_and_x[:3]
     if isinstance(axis, tuple):
         axis = axis[0]
     helpers.test_frontend_function(

--- a/ivy_tests/test_ivy/test_frontends/test_tensorflow/test_math.py
+++ b/ivy_tests/test_ivy/test_frontends/test_tensorflow/test_math.py
@@ -286,7 +286,7 @@ def test_tensorflow_argmin(
     on_device,
     output_type,
 ):
-    input_dtype, x, axis = dtype_and_x[:3]
+    input_dtype, x, axis, *_ = dtype_and_x
     if isinstance(axis, tuple):
         axis = axis[0]
     helpers.test_frontend_function(

--- a/ivy_tests/test_ivy/test_frontends/test_tensorflow/test_math.py
+++ b/ivy_tests/test_ivy/test_frontends/test_tensorflow/test_math.py
@@ -286,7 +286,7 @@ def test_tensorflow_argmin(
     on_device,
     output_type,
 ):
-    input_dtype, x, axis = dtype_and_x
+    input_dtype, x, axis, dtype3, where = dtype_and_x
     if isinstance(axis, tuple):
         axis = axis[0]
     helpers.test_frontend_function(


### PR DESCRIPTION
# PR Description
Fixed `tf.math.argmin` for torch, jax, and paddle backends

![image](https://github.com/unifyai/ivy/assets/87087741/1430e9d2-f462-4345-9b68-d0b8ff5c6a8b)


## Related Issue
Closes #28339
Closes #28340
Closes #28341

## Checklist

- [ ] Did you add a function?
- [ ] Did you add the tests?
- [x] Did you run your tests and are your tests passing?
- [x] Did pre-commit not fail on any check?
- [x] Did you follow the steps we provided?

### Socials
