### PR TITLE
Fixed math.paddle.conj for jax, numpy, tensorflow and torch

### DIFF
--- a/ivy/functional/frontends/paddle/math.py
+++ b/ivy/functional/frontends/paddle/math.py
@@ -140,7 +140,19 @@ def ceil(x, name=None):
     return ivy.ceil(x)
 
 
-@with_unsupported_dtypes({"2.4.2 and below": ("int16", "float16")}, "paddle")
+@with_supported_dtypes(
+    {
+        "2.6.0 and below": (
+            "complex64",
+            "complex128",
+            "float32",
+            "float64",
+            "int32",
+            "int64",
+        )
+    },
+    "paddle",
+)
 @to_ivy_arrays_and_back
 def conj(x, name=None):
     return ivy.conj(x)


### PR DESCRIPTION
<!--
This template will help you to have a meaningful PR, please follow it and do not leave it blank.
-->

# PR Description
Some dtypes in numeric aren't supported by paddle.conj, changed it so that it is more consistent with the paddle docs.
Not sure why float16 was not supported as well despite paddle docs mention it is supported.

```
FAILED ivy_tests/test_ivy/test_frontends/test_paddle/test_math.py::test_paddle_conj[cpu-tensorflow-False-False] - RuntimeError: (NotFound) The kernel with key (CPU, Undefined(AnyLayout), float16) of kernel conj is not registered. Selected wrong DataType float16. Paddle support following DataTypes: int32, int64, float64, complex128,...
```
![ivy conj](https://github.com/unifyai/ivy/assets/91728831/16556b4c-d912-4c56-acf2-222abe1c5d41)

ref : https://www.paddlepaddle.org.cn/documentation/docs/en/api/paddle/conj_en.html#conj

<!--
If there is no related issue, please add a short description about your PR.
-->

## Related Issue

<!--
Please use this format to link other issues with their numbers: Close #123
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes #https://github.com/unifyai/ivy/issues/28511
Closes #https://github.com/unifyai/ivy/issues/28510
Closes #https://github.com/unifyai/ivy/issues/28509
Closes #https://github.com/unifyai/ivy/issues/28508

## Checklist

- [ ] Did you add a function?
- [ ] Did you add the tests?
- [x] Did you run your tests and are your tests passing?
- [x] Did pre-commit not fail on any check?
- [x] Did you follow the steps we provided?

