### PR TITLE
fix: Fixed `tf.math.argmax` for jax, torch, paddle, and tensorflow backends

### DIFF
--- a/ivy/functional/backends/tensorflow/searching.py
+++ b/ivy/functional/backends/tensorflow/searching.py
@@ -45,6 +45,7 @@ def argmax(
     return tf.cast(ret, dtype) if dtype is not None else ret
 
 
+@with_unsupported_dtypes({"2.15.0 and below": ("complex",)}, backend_version)
 def argmin(
     x: Union[tf.Tensor, tf.Variable],
     /,

--- a/ivy/functional/backends/torch/searching.py
+++ b/ivy/functional/backends/torch/searching.py
@@ -13,7 +13,15 @@ from . import backend_version
 # ------------------ #
 
 
-@with_unsupported_dtypes({"2.2 and below": ("complex",)}, backend_version)
+@with_unsupported_dtypes(
+    {
+        "2.2 and below": (
+            "complex",
+            "bool",
+        )
+    },
+    backend_version,
+)
 def argmax(
     x: torch.Tensor,
     /,

--- a/ivy/functional/frontends/tensorflow/math.py
+++ b/ivy/functional/frontends/tensorflow/math.py
@@ -196,7 +196,7 @@ def angle(input, name=None):
 @to_ivy_arrays_and_back
 def argmax(input, axis, output_type=None, name=None):
     output_type = to_ivy_dtype(output_type)
-    if output_type in ["uint16", "int16", "int32", "int64"]:
+    if output_type in ["int32", "int64"]:
         return ivy.astype(ivy.argmax(input, axis=axis), output_type)
     else:
         return ivy.astype(ivy.argmax(input, axis=axis), "int64")

--- a/ivy/functional/frontends/tensorflow/math.py
+++ b/ivy/functional/frontends/tensorflow/math.py
@@ -193,6 +193,10 @@ def angle(input, name=None):
     return ivy.angle(input)
 
 
+@with_unsupported_dtypes(
+    {"2.15.0 and below": ("complex",)},
+    "tensorflow",
+)
 @to_ivy_arrays_and_back
 def argmax(input, axis, output_type=None, name=None):
     output_type = to_ivy_dtype(output_type)
@@ -202,6 +206,10 @@ def argmax(input, axis, output_type=None, name=None):
         return ivy.astype(ivy.argmax(input, axis=axis), "int64")
 
 
+@with_unsupported_dtypes(
+    {"2.15.0 and below": ("complex",)},
+    "tensorflow",
+)
 @to_ivy_arrays_and_back
 def argmin(input, axis=None, output_type="int64", name=None):
     output_type = to_ivy_dtype(output_type)

--- a/ivy_tests/test_ivy/test_frontends/test_tensorflow/test_math.py
+++ b/ivy_tests/test_ivy/test_frontends/test_tensorflow/test_math.py
@@ -238,7 +238,7 @@ def test_tensorflow_angle(
 @handle_frontend_test(
     fn_tree="tensorflow.math.argmax",
     dtype_and_x=_statistical_dtype_values(function="argmax"),
-    output_type=st.sampled_from(["int16", "uint16", "int32", "int64"]),
+    output_type=st.sampled_from(["int32", "int64"]),
     test_with_out=st.just(False),
 )
 def test_tensorflow_argmax(
@@ -251,9 +251,7 @@ def test_tensorflow_argmax(
     on_device,
     output_type,
 ):
-    if backend_fw in ("torch", "paddle"):
-        assume(output_type != "uint16")
-    input_dtype, x, axis = dtype_and_x
+    input_dtype, x, axis = dtype_and_x[:3]
     if isinstance(axis, tuple):
         axis = axis[0]
     helpers.test_frontend_function(

--- a/ivy_tests/test_ivy/test_frontends/test_tensorflow/test_math.py
+++ b/ivy_tests/test_ivy/test_frontends/test_tensorflow/test_math.py
@@ -251,7 +251,7 @@ def test_tensorflow_argmax(
     on_device,
     output_type,
 ):
-    input_dtype, x, axis = dtype_and_x[:3]
+    input_dtype, x, axis, *_ = dtype_and_x[:3]
     if isinstance(axis, tuple):
         axis = axis[0]
     helpers.test_frontend_function(

--- a/ivy_tests/test_ivy/test_frontends/test_tensorflow/test_math.py
+++ b/ivy_tests/test_ivy/test_frontends/test_tensorflow/test_math.py
@@ -251,7 +251,7 @@ def test_tensorflow_argmax(
     on_device,
     output_type,
 ):
-    input_dtype, x, axis, *_ = dtype_and_x[:3]
+    input_dtype, x, axis, *_ = dtype_and_x
     if isinstance(axis, tuple):
         axis = axis[0]
     helpers.test_frontend_function(


### PR DESCRIPTION
# PR Description
Fixed `tf.math.argmax` for all the backends.

![image](https://github.com/unifyai/ivy/assets/87087741/b252e671-7f7f-4b78-a0eb-ef20ebb529e7)


Fixed `tf.math.argmin` for the remaining tensorflow and numpy backends.

![image](https://github.com/unifyai/ivy/assets/87087741/f727758c-f7cc-4067-ac2f-15b3779c0658)


## Related Issue
Closes #28343
Closes #28344
Closes #28345
Closes #28346
Closes #28348
Closes #28349
Closes #28350

## Checklist

- [ ] Did you add a function?
- [ ] Did you add the tests?
- [x] Did you run your tests and are your tests passing?
- [x] Did pre-commit not fail on any check?
- [x] Did you follow the steps we provided?

### Socials
