### PR TITLE
fix: enable tensorflow numpy api indexing in get_item for tf backend 

### DIFF
--- a/ivy/functional/backends/tensorflow/general.py
+++ b/ivy/functional/backends/tensorflow/general.py
@@ -67,19 +67,8 @@ def get_item(
             return tf.expand_dims(x, 0)
     if ivy.is_array(query) and not ivy.is_bool_dtype(query):
         return tf.gather(x, query)
+    tf.experimental.numpy.experimental_enable_numpy_behavior()
     return x.__getitem__(query)
-
-
-def _get_item_condition(x, query, **kwargs):
-    return (
-        all(_check_query(i) for i in query)
-        and len({i.shape for i in query if ivy.is_array(i)}) <= 1
-        if isinstance(query, tuple)
-        else _check_query(query) or ivy.is_array(query)
-    )
-
-
-get_item.partial_mixed_handler = _get_item_condition
 
 
 def to_numpy(x: Union[tf.Tensor, tf.Variable], /, *, copy: bool = True) -> np.ndarray:

--- a/ivy_tests/test_ivy/test_functional/test_core/test_general.py
+++ b/ivy_tests/test_ivy/test_functional/test_core/test_general.py
@@ -1865,14 +1865,14 @@ def test_supports_inplace_updates(
     )
 
 
-def test_tensorflow_get_item_condition():
-    from ivy.functional.backends.tensorflow.general import _get_item_condition
-
-    query = tf.constant([0])
-    assert _get_item_condition(None, query)
-
-    query = tf.constant([[0, 1], [2, 2]])
-    assert _get_item_condition(None, query)
+# def test_tensorflow_get_item_condition():
+#     from ivy.functional.backends.tensorflow.general import _get_item_condition
+#
+#     query = tf.constant([0])
+#     assert _get_item_condition(None, query)
+#
+#     query = tf.constant([[0, 1], [2, 2]])
+#     assert _get_item_condition(None, query)
 
 
 # to_list


### PR DESCRIPTION
Also removes the _get_item_condition as we perhaps don't need the compositional version for tf. Will restore in case there are scenarios where that is still required.