### PR TITLE
fix: add unsupported dtypes to some tf backend fns

### DIFF
--- a/ivy/functional/backends/tensorflow/elementwise.py
+++ b/ivy/functional/backends/tensorflow/elementwise.py
@@ -706,6 +706,7 @@ def sinh(
     return tf.sinh(x)
 
 
+@with_unsupported_dtypes({"2.15.0 and below": ("integer",)}, backend_version)
 def sqrt(
     x: Union[tf.Tensor, tf.Variable],
     /,
@@ -740,6 +741,7 @@ def subtract(
     return tf.subtract(x1, x2)
 
 
+@with_unsupported_dtypes({"2.15.0 and below": ("integer",)}, backend_version)
 def tan(
     x: Union[tf.Tensor, tf.Variable],
     /,
@@ -749,6 +751,7 @@ def tan(
     return tf.tan(x)
 
 
+@with_unsupported_dtypes({"2.15.0 and below": ("integer",)}, backend_version)
 def tanh(
     x: Union[tf.Tensor, tf.Variable],
     /,

--- a/ivy/functional/backends/tensorflow/layers.py
+++ b/ivy/functional/backends/tensorflow/layers.py
@@ -410,7 +410,9 @@ def conv3d_transpose(
     return res
 
 
-@with_unsupported_dtypes({"2.15.0 and below": ("bfloat16", "complex")}, backend_version)
+@with_unsupported_dtypes(
+    {"2.15.0 and below": ("bfloat16", "complex", "integer")}, backend_version
+)
 def conv_general_dilated(
     x: Union[tf.Tensor, tf.Variable],
     filters: Union[tf.Tensor, tf.Variable],


### PR DESCRIPTION
add unsupported dtypes to these tf backend functions:
- sqrt
- tan
- tanh
- conv_general_dilated