### PR TITLE
feat: Add Hamming loss function to sklearn metrics in Ivy frontends

### DIFF
--- a/ivy/functional/frontends/sklearn/metrics/_classification.py
+++ b/ivy/functional/frontends/sklearn/metrics/_classification.py
@@ -133,3 +133,34 @@ def recall_score(y_true, y_pred, *, sample_weight=None):
 
     ret = ret.astype("float64")
     return ret
+
+
+@to_ivy_arrays_and_back
+def hamming_loss(y_true, y_pred, *, sample_weight=None):
+    # Ensure that y_true and y_pred have the same shape
+    if y_true.shape != y_pred.shape:
+        raise IvyValueError("y_true and y_pred must have the same shape")
+
+    # Check if sample_weight is provided and normalize it
+    if sample_weight is not None:
+        sample_weight = ivy.array(sample_weight)
+        if sample_weight.shape[0] != y_true.shape[0]:
+            raise IvyValueError(
+                "sample_weight must have the same length as y_true and y_pred"
+            )
+        sample_weight = sample_weight / ivy.sum(sample_weight)
+    else:
+        sample_weight = ivy.ones_like(y_true)
+
+    # Calculate the Hamming loss
+    incorrect_predictions = ivy.not_equal(y_true, y_pred).astype(
+        "int64"
+    )
+    # Apply sample weights
+    weighted_incorrect_predictions = ivy.multiply(incorrect_predictions, sample_weight)
+
+    #Compute hamming loss
+    loss = ivy.sum(weighted_incorrect_predictions) / y_true.shape[0]
+
+    loss = loss.astype("float64")
+    return loss

--- a/ivy/functional/frontends/sklearn/metrics/_classification.py
+++ b/ivy/functional/frontends/sklearn/metrics/_classification.py
@@ -70,6 +70,35 @@ def f1_score(y_true, y_pred, *, sample_weight=None):
 
 
 @to_ivy_arrays_and_back
+def hamming_loss(y_true, y_pred, *, sample_weight=None):
+    # Ensure that y_true and y_pred have the same shape
+    if y_true.shape != y_pred.shape:
+        raise IvyValueError("y_true and y_pred must have the same shape")
+
+    # Check if sample_weight is provided and normalize it
+    if sample_weight is not None:
+        sample_weight = ivy.array(sample_weight)
+        if sample_weight.shape[0] != y_true.shape[0]:
+            raise IvyValueError(
+                "sample_weight must have the same length as y_true and y_pred"
+            )
+        sample_weight = sample_weight / ivy.sum(sample_weight)
+    else:
+        sample_weight = ivy.ones_like(y_true)
+
+    # Calculate the Hamming loss
+    incorrect_predictions = ivy.not_equal(y_true, y_pred).astype("int64")
+    # Apply sample weights
+    weighted_incorrect_predictions = ivy.multiply(incorrect_predictions, sample_weight)
+
+    # Compute hamming loss
+    loss = ivy.sum(weighted_incorrect_predictions) / y_true.shape[0]
+
+    loss = loss.astype("float64")
+    return loss
+
+
+@to_ivy_arrays_and_back
 def precision_score(y_true, y_pred, *, sample_weight=None):
     # Ensure that y_true and y_pred have the same shape
     if y_true.shape != y_pred.shape:
@@ -133,34 +162,3 @@ def recall_score(y_true, y_pred, *, sample_weight=None):
 
     ret = ret.astype("float64")
     return ret
-
-
-@to_ivy_arrays_and_back
-def hamming_loss(y_true, y_pred, *, sample_weight=None):
-    # Ensure that y_true and y_pred have the same shape
-    if y_true.shape != y_pred.shape:
-        raise IvyValueError("y_true and y_pred must have the same shape")
-
-    # Check if sample_weight is provided and normalize it
-    if sample_weight is not None:
-        sample_weight = ivy.array(sample_weight)
-        if sample_weight.shape[0] != y_true.shape[0]:
-            raise IvyValueError(
-                "sample_weight must have the same length as y_true and y_pred"
-            )
-        sample_weight = sample_weight / ivy.sum(sample_weight)
-    else:
-        sample_weight = ivy.ones_like(y_true)
-
-    # Calculate the Hamming loss
-    incorrect_predictions = ivy.not_equal(y_true, y_pred).astype(
-        "int64"
-    )
-    # Apply sample weights
-    weighted_incorrect_predictions = ivy.multiply(incorrect_predictions, sample_weight)
-
-    #Compute hamming loss
-    loss = ivy.sum(weighted_incorrect_predictions) / y_true.shape[0]
-
-    loss = loss.astype("float64")
-    return loss

--- a/ivy_tests/test_ivy/test_frontends/test_sklearn/test_metrics/test_classification.py
+++ b/ivy_tests/test_ivy/test_frontends/test_sklearn/test_metrics/test_classification.py
@@ -236,3 +236,68 @@ def test_sklearn_recall_score(
         y_pred=values[1],
         sample_weight=sample_weight,
     )
+
+
+@handle_frontend_test(
+    fn_tree="sklearn.metrics.hamming_loss",
+    arrays_and_dtypes=helpers.dtype_and_values(
+        available_dtypes=helpers.get_dtypes("integer"),
+        num_arrays=2,
+        min_value=0,
+        max_value=1,  # Hamming loss is for binary classification
+        shared_dtype=True,
+        shape=(helpers.ints(min_value=2, max_value=5)),
+    ),
+    sample_weight=st.lists(
+        st.floats(min_value=0.1, max_value=1), min_size=2, max_size=5
+    ),
+)
+def test_sklearn_hamming_loss(
+    arrays_and_dtypes,
+    on_device,
+    fn_tree,
+    frontend,
+    test_flags,
+    backend_fw,
+    sample_weight,
+):
+    dtypes, values = arrays_and_dtypes
+    # Ensure the values are binary by rounding and converting to int
+    for i in range(2):
+        values[i] = np.round(values[i]).astype(int)
+
+    # Adjust sample_weight to have the correct length
+    sample_weight = np.array(sample_weight).astype(float)
+    if len(sample_weight) != len(values[0]):
+        # If sample_weight is shorter, extend it with ones
+        sample_weight = np.pad(
+            sample_weight, 
+            (0, max(0, len(values[0]) - len(sample_weight))), 
+            "constant",
+            constant_values=1.0
+        )
+        # If sample_weight is longer, truncate it
+        sample_weight = sample_weight[:len(values[0])]
+
+    # Detach tensors if they require grad before converting to NumPy arrays
+    if backend_fw == 'torch':
+        values = [
+            (
+                value.detach().numpy() 
+                if isinstance(value, torch.Tensor) and value.requires_grad 
+                else value
+            )
+            for value in values
+        ]
+
+    helpers.test_frontend_function(
+        input_dtypes=dtypes,
+        backend_to_test=backend_fw,
+        test_flags=test_flags,
+        fn_tree=fn_tree,
+        frontend=frontend,
+        on_device=on_device,
+        y_true=values[0],
+        y_pred=values[1],
+        sample_weight=sample_weight,
+    )

--- a/ivy_tests/test_ivy/test_frontends/test_sklearn/test_metrics/test_classification.py
+++ b/ivy_tests/test_ivy/test_frontends/test_sklearn/test_metrics/test_classification.py
@@ -109,6 +109,71 @@ def test_sklearn_f1_score(
 
 
 @handle_frontend_test(
+    fn_tree="sklearn.metrics.hamming_loss",
+    arrays_and_dtypes=helpers.dtype_and_values(
+        available_dtypes=helpers.get_dtypes("integer"),
+        num_arrays=2,
+        min_value=0,
+        max_value=1,  # Hamming loss is for binary classification
+        shared_dtype=True,
+        shape=(helpers.ints(min_value=2, max_value=5)),
+    ),
+    sample_weight=st.lists(
+        st.floats(min_value=0.1, max_value=1), min_size=2, max_size=5
+    ),
+)
+def test_sklearn_hamming_loss(
+    arrays_and_dtypes,
+    on_device,
+    fn_tree,
+    frontend,
+    test_flags,
+    backend_fw,
+    sample_weight,
+):
+    dtypes, values = arrays_and_dtypes
+    # Ensure the values are binary by rounding and converting to int
+    for i in range(2):
+        values[i] = np.round(values[i]).astype(int)
+
+    # Adjust sample_weight to have the correct length
+    sample_weight = np.array(sample_weight).astype(float)
+    if len(sample_weight) != len(values[0]):
+        # If sample_weight is shorter, extend it with ones
+        sample_weight = np.pad(
+            sample_weight,
+            (0, max(0, len(values[0]) - len(sample_weight))),
+            "constant",
+            constant_values=1.0,
+        )
+        # If sample_weight is longer, truncate it
+        sample_weight = sample_weight[: len(values[0])]
+
+    # Detach tensors if they require grad before converting to NumPy arrays
+    if backend_fw == "torch":
+        values = [
+            (
+                value.detach().numpy()
+                if isinstance(value, torch.Tensor) and value.requires_grad
+                else value
+            )
+            for value in values
+        ]
+
+    helpers.test_frontend_function(
+        input_dtypes=dtypes,
+        backend_to_test=backend_fw,
+        test_flags=test_flags,
+        fn_tree=fn_tree,
+        frontend=frontend,
+        on_device=on_device,
+        y_true=values[0],
+        y_pred=values[1],
+        sample_weight=sample_weight,
+    )
+
+
+@handle_frontend_test(
     fn_tree="sklearn.metrics.precision_score",
     arrays_and_dtypes=helpers.dtype_and_values(
         available_dtypes=helpers.get_dtypes("integer"),
@@ -220,71 +285,6 @@ def test_sklearn_recall_score(
             (
                 value.detach().numpy()
                 if isinstance(value, torch.Tensor) and value.requires_grad
-                else value
-            )
-            for value in values
-        ]
-
-    helpers.test_frontend_function(
-        input_dtypes=dtypes,
-        backend_to_test=backend_fw,
-        test_flags=test_flags,
-        fn_tree=fn_tree,
-        frontend=frontend,
-        on_device=on_device,
-        y_true=values[0],
-        y_pred=values[1],
-        sample_weight=sample_weight,
-    )
-
-
-@handle_frontend_test(
-    fn_tree="sklearn.metrics.hamming_loss",
-    arrays_and_dtypes=helpers.dtype_and_values(
-        available_dtypes=helpers.get_dtypes("integer"),
-        num_arrays=2,
-        min_value=0,
-        max_value=1,  # Hamming loss is for binary classification
-        shared_dtype=True,
-        shape=(helpers.ints(min_value=2, max_value=5)),
-    ),
-    sample_weight=st.lists(
-        st.floats(min_value=0.1, max_value=1), min_size=2, max_size=5
-    ),
-)
-def test_sklearn_hamming_loss(
-    arrays_and_dtypes,
-    on_device,
-    fn_tree,
-    frontend,
-    test_flags,
-    backend_fw,
-    sample_weight,
-):
-    dtypes, values = arrays_and_dtypes
-    # Ensure the values are binary by rounding and converting to int
-    for i in range(2):
-        values[i] = np.round(values[i]).astype(int)
-
-    # Adjust sample_weight to have the correct length
-    sample_weight = np.array(sample_weight).astype(float)
-    if len(sample_weight) != len(values[0]):
-        # If sample_weight is shorter, extend it with ones
-        sample_weight = np.pad(
-            sample_weight, 
-            (0, max(0, len(values[0]) - len(sample_weight))), 
-            "constant",
-            constant_values=1.0
-        )
-        # If sample_weight is longer, truncate it
-        sample_weight = sample_weight[:len(values[0])]
-
-    # Detach tensors if they require grad before converting to NumPy arrays
-    if backend_fw == 'torch':
-        values = [
-            (
-                value.detach().numpy() 
-                if isinstance(value, torch.Tensor) and value.requires_grad 
                 else value
             )
             for value in values


### PR DESCRIPTION
## Pull Request - Add Hamming Loss Function for Binary Classification

### Changes Proposed:
This PR introduces the Hamming loss function, a standard metric for binary classification performance evaluation, to the sklearn metrics module of Ivy frontends.

### Implementation Details:
- The `hamming_loss` function is implemented to compute the proportion of incorrect predictions.
- It supports both weighted and unweighted calculations.
- The implementation is designed to be compatible with binary classification tasks.

### Benefits:
- The addition of the Hamming loss provides Ivy users with a crucial metric for binary classification model evaluation.
- It enhances the Ivy metrics module, offering a comprehensive suite of performance evaluation tools.

### Usage:
The `hamming_loss` function can be utilized by passing the true and predicted binary labels, with an optional `sample_weight` parameter for a weighted assessment.

### Example:

from ivy.functional.frontends.sklearn.metrics import hamming_loss

y_true = [1, 0, 1, 0]
y_pred = [0, 1, 1, 0]
print(hamming_loss(y_true, y_pred))

## Checklist

- [x] Did you add a function?
- [x] Did you add the tests?
- [x] Did you run your tests and are your tests passing?
- [x] Did pre-commit not fail on any check?
- [x] Did you follow the steps we provided?


