### PR TITLE
fix: fixed frontend test for `torch.Tensor.repeat`

### DIFF
--- a/ivy_tests/test_ivy/test_frontends/test_torch/test_tensor.py
+++ b/ivy_tests/test_ivy/test_frontends/test_torch/test_tensor.py
@@ -347,7 +347,15 @@ def _repeat_helper(draw):
         )
     )
 
-    repeats = draw(st.lists(st.integers(min_value=1, max_value=5), min_size=len(shape)))
+    MAX_NUMPY_DIMS = 32
+    repeats = draw(
+        st.lists(
+            st.integers(min_value=1, max_value=5),
+            min_size=len(shape),
+            max_size=MAX_NUMPY_DIMS,
+        )
+    )
+    assume(np.prod(repeats) * np.prod(shape) <= 2**28)
     return input_dtype, x, repeats
 
 


### PR DESCRIPTION



<!--
This template will help you to have a meaningful PR, please follow it and do not leave it blank.
-->

# PR Description

- Set max_size for 'repeat' array to be same as the max dims allowed by numpy as numpy was throwing an error. 
- Limited the size of resultant array to 2^28 elements (around 300 million). This is because without a limit the function was sometimes trying to generate a list of size more than 1 TB during testing.

<!--
If there is no related issue, please add a short description about your PR.
-->

## Related Issue

<!--
Please use this format to link other issues with their numbers: Close #123
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes #28581
Closes #28580

## Checklist

- [ ] Did you add a function?
- [ ] Did you add the tests?
- [x] Did you run your tests and are your tests passing?
- [x] Did pre-commit not fail on any check?
- [x] Did you follow the steps we provided?

<!--
Please mark your PR as a draft if you realise after the fact that your tests are not passing or
that your pre-commit check has some failures.

Here are some relevant resources regarding tests and pre-commit:

https://unify.ai/docs/ivy/overview/deep_dive/ivy_tests.html
https://unify.ai/docs/ivy/overview/deep_dive/formatting.html#pre-commit

-->

<!--
If you have Twitter, please provide it here otherwise just ignore this.
-->
