### PR TITLE
fix: failing test test_jax_svd

### DIFF
--- a/ivy_tests/test_ivy/test_frontends/test_jax/test_numpy/test_linalg.py
+++ b/ivy_tests/test_ivy/test_frontends/test_jax/test_numpy/test_linalg.py
@@ -268,8 +268,8 @@ def test_jax_eig(
 ):
     dtype, x = dtype_and_x
     x = np.array(x[0], dtype=dtype[0])
-    """Make symmetric positive-definite since ivy does not support complex data dtypes
-    currently."""
+    """Make symmetric positive-definite since ivy does not support complex data
+    dtypes currently."""
     x = np.matmul(x.T, x) + np.identity(x.shape[0]) * 1e-3
 
     ret, frontend_ret = helpers.test_frontend_function(

--- a/ivy_tests/test_ivy/test_frontends/test_jax/test_numpy/test_linalg.py
+++ b/ivy_tests/test_ivy/test_frontends/test_jax/test_numpy/test_linalg.py
@@ -268,8 +268,8 @@ def test_jax_eig(
 ):
     dtype, x = dtype_and_x
     x = np.array(x[0], dtype=dtype[0])
-    """Make symmetric positive-definite since ivy does not support complex data
-    dtypes currently."""
+    """Make symmetric positive-definite since ivy does not support complex data dtypes
+    currently."""
     x = np.matmul(x.T, x) + np.identity(x.shape[0]) * 1e-3
 
     ret, frontend_ret = helpers.test_frontend_function(
@@ -899,7 +899,7 @@ def test_jax_svd(
 
     if compute_uv:
         with BackendHandler.update_backend(backend_fw) as ivy_backend:
-            ret = [ivy_backend.to_numpy(x) for x in ret]
+            ret = [ivy_backend.to_numpy(x).astype(np.float64) for x in ret]
         frontend_ret = [np.asarray(x) for x in frontend_ret]
 
         u, s, vh = ret
@@ -915,10 +915,11 @@ def test_jax_svd(
         )
     else:
         with BackendHandler.update_backend(backend_fw) as ivy_backend:
-            ret = ivy_backend.to_numpy(ret)
+            ret = ivy_backend.to_numpy(ret).astype(np.float64)
+        frontend_ret = np.asarray(frontend_ret)
         assert_all_close(
             ret_np=ret,
-            ret_from_gt_np=np.asarray(frontend_ret[0]),
+            ret_from_gt_np=frontend_ret,
             rtol=1e-2,
             atol=1e-2,
             backend=backend_fw,


### PR DESCRIPTION
# PR Description
Fixed failing test test_jax_svd, the issue seems to be a basic float 32 vs float 64 dtype issue as  np.asarray  returned np.float64 dtype and ivy_backend.to_numpy returned np.float32 dtype. Also, when compute_uv was false, we were comparing a float to an array.

## Related Issue
Closes #28734 

## Checklist

- [ ] Did you add a function?
- [ ] Did you add the tests?
- [x] Did you run your tests and are your tests passing?
- [x] Did pre-commit not fail on any check?
- [x] Did you follow the steps we provided?


### Socials
https://twitter.com/free_thinker_9