### PR TITLE
fix: torch frontend allowing negative padding values

### DIFF
--- a/ivy/functional/frontends/torch/nn/functional/vision_functions.py
+++ b/ivy/functional/frontends/torch/nn/functional/vision_functions.py
@@ -395,6 +395,27 @@ def interpolate(
 
 @to_ivy_arrays_and_back
 def pad(input, pad, mode="constant", value=0):
+    # deal with any negative pad values
+    if any([pad_value < 0 for pad_value in pad]):
+        pad = list(pad)
+        slices = []
+        for n in reversed(range(len(pad) // 2)):
+            i = n * 2
+            j = i + 1
+            start = None
+            stop = None
+            if pad[i] < 0:
+                start = -pad[i]
+                pad[i] = 0
+            if pad[j] < 0:
+                stop = pad[j]
+                pad[j] = 0
+            slices.append(slice(start, stop))
+        ndim = len(input.shape)
+        while len(slices) < ndim:
+            slices.insert(0, slice(None))
+        input = input[tuple(slices)]
+
     value = 0 if value is None else value
     mode_dict = {
         "constant": "constant",

--- a/ivy_tests/test_ivy/test_frontends/test_torch/test_nn/test_functional/test_vision_functions.py
+++ b/ivy_tests/test_ivy/test_frontends/test_torch/test_nn/test_functional/test_vision_functions.py
@@ -68,8 +68,8 @@ def _pad_generator(draw, shape, mode):
             max_pad_value = shape[i] - 1
         pad = pad + draw(
             st.tuples(
-                st.integers(min_value=0, max_value=max(0, max_pad_value)),
-                st.integers(min_value=0, max_value=max(0, max_pad_value)),
+                st.integers(min_value=-3, max_value=max(0, max_pad_value)),
+                st.integers(min_value=-3, max_value=max(0, max_pad_value)),
             )
         )
     return pad
@@ -99,7 +99,7 @@ def _pad_helper(draw):
             ret_shape=True,
             min_num_dims=min_v,
             max_num_dims=max_v,
-            min_dim_size=2,
+            min_dim_size=5,
             min_value=-1e05,
             max_value=1e05,
         )


### PR DESCRIPTION
torch.nn.functional.pad allowing the padding to include negative values, which reduce the size of the tensor. This was something the torch frontend pad did not support for any backend aside torch - so this extends the frontend to support this for all backends, and extends the frontend test to cover this case.