### PR TITLE
Fix Frontend Failing Test: jax, numpy, torch - math.tensorflow.math.reduce_prod

### DIFF
--- a/ivy_tests/test_ivy/test_frontends/test_tensorflow/test_math.py
+++ b/ivy_tests/test_ivy/test_frontends/test_tensorflow/test_math.py
@@ -2432,6 +2432,8 @@ def test_tensorflow_reduce_min(
     fn_tree="tensorflow.math.reduce_prod",
     dtype_and_x=helpers.dtype_and_values(
         available_dtypes=helpers.get_dtypes("numeric"),
+        min_value=-5,
+        max_value=5,
     ),
     test_with_out=st.just(False),
 )
@@ -2453,6 +2455,8 @@ def test_tensorflow_reduce_prod(
         fn_tree=fn_tree,
         on_device=on_device,
         input_tensor=x[0],
+        rtol=1e-02,
+        atol=1e-02,
     )
 
 

--- a/ivy_tests/test_ivy/test_frontends/test_tensorflow/test_math.py
+++ b/ivy_tests/test_ivy/test_frontends/test_tensorflow/test_math.py
@@ -2432,8 +2432,9 @@ def test_tensorflow_reduce_min(
     fn_tree="tensorflow.math.reduce_prod",
     dtype_and_x=helpers.dtype_and_values(
         available_dtypes=helpers.get_dtypes("numeric"),
-        min_value=-5,
-        max_value=5,
+        large_abs_safety_factor=24,
+        small_abs_safety_factor=24,
+        safety_factor_scale="log",
     ),
     test_with_out=st.just(False),
 )
@@ -2455,8 +2456,6 @@ def test_tensorflow_reduce_prod(
         fn_tree=fn_tree,
         on_device=on_device,
         input_tensor=x[0],
-        rtol=1e-02,
-        atol=1e-02,
     )
 
 


### PR DESCRIPTION
# PR Description
Test was failing because of small floating point rounding difference and too small/large values causing the results to be `inf` in some frameworks.
Fixed by adding tolerance and min max x values.

<!--
If there is no related issue, please add a short description about your PR.
-->

## Related Issue

<!--
Please use this format to link other issues with their numbers: Close #123
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Close https://github.com/unifyai/ivy/issues/28541
Close https://github.com/unifyai/ivy/issues/28540
Close https://github.com/unifyai/ivy/issues/28539

## Checklist

- [ ] Did you add a function?
- [ ] Did you add the tests?
- [x] Did you run your tests and are your tests passing?
- [x] Did pre-commit not fail on any check?
- [x] Did you follow the steps we provided?

<!--
Please mark your PR as a draft if you realise after the fact that your tests are not passing or
that your pre-commit check has some failures.

Here are some relevant resources regarding tests and pre-commit:

https://unify.ai/docs/ivy/overview/deep_dive/ivy_tests.html
https://unify.ai/docs/ivy/overview/deep_dive/formatting.html#pre-commit

-->

### Socials

<!--
If you have Twitter, please provide it here otherwise just ignore this.
-->
