### PR TITLE
feat: Added `flatten` and `to_tensors` methods to the `Shape` class refering to `tf.TensorShape` class

### DIFF
--- a/ivy/__init__.py
+++ b/ivy/__init__.py
@@ -501,6 +501,10 @@ class Shape(Sequence):
     def __concat__(self, other):
         return self.concatenate(other)
 
+    def flatten(self):
+        # check from https://github.com/tensorflow/tensorflow/blob/0d2d8a66fca1cbcdd6dd4e0cd6971792782e6844/tensorflow/python/framework/tensor_shape.py#L1299 # noqa: E501
+        return []
+
 
 class IntDtype(Dtype):
     def __new__(cls, dtype_str):

--- a/ivy/__init__.py
+++ b/ivy/__init__.py
@@ -502,7 +502,12 @@ class Shape(Sequence):
         return self.concatenate(other)
 
     def flatten(self):
-        # check from https://github.com/tensorflow/tensorflow/blob/0d2d8a66fca1cbcdd6dd4e0cd6971792782e6844/tensorflow/python/framework/tensor_shape.py#L1299 # noqa: E501
+        # check https://github.com/tensorflow/tensorflow/blob/0d2d8a66fca1cbcdd6dd4e0cd6971792782e6844/tensorflow/python/framework/tensor_shape.py#L1299 # noqa: E501
+        return []
+
+    def to_tensors(self, value):
+        # check https://github.com/tensorflow/tensorflow/blob/0d2d8a66fca1cbcdd6dd4e0cd6971792782e6844/tensorflow/python/framework/tensor_shape.py#L1294 # noqa: E501
+        del value
         return []
 
 


### PR DESCRIPTION
<!--
This template will help you to have a meaningful PR, please follow it and do not leave it blank.
-->

# PR Description
Added `flatten` and `to_tensors` methods to the `ivy.Shape` class.
They seem to be placeholder instances for the `TensorShape` class
<!--
If there is no related issue, please add a short description about your PR.
-->

## Related Issue
Part of https://github.com/unifyai/ivy/issues/28617
closes #28660
closes #28659 
<!--
Please use this format to link other issues with their numbers: Close #123
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes #

## Checklist

- [x] Did you add a function?
- [ ] Did you add the tests?
- [ ] Did you run your tests and are your tests passing?
- [x] Did pre-commit not fail on any check?
- [ ] Did you follow the steps we provided?

<!--
Please mark your PR as a draft if you realise after the fact that your tests are not passing or
that your pre-commit check has some failures.

Here are some relevant resources regarding tests and pre-commit:

https://unify.ai/docs/ivy/overview/deep_dive/ivy_tests.html
https://unify.ai/docs/ivy/overview/deep_dive/formatting.html#pre-commit

-->

### Socials

<!--
If you have Twitter, please provide it here otherwise just ignore this.
-->
