### PR TITLE
Fix Frontend Failing Test: paddle - comparison_ops.torch.equal

### DIFF
--- a/ivy_tests/test_ivy/test_frontends/test_torch/test_comparison_ops.py
+++ b/ivy_tests/test_ivy/test_frontends/test_torch/test_comparison_ops.py
@@ -143,7 +143,7 @@ def test_torch_eq(
         num_arrays=2,
         allow_inf=False,
         shared_dtype=True,
-        min_value=1e-07,
+        abs_smallest_val=1e-07,
     ),
 )
 def test_torch_equal(

--- a/ivy_tests/test_ivy/test_frontends/test_torch/test_comparison_ops.py
+++ b/ivy_tests/test_ivy/test_frontends/test_torch/test_comparison_ops.py
@@ -143,6 +143,7 @@ def test_torch_eq(
         num_arrays=2,
         allow_inf=False,
         shared_dtype=True,
+        min_value=1e-07,
     ),
 )
 def test_torch_equal(


### PR DESCRIPTION
<!--
This template will help you to have a meaningful PR, please follow it and do not leave it blank.
-->

# PR Description
![image](https://github.com/unifyai/ivy/assets/91728831/473d4521-98a5-46a7-a113-c6624d6ea40a)
Failing due to very small precision error by paddle, fixed by restricting the min value of the test

<!--
If there is no related issue, please add a short description about your PR.
-->

## Related Issue

<!--
Please use this format to link other issues with their numbers: Close #123
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Close https://github.com/unifyai/ivy/issues/28725

## Checklist

- [ ] Did you add a function?
- [ ] Did you add the tests?
- [x] Did you run your tests and are your tests passing?
- [x] Did pre-commit not fail on any check?
- [x] Did you follow the steps we provided?

<!--
Please mark your PR as a draft if you realise after the fact that your tests are not passing or
that your pre-commit check has some failures.

Here are some relevant resources regarding tests and pre-commit:

https://unify.ai/docs/ivy/overview/deep_dive/ivy_tests.html
https://unify.ai/docs/ivy/overview/deep_dive/formatting.html#pre-commit

-->

### Socials

<!--
If you have Twitter, please provide it here otherwise just ignore this.
-->
