### PR TITLE
fix: fixed `numpy.ptp` for all backends

### DIFF
--- a/ivy/functional/frontends/numpy/statistics/order_statistics.py
+++ b/ivy/functional/frontends/numpy/statistics/order_statistics.py
@@ -1,5 +1,6 @@
 # global
 import ivy
+from ivy.func_wrapper import with_unsupported_dtypes
 from ivy.functional.frontends.numpy.func_wrapper import (
     to_ivy_arrays_and_back,
     handle_numpy_out,
@@ -119,6 +120,7 @@ def nanpercentile(
 
 @to_ivy_arrays_and_back
 @handle_numpy_out
+@with_unsupported_dtypes({"1.26.4 and below": ("bool",)}, "numpy")
 def ptp(a, axis=None, out=None, keepdims=False):
     x = ivy.max(a, axis=axis, keepdims=keepdims)
     y = ivy.min(a, axis=axis, keepdims=keepdims)

--- a/ivy_tests/test_ivy/test_frontends/test_numpy/test_statistics/test_order_statistics.py
+++ b/ivy_tests/test_ivy/test_frontends/test_numpy/test_statistics/test_order_statistics.py
@@ -70,7 +70,7 @@ def test_numpy_ptp(
     fn_tree,
     keep_dims,
 ):
-    input_dtypes, values, axis = dtype_values_axis
+    input_dtypes, values, axis, _, _ = dtype_values_axis
     if isinstance(axis, tuple):
         axis = axis[0]
 


### PR DESCRIPTION



<!--
This template will help you to have a meaningful PR, please follow it and do not leave it blank.
-->

# PR Description

<!--
If there is no related issue, please add a short description about your PR.
-->

- added `bool` as unsupported dtype.
- fixed `dtype_values_axis` unpacking in the test function.

## Related Issue

<!--
Please use this format to link other issues with their numbers: Close #123
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes #28638
Closes #28639
Closes #28640
Closes #28641
Closes #28642

## Checklist

- [ ] Did you add a function?
- [ ] Did you add the tests?
- [x] Did you run your tests and are your tests passing?
- [x] Did pre-commit not fail on any check?
- [x] Did you follow the steps we provided?

<!--
Please mark your PR as a draft if you realise after the fact that your tests are not passing or
that your pre-commit check has some failures.

Here are some relevant resources regarding tests and pre-commit:

https://unify.ai/docs/ivy/overview/deep_dive/ivy_tests.html
https://unify.ai/docs/ivy/overview/deep_dive/formatting.html#pre-commit

-->

### Socials

<!--
If you have Twitter, please provide it here otherwise just ignore this.
-->
