### PR TITLE
fix: ensure traced function return is turned to ivy arrays

### DIFF
--- a/ivy_tests/test_ivy/helpers/function_testing.py
+++ b/ivy_tests/test_ivy/helpers/function_testing.py
@@ -2581,7 +2581,7 @@ def get_ret_and_flattened_np_array(
         with ivy_backend.PreciseMode(precision_mode):
             ret = fn(*args, **kwargs)
             if test_trace or test_trace_each:
-                ret = ivy.to_ivy(ret, True)
+                ret = ivy_backend.to_ivy(ret, True)
 
         def map_fn(x):
             if _is_frontend_array(x):

--- a/ivy_tests/test_ivy/helpers/function_testing.py
+++ b/ivy_tests/test_ivy/helpers/function_testing.py
@@ -2580,6 +2580,8 @@ def get_ret_and_flattened_np_array(
     with BackendHandler.update_backend(backend_to_test) as ivy_backend:
         with ivy_backend.PreciseMode(precision_mode):
             ret = fn(*args, **kwargs)
+            if test_trace or test_trace_each:
+                ret = ivy.to_ivy(ret, True)
 
         def map_fn(x):
             if _is_frontend_array(x):


### PR DESCRIPTION
This fixes the issues with `is_ivy_array` check in test_functions flattening process