### PR TITLE
Fix Frontend Failing Test: all frontends- math.paddle.trunc

### DIFF
--- a/ivy/functional/frontends/paddle/math.py
+++ b/ivy/functional/frontends/paddle/math.py
@@ -695,11 +695,11 @@ def trace(x, offset=0, axis1=0, axis2=1, name=None):
 
 
 @with_supported_dtypes(
-    {"2.4.2 and below": ("float32", "float64", "int32", "int64")}, "paddle"
+    {"2.6.0 and below": ("float32", "float64", "int32", "int64")}, "paddle"
 )
 @to_ivy_arrays_and_back
-def trunc(x, name=None):
-    return ivy.trunc(x)
+def trunc(input, name=None):
+    return ivy.trunc(input)
 
 
 mod = remainder

--- a/ivy_tests/test_ivy/test_frontends/test_paddle/test_math.py
+++ b/ivy_tests/test_ivy/test_frontends/test_paddle/test_math.py
@@ -2733,7 +2733,7 @@ def test_paddle_trace(
 @handle_frontend_test(
     fn_tree="paddle.trunc",
     dtype_and_x=helpers.dtype_and_values(
-        available_dtypes=helpers.get_dtypes("float", "int"),
+        available_dtypes=helpers.get_dtypes("valid"),
     ),
 )
 def test_paddle_trunc(
@@ -2753,5 +2753,5 @@ def test_paddle_trunc(
         test_flags=test_flags,
         fn_tree=fn_tree,
         on_device=on_device,
-        x=x[0],
+        input=x[0],
     )


### PR DESCRIPTION
<!--
This template will help you to have a meaningful PR, please follow it and do not leave it blank.
-->

# PR Description
Error was caused by paddle.trunc uses input instead of x, fixed by using input as the argument instead of x

<!--
If there is no related issue, please add a short description about your PR.
-->

## Related Issue

<!--
Please use this format to link other issues with their numbers: Close #123
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes #https://github.com/unifyai/ivy/issues/28505
Closes #https://github.com/unifyai/ivy/issues/28531
Closes #https://github.com/unifyai/ivy/issues/28530
Closes #https://github.com/unifyai/ivy/issues/28529
Closes #https://github.com/unifyai/ivy/issues/28528

## Checklist

- [ ] Did you add a function?
- [ ] Did you add the tests?
- [x] Did you run your tests and are your tests passing?
- [x] Did pre-commit not fail on any check?
- [x] Did you follow the steps we provided?

<!--
Please mark your PR as a draft if you realise after the fact that your tests are not passing or
that your pre-commit check has some failures.

Here are some relevant resources regarding tests and pre-commit:

https://unify.ai/docs/ivy/overview/deep_dive/ivy_tests.html
https://unify.ai/docs/ivy/overview/deep_dive/formatting.html#pre-commit

-->

### Socials

<!--
If you have Twitter, please provide it here otherwise just ignore this.
-->
