### PR TITLE
fix: Fixed `ivy.argsort` for jax backend

### DIFF
--- a/ivy/functional/backends/jax/sorting.py
+++ b/ivy/functional/backends/jax/sorting.py
@@ -20,7 +20,7 @@ def argsort(
 ) -> JaxArray:
     kind = "stable" if stable else "quicksort"
     return (
-        jnp.argsort(-x, axis=axis, kind=kind)
+        jnp.argsort(x, axis=axis, kind=kind, descending=descending)
         if descending
         else jnp.argsort(x, axis=axis, kind=kind)
     )


### PR DESCRIPTION
# PR Description
Fixed `ivy.argsort` for jax backend

![image](https://github.com/unifyai/ivy/assets/87087741/b9c15531-9b17-44cf-8cc0-076add0baeac)



## Related Issue
Closes #28421

## Checklist

- [ ] Did you add a function?
- [ ] Did you add the tests?
- [x] Did you run your tests and are your tests passing?
- [x] Did pre-commit not fail on any check?
- [x] Did you follow the steps we provided?

### Socials
