### PR TITLE
Fix Frontend Failing Test: jax, numpy, torch, tensorflow, paddle - averages_and_variances.numpy.average

### DIFF
--- a/ivy_tests/test_ivy/test_frontends/test_numpy/test_statistics/test_averages_and_variances.py
+++ b/ivy_tests/test_ivy/test_frontends/test_numpy/test_statistics/test_averages_and_variances.py
@@ -130,9 +130,9 @@ def test_numpy_average(
     on_device,
 ):
     try:
-        input_dtype, a, axis = dtype_and_a
+        input_dtype, a, axis, *_ = dtype_and_a
 
-        input_dtypes, xs, axiss = dtype_and_x
+        input_dtypes, xs, axiss, *_ = dtype_and_x
 
         if isinstance(axis, tuple):
             axis = axis[0]


### PR DESCRIPTION
<!--
This template will help you to have a meaningful PR, please follow it and do not leave it blank.
-->

# PR Description
<img width="470" alt="Screenshot 2024-03-19 at 18 27 08" src="https://github.com/unifyai/ivy/assets/91728831/c9deb2d0-f711-4b48-90c7-1ad78c008bbd">

Error was because `_statistical_dtype_values` returns more than 3 values


<!--
If there is no related issue, please add a short description about your PR.
-->

## Related Issue

<!--
Please use this format to link other issues with their numbers: Close #123
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Close https://github.com/unifyai/ivy/issues/28648
Close https://github.com/unifyai/ivy/issues/28647
Close https://github.com/unifyai/ivy/issues/28646
Close https://github.com/unifyai/ivy/issues/28645
Close https://github.com/unifyai/ivy/issues/28644

## Checklist

- [ ] Did you add a function?
- [ ] Did you add the tests?
- [x] Did you run your tests and are your tests passing?
- [x] Did pre-commit not fail on any check?
- [x] Did you follow the steps we provided?

<!--
Please mark your PR as a draft if you realise after the fact that your tests are not passing or
that your pre-commit check has some failures.

Here are some relevant resources regarding tests and pre-commit:

https://unify.ai/docs/ivy/overview/deep_dive/ivy_tests.html
https://unify.ai/docs/ivy/overview/deep_dive/formatting.html#pre-commit

-->

### Socials

<!--
If you have Twitter, please provide it here otherwise just ignore this.
-->
