### PR TITLE
fix: fixed frontend test `test_torch_unfold` for paddle backend

### DIFF
--- a/ivy_tests/test_ivy/test_frontends/test_torch/test_nn/test_functional/test_convolution_functions.py
+++ b/ivy_tests/test_ivy/test_frontends/test_torch/test_nn/test_functional/test_convolution_functions.py
@@ -523,6 +523,9 @@ def test_torch_unfold(
     backend_fw,
 ):
     dtype, vals, kernel_shape, dilations, strides, padding = dtype_vals
+    # TODO add bfloat16 to unsupported dtypes of the tested function
+    if backend_fw == "paddle":
+        assume("bfloat16" not in dtype[0])
     helpers.test_frontend_function(
         input_dtypes=dtype,
         backend_to_test=backend_fw,


### PR DESCRIPTION

<!--
This template will help you to have a meaningful PR, please follow it and do not leave it blank.
-->

# PR Description

<!--
If there is no related issue, please add a short description about your PR.
-->

- Parameter 's' of '_parse_slice' is converted to int when the function is called. **Reason:** Sometimes a ivy.Array was being passed as 's' which caused ivy.arange to throw an error.
- Added an assumption so that bfloat arrays are not passed to the function when testing paddle backend. **Reason:** When paddle backend is set, one of the functions called inside the frontend function does not accept `bfloat` dtype. Since a direct backend implementation is not called, I could not restrict dtypes through decorators.

## Related Issue

<!--
Please use this format to link other issues with their numbers: Close #123
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes #28600

## Checklist

- [ ] Did you add a function?
- [ ] Did you add the tests?
- [x] Did you run your tests and are your tests passing?
- [x] Did pre-commit not fail on any check?
- [x] Did you follow the steps we provided?

<!--
Please mark your PR as a draft if you realise after the fact that your tests are not passing or
that your pre-commit check has some failures.

Here are some relevant resources regarding tests and pre-commit:

https://unify.ai/docs/ivy/overview/deep_dive/ivy_tests.html
https://unify.ai/docs/ivy/overview/deep_dive/formatting.html#pre-commit

-->

<!--
If you have Twitter, please provide it here otherwise just ignore this.
-->
