### PR TITLE
Fix Frontend Failing Test: paddle - search.paddle.index_sample

### DIFF
--- a/ivy/functional/frontends/paddle/search.py
+++ b/ivy/functional/frontends/paddle/search.py
@@ -39,7 +39,9 @@ def argsort(x, /, *, axis=-1, descending=False, name=None):
 )
 @to_ivy_arrays_and_back
 def index_sample(x, index):
-    return x[ivy.arange(x.shape[0])[:, None], index]
+    index_dtype = index.dtype
+    arange_tensor = ivy.arange(x.shape[0], dtype=index_dtype)[:, None]
+    return x[arange_tensor, index]
 
 
 # kthvalue


### PR DESCRIPTION
<!--
This template will help you to have a meaningful PR, please follow it and do not leave it blank.
-->

# PR Description
<img width="1093" alt="Screenshot 2024-03-17 at 18 28 59" src="https://github.com/unifyai/ivy/assets/91728831/1efad12e-9bce-49b1-a717-dbe01e06bc91">
Error was thrown because index and x are different dtypes
<!--
If there is no related issue, please add a short description about your PR.
-->

## Related Issue

<!--
Please use this format to link other issues with their numbers: Close #123
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Close #28624

## Checklist

- [ ] Did you add a function?
- [ ] Did you add the tests?
- [x] Did you run your tests and are your tests passing?
- [x] Did pre-commit not fail on any check?
- [x] Did you follow the steps we provided?

<!--
Please mark your PR as a draft if you realise after the fact that your tests are not passing or
that your pre-commit check has some failures.

Here are some relevant resources regarding tests and pre-commit:

https://unify.ai/docs/ivy/overview/deep_dive/ivy_tests.html
https://unify.ai/docs/ivy/overview/deep_dive/formatting.html#pre-commit

-->

### Socials

<!--
If you have Twitter, please provide it here otherwise just ignore this.
-->
