### PR TITLE
fix: fixed softplus at tf frontend

### DIFF
--- a/ivy/functional/backends/paddle/activations.py
+++ b/ivy/functional/backends/paddle/activations.py
@@ -117,6 +117,9 @@ def softmax(
     return paddle.divide(exp_x, paddle.sum(exp_x, axis=axis, keepdim=True))
 
 
+@with_unsupported_device_and_dtypes(
+    {"2.6.0 and below": {"cpu": ("float16", "bfloat16")}}, backend_version
+)
 def softplus(
     x: paddle.Tensor,
     /,


### PR DESCRIPTION
<!--
This template will help you to have a meaningful PR, please follow it and do not leave it blank.
-->

# fixed softplus at tf frontend not passing the tests at paddle backend bcz the paddle abs not support the bfloat16 dtype.

<!--
If there is no related issue, please add a short description about your PR.
-->

## passing all tests at local.

![image](https://github.com/unifyai/ivy/assets/83540902/6a929220-297d-4ee1-b3ce-567bff476b75)


<!--
Please use this format to link other issues with their numbers: Close #123
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes #28608

## Checklist

- [ ] Did you add a function?
- [ ] Did you add the tests?
- [x] Did you run your tests and are your tests passing?
- [x] Did pre-commit not fail on any check?
- [x] Did you follow the steps we provided?

<!--
Please mark your PR as a draft if you realise after the fact that your tests are not passing or
that your pre-commit check has some failures.

Here are some relevant resources regarding tests and pre-commit:

https://unify.ai/docs/ivy/overview/deep_dive/ivy_tests.html
https://unify.ai/docs/ivy/overview/deep_dive/formatting.html#pre-commit

-->


<!--
If you have Twitter, please provide it here otherwise just ignore this.
-->
