### PR TITLE
Fixed paddle.math.heaviside for all frontends

### DIFF
--- a/ivy/functional/frontends/paddle/math.py
+++ b/ivy/functional/frontends/paddle/math.py
@@ -315,7 +315,7 @@ def gcd(x, y, name=None):
 
 
 @with_supported_dtypes(
-    {"2.6.0 and below": ("float16", "float32", "float64", "int32", "int64")}, "paddle"
+    {"2.6.0 and below": ("float32", "float64", "int32", "int64")}, "paddle"
 )
 @to_ivy_arrays_and_back
 def heaviside(x, y, name=None):


### PR DESCRIPTION
<!--
This template will help you to have a meaningful PR, please follow it and do not leave it blank.
-->

# PR Description
float16 is unsupported and causing the error
<img width="1150" alt="Screenshot 2024-03-09 at 14 52 57" src="https://github.com/unifyai/ivy/assets/91728831/3fd9bfd9-b5ad-433d-adc2-cd50483e47f3">


## Related Issue

<!--
Please use this format to link other issues with their numbers: Close #123
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes # https://github.com/unifyai/ivy/issues/28514
Closes # https://github.com/unifyai/ivy/issues/28514
Closes # https://github.com/unifyai/ivy/issues/28514

## Checklist

- [ ] Did you add a function?
- [ ] Did you add the tests?
- [ ] Did you run your tests and are your tests passing?
- [ ] Did pre-commit not fail on any check?
- [ ] Did you follow the steps we provided?

<!--
Please mark your PR as a draft if you realise after the fact that your tests are not passing or
that your pre-commit check has some failures.

Here are some relevant resources regarding tests and pre-commit:

https://unify.ai/docs/ivy/overview/deep_dive/ivy_tests.html
https://unify.ai/docs/ivy/overview/deep_dive/formatting.html#pre-commit

-->

### Socials

<!--
If you have Twitter, please provide it here otherwise just ignore this.
-->
