### PR TITLE
fix: fixing the tests for `ivy.Shape` method

### DIFF
--- a/ivy/__init__.py
+++ b/ivy/__init__.py
@@ -308,12 +308,6 @@ class Shape(Sequence):
             return builtins.bool(builtins.tuple(self._shape))
         return builtins.bool(self._shape)
 
-    def __div__(self, other):
-        return self._shape // other
-
-    def __floordiv__(self, other):
-        return self._shape // other
-
     def __reduce__(self):
         return (self.__class__, (self._shape,))
 

--- a/ivy/__init__.py
+++ b/ivy/__init__.py
@@ -314,9 +314,6 @@ class Shape(Sequence):
     def __floordiv__(self, other):
         return self._shape // other
 
-    def __rmod__(self, other):
-        return other % self._shape
-
     def __reduce__(self):
         return (self.__class__, (self._shape,))
 

--- a/ivy/__init__.py
+++ b/ivy/__init__.py
@@ -314,12 +314,6 @@ class Shape(Sequence):
     def __floordiv__(self, other):
         return self._shape // other
 
-    def __mod__(self, other):
-        return self._shape % other
-
-    def __rdiv__(self, other):
-        return other // self._shape
-
     def __rmod__(self, other):
         return other % self._shape
 
@@ -332,32 +326,9 @@ class Shape(Sequence):
         else:
             return self._shape
 
-    def __sub__(self, other):
-        try:
-            self._shape = self._shape - other
-        except TypeError:
-            self._shape = self._shape - list(other)
-        return self
-
-    def __rsub__(self, other):
-        try:
-            self._shape = other - self._shape
-        except TypeError:
-            self._shape = list(other) - self._shape
-        return self
-
     def __eq__(self, other):
         self._shape = Shape._shape_casting_helper(self._shape, other)
         return self._shape == other
-
-    def __int__(self):
-        if hasattr(self._shape, "__int__"):
-            res = self._shape.__int__()
-        else:
-            res = int(self._shape)
-        if res is NotImplemented:
-            return res
-        return to_ivy(res)
 
     def __ge__(self, other):
         self._shape = Shape._shape_casting_helper(self._shape, other)

--- a/ivy/__init__.py
+++ b/ivy/__init__.py
@@ -304,6 +304,8 @@ class Shape(Sequence):
         return self
 
     def __bool__(self):
+        if ivy.current_backend_str() == "tensorflow":
+            return builtins.bool(builtins.tuple(self._shape))
         return builtins.bool(self._shape)
 
     def __div__(self, other):

--- a/ivy/__init__.py
+++ b/ivy/__init__.py
@@ -308,21 +308,6 @@ class Shape(Sequence):
             return builtins.bool(builtins.tuple(self._shape))
         return builtins.bool(self._shape)
 
-    def __div__(self, other):
-        return to_ivy(self._shape // other)
-
-    def __floordiv__(self, other):
-        return to_ivy(self._shape // other)
-
-    def __mod__(self, other):
-        return to_ivy(self._shape % other)
-
-    def __rdiv__(self, other):
-        return to_ivy(other // self._shape)
-
-    def __rmod__(self, other):
-        return to_ivy(other % self._shape)
-
     def __reduce__(self):
         return (self.__class__, (self._shape,))
 

--- a/ivy_tests/test_ivy/test_misc/test_shape.py
+++ b/ivy_tests/test_ivy/test_misc/test_shape.py
@@ -44,16 +44,12 @@ def test_shape__add__(
 
 
 @handle_method(
+    init_tree=CLASS_TREE,
     method_tree="Shape.__bool__",
-    dtype_and_x=helpers.dtype_and_values(
-        available_dtypes=st.one_of(st.just(("bool",)), helpers.get_dtypes("integer")),
-        max_num_dims=0,
-        min_value=0,
-        max_value=1,
-    ),
+    shape=helpers.get_shape(min_num_dims=0),
 )
 def test_shape__bool__(
-    dtype_and_x,
+    shape,
     method_name,
     class_name,
     ground_truth_backend,
@@ -62,15 +58,14 @@ def test_shape__bool__(
     method_flags,
     on_device,
 ):
-    dtype, x = dtype_and_x
     helpers.test_method(
         on_device=on_device,
         ground_truth_backend=ground_truth_backend,
         backend_to_test=backend_fw,
         init_flags=init_flags,
         method_flags=method_flags,
-        init_all_as_kwargs_np={"data": x[0]},
-        init_input_dtypes=dtype,
+        init_all_as_kwargs_np={"shape_tup": shape},
+        init_input_dtypes=DUMMY_DTYPE,
         method_input_dtypes=[],
         method_all_as_kwargs_np={},
         class_name=class_name,


### PR DESCRIPTION
<!--
This template will help you to have a meaningful PR, please follow it and do not leave it blank.
-->

# PR Description

Hi, @vedpatwardhan and @Ishticode I walked through the `ivy.Shape` class and given that shape implements the `Sequence` like behaviour. I believe that some of the magic methods implemented for this class always raise `TypeError` and I decided to remove them as they are not needed for the implementation.
Removed methods
* `__mod__`
*  `__rmod__`
*  `__rdiv__`
*  `__div__`
*  `__sub__`
*  `__rsub__`
*  `__int__`
*  `__floordiv__`

After removing these methods I refactored all unit tests of the `ivy.Shape` methods as most of them were failing due to wrong passing of parameters.

<!--
If there is no related issue, please add a short description about your PR.
-->

## Related Issue

<!--
Please use this format to link other issues with their numbers: Close #123
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes #

## Checklist

- [ ] Did you add a function?
- [ ] Did you add the tests?
- [x] Did you run your tests and are your tests passing?
- [x] Did pre-commit not fail on any check?
- [x] Did you follow the steps we provided?

<!--
Please mark your PR as a draft if you realise after the fact that your tests are not passing or
that your pre-commit check has some failures.

Here are some relevant resources regarding tests and pre-commit:

https://unify.ai/docs/ivy/overview/deep_dive/ivy_tests.html
https://unify.ai/docs/ivy/overview/deep_dive/formatting.html#pre-commit

-->

### Socials

<!--
If you have Twitter, please provide it here otherwise just ignore this.
-->
