### PR TITLE
Fix Frontend Failing Test: paddle - comparison.numpy.greater_equal

### DIFF
--- a/ivy/functional/backends/paddle/elementwise.py
+++ b/ivy/functional/backends/paddle/elementwise.py
@@ -470,6 +470,7 @@ def greater(
             "int16",
             "int32",
             "int64",
+            "complex",
         )
     },
     backend_version,
@@ -481,7 +482,16 @@ def greater_equal(
     *,
     out: Optional[paddle.Tensor] = None,
 ) -> paddle.Tensor:
-    x1, x2, ret_dtype = _elementwise_helper(x1, x2)
+    x1, x2, _ = _elementwise_helper(x1, x2)
+    if isinstance(x1, paddle.Tensor) and isinstance(x2, paddle.Tensor):
+        if paddle.is_complex(x1) and paddle.is_complex(x2):
+            real_greater_equal = paddle.real(x1) >= paddle.real(x2)
+            real_equal = paddle.real(x1) == paddle.real(x2)
+            imag_greater_equal = paddle.imag(x1) >= paddle.imag(x2)
+            return paddle.logical_or(
+                real_greater_equal, paddle.logical_and(real_equal, imag_greater_equal)
+            )
+
     return paddle.greater_equal(x1, x2)
 
 

--- a/ivy/functional/backends/paddle/elementwise.py
+++ b/ivy/functional/backends/paddle/elementwise.py
@@ -470,7 +470,6 @@ def greater(
             "int16",
             "int32",
             "int64",
-            "complex",
         )
     },
     backend_version,
@@ -483,11 +482,6 @@ def greater_equal(
     out: Optional[paddle.Tensor] = None,
 ) -> paddle.Tensor:
     x1, x2, ret_dtype = _elementwise_helper(x1, x2)
-    if isinstance(x1, paddle.Tensor) and isinstance(x2, paddle.Tensor):
-        if paddle.is_complex(x1) and paddle.is_complex(x2):
-            real = paddle.greater_equal(x1.real(), x2.real())
-            imag = paddle.greater_equal(x1.imag(), x2.imag())
-            return paddle.logical_and(real, imag)
     return paddle.greater_equal(x1, x2)
 
 


### PR DESCRIPTION
<!--
This template will help you to have a meaningful PR, please follow it and do not leave it blank.
-->

# PR Description
Error thrown due to complex comparison, `paddle` does not support complex for `greater equal` not sure why the function was trying to do so, removing the comparison works, but not sure if it was essential to make a "`complex` acceptable" `paddle.greater_equal`

ref: https://www.paddlepaddle.org.cn/documentation/docs/en/2.2/api/paddle/greater_equal_en.html#greater-equal

<!--
If there is no related issue, please add a short description about your PR.
-->

## Related Issue

<!--
Please use this format to link other issues with their numbers: Close #123
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Close https://github.com/unifyai/ivy/issues/28700

## Checklist

- [ ] Did you add a function?
- [ ] Did you add the tests?
- [x] Did you run your tests and are your tests passing?
- [x] Did pre-commit not fail on any check?
- [x] Did you follow the steps we provided?

<!--
Please mark your PR as a draft if you realise after the fact that your tests are not passing or
that your pre-commit check has some failures.

Here are some relevant resources regarding tests and pre-commit:

https://unify.ai/docs/ivy/overview/deep_dive/ivy_tests.html
https://unify.ai/docs/ivy/overview/deep_dive/formatting.html#pre-commit

-->

### Socials

<!--
If you have Twitter, please provide it here otherwise just ignore this.
-->
