### PR TITLE
remove to_list call in ivy's get item

### DIFF
--- a/ivy/functional/ivy/general.py
+++ b/ivy/functional/ivy/general.py
@@ -3127,7 +3127,7 @@ def _parse_slice(idx, s):
                     stop = 0
                 elif stop < 0:
                     stop = stop + s
-    q_i = ivy.arange(start, stop, step).to_list()
+    q_i = ivy.arange(start, stop, step)
     q_i = [q for q in q_i if 0 <= q < s]
     q_i = (
         ivy.array(q_i)


### PR DESCRIPTION
remove to_list call to fix some symbolic tensor issues with numpy calls.