### PR TITLE
Fixed creation.paddle.assign for all frontends

### DIFF
--- a/ivy/functional/frontends/paddle/creation.py
+++ b/ivy/functional/frontends/paddle/creation.py
@@ -19,11 +19,7 @@ def arange(start, end=None, step=1, dtype=None, name=None):
 )
 @to_ivy_arrays_and_back
 def assign(x, output=None):
-    if len(ivy.shape(x)) == 0:
-        x = ivy.reshape(ivy.Array(x), (1,))
-        if ivy.exists(output):
-            output = ivy.reshape(ivy.Array(output), (1,))
-    else:
+    if len(ivy.shape(x)) != 0:
         x = ivy.reshape(x, ivy.shape(x))
     ret = ivy.copy_array(x, to_ivy_array=False, out=output)
     return ret


### PR DESCRIPTION
<!--
This template will help you to have a meaningful PR, please follow it and do not leave it blank.
-->

# PR Description
![paddle assign](https://github.com/unifyai/ivy/assets/91728831/63cbebcf-c927-48e1-9047-4a80cb44d852)
Failing because when a scalar is given, it is being reshaped into a 1-d array, which does not align with the paddle docs where output tensor has "the same shape, data type and value as x". Fixed it by only reshaping it if x isn't a scalar
<!--
If there is no related issue, please add a short description about your PR.
-->

## Related Issue

<!--
Please use this format to link other issues with their numbers: Close #123
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes #https://github.com/unifyai/ivy/issues/28561
Closes #https://github.com/unifyai/ivy/issues/28560
Closes #https://github.com/unifyai/ivy/issues/28559
Closes #https://github.com/unifyai/ivy/issues/28558
Closes #https://github.com/unifyai/ivy/issues/28557

## Checklist

- [ ] Did you add a function?
- [ ] Did you add the tests?
- [x] Did you run your tests and are your tests passing?
- [x] Did pre-commit not fail on any check?
- [x] Did you follow the steps we provided?

<!--
Please mark your PR as a draft if you realise after the fact that your tests are not passing or
that your pre-commit check has some failures.

Here are some relevant resources regarding tests and pre-commit:

https://unify.ai/docs/ivy/overview/deep_dive/ivy_tests.html
https://unify.ai/docs/ivy/overview/deep_dive/formatting.html#pre-commit

-->

### Socials

<!--
If you have Twitter, please provide it here otherwise just ignore this.
-->
