### PR TITLE
fix: failing test test_jax_min

### DIFF
--- a/ivy/functional/backends/paddle/elementwise.py
+++ b/ivy/functional/backends/paddle/elementwise.py
@@ -1067,7 +1067,7 @@ def erf(x: paddle.Tensor, /, *, out: Optional[paddle.Tensor] = None) -> paddle.T
 
 
 @with_supported_dtypes(
-    {"2.6.0 and below": ("float32", "float64", "int32", "int64", "complex")},
+    {"2.6.0 and below": ("float32", "float64", "int32", "int64", "complex64")},
     backend_version,
 )
 def minimum(


### PR DESCRIPTION
# PR Description

The test test_jax_min failing seems to be an issue with the paddle real function(https://www.paddlepaddle.org.cn/documentation/docs/en/api/paddle/real_en.html). When it converts a float64 object, it turns it into float32, losing precision and often rounding numbers close to each other to the same number. Setting the supported dtype of minimum function to only complex64 solves this

## Related Issue


Closes #28737 

## Checklist

- [ ] Did you add a function?
- [ ] Did you add the tests?
- [x] Did you run your tests and are your tests passing?
- [x] Did pre-commit not fail on any check?
- [x] Did you follow the steps we provided?

<!--
Please mark your PR as a draft if you realise after the fact that your tests are not passing or
that your pre-commit check has some failures.

Here are some relevant resources regarding tests and pre-commit:

https://unify.ai/docs/ivy/overview/deep_dive/ivy_tests.html
https://unify.ai/docs/ivy/overview/deep_dive/formatting.html#pre-commit

-->

### Socials

https://twitter.com/free_thinker_9