### PR TITLE
fix: setting torch frontend tensor 'data' attribute

### DIFF
--- a/ivy/functional/frontends/torch/tensor.py
+++ b/ivy/functional/frontends/torch/tensor.py
@@ -49,7 +49,7 @@ class Tensor:
 
     def __setattr__(self, name, value):
         if name == "data":
-            self = value
+            pass
         else:
             super().__setattr__(name, value)
 

--- a/ivy/functional/frontends/torch/tensor.py
+++ b/ivy/functional/frontends/torch/tensor.py
@@ -47,6 +47,12 @@ class Tensor:
     def __hash__(self):
         return id(self)
 
+    def __setattr__(self, name, value):
+        if name == "data":
+            self = value
+        else:
+            super().__setattr__(name, value)
+
     # Properties #
     # ---------- #
 

--- a/ivy/functional/frontends/torch/tensor.py
+++ b/ivy/functional/frontends/torch/tensor.py
@@ -49,7 +49,7 @@ class Tensor:
 
     def __setattr__(self, name, value):
         if name == "data":
-            self.ivy_array = value.ivy_array  # noqa
+            self.ivy_array = value.ivy_array
         else:
             super().__setattr__(name, value)
 

--- a/ivy/functional/frontends/torch/tensor.py
+++ b/ivy/functional/frontends/torch/tensor.py
@@ -49,7 +49,7 @@ class Tensor:
 
     def __setattr__(self, name, value):
         if name == "data":
-            pass
+            self.ivy_array = value.ivy_array  # noqa
         else:
             super().__setattr__(name, value)
 


### PR DESCRIPTION
Fixes setting the `data` attribute of a frontend tensor to match the behaviour of native torch, such as this minimal example which prior to this fix would throw `AttributeError: can't set attribute 'data'` for the frontend:
```
import torch
import ivy.functional.frontends.torch as torch_frontend

x = torch.randn((1, 3, 3))
y = torch.randn((1, 3, 3))
x.__setattr__('data', y)
print(x)

x = torch_frontend.randn((1, 3, 3))
y = torch_frontend.randn((1, 3, 3))
x.__setattr__('data', y)
print(x)
```
Does this look ok to you @Ishticode?