### PR TITLE
fix: added a check for when the dtype argument is None in check_unsupported_dtype

### DIFF
--- a/ivy_tests/test_ivy/helpers/assertions.py
+++ b/ivy_tests/test_ivy/helpers/assertions.py
@@ -211,6 +211,7 @@ def check_unsupported_dtype(*, fn, input_dtypes, all_as_kwargs_np):
                 break
         if (
             "dtype" in all_as_kwargs_np
+            and all_as_kwargs_np["dtype"] is not None
             and all_as_kwargs_np["dtype"] in unsupported_dtypes_fn
         ):
             test_unsupported = True
@@ -221,6 +222,7 @@ def check_unsupported_dtype(*, fn, input_dtypes, all_as_kwargs_np):
                 break
         if (
             "dtype" in all_as_kwargs_np
+            and all_as_kwargs_np["dtype"] is not None
             and all_as_kwargs_np["dtype"] not in supported_dtypes_fn
         ):
             test_unsupported = True


### PR DESCRIPTION



<!--
This template will help you to have a meaningful PR, please follow it and do not leave it blank.
-->

# PR Description

<!--
If there is no related issue, please add a short description about your PR.
-->

## Related Issue

<!--
Please use this format to link other issues with their numbers: Close #123
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes #

## Checklist

- [ ] Did you add a function?
- [ ] Did you add the tests?
- [ ] Did you run your tests and are your tests passing?
- [ ] Did pre-commit not fail on any check?
- [ ] Did you follow the steps we provided?

<!--
Please mark your PR as a draft if you realise after the fact that your tests are not passing or
that your pre-commit check has some failures.

Here are some relevant resources regarding tests and pre-commit:

https://unify.ai/docs/ivy/overview/deep_dive/ivy_tests.html
https://unify.ai/docs/ivy/overview/deep_dive/formatting.html#pre-commit

-->

### Socials

<!--
If you have Twitter, please provide it here otherwise just ignore this.
-->
