### PR TITLE
fix: fixed the `less_equal` to support the complex dtype

### DIFF
--- a/ivy/functional/backends/paddle/elementwise.py
+++ b/ivy/functional/backends/paddle/elementwise.py
@@ -140,8 +140,8 @@ def equal(
     return paddle.equal(x1, x2)
 
 
-@with_supported_dtypes(
-    {"2.6.0 and below": ("bool", "float32", "float64", "int32", "int64", "complex")},
+@with_unsupported_dtypes(
+    {"2.6.0 and below": ("bool",)},
     backend_version,
 )
 def less_equal(
@@ -154,9 +154,11 @@ def less_equal(
     x1, x2, ret_dtype = _elementwise_helper(x1, x2)
     if isinstance(x1, paddle.Tensor) and isinstance(x2, paddle.Tensor):
         if paddle.is_complex(x1) and paddle.is_complex(x2):
-            real = paddle.less_equal(x1.real(), x2.real())
-            imag = paddle.less_equal(x1.imag(), x2.imag())
-            return paddle_backend.logical_and(real, imag)
+            real_comparison = paddle.real(x1) < paddle.real(x2)
+            imag_comparison = paddle_backend.logical_and(
+                paddle.real(x1) == paddle.real(x2), paddle.imag(x1) < paddle.imag(x2)
+            )
+            return paddle_backend.logical_or(real_comparison, imag_comparison)
 
     return paddle.less_equal(x1, x2)
 

--- a/ivy/functional/backends/tensorflow/elementwise.py
+++ b/ivy/functional/backends/tensorflow/elementwise.py
@@ -423,7 +423,7 @@ def less(
     return tf.math.less(x1, x2)
 
 
-@with_unsupported_dtypes({"2.15.0 and below": ("complex",)}, backend_version)
+@with_unsupported_dtypes({"2.15.0 and below": ("complex", "bool")}, backend_version)
 def less_equal(
     x1: Union[float, tf.Tensor, tf.Variable],
     x2: Union[float, tf.Tensor, tf.Variable],

--- a/ivy_tests/test_ivy/test_functional/test_core/test_elementwise.py
+++ b/ivy_tests/test_ivy/test_functional/test_core/test_elementwise.py
@@ -1183,7 +1183,11 @@ def test_less(*, dtype_and_x, test_flags, backend_fw, fn_name, on_device):
 @handle_test(
     fn_tree="functional.ivy.less_equal",
     dtype_and_x=helpers.dtype_and_values(
-        available_dtypes=helpers.get_dtypes("numeric"), num_arrays=2
+        available_dtypes=helpers.get_dtypes("numeric"),
+        num_arrays=2,
+        large_abs_safety_factor=6,
+        small_abs_safety_factor=6,
+        safety_factor_scale="log",
     ),
     test_gradients=st.just(False),
     ground_truth_backend="jax",


### PR DESCRIPTION
<!--
This template will help you to have a meaningful PR, please follow it and do not leave it blank.
-->

# fixed the `less_equal` to support the complex dtype and tests are not passing at paddle backend

<!--
If there is no related issue, please add a short description about your PR.
-->

## passing all tests at local.
![image](https://github.com/unifyai/ivy/assets/83540902/9255df4d-63c4-4767-9ea7-82e00c002506)


<!--
Please use this format to link other issues with their numbers: Close #123
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes #28428

## Checklist

- [ ] Did you add a function?
- [ ] Did you add the tests?
- [ ] Did you run your tests and are your tests passing?
- [ ] Did pre-commit not fail on any check?
- [ ] Did you follow the steps we provided?

<!--
Please mark your PR as a draft if you realise after the fact that your tests are not passing or
that your pre-commit check has some failures.

Here are some relevant resources regarding tests and pre-commit:

https://unify.ai/docs/ivy/overview/deep_dive/ivy_tests.html
https://unify.ai/docs/ivy/overview/deep_dive/formatting.html#pre-commit

-->


<!--
If you have Twitter, please provide it here otherwise just ignore this.
-->
