### PR TITLE
fix: fixed the complex dtype support for ivy.maximum at paddle backend

### DIFF
--- a/ivy/functional/backends/paddle/elementwise.py
+++ b/ivy/functional/backends/paddle/elementwise.py
@@ -1122,7 +1122,13 @@ def maximum(
 ) -> paddle.Tensor:
     x1, x2, ret_dtype = _elementwise_helper(x1, x2)
     if paddle.is_complex(x1):
-        use_where = True
+        real_comparison = paddle.real(x1) > paddle.real(x2)
+        imag_comparison = paddle_backend.logical_and(
+            paddle.real(x1) == paddle.real(x2), paddle.imag(x1) > paddle.imag(x2)
+        )
+        return paddle_backend.where(
+            paddle_backend.logical_or(real_comparison, imag_comparison), x1, x2
+        ).astype(ret_dtype)
     if use_where:
         return paddle_backend.where(
             paddle_backend.greater_equal(x1, x2), x1, x2

--- a/ivy_tests/test_ivy/test_functional/test_core/test_elementwise.py
+++ b/ivy_tests/test_ivy/test_functional/test_core/test_elementwise.py
@@ -69,7 +69,7 @@ def min_max_helper(draw):
     if use_where:
         dtype_and_x = draw(
             helpers.dtype_and_values(
-                available_dtypes=helpers.get_dtypes("numeric"),
+                available_dtypes=helpers.get_dtypes("numeric", full=False),
                 num_arrays=2,
                 small_abs_safety_factor=6,
                 large_abs_safety_factor=6,
@@ -79,7 +79,7 @@ def min_max_helper(draw):
     else:
         dtype_and_x = draw(
             helpers.dtype_and_values(
-                available_dtypes=helpers.get_dtypes("numeric"),
+                available_dtypes=helpers.get_dtypes("numeric", full=False),
                 num_arrays=2,
                 min_value=-1e5,
                 max_value=1e5,
@@ -1438,6 +1438,7 @@ def test_logical_xor(*, dtype_and_x, test_flags, backend_fw, fn_name, on_device)
     fn_tree="functional.ivy.maximum",
     dtype_and_x_and_use_where=min_max_helper(),
     test_gradients=st.just(False),
+    ground_truth_backend="jax",
 )
 def test_maximum(
     *, dtype_and_x_and_use_where, test_flags, backend_fw, fn_name, on_device


### PR DESCRIPTION
<!--
This template will help you to have a meaningful PR, please follow it and do not leave it blank.
-->

# fixed the complex dtype support for ivy.maximum at paddle backend

<!--
If there is no related issue, please add a short description about your PR.
-->

## passing all the tests at local.
![image](https://github.com/unifyai/ivy/assets/83540902/1026a0d9-828c-439b-a624-161cf267f88a)


<!--
Please use this format to link other issues with their numbers: Close #123
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes #28352

## Checklist

- [ ] Did you add a function?
- [ ] Did you add the tests?
- [x] Did you run your tests and are your tests passing?
- [x] Did pre-commit not fail on any check?
- [x] Did you follow the steps we provided?

<!--
Please mark your PR as a draft if you realise after the fact that your tests are not passing or
that your pre-commit check has some failures.

Here are some relevant resources regarding tests and pre-commit:

https://unify.ai/docs/ivy/overview/deep_dive/ivy_tests.html
https://unify.ai/docs/ivy/overview/deep_dive/formatting.html#pre-commit

-->


<!--
If you have Twitter, please provide it here otherwise just ignore this.
-->
