### PR TITLE
fix: tf backend unflatten not supporting dim size inference

### DIFF
--- a/ivy/functional/backends/tensorflow/experimental/manipulation.py
+++ b/ivy/functional/backends/tensorflow/experimental/manipulation.py
@@ -578,6 +578,14 @@ def unflatten(
     name: Optional[str] = None,
 ) -> tf.Tensor:
     dim = abs(len(x.shape) + dim) if dim < 0 else dim
+
+    # infer the size of any dimensions that are -1
+    tf_shape = tf.constant(shape)
+    inferred_size = tf.reduce_prod(x.shape[dim]) // tf.reduce_prod(
+        tf.where(tf_shape != -1, x=shape, y=tf.constant(1))
+    )
+    shape = tf.where(tf_shape != -1, x=shape, y=inferred_size)
+
     res_shape = x.shape[:dim] + tf.TensorShape(shape) + x.shape[dim + 1 :]
     res = tf.reshape(x, res_shape, name)
     return res

--- a/ivy_tests/test_ivy/test_frontends/test_torch/test_miscellaneous_ops.py
+++ b/ivy_tests/test_ivy/test_frontends/test_torch/test_miscellaneous_ops.py
@@ -1818,6 +1818,7 @@ def test_torch_triu_indices(
         shape=st.shared(helpers.get_shape(min_num_dims=1), key="shape"),
         force_int=True,
     ),
+    infer_dim=st.booleans(),
 )
 def test_torch_unflatten(
     *,
@@ -1829,9 +1830,14 @@ def test_torch_unflatten(
     backend_fw,
     shape,
     axis,
+    infer_dim,
 ):
     dtype, x = dtype_and_values
     sizes = sizes_(shape, axis)
+    if infer_dim and len(sizes) > 1:
+        sizes = list(sizes)
+        sizes[0] = -1
+        sizes = tuple(sizes)
     helpers.test_frontend_function(
         input_dtypes=dtype,
         frontend=frontend,


### PR DESCRIPTION
Add support for the `shape` argument containing a -1, indicating that the dimension size needs to be inferred. Also expand the torch frontend test for unflatten to cover this case.