### PR TITLE
fix: Fixed `tf.math.zero_fraction` for jax backend

### DIFF
--- a/ivy/functional/frontends/tensorflow/math.py
+++ b/ivy/functional/frontends/tensorflow/math.py
@@ -1043,8 +1043,8 @@ def xlogy(x, y, name=None):
 def zero_fraction(value, name="zero_fraction"):
     zero = ivy.zeros(tuple(value.shape), dtype=ivy.float32)
     x = ivy.array(value, dtype=ivy.float32)
-    count_zero = ivy.sum(ivy.equal(x, zero))
-    count_nonzero = ivy.sum(ivy.not_equal(x, zero))
+    count_zero = ivy.sum(ivy.equal(x, zero), dtype=ivy.float32)
+    count_nonzero = ivy.sum(ivy.not_equal(x, zero), dtype=ivy.float32)
     return ivy.divide(count_zero, ivy.add(count_zero, count_nonzero))
 
 


### PR DESCRIPTION
# PR Description
Fixed `tf.math.zero_fraction` for paddle backend.

![image](https://github.com/unifyai/ivy/assets/87087741/da99b620-3576-4a90-a825-a485d8dfdebb)


## Related Issue
Closes #28371

## Checklist

- [ ] Did you add a function?
- [ ] Did you add the tests?
- [x] Did you run your tests and are your tests passing?
- [x] Did pre-commit not fail on any check?
- [x] Did you follow the steps we provided?

### Socials
