### PR TITLE
fix: Frontend Failing Test: torch.linalg.matrix_rank

### DIFF
--- a/ivy/functional/frontends/torch/linalg.py
+++ b/ivy/functional/frontends/torch/linalg.py
@@ -190,8 +190,8 @@ def matrix_power(A, n, *, out=None):
 @with_supported_dtypes(
     {"2.2 and below": ("float32", "float64", "complex32", "complex64")}, "torch"
 )
-def matrix_rank(A, *, atol=None, rtol=None, hermitian=False, out=None):
-    return ivy.matrix_rank(A, atol=atol, rtol=rtol, hermitian=hermitian, out=out)
+def matrix_rank(input, *, atol=None, rtol=None, hermitian=False, out=None):
+    return ivy.matrix_rank(input, atol=atol, rtol=rtol, hermitian=hermitian, out=out)
 
 
 @to_ivy_arrays_and_back

--- a/ivy_tests/test_ivy/helpers/function_testing.py
+++ b/ivy_tests/test_ivy/helpers/function_testing.py
@@ -806,6 +806,8 @@ def test_frontend_function(
         if True, test for the correctness of the resulting values.
     all_as_kwargs_np
         input arguments to the function as keyword arguments.
+        If an input argument has the same name as any other parameter
+        of this function, add "arg_" before the argument name.
 
     Returns
     -------
@@ -824,6 +826,10 @@ def test_frontend_function(
     if test_flags.with_copy is True:
         test_flags.with_out = False
         test_flags.inplace = False
+
+    all_as_kwargs_np = {
+        k[4:] if k.startswith("arg_") else k: v for k, v in all_as_kwargs_np.items()
+    }
 
     # split the arguments into their positional and keyword components
     args_np, kwargs_np = kwargs_to_args_n_kwargs(

--- a/ivy_tests/test_ivy/test_frontends/test_torch/test_linalg.py
+++ b/ivy_tests/test_ivy/test_frontends/test_torch/test_linalg.py
@@ -1002,9 +1002,11 @@ def test_torch_matrix_rank(
         test_flags=test_flags,
         fn_tree=fn_tree,
         on_device=on_device,
+        rtol=0,
+        atol=0,
         input=x,
-        rtol=rtol,
-        atol=atol,
+        arg_rtol=rtol,
+        arg_atol=atol,
         hermitian=hermitian,
     )
 

--- a/ivy_tests/test_ivy/test_functional/test_core/test_linalg.py
+++ b/ivy_tests/test_ivy/test_functional/test_core/test_linalg.py
@@ -279,6 +279,9 @@ def _matrix_rank_helper(draw):
     )
     atol = draw(tol_strategy)
     rtol = draw(tol_strategy)
+    if not (atol is None or rtol is None):
+        assume(type(atol) is type(rtol))
+
     return dtype, x[0], hermitian, atol, rtol
 
 


### PR DESCRIPTION
<!--
This template will help you to have a meaningful PR, please follow it and do not leave it blank.
-->

# PR Description

- Pytorch docs mistakenly say that matrix_rank() takes 'A' as the first argument, but it actually takes 'input'. Thus, parameter 'A' changed to 'input' in ivy.functional.frontends.torch.linalg.matrix_rank.
- 'atol' and 'rtol' args were not being passed to the frontend function because testing function was eating them up. Hence added support for kwargs with same names as test_frontend_function params.
- 'atol' and 'rtol' for testing are set to 0, since matrix_rank outputs whole numbers.
- Both 'atol' and 'rtol' for matrix_rank must be either floats or Tensors or either one should be None, i.e. they should have the same type when not None.

<!--
Please use this format to link other issues with their numbers: Close #123
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes #28385
Closes #28388
Closes #28389

## Checklist

- [ ] Did you add a function?
- [ ] Did you add the tests?
- [x] Did you run your tests and are your tests passing?
- [x] Did pre-commit not fail on any check?
- [x] Did you follow the steps we provided?

<!--
Please mark your PR as a draft if you realise after the fact that your tests are not passing or
that your pre-commit check has some failures.

Here are some relevant resources regarding tests and pre-commit:

https://unify.ai/docs/ivy/overview/deep_dive/ivy_tests.html
https://unify.ai/docs/ivy/overview/deep_dive/formatting.html#pre-commit

-->


<!--
If you have Twitter, please provide it here otherwise just ignore this.
-->
