### PR TITLE
fix: Fixed `paddle.math.floor` for jax, torch, and tensorflow backends

### DIFF
--- a/ivy/functional/frontends/paddle/math.py
+++ b/ivy/functional/frontends/paddle/math.py
@@ -257,9 +257,7 @@ def expm1(x, name=None):
     return ivy.expm1(x)
 
 
-@with_supported_dtypes(
-    {"2.6.0 and below": ("bfloat16", "float32", "float64")}, "paddle"
-)
+@with_supported_dtypes({"2.6.0 and below": ("float32", "float64")}, "paddle")
 @to_ivy_arrays_and_back
 def floor(x, name=None):
     return ivy.floor(x)


### PR DESCRIPTION
# PR Description
Fixed `paddle.math.floor` for jax, torch, and tensorflow backends

![image](https://github.com/unifyai/ivy/assets/87087741/d73fe026-7d87-47ad-bec0-21d56c7065d8)


## Related Issue
Closes #28417
Closes #28418
Closes #28419

## Checklist

- [ ] Did you add a function?
- [ ] Did you add the tests?
- [x] Did you run your tests and are your tests passing?
- [x] Did pre-commit not fail on any check?
- [x] Did you follow the steps we provided?

### Socials
