### PR TITLE
Fix Frontend Failing Test: paddle - creation.jax.numpy.identity

### DIFF
--- a/ivy/functional/backends/paddle/creation.py
+++ b/ivy/functional/backends/paddle/creation.py
@@ -152,6 +152,7 @@ def empty_like(
                 "complex64",
                 "complex128",
                 "bool",
+                "bfloat16",
             )
         }
     },


### PR DESCRIPTION
<!--
This template will help you to have a meaningful PR, please follow it and do not leave it blank.
-->

# PR Description
![image](https://github.com/unifyai/ivy/assets/91728831/aad5455f-b1fe-49f9-be6d-544097ba9300)
Failing because of `bfloat16` specify that as unsupported
<!--
If there is no related issue, please add a short description about your PR.
-->

## Related Issue

<!--
Please use this format to link other issues with their numbers: Close #123
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Close https://github.com/unifyai/ivy/issues/28708

## Checklist

- [ ] Did you add a function?
- [ ] Did you add the tests?
- [x] Did you run your tests and are your tests passing?
- [x] Did pre-commit not fail on any check?
- [x] Did you follow the steps we provided?

<!--
Please mark your PR as a draft if you realise after the fact that your tests are not passing or
that your pre-commit check has some failures.

Here are some relevant resources regarding tests and pre-commit:

https://unify.ai/docs/ivy/overview/deep_dive/ivy_tests.html
https://unify.ai/docs/ivy/overview/deep_dive/formatting.html#pre-commit

-->

### Socials

<!--
If you have Twitter, please provide it here otherwise just ignore this.
-->
