### PR TITLE
Fix Frontend Failing Test: paddle - operators.jax.lax.ne

### DIFF
--- a/ivy_tests/test_ivy/test_frontends/test_jax/test_lax/test_operators.py
+++ b/ivy_tests/test_ivy/test_frontends/test_jax/test_lax/test_operators.py
@@ -2266,6 +2266,7 @@ def test_jax_mul(
         available_dtypes=helpers.get_dtypes("numeric"),
         num_arrays=2,
         shared_dtype=True,
+        abs_smallest_val=1e-07,
     ),
     test_with_out=st.just(False),
 )


### PR DESCRIPTION
<!--
This template will help you to have a meaningful PR, please follow it and do not leave it blank.
-->

# PR Description
Error was due to very small abs differences, where jax rounds down to `0` but `paddlepaddle` takes the value. Fix by limiting the smallest abs value that can be generated for testing

eg: `-2.23517418e-08` and `-1.49011612e-08`, is labelled as `False` in `paddle` but `True` in `jax` 

<!--
If there is no related issue, please add a short description about your PR.
-->

## Related Issue

<!--
Please use this format to link other issues with their numbers: Close #123
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Close https://github.com/unifyai/ivy/issues/28727

## Checklist

- [ ] Did you add a function?
- [ ] Did you add the tests?
- [x] Did you run your tests and are your tests passing?
- [x] Did pre-commit not fail on any check?
- [x] Did you follow the steps we provided?

<!--
Please mark your PR as a draft if you realise after the fact that your tests are not passing or
that your pre-commit check has some failures.

Here are some relevant resources regarding tests and pre-commit:

https://unify.ai/docs/ivy/overview/deep_dive/ivy_tests.html
https://unify.ai/docs/ivy/overview/deep_dive/formatting.html#pre-commit

-->

### Socials

<!--
If you have Twitter, please provide it here otherwise just ignore this.
-->
