### PR TITLE
Fix Frontend Failing Test: paddle - general_functions.tensorflow.clip_by_value

### DIFF
--- a/ivy/functional/frontends/tensorflow/general_functions.py
+++ b/ivy/functional/frontends/tensorflow/general_functions.py
@@ -94,7 +94,7 @@ def clip_by_norm(t, clip_norm, axes=None):
 
 
 @to_ivy_arrays_and_back
-@with_unsupported_dtypes({"2.15.0 and below": ("float16",)}, "tensorflow")
+@with_unsupported_dtypes({"2.15.0 and below": ("float16", "complex")}, "tensorflow")
 def clip_by_value(t, clip_value_min, clip_value_max):
     ivy.utils.assertions.check_all_or_any_fn(
         clip_value_min,

--- a/ivy_tests/test_ivy/test_frontends/test_tensorflow/test_general_functions.py
+++ b/ivy_tests/test_ivy/test_frontends/test_tensorflow/test_general_functions.py
@@ -575,6 +575,13 @@ def test_tensorflow_clip_by_value(
     on_device,
 ):
     x_dtype, x, min, max = input_and_ranges
+    if backend_fw == "paddle" and x_dtype not in [
+        "int32",
+        "int64",
+        "float64",
+        "float32",
+    ]:
+        return
     helpers.test_frontend_function(
         input_dtypes=x_dtype,
         frontend=frontend,


### PR DESCRIPTION
<!--
This template will help you to have a meaningful PR, please follow it and do not leave it blank.
-->

# PR Description
![generalfunction clip_by_value](https://github.com/unifyai/ivy/assets/91728831/2d192bf8-e90e-4aa3-9bd4-2243f733e223)
![clip_by_value paddl](https://github.com/unifyai/ivy/assets/91728831/74b493fa-8076-4e61-99e5-9a89cb54520c)

Paddle does not support some dtypes so handled that, not sure why `complex` is not supported, test were kinda flaky where sometimes `jax` passes and `numpy` fails or `tensorflow` passes and `torch` fails, all of them threw the same error (in the pic) saying `complex` is not supported, so added that to the unsupported dtypes.



<!--
If there is no related issue, please add a short description about your PR.
-->

## Related Issue

<!--
Please use this format to link other issues with their numbers: Close #123
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Close https://github.com/unifyai/ivy/issues/28664

## Checklist

- [ ] Did you add a function?
- [ ] Did you add the tests?
- [ ] Did you run your tests and are your tests passing?
- [ ] Did pre-commit not fail on any check?
- [ ] Did you follow the steps we provided?

<!--
Please mark your PR as a draft if you realise after the fact that your tests are not passing or
that your pre-commit check has some failures.

Here are some relevant resources regarding tests and pre-commit:

https://unify.ai/docs/ivy/overview/deep_dive/ivy_tests.html
https://unify.ai/docs/ivy/overview/deep_dive/formatting.html#pre-commit

-->

### Socials

<!--
If you have Twitter, please provide it here otherwise just ignore this.
-->
