### PR TITLE
fix: torch.masked_fill

### DIFF
--- a/ivy/functional/frontends/torch/tensor.py
+++ b/ivy/functional/frontends/torch/tensor.py
@@ -1062,8 +1062,8 @@ class Tensor:
         return torch_frontend.acosh(self)
 
     def masked_fill(self, mask, value):
-        dtype = self.dtype
-        return torch_frontend.where(mask, value, self).to(dtype)
+        dtype = ivy.as_native_dtype(self.dtype)
+        return ivy.astype(torch_frontend.where(mask, value, self), dtype)
 
     def masked_fill_(self, mask, value):
         self.ivy_array = self.masked_fill(mask, value).ivy_array

--- a/ivy/functional/frontends/torch/tensor.py
+++ b/ivy/functional/frontends/torch/tensor.py
@@ -1063,7 +1063,7 @@ class Tensor:
 
     def masked_fill(self, mask, value):
         dtype = self.dtype
-        return torch_frontend.where(mask, value, self).as_type(dtype)
+        return torch_frontend.where(mask, value, self).to(dtype)
 
     def masked_fill_(self, mask, value):
         self.ivy_array = self.masked_fill(mask, value).ivy_array

--- a/ivy/functional/frontends/torch/tensor.py
+++ b/ivy/functional/frontends/torch/tensor.py
@@ -1062,9 +1062,8 @@ class Tensor:
         return torch_frontend.acosh(self)
 
     def masked_fill(self, mask, value):
-        return torch_frontend.tensor(
-            torch_frontend.where(mask, value, self), dtype=self.dtype
-        )
+        dtype = self.dtype
+        return torch_frontend.where(mask, value, self).as_type(dtype)
 
     def masked_fill_(self, mask, value):
         self.ivy_array = self.masked_fill(mask, value).ivy_array

--- a/ivy/functional/frontends/torch/tensor.py
+++ b/ivy/functional/frontends/torch/tensor.py
@@ -1063,7 +1063,9 @@ class Tensor:
 
     def masked_fill(self, mask, value):
         dtype = ivy.as_native_dtype(self.dtype)
-        return ivy.astype(torch_frontend.where(mask, value, self), dtype)
+        return torch_frontend.tensor(
+            ivy.astype(torch_frontend.where(mask, value, self), dtype)
+        )
 
     def masked_fill_(self, mask, value):
         self.ivy_array = self.masked_fill(mask, value).ivy_array


### PR DESCRIPTION
<!--
This template will help you to have a meaningful PR, please follow it and do not leave it blank.
-->

# PR Description
Changed the way type-casting was done in the frontend. Previous implementation did not enforce keeping the input's dtype and paddle backend utilises type promotion in the function called by torch's frontend `.masked_fill()`. This resulted in the failure of dtype assertions and a failed paddle pytest. All of the backends use `.where()` to get the same results as `torch.masked_fill()`, with paddle's solution being probably a bit overcomplicated- but the tests for `.where()` are passing, so I did not want to alter that.

Potentially to-do:
- if it's not too redundant: adding `.masked_fill()` for the superset behaviour (even torch backend uses `.where()` when `.masked_fill()` is called);
- reformatting paddle's backend implementation of `.where()`.

<!--
If there is no related issue, please add a short description about your PR.
-->

## Related Issue

<!--
Please use this format to link other issues with their numbers: Close #123
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes #28437

## Checklist

- [ ] Did you add a function?
- [ ] Did you add the tests?
- [x] Did you run your tests and are your tests passing?
- [x] Did pre-commit not fail on any check?
- [x] Did you follow the steps we provided?

<!--
Please mark your PR as a draft if you realise after the fact that your tests are not passing or
that your pre-commit check has some failures.

Here are some relevant resources regarding tests and pre-commit:

https://unify.ai/docs/ivy/overview/deep_dive/ivy_tests.html
https://unify.ai/docs/ivy/overview/deep_dive/formatting.html#pre-commit

-->

### Socials

<!--
If you have Twitter, please provide it here otherwise just ignore this.
-->
