### PR TITLE
fix: updated ivy.Shape, added interpolate with the paddle backend and updated expand

### DIFF
--- a/ivy/__init__.py
+++ b/ivy/__init__.py
@@ -307,28 +307,28 @@ class Shape(Sequence):
         return builtins.bool(self._shape)
 
     def __div__(self, other):
-        return self._shape // other
+        return to_ivy(self._shape // other)
 
     def __floordiv__(self, other):
-        return self._shape // other
+        return to_ivy(self._shape // other)
 
     def __mod__(self, other):
-        return self._shape % other
+        return to_ivy(self._shape % other)
 
     def __rdiv__(self, other):
-        return other // self._shape
+        return to_ivy(other // self._shape)
 
     def __rmod__(self, other):
-        return other % self._shape
+        return to_ivy(other % self._shape)
 
     def __reduce__(self):
         return (self.__class__, (self._shape,))
 
     def as_dimension(self, other):
         if isinstance(other, self._shape):
-            return other
+            return to_ivy(other)
         else:
-            return self._shape
+            return to_ivy(self._shape)
 
     def __sub__(self, other):
         try:
@@ -378,7 +378,7 @@ class Shape(Sequence):
 
     def __getitem__(self, key):
         try:
-            return self._shape[key]
+            return to_ivy(self._shape[key])
         except (TypeError, IndexError):
             return None
 
@@ -416,11 +416,11 @@ class Shape(Sequence):
         if self._shape.rank is None:
             return Shape(None)
         else:
-            return self._shape[index]
+            return to_ivy(self._shape[index])
 
     def as_dimension(self):
         if isinstance(self._shape, Shape):
-            return self._shape
+            return to_ivy(self._shape)
         else:
             return Shape(self._shape)
 

--- a/ivy/functional/backends/paddle/experimental/layers.py
+++ b/ivy/functional/backends/paddle/experimental/layers.py
@@ -469,7 +469,35 @@ def interpolate(
     antialias: Optional[bool] = False,
     out: Optional[paddle.Tensor] = None,
 ):
-    raise IvyNotImplementedException()
+    if mode not in ["linear", "bilinear", "bicubic", "trilinear"]:
+        align_corners = None
+    return paddle.nn.functional.interpolate(
+        x,
+        size=size,
+        scale_factor=scale_factor,
+        mode=mode,
+        align_corners=align_corners,
+    )
+
+
+interpolate.partial_mixed_handler = (
+    lambda *args, **kwargs: kwargs.get("mode", "linear")
+    not in [
+        "tf_area",
+        "nd",
+        "tf_bicubic",
+        "mitchellcubic",
+        "lanczos3",
+        "lanczos5",
+        "gaussian",
+    ]
+    and (
+        kwargs.get("mode", "linear") in ["linear", "bilinear", "bicubic", "trilinear"]
+        or not kwargs.get("align_corners", False)
+    )
+    and not kwargs.get("antialias", False)
+    and not kwargs.get("recompute_scale_factor", False)
+)
 
 
 def adaptive_max_pool2d(

--- a/ivy/functional/backends/paddle/experimental/manipulation.py
+++ b/ivy/functional/backends/paddle/experimental/manipulation.py
@@ -598,6 +598,14 @@ def expand(
     copy: Optional[bool] = None,
     out: Optional[paddle.Tensor] = None,
 ) -> paddle.Tensor:
+    shape = list(shape)
+    n_extra_dims = len(shape) - x.ndim
+    if n_extra_dims > 0:
+        with ivy.ArrayMode(False):
+            x = paddle_backend.expand_dims(x, tuple(range(n_extra_dims)))
+    for i, dim in enumerate(shape):
+        if dim < 0:
+            shape[i] = x.shape[i]
     return paddle_backend.broadcast_to(x, shape)
 
 


### PR DESCRIPTION
1. Updated ivy.Shape to convert the results of a few methods to ivy.Shape instead of ivy.NativeShape
2. Added the implementation of ivy.interpolate with the paddle backend
3. Updated ivy.expand with the paddle backend to deal with negative indices for broadcasting