### PR TITLE
fix: fixed frontend function `torch.mean` for all backends

### DIFF
--- a/ivy/functional/frontends/torch/reduction_ops.py
+++ b/ivy/functional/frontends/torch/reduction_ops.py
@@ -135,6 +135,19 @@ def max(*input, dim=None, keepdim=False, out=None):
 
 @numpy_to_torch_style_args
 @to_ivy_arrays_and_back
+@with_supported_dtypes(
+    {
+        "2.2.1 and below": (
+            "bfloat16",
+            "float16",
+            "float32",
+            "float64",
+            "complex64",
+            "complex128",
+        )
+    },
+    "torch",
+)
 def mean(input, dim=None, keepdim=False, *, dtype=None, out=None):
     if dtype is not None:
         input = input.astype(dtype)

--- a/ivy_tests/test_ivy/test_functional/test_core/test_statistical.py
+++ b/ivy_tests/test_ivy/test_functional/test_core/test_statistical.py
@@ -63,10 +63,9 @@ def _statistical_dtype_values(draw, *, function, min_value=None, max_value=None)
     shape = values[0].shape
     size = values[0].size
     max_correction = np.min(shape)
-    if "complex" in dtype[0]:
-        # TODO skip complex median test until added ?
-        #  because it is not supported in tensorflow (ground truth backend)
-        dtype = ["float32"]
+    # TODO skip complex median test until added ?
+    #  because it is not supported in tensorflow (ground truth backend)
+    assume("complex" not in dtype[0])
     if any(ele in function for ele in ["std", "var"]):
         if size == 1:
             correction = 0


### PR DESCRIPTION


<!--
This template will help you to have a meaningful PR, please follow it and do not leave it blank.
-->

# PR Description

- Fixed data type conversion occuring due to incorrect input_dtype supplied to test_frontend_function.
- Added `@with_supported_dtypes` to frontend function `torch.mean`.

<!--
If there is no related issue, please add a short description about your PR.
-->

## Related Issue

<!--
Please use this format to link other issues with their numbers: Close #123
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes #28563
Closes #28564
Closes #28565
Closes #28566

## Checklist

- [ ] Did you add a function?
- [ ] Did you add the tests?
- [x] Did you run your tests and are your tests passing?
- [x] Did pre-commit not fail on any check?
- [x] Did you follow the steps we provided?

<!--
Please mark your PR as a draft if you realise after the fact that your tests are not passing or
that your pre-commit check has some failures.

Here are some relevant resources regarding tests and pre-commit:

https://unify.ai/docs/ivy/overview/deep_dive/ivy_tests.html
https://unify.ai/docs/ivy/overview/deep_dive/formatting.html#pre-commit

-->


<!--
If you have Twitter, please provide it here otherwise just ignore this.
-->
