### PR TITLE
fix: downgraded tensorflow to 2.15.1 in the GPU docker image as 2.16.1 can't detect a GPU

### DIFF
--- a/docker/gpu_framework_directory.py
+++ b/docker/gpu_framework_directory.py
@@ -67,7 +67,7 @@ def install_pkg(path, pkg, base="fw/"):
         )
     elif pkg.split("==")[0] if "==" in pkg else pkg == "tensorflow":
         subprocess.run(
-            f"yes |pip install tensorflow[and-cuda] --target {path}",
+            f"yes |pip install tensorflow[and-cuda]==2.15.1 --target {path}",
             shell=True,
         )
     else:


### PR DESCRIPTION
This is being tracked in https://github.com/tensorflow/tensorflow/issues/63362