### PR TITLE
fix: minimum for complex dtype 

### DIFF
--- a/ivy/functional/backends/paddle/elementwise.py
+++ b/ivy/functional/backends/paddle/elementwise.py
@@ -1098,7 +1098,13 @@ def minimum(
 ) -> paddle.Tensor:
     x1, x2, ret_dtype = _elementwise_helper(x1, x2)
     if paddle.is_complex(x1):
-        use_where = True
+        real_comparison = paddle.real(x1) < paddle.real(x2)
+        imag_comparison = paddle_backend.logical_and(
+            paddle.real(x1) == paddle.real(x2), paddle.imag(x1) < paddle.imag(x2)
+        )
+        return paddle_backend.where(
+            paddle_backend.logical_or(real_comparison, imag_comparison), x1, x2
+        ).astype(ret_dtype)
 
     if use_where:
         return paddle_backend.where(paddle_backend.less_equal(x1, x2), x1, x2).astype(

--- a/ivy_tests/test_ivy/test_functional/test_core/test_elementwise.py
+++ b/ivy_tests/test_ivy/test_functional/test_core/test_elementwise.py
@@ -83,6 +83,8 @@ def min_max_helper(draw):
                 num_arrays=2,
                 min_value=-1e5,
                 max_value=1e5,
+                small_abs_safety_factor=6,
+                large_abs_safety_factor=6,
                 safety_factor_scale="log",
             )
         )
@@ -1182,9 +1184,11 @@ def test_less(*, dtype_and_x, test_flags, backend_fw, fn_name, on_device):
         available_dtypes=helpers.get_dtypes("numeric"), num_arrays=2
     ),
     test_gradients=st.just(False),
+    ground_truth_backend="jax",
 )
 def test_less_equal(*, dtype_and_x, test_flags, backend_fw, fn_name, on_device):
     input_dtype, x = dtype_and_x
+    print(f"input_dtype: {input_dtype}")
     # bfloat16 is not supported by numpy
     assume("bfloat16" not in input_dtype)
     # make sure they're not too close together
@@ -1463,6 +1467,7 @@ def test_maximum(
     fn_tree="functional.ivy.minimum",
     dtype_and_x_and_use_where=min_max_helper(),
     test_gradients=st.just(False),
+    ground_truth_backend="jax",
 )
 def test_minimum(
     *, dtype_and_x_and_use_where, test_flags, backend_fw, fn_name, on_device

--- a/ivy_tests/test_ivy/test_functional/test_core/test_elementwise.py
+++ b/ivy_tests/test_ivy/test_functional/test_core/test_elementwise.py
@@ -1188,7 +1188,6 @@ def test_less(*, dtype_and_x, test_flags, backend_fw, fn_name, on_device):
 )
 def test_less_equal(*, dtype_and_x, test_flags, backend_fw, fn_name, on_device):
     input_dtype, x = dtype_and_x
-    print(f"input_dtype: {input_dtype}")
     # bfloat16 is not supported by numpy
     assume("bfloat16" not in input_dtype)
     # make sure they're not too close together


### PR DESCRIPTION
<!--
This template will help you to have a meaningful PR, please follow it and do not leave it blank.
-->

#  fixed complex dtype support of ivy.minimum at paddle backend

<!--
If there is no related issue, please add a short description about your PR.
-->

## passing all test in local.
![image](https://github.com/unifyai/ivy/assets/83540902/c77dbabc-96a6-4885-8b99-3495bdb1d466)


<!--
Please use this format to link other issues with their numbers: Close #123
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes #28363

## Checklist

- [ ] Did you add a function?
- [ ] Did you add the tests?
- [x] Did you run your tests and are your tests passing?
- [x] Did pre-commit not fail on any check?
- [x] Did you follow the steps we provided?

<!--
Please mark your PR as a draft if you realise after the fact that your tests are not passing or
that your pre-commit check has some failures.

Here are some relevant resources regarding tests and pre-commit:

https://unify.ai/docs/ivy/overview/deep_dive/ivy_tests.html
https://unify.ai/docs/ivy/overview/deep_dive/formatting.html#pre-commit

-->


<!--
If you have Twitter, please provide it here otherwise just ignore this.
-->
