### PR TITLE
fix(get-item): Use dynamic shape rather than static (x.shape) when possible in `_parse_query`

### DIFF
--- a/ivy/functional/ivy/general.py
+++ b/ivy/functional/ivy/general.py
@@ -2802,7 +2802,9 @@ def get_item(
         query = ivy.nonzero(query, as_tuple=False)
         ret = ivy.gather_nd(x, query)
     else:
-        query, target_shape, vector_inds = _parse_query(query, x.shape)
+        query, target_shape, vector_inds = _parse_query(
+            query, ivy.shape(x, as_array=True)
+        )
         if vector_inds is not None:
             x = ivy.permute_dims(
                 x,
@@ -2888,7 +2890,9 @@ def set_item(
         target_shape = ivy.get_item(x, query).shape
         indices = ivy.nonzero(query, as_tuple=False)
     else:
-        indices, target_shape, _ = _parse_query(query, x.shape, scatter=True)
+        indices, target_shape, _ = _parse_query(
+            query, ivy.shape(x, as_array=True), scatter=True
+        )
         if indices is None:
             return x
     val = _broadcast_to(val, target_shape).astype(x.dtype)


### PR DESCRIPTION
<!--
This template will help you to have a meaningful PR, please follow it and do not leave it blank.
-->

# PR Description
Use dynamic shape when available rather than static `x.shape` e.g. when the backend is set as `tensorflow` in `_parse_query`, allows `get_item` to be compilable with `tf.function`

<!--
If there is no related issue, please add a short description about your PR.
-->

## Related Issue

<!--
Please use this format to link other issues with their numbers: Close #123
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes #

## Checklist

- [ ] Did you add a function?
- [ ] Did you add the tests?
- [ ] Did you run your tests and are your tests passing?
- [ ] Did pre-commit not fail on any check?
- [ ] Did you follow the steps we provided?

<!--
Please mark your PR as a draft if you realise after the fact that your tests are not passing or
that your pre-commit check has some failures.

Here are some relevant resources regarding tests and pre-commit:

https://unify.ai/docs/ivy/overview/deep_dive/ivy_tests.html
https://unify.ai/docs/ivy/overview/deep_dive/formatting.html#pre-commit

-->

### Socials

<!--
If you have Twitter, please provide it here otherwise just ignore this.
-->
