### PR TITLE
fixed tesorflow.keras.activations.get

### DIFF
--- a/ivy_tests/test_ivy/test_frontends/test_tensorflow/test_keras/test_activations.py
+++ b/ivy_tests/test_ivy/test_frontends/test_tensorflow/test_keras/test_activations.py
@@ -13,6 +13,18 @@ try:
 except ImportError:
     tf = SimpleNamespace()
 
+# Activation functions for testing
+ACTIVATION_FUNCTIONS = [
+    "gelu",
+    "leaky_relu",
+    "log_softmax",
+    "relu",
+    "sigmoid",
+    "silu",
+    "softmax",
+    "softplus",
+]
+
 
 # Helper function for deserialize.
 def get_callable_functions(
@@ -39,6 +51,7 @@ def simple_test_two_function(
     atol_: float = 1e-06,
     ivy_submodules: list = [],
     framework_submodules: list = [],
+    backend: str,
 ):
     ivy.set_backend(frontend)
     fn_ivy = ivy.functional.frontends.__dict__[frontend]
@@ -58,14 +71,15 @@ def simple_test_two_function(
     ret_ivy = ivy.array(ret_ivy, dtype=dtype_data)
     ret = ivy.array(ret, dtype=dtype_data)
 
-    ret_np_flat = helpers.flatten_and_to_np(ret=ret)
-    frontend_ret_np_flat = helpers.flatten_and_to_np(ret=ret_ivy)
+    ret_np_flat = helpers.flatten_and_to_np(backend=backend, ret=ret)
+    frontend_ret_np_flat = helpers.flatten_and_to_np(backend=backend, ret=ret_ivy)
 
     helpers.value_test(
         ret_np_flat=ret_np_flat,
         ret_np_from_gt_flat=frontend_ret_np_flat,
         rtol=rtol_,
         atol=atol_,
+        backend=backend,
         ground_truth_backend=frontend,
     )
     ivy.previous_backend()
@@ -190,17 +204,7 @@ def test_tensorflow_gelu(
 @handle_frontend_test(
     fn_tree="tensorflow.keras.activations.get",
     fn_name=st.sampled_from(get_callable_functions("keras.activations")).filter(
-        lambda x: not x[0].isupper()
-        and x
-        not in [
-            "deserialize",
-            "get",
-            "keras_export",
-            "serialize",
-            "deserialize_keras_object",
-            "serialize_keras_object",
-            "get_globals",
-        ]
+        lambda x: not x[0].isupper() and x in ACTIVATION_FUNCTIONS
     ),
     dtype_and_data=helpers.dtype_and_values(
         available_dtypes=helpers.get_dtypes("float"),
@@ -209,12 +213,13 @@ def test_tensorflow_gelu(
         shape=helpers.ints(min_value=2, max_value=5).map(lambda x: (x, x)),
     ),
 )
-def test_tensorflow_get(fn_name, dtype_and_data):
+def test_tensorflow_get(fn_name, dtype_and_data, backend_fw):
     dtype_data, data = dtype_and_data
     simple_test_two_function(
         fn_name=fn_name,
         x=data[0],
         frontend="tensorflow",
+        backend=backend_fw,
         fn_str="get",
         dtype_data=dtype_data[0],
         rtol_=1e-01,


### PR DESCRIPTION
<!--
This template will help you to have a meaningful PR, please follow it and do not leave it blank.
-->

# PR Description
`flatten_and_to_np` needed backend variable, so passed it down from the test function, the lambda function isn't filtering out some activations that can't be tested but in `keras.activations`, instead I filter out the functions that can be tested (got the list from `ivy/functional/frontends/tensorflow/keras/activations.py`)

<!--
If there is no related issue, please add a short description about your PR.
-->

## Related Issue

<!--
Please use this format to link other issues with their numbers: Close #123
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Close https://github.com/unifyai/ivy/issues/28636
Close https://github.com/unifyai/ivy/issues/28635
Close https://github.com/unifyai/ivy/issues/28634
Close https://github.com/unifyai/ivy/issues/28633
Close https://github.com/unifyai/ivy/issues/28632

## Checklist

- [ ] Did you add a function?
- [ ] Did you add the tests?
- [x] Did you run your tests and are your tests passing?
- [x] Did pre-commit not fail on any check?
- [x] Did you follow the steps we provided?

<!--
Please mark your PR as a draft if you realise after the fact that your tests are not passing or
that your pre-commit check has some failures.

Here are some relevant resources regarding tests and pre-commit:

https://unify.ai/docs/ivy/overview/deep_dive/ivy_tests.html
https://unify.ai/docs/ivy/overview/deep_dive/formatting.html#pre-commit

-->

### Socials

<!--
If you have Twitter, please provide it here otherwise just ignore this.
-->
